### PR TITLE
fix(ci): add custom_model_max_tokens for Gemini 3 Pro

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -6,6 +6,8 @@ model = "gemini/gemini-3-pro-preview"
 model_turbo = "gemini/gemini-3-flash-preview"
 fallback_models = ["gemini/gemini-2.5-pro", "gemini/gemini-2.5-flash"]
 use_repo_settings_file = true
+# Gemini 3 Pro: 1M input, 64K output tokens
+custom_model_max_tokens = 65536
 
 [pr_reviewer]
 require_focused_review = false


### PR DESCRIPTION
### **User description**
## Description

PR-Agent was falling back to `gemini-2.5-pro` instead of using the configured `gemini-3-pro-preview` model because the model is not in PR-Agent's built-in MAX_TOKENS list.

## Related Issue

N/A - Bug discovered during PR #32 review

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `custom_model_max_tokens = 65536` to `.pr_agent.toml` config

## Screenshots / Videos

**Before (from PR #32 logs):**
```
Model gemini/gemini-3-pro-preview is not defined in MAX_TOKENS
Failed to generate prediction with gemini/gemini-3-pro-preview
Generating prediction with gemini/gemini-2.5-pro  ← fallback
```

**After:**
Should use `gemini-3-pro-preview` directly without fallback.

## Testing

### Test Environment

- OS: Windows 11
- Node.js version: N/A (CI config change)
- Rust version: N/A (CI config change)

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [ ] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Gemini 3 Pro has 1M input tokens and 64K output tokens limit.


___

### **PR Type**
Bug fix


___

### **Description**
- Sets `custom_model_max_tokens` in PR-Agent config.

- Prevents fallback from `gemini-3-pro-preview` model.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Set custom max tokens for Gemini 3 Pro model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Adds the <code>custom_model_max_tokens</code> setting with a value of <code>65536</code>.<br> <li> This ensures the <code>gemini-3-pro-preview</code> model is used correctly without <br>falling back to an older version.</ul>


</details>


  </td>
  <td><a href="https://github.com/Junseo5/openreelio/pull/33/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

