### PR TITLE
feat(ai): add tool reference section to agent system prompts

### DIFF
--- a/src/agents/engine/prompts/system.test.ts
+++ b/src/agents/engine/prompts/system.test.ts
@@ -60,6 +60,36 @@ describe('assembleSystemPrompt', () => {
     expect(result).toContain('Project: test-project');
   });
 
+  it('should include tool reference with all sections for editor role', () => {
+    const result = assembleSystemPrompt({
+      role: 'editor',
+      context: makeContext(),
+    });
+
+    expect(result).toContain('<tool_reference>');
+    expect(result).toContain('## Query Actions');
+    expect(result).toContain('## Edit Actions');
+    expect(result).toContain('## Audio Actions');
+    expect(result).toContain('## Effects Actions');
+    expect(result).toContain('## Text Actions');
+    expect(result).toContain('## Common Workflows');
+    expect(result).toContain('</tool_reference>');
+  });
+
+  it('should include only query tools for analyst role', () => {
+    const result = assembleSystemPrompt({
+      role: 'analyst',
+      context: makeContext(),
+    });
+
+    expect(result).toContain('<tool_reference>');
+    expect(result).toContain('## Query Actions');
+    expect(result).not.toContain('## Edit Actions');
+    expect(result).not.toContain('## Audio Actions');
+    expect(result).not.toContain('## Effects Actions');
+    expect(result).toContain('</tool_reference>');
+  });
+
   it('should include knowledge entries when provided', () => {
     const result = assembleSystemPrompt({
       role: 'editor',
@@ -133,15 +163,17 @@ describe('assembleSystemPrompt', () => {
       customInstructions: 'Custom rule here',
     });
 
-    // Verify ordering: base prompt → environment → knowledge → language → custom
+    // Verify ordering: base → environment → tool_reference → knowledge → language → custom
     const baseIdx = result.indexOf('AI video editing assistant');
     const envIdx = result.indexOf('<environment>');
+    const toolRefIdx = result.indexOf('<tool_reference>');
     const knowledgeIdx = result.indexOf('<knowledge>');
     const langIdx = result.indexOf('<language_policy>');
     const customIdx = result.indexOf('<custom_instructions>');
 
     expect(baseIdx).toBeLessThan(envIdx);
-    expect(envIdx).toBeLessThan(knowledgeIdx);
+    expect(envIdx).toBeLessThan(toolRefIdx);
+    expect(toolRefIdx).toBeLessThan(knowledgeIdx);
     expect(knowledgeIdx).toBeLessThan(langIdx);
     expect(langIdx).toBeLessThan(customIdx);
   });

--- a/src/agents/engine/prompts/system.ts
+++ b/src/agents/engine/prompts/system.ts
@@ -4,9 +4,10 @@
  * Assembles the full system prompt for agent loops by combining:
  * 1. Base prompt (agent role and capabilities)
  * 2. Environment context (project state, timeline, assets)
- * 3. Knowledge base (learned conventions and preferences)
- * 4. Tool descriptions (from registry)
+ * 3. Tool reference (action docs, workflow recipes, CLI guide)
+ * 4. Knowledge base (learned conventions and preferences)
  * 5. Language policy
+ * 6. Custom instructions
  *
  * Follows the opencode pattern for structured prompt assembly.
  */
@@ -14,6 +15,7 @@
 import type { AgentContext } from '../core/types';
 import { buildFullEnvironmentPrompt } from './environment';
 import { EDITOR_PROMPT, ANALYST_PROMPT, COLORIST_PROMPT, AUDIO_PROMPT } from './agentPrompts';
+import { buildToolReference } from './toolReference';
 
 // =============================================================================
 // Types
@@ -87,9 +89,10 @@ function buildKnowledgeSection(knowledge: string[]): string | null {
  * Assembly order:
  * 1. Base prompt (agent-specific role and capabilities)
  * 2. Environment context (project info, timeline state, assets)
- * 3. Knowledge base (learned conventions/preferences)
- * 4. Language policy
- * 5. Custom instructions
+ * 3. Tool reference (action descriptions, workflows, CLI guide)
+ * 4. Knowledge base (learned conventions/preferences)
+ * 5. Language policy
+ * 6. Custom instructions
  */
 export function assembleSystemPrompt(options: SystemPromptOptions): string {
   const { role, context, knowledge = [], customInstructions } = options;
@@ -102,15 +105,18 @@ export function assembleSystemPrompt(options: SystemPromptOptions): string {
   // 2. Environment context
   sections.push(buildFullEnvironmentPrompt(context));
 
-  // 3. Knowledge base
+  // 3. Tool reference (action docs, workflows, CLI — filtered by role)
+  sections.push(buildToolReference(role));
+
+  // 4. Knowledge base
   const knowledgeSection = buildKnowledgeSection(knowledge);
   if (knowledgeSection) sections.push(knowledgeSection);
 
-  // 4. Language policy
+  // 5. Language policy
   const languageSection = buildLanguageSection(context);
   if (languageSection) sections.push(languageSection);
 
-  // 5. Custom instructions
+  // 6. Custom instructions
   if (customInstructions) {
     sections.push([
       '<custom_instructions>',

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -1,0 +1,156 @@
+/**
+ * Compact Tool Reference for Agent System Prompts
+ *
+ * Provides action-level documentation, workflow recipes, and CLI reference
+ * that the LLM needs to correctly select and invoke tools. Designed to be
+ * injected into the system prompt alongside meta-tool schemas.
+ *
+ * Sections are composed per agent role to avoid injecting irrelevant tools
+ * (e.g., analyst agents don't receive editing tool docs).
+ *
+ * Token budget: ~700 tokens full, ~200-300 for specialized roles.
+ */
+
+// =============================================================================
+// Role type (duplicated from system.ts to avoid circular dependency)
+// =============================================================================
+
+type ToolReferenceRole = 'editor' | 'analyst' | 'colorist' | 'audio';
+
+// =============================================================================
+// Sections
+// =============================================================================
+
+const QUERY_ACTIONS = `## Query Actions (meta-tool: query)
+- get_timeline_info → timeline duration, track/clip counts, playhead position
+- list_all_clips → all clips across all tracks with positions
+- list_tracks → all tracks with type, clip count, lock/mute status
+- get_clip_info(clipId) → detailed clip: position, duration, speed, effects, source range
+- get_track_clips(trackId) → all clips on one track
+- get_clips_at_time(time) → clips spanning a specific time point
+- get_selected_clips → currently selected clips (full detail)
+- get_playhead_position → current playhead seconds + total duration
+- find_clips_by_asset(assetId) → clips using a specific asset
+- find_gaps(trackId?, minDuration?) → empty spaces between clips
+- find_overlaps(trackId?) → overlapping clips on same track
+- get_asset_catalog → all assets with timeline usage status
+- get_unused_assets(kind?) → assets not placed on timeline
+- get_asset_info(assetId) → asset metadata (codec, resolution, duration)
+- get_workspace_files(kind?) → media files in project folder
+- find_workspace_file(query) → find file by name/path substring
+- get_unregistered_files(kind?) → workspace files not yet imported as assets
+- analyze_asset(assetId) → run backend analysis (shots/transcript/objects/faces/textOcr)
+- analyze_workspace_video(file) → find file + analyze in one step
+- get_analysis_status(assetId) → analysis progress check
+- get_asset_annotation(assetId) → stored analysis results
+- get_analysis_cost_estimate(assetId) → cost estimate for cloud analysis
+- get_analysis_providers → available analysis backends`;
+
+const EDIT_ACTIONS = `## Edit Actions (meta-tool: edit, all require sequenceId)
+- insert_clip(trackId, assetId, timelineStart) → place asset on timeline
+- insert_clip_from_file(file, trackId, timelineStart) → insert by filename (auto-imports)
+- move_clip(trackId, clipId, newTimelineIn, newTrackId?) → reposition or cross-track move
+- trim_clip(trackId, clipId, newSourceIn?, newSourceOut?) → adjust source boundaries
+- split_clip(trackId, clipId, splitTime) → divide into two clips at time point
+- delete_clip(trackId, clipId) → remove clip from timeline
+- delete_clips_in_range(startTime, endTime, trackId?) → bulk remove by time range
+- change_clip_speed(trackId, clipId, speed) → speed 0.1–10.0, duration auto-adjusts
+- freeze_frame(trackId, clipId, frameTime, duration?) → still image at time (default 2s)
+- ripple_edit(trackId, clipId, trimEnd) → trim clip end + shift all subsequent clips to close gap
+- roll_edit(trackId, leftClipId, rightClipId, rollAmount) → move cut point between two adjacent clips (one extends, other shortens)
+- slip_edit(trackId, clipId, offsetSeconds) → shift source window without moving clip on timeline
+- slide_edit(trackId, clipId, slideAmount) → move clip on timeline, neighbors auto-adjust
+- add_track(kind, name) → create video or audio track
+- remove_track(trackId) → delete empty track (fails if clips exist)
+- rename_track(trackId, name) → change track display name
+- add_marker(time, label, color?) → timeline marker at position
+- remove_marker(markerId) → delete marker
+- list_markers(fromTime?, toTime?) → list markers in range
+- navigate_to_marker(time) → move playhead to time`;
+
+const AUDIO_ACTIONS = `## Audio Actions (meta-tool: audio, require sequenceId + trackId)
+- adjust_volume(clipId?, volume) → set volume 0–200% (omit clipId for whole track)
+- add_fade_in(clipId, duration) → fade-in at clip start
+- add_fade_out(clipId, duration) → fade-out at clip end
+- mute_clip(clipId, muted) → mute/unmute single clip
+- mute_track(muted) → mute/unmute entire track
+- normalize_audio(clipId, targetLevel?) → normalize to dB target (default -3dB)`;
+
+const EFFECTS_ACTIONS = `## Effects Actions (meta-tool: effects)
+- add_effect(clipId, effectType, parameters?) → apply blur/brightness/contrast/saturation
+- remove_effect(clipId, effectId) → remove one effect
+- adjust_effect_param(clipId, effectId, paramName, paramValue) → tune effect parameter
+- copy_effects(sourceClipId, targetClipId) → copy all effects between clips
+- reset_effects(clipId) → remove all effects from clip
+- add_transition(clipId, transitionType, duration) → dissolve/wipe/slide/zoom/fade
+- remove_transition(transitionId) → remove transition
+- set_transition_duration(transitionId, duration) → change transition length`;
+
+const TEXT_ACTIONS = `## Text Actions (meta-tool: text, require sequenceId)
+- add_caption(text, startTime, endTime) → add subtitle (track auto-created if needed)
+- update_caption(captionId, text?, startTime?, endTime?) → edit caption
+- delete_caption(captionId) → remove caption
+- style_caption(captionId, fontSize?, fontFamily?, color?, position?) → style caption`;
+
+const WORKSPACE_TOOLS = `## Workspace Tools (always available, not behind meta-tools)
+- list_workspace_documents / read_workspace_document / write_workspace_document
+- replace_workspace_document_text / create_workspace_folder
+- rename_workspace_entry / move_workspace_entry / delete_workspace_entry`;
+
+const BATCH_EXECUTION = `## Batch Execution (meta-tool: execute_plan)
+Use for multi-step atomic edits. Each step: { id, toolName, params, dependsOn? }.
+Stops on first failure; completed steps are NOT rolled back.`;
+
+const EDITING_CONCEPTS = `## Editing Concepts
+- Ripple: trim + shift subsequent clips to fill/accommodate
+- Roll: move cut point between adjacent clips (total duration unchanged)
+- Slip: change which part of source shows, clip stays in place on timeline
+- Slide: move clip along timeline, neighbors stretch/shrink to compensate
+- J-cut: audio from next clip starts before video transition
+- L-cut: audio from current clip continues after video transitions to next`;
+
+const COMMON_WORKFLOWS = `## Common Workflows
+1. Import & arrange: get_workspace_files → insert_clip_from_file per file
+2. Remove section: split_clip at start → split_clip at end → delete_clip middle
+3. Remove silence: find_gaps → delete_clips_in_range or manual split+delete
+4. Speed ramp: split_clip at boundaries → change_clip_speed on middle segment
+5. Batch edit: use execute_plan with steps array for atomic multi-step operations`;
+
+const CLI_REFERENCE = `## CLI (headless alternative)
+openreelio-cli --path <dir> <group> <command> [--args]
+Groups: project, asset, timeline, caption, plan, state, render
+Key: plan execute --file <plan.json> for atomic batch operations
+Run help-json for machine-readable full schema.`;
+
+// =============================================================================
+// Role → Sections Mapping
+// =============================================================================
+
+function getSectionsForRole(role: ToolReferenceRole): string[] {
+  switch (role) {
+    case 'editor':
+      return [
+        QUERY_ACTIONS, EDIT_ACTIONS, AUDIO_ACTIONS, EFFECTS_ACTIONS, TEXT_ACTIONS,
+        WORKSPACE_TOOLS, BATCH_EXECUTION, EDITING_CONCEPTS, COMMON_WORKFLOWS, CLI_REFERENCE,
+      ];
+    case 'analyst':
+      return [QUERY_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
+    case 'colorist':
+      return [QUERY_ACTIONS, EFFECTS_ACTIONS, WORKSPACE_TOOLS, EDITING_CONCEPTS, CLI_REFERENCE];
+    case 'audio':
+      return [QUERY_ACTIONS, AUDIO_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Build the tool reference section for the system prompt.
+ * Filters sections to only include tools relevant to the given agent role.
+ */
+export function buildToolReference(role: ToolReferenceRole = 'editor'): string {
+  const sections = getSectionsForRole(role);
+  return `<tool_reference>\n\n${sections.join('\n\n')}\n\n</tool_reference>`;
+}


### PR DESCRIPTION
## Description

Add a compact, role-filtered tool reference section to agent system prompts. This gives the LLM inline action-level documentation for all meta-tools (query, edit, audio, effects, text), common workflow recipes, editing concept definitions, and CLI reference — enabling more accurate tool selection and multi-step operation composition.

## Related Issue

Closes #442

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `src/agents/engine/prompts/toolReference.ts` — new module with action-level docs for all 6 meta-tools, role-based section filtering, workflow recipes, editing concepts (ripple/roll/slip/slide), and CLI reference (~700 tokens for editor role, ~200-300 for specialized roles)
- Modify `src/agents/engine/prompts/system.ts` — import and call `buildToolReference(role)` as section 3 in prompt assembly, reorder subsequent sections (knowledge → 4, language → 5, custom → 6)
- Modify `src/agents/engine/prompts/system.test.ts` — add 2 new tests (editor role includes all tool sections; analyst role includes query-only) and update section ordering assertion

## Screenshots / Videos

N/A — no visual changes. This is a system prompt content change for the AI agent engine.

## Testing

### Test Environment

- OS: Windows 11 (WSL2)
- Node.js version: 22.x
- Rust version: 1.85.0

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`) — no Rust changes
- [x] Manual testing performed
- [x] New tests added for changes

**Test results:** 13/13 tests passing in `system.test.ts`, including:
- `should include tool reference with all sections for editor role` — verifies editor gets query, edit, audio, effects, text, and workflow sections
- `should include only query tools for analyst role` — verifies analyst does NOT receive edit/audio/effects sections
- `should assemble sections in correct order` — verifies base → environment → tool_reference → knowledge → language → custom ordering

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- Token budget is intentionally compact: ~700 tokens for full editor role, ~200-300 for specialized roles (analyst, colorist, audio)
- Section filtering uses a simple switch/case per role — easy to extend when new agent roles are added
- The `ToolReferenceRole` type is duplicated from `system.ts` to avoid circular dependency
- No runtime behavior change for existing code — this only affects the content of system prompts sent to the LLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated role-specific tool references into agent system prompts for improved context-aware functionality.
  * Editor and Analyst roles now receive tailored tool documentation based on their responsibilities.

* **Tests**
  * Added validation tests for tool reference inclusion and role-specific content structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->