### PR TITLE
chore(ci): reduce CI runner minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
   # ==========================================================================
   build-check:
     name: Build Check
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.full_matrix == 'true'
+    if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     needs: [frontend-test, rust-test]
 


### PR DESCRIPTION
## Summary
- Default CI runs Ubuntu-only to reduce GitHub-hosted runner minutes.
- Full OS matrix (Ubuntu + Windows + macOS) is still available via manual dispatch.
- Security audit runs weekly (schedule) and can be triggered manually.

## Why
Recent CI failures were caused by GitHub Actions being blocked due to account billing/spending-limit issues (jobs not starting). This change reduces baseline CI usage so normal PRs consume fewer minutes.

## How to run full matrix
- Actions ? CI ? Run workflow ? enable `full_matrix`.