### PR TITLE
feat: detect and import Codex OpenAI credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "openreelio",
       "version": "0.1.0",
       "dependencies": {
+        "@mariozechner/pi-ai": "^0.60.0",
         "@tauri-apps/api": "^2.9.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "immer": "^10.1.1",
@@ -68,6 +69,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -86,6 +107,701 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1013.0.tgz",
+      "integrity": "sha512-LU80q1avpBwQ0eVAGbQpPApdVY4vcdBEIycY5iaznI10mdabeG83nrFySJrZ8knX7G6hl5d5KIOSjcpnolMKSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/eventstream-handler-node": "^3.972.11",
+        "@aws-sdk/middleware-eventstream": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/middleware-websocket": "^3.972.13",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/token-providers": "3.1013.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.22.tgz",
+      "integrity": "sha512-lY6g5L95jBNgOUitUhfV2N/W+i08jHEl3xuLODYSQH5Sf50V+LkVYBSyZRLtv2RyuXZXiV7yQ+acpswK1tlrOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.14",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.20.tgz",
+      "integrity": "sha512-vI0QN96DFx3g9AunfOWF3CS4cMkqFiR/WM/FyP9QHr5rZ2dKPkYwP3tCgAOvGuu9CXI7dC1vU2FVUuZ+tfpNvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.22.tgz",
+      "integrity": "sha512-aS/81smalpe7XDnuQfOq4LIPuaV2PRKU2aMTrHcqO5BD4HwO5kESOHNcec2AYfBtLtIDqgF6RXisgBnfK/jt0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.22.tgz",
+      "integrity": "sha512-rpF8fBT0LllMDp78s62aL2A/8MaccjyJ0ORzqu+ZADeECLSrrCWIeeXsuRam+pxiAMkI1uIyDZJmgLGdadkPXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-env": "^3.972.20",
+        "@aws-sdk/credential-provider-http": "^3.972.22",
+        "@aws-sdk/credential-provider-login": "^3.972.22",
+        "@aws-sdk/credential-provider-process": "^3.972.20",
+        "@aws-sdk/credential-provider-sso": "^3.972.22",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.22.tgz",
+      "integrity": "sha512-u33CO9zeNznlVSg9tWTCRYxaGkqr1ufU6qeClpmzAabXZa8RZxQoVXxL5T53oZJFzQYj+FImORCSsi7H7B77gQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.23.tgz",
+      "integrity": "sha512-U8tyLbLOZItuVWTH0ay9gWo4xMqZwqQbg1oMzdU4FQSkTpqXemm4X0uoKBR6llqAStgBp30ziKFJHTA43l4qMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.20",
+        "@aws-sdk/credential-provider-http": "^3.972.22",
+        "@aws-sdk/credential-provider-ini": "^3.972.22",
+        "@aws-sdk/credential-provider-process": "^3.972.20",
+        "@aws-sdk/credential-provider-sso": "^3.972.22",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.20.tgz",
+      "integrity": "sha512-QRfk7GbA4/HDRjhP3QYR6QBr/QKreVoOzvvlRHnOuGgYJkeoPgPY3LAI1kK1ZMgZ4hH9KiGp757/ntol+INAig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.22.tgz",
+      "integrity": "sha512-4vqlSaUbBj4aNPVKfB6yXuIQ2Z2mvLfIGba2OzzF6zUkN437/PGWsxBU2F8QPSFHti6seckvyCXidU3H+R8NvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/token-providers": "3.1013.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.22.tgz",
+      "integrity": "sha512-/wN1CYg2rVLhW8/jLxMWacQrkpaynnL+4j/Z+e6X1PfoE6NiC0BeOw3i0JmtZrKun85wNV5GmspvuWJihfeeUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.11.tgz",
+      "integrity": "sha512-2IrLrOruRr1NhTK0vguBL1gCWv1pu4bf4KaqpsA+/vCJpFEbvXFawn71GvCzk1wyjnDUsemtKypqoKGv4cSGbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+      "integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.23.tgz",
+      "integrity": "sha512-HQu8QoqGZZTvg0Spl9H39QTsSMFwgu+8yz/QGKndXFLk9FZMiCiIgBCVlTVKMDvVbgqIzD9ig+/HmXsIL2Rb+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.13.tgz",
+      "integrity": "sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.12.tgz",
+      "integrity": "sha512-KLdQGJPSm98uLINolQ0Tol8OAbk7g0Y7zplHJ1K83vbMIH13aoCvR6Tho66xueW4l4aZlEgVGLWBnD8ifUMsGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+      "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1013.0.tgz",
+      "integrity": "sha512-IL1c54UvbuERrs9oLm5rvkzMciwhhpn1FL0SlC3XUMoLlFhdBsWJgQKK8O5fsQLxbFVqjbjFx9OBkrn44X9PHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.9.tgz",
+      "integrity": "sha512-jeFqqp8KD/P5O+qeKxyGeu7WEVIZFNprnkaDjGmBOjwxYwafCBhpxTgV1TlW6L8e76Vh/siNylNmN/OmSIFBUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.14.tgz",
+      "integrity": "sha512-G/Yd8Bnnyh8QrqLf8jWJbixEnScUFW24e/wOBGYdw1Cl4r80KX/DvHyM2GVZ2vTp7J4gTEr8IXJlTadA8+UfuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -325,7 +1041,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1075,6 +1790,29 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.46.0.tgz",
+      "integrity": "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1177,6 +1915,77 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mariozechner/pi-ai": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.60.0.tgz",
+      "integrity": "sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "1.14.1",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.24.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1230,6 +2039,70 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -1588,6 +2461,663 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
@@ -1914,6 +3444,12 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2003,7 +3539,6 @@
       "version": "22.19.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.5.tgz",
       "integrity": "sha512-HfF8+mYcHPcPypui3w3mvzuIErlNOh2OAG+BCeBZCEwyiD5ls2SiCwEyT47OELtf7M3nHxBdu0FsmzdKxkN52Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2036,6 +3571,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.52.0",
@@ -2469,7 +4010,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2491,6 +4031,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2573,6 +4152,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2624,6 +4215,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
@@ -2632,6 +4243,24 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -2646,6 +4275,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2717,6 +4352,12 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -2978,6 +4619,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2995,7 +4645,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3043,6 +4692,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3081,6 +4744,15 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -3201,6 +4873,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -3334,6 +5037,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3364,7 +5080,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3384,7 +5099,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3400,11 +5114,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3451,6 +5170,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3459,6 +5229,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3558,6 +5351,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3604,6 +5409,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3635,6 +5468,29 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -3683,6 +5539,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gzip-size": {
@@ -3740,7 +5622,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -3754,7 +5635,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -3867,6 +5747,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4081,12 +5970,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4113,6 +6024,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -4188,6 +6120,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4322,7 +6260,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4361,6 +6298,53 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -4433,6 +6417,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4483,6 +6488,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4508,6 +6558,12 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4516,6 +6572,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4868,6 +6939,64 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5027,6 +7156,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5066,6 +7204,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -5212,6 +7359,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5285,6 +7452,44 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -5485,6 +7690,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/sucrase": {
@@ -5765,6 +7982,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -5784,6 +8007,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -5856,11 +8085,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -6139,6 +8376,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6255,7 +8501,6 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6356,6 +8601,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.60.0",
-        "@tauri-apps/api": "^2.9.0",
+        "@tauri-apps/api": "^2.10.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "immer": "^10.1.1",
         "lucide-react": "^0.562.0",
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.0",
         "@playwright/test": "^1.57.0",
-        "@tauri-apps/cli": "^2.9.6",
+        "@tauri-apps/cli": "^2.10.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -3119,9 +3119,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
-      "integrity": "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -3129,9 +3129,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.9.6.tgz",
-      "integrity": "sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
+      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -3145,23 +3145,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.9.6",
-        "@tauri-apps/cli-darwin-x64": "2.9.6",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.9.6",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.9.6",
-        "@tauri-apps/cli-linux-arm64-musl": "2.9.6",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.9.6",
-        "@tauri-apps/cli-linux-x64-gnu": "2.9.6",
-        "@tauri-apps/cli-linux-x64-musl": "2.9.6",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.9.6",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.9.6",
-        "@tauri-apps/cli-win32-x64-msvc": "2.9.6"
+        "@tauri-apps/cli-darwin-arm64": "2.10.1",
+        "@tauri-apps/cli-darwin-x64": "2.10.1",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
+        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
+        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
+        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
+        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.9.6.tgz",
-      "integrity": "sha512-gf5no6N9FCk1qMrti4lfwP77JHP5haASZgVbBgpZG7BUepB3fhiLCXGUK8LvuOjP36HivXewjg72LTnPDScnQQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
+      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
       "cpu": [
         "arm64"
       ],
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.9.6.tgz",
-      "integrity": "sha512-oWh74WmqbERwwrwcueJyY6HYhgCksUc6NT7WKeXyrlY/FPmNgdyQAgcLuTSkhRFuQ6zh4Np1HZpOqCTpeZBDcw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
+      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
       "cpu": [
         "x64"
       ],
@@ -3193,9 +3193,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.9.6.tgz",
-      "integrity": "sha512-/zde3bFroFsNXOHN204DC2qUxAcAanUjVXXSdEGmhwMUZeAQalNj5cz2Qli2elsRjKN/hVbZOJj0gQ5zaYUjSg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
+      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
       "cpu": [
         "arm"
       ],
@@ -3210,9 +3210,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.9.6.tgz",
-      "integrity": "sha512-pvbljdhp9VOo4RnID5ywSxgBs7qiylTPlK56cTk7InR3kYSTJKYMqv/4Q/4rGo/mG8cVppesKIeBMH42fw6wjg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
+      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
       "cpu": [
         "arm64"
       ],
@@ -3227,9 +3227,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.9.6.tgz",
-      "integrity": "sha512-02TKUndpodXBCR0oP//6dZWGYcc22Upf2eP27NvC6z0DIqvkBBFziQUcvi2n6SrwTRL0yGgQjkm9K5NIn8s6jw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
+      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
       "cpu": [
         "arm64"
       ],
@@ -3244,9 +3244,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.9.6.tgz",
-      "integrity": "sha512-fmp1hnulbqzl1GkXl4aTX9fV+ubHw2LqlLH1PE3BxZ11EQk+l/TmiEongjnxF0ie4kV8DQfDNJ1KGiIdWe1GvQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
+      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
       "cpu": [
         "riscv64"
       ],
@@ -3261,9 +3261,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.9.6.tgz",
-      "integrity": "sha512-vY0le8ad2KaV1PJr+jCd8fUF9VOjwwQP/uBuTJvhvKTloEwxYA/kAjKK9OpIslGA9m/zcnSo74czI6bBrm2sYA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
+      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
       "cpu": [
         "x64"
       ],
@@ -3278,9 +3278,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.9.6.tgz",
-      "integrity": "sha512-TOEuB8YCFZTWVDzsO2yW0+zGcoMiPPwcUgdnW1ODnmgfwccpnihDRoks+ABT1e3fHb1ol8QQWsHSCovb3o2ENQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
+      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
       "cpu": [
         "x64"
       ],
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.9.6.tgz",
-      "integrity": "sha512-ujmDGMRc4qRLAnj8nNG26Rlz9klJ0I0jmZs2BPpmNNf0gM/rcVHhqbEkAaHPTBVIrtUdf7bGvQAD2pyIiUrBHQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
+      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
       "cpu": [
         "arm64"
       ],
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.9.6.tgz",
-      "integrity": "sha512-S4pT0yAJgFX8QRCyKA1iKjZ9Q/oPjCZf66A/VlG5Yw54Nnr88J1uBpmenINbXxzyhduWrIXBaUbEY1K80ZbpMg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
+      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
       "cpu": [
         "ia32"
       ],
@@ -3329,9 +3329,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.9.6.tgz",
-      "integrity": "sha512-ldWuWSSkWbKOPjQMJoYVj9wLHcOniv7diyI5UAJ4XsBdtaFB0pKHQsqw/ItUma0VXGC7vB4E9fZjivmxur60aw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
+      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@mariozechner/pi-ai": "^0.60.0",
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "immer": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@mariozechner/pi-ai": "^0.60.0",
-    "@tauri-apps/api": "^2.9.0",
+    "@tauri-apps/api": "^2.10.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "immer": "^10.1.1",
     "lucide-react": "^0.562.0",
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.0",
     "@playwright/test": "^1.57.0",
-    "@tauri-apps/cli": "^2.9.6",
+    "@tauri-apps/cli": "^2.10.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",

--- a/scripts/codex-auth-exchange.mjs
+++ b/scripts/codex-auth-exchange.mjs
@@ -1,11 +1,12 @@
 import { Buffer } from "node:buffer";
-import { execSync } from "node:child_process";
+import { execFile, execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { getOAuthApiKey } from "@mariozechner/pi-ai/oauth";
+import { complete, getModel, getModels } from "@mariozechner/pi-ai";
+import { getOAuthApiKey, loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
 
 const CODEX_CLI_AUTH_FILENAME = "auth.json";
 
@@ -137,6 +138,181 @@ function readCodexCredentials() {
   return readCodexKeychainCredentials() ?? readCodexFileCredentials();
 }
 
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function exchangeOauth(oauth, source = "vault") {
+  const result = await getOAuthApiKey("openai-codex", { "openai-codex": oauth });
+  if (!result?.apiKey) {
+    return {
+      ok: false,
+      message: "Failed to exchange Codex OAuth credentials for an API key.",
+    };
+  }
+
+  return {
+    ok: true,
+    mode: "oauth_exchange",
+    apiKey: result.apiKey,
+    source,
+    newCredentials: result.newCredentials ?? null,
+  };
+}
+
+function extractAssistantText(message) {
+  if (!message || !Array.isArray(message.content)) return "";
+  return message.content
+    .filter((part) => part && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+function normalizeCodexModels(models) {
+  return [...new Set(models.map((model) => model.id).filter((id) => typeof id === "string" && id))]
+    .sort((a, b) => a.localeCompare(b));
+}
+
+const DEFAULT_CODEX_SYSTEM_PROMPT = "You are OpenReelio's AI assistant.";
+
+function buildCodexHistoryMessage(message, timestamp, index, modelId) {
+  const role = message?.role === "assistant" ? "assistant" : "user";
+  const content = typeof message?.content === "string" ? message.content : "";
+
+  if (role === "assistant") {
+    return {
+      role: "assistant",
+      content: content.length > 0 ? [{ type: "text", text: content }] : [],
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      model: modelId,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: timestamp + index,
+    };
+  }
+
+  return {
+    role: "user",
+    content,
+    timestamp: timestamp + index,
+  };
+}
+
+async function completeWithOauth(payload) {
+  const oauth = payload?.oauth;
+  const request = payload?.request;
+  if (!oauth || !request || typeof request !== "object") {
+    return {
+      ok: false,
+      message: "Both oauth and request are required.",
+    };
+  }
+
+  const oauthResult = await getOAuthApiKey("openai-codex", { "openai-codex": oauth });
+  if (!oauthResult?.apiKey) {
+    return {
+      ok: false,
+      message: "Failed to exchange Codex OAuth credentials for a runtime key.",
+    };
+  }
+
+  const modelId =
+    typeof request.model === "string" && request.model.trim().length > 0 ? request.model.trim() : "gpt-5.4";
+  const model = getModel("openai-codex", modelId);
+  if (!model) {
+    return {
+      ok: false,
+      message: `Unknown OpenAI Codex model: ${modelId}`,
+    };
+  }
+
+  const timestamp = Date.now();
+  const messages = Array.isArray(request.messages) && request.messages.length > 0
+    ? request.messages.map((message, index) => buildCodexHistoryMessage(message, timestamp, index, modelId))
+    : [
+        {
+          role: "user",
+          content: typeof request.prompt === "string" ? request.prompt : "",
+          timestamp,
+        },
+      ];
+
+  const systemPromptParts = [];
+  if (typeof request.system === "string" && request.system.trim().length > 0) {
+    systemPromptParts.push(request.system.trim());
+  }
+  if (request.jsonMode) {
+    systemPromptParts.push("Respond with valid JSON only.");
+  }
+
+  const response = await complete(
+    model,
+    {
+      systemPrompt:
+        systemPromptParts.length > 0
+          ? systemPromptParts.join("\n\n")
+          : DEFAULT_CODEX_SYSTEM_PROMPT,
+      messages,
+    },
+    {
+      apiKey: oauthResult.apiKey,
+      ...(typeof request.maxTokens === "number" ? { maxTokens: request.maxTokens } : {}),
+    },
+  );
+
+  return {
+    ok: response.stopReason !== "error" && response.stopReason !== "aborted",
+    provider: response.provider,
+    api: response.api,
+    model: response.model,
+    text: extractAssistantText(response),
+    usage: response.usage ?? null,
+    stopReason: response.stopReason ?? null,
+    errorMessage: response.errorMessage ?? null,
+    newCredentials: oauthResult.newCredentials ?? null,
+  };
+}
+
+function openExternalUrl(url) {
+  return new Promise((resolve, reject) => {
+    let command;
+    let args;
+    if (process.platform === "darwin") {
+      command = "open";
+      args = [url];
+    } else if (process.platform === "win32") {
+      command = "cmd";
+      args = ["/c", "start", "", url];
+    } else {
+      command = "xdg-open";
+      args = [url];
+    }
+
+    execFile(command, args, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
 async function main() {
   const command = process.argv[2] ?? "status";
   const creds = readCodexCredentials();
@@ -192,12 +368,18 @@ async function main() {
       return;
     }
 
-    const result = await getOAuthApiKey("openai-codex", { "openai-codex": creds.oauth });
-    if (!result?.apiKey) {
+    process.stdout.write(JSON.stringify(await exchangeOauth(creds.oauth, creds.source)));
+    return;
+  }
+
+  if (command === "export-oauth") {
+    if (!creds?.oauth) {
       process.stdout.write(
         JSON.stringify({
           ok: false,
-          message: "Failed to exchange Codex OAuth credentials for an API key.",
+          message: creds
+            ? "Codex auth did not include reusable OAuth credentials."
+            : "Codex auth not found.",
         }),
       );
       return;
@@ -206,10 +388,80 @@ async function main() {
     process.stdout.write(
       JSON.stringify({
         ok: true,
-        mode: "oauth_exchange",
-        apiKey: result.apiKey,
+        oauth: creds.oauth,
         source: creds.source,
-        newCredentials: result.newCredentials ?? null,
+      }),
+    );
+    return;
+  }
+
+  if (command === "exchange-oauth-stdin") {
+    const raw = (await readStdin()).trim();
+    if (!raw) {
+      process.stdout.write(JSON.stringify({ ok: false, message: "No OAuth payload provided." }));
+      return;
+    }
+
+    const oauth = JSON.parse(raw);
+    process.stdout.write(JSON.stringify(await exchangeOauth(oauth, "vault")));
+    return;
+  }
+
+  if (command === "list-models") {
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        models: normalizeCodexModels(getModels("openai-codex")),
+      }),
+    );
+    return;
+  }
+
+  if (command === "complete-oauth-stdin") {
+    const raw = (await readStdin()).trim();
+    if (!raw) {
+      process.stdout.write(JSON.stringify({ ok: false, message: "No completion payload provided." }));
+      return;
+    }
+
+    const payload = JSON.parse(raw);
+    process.stdout.write(JSON.stringify(await completeWithOauth(payload)));
+    return;
+  }
+
+  if (command === "login-oauth") {
+    const credentials = await loginOpenAICodex({
+      onAuth: async ({ url, instructions }) => {
+        if (instructions) {
+          process.stderr.write(`${instructions}\n`);
+        }
+        process.stderr.write(`Opening browser for OpenAI sign-in: ${url}\n`);
+        await openExternalUrl(url);
+      },
+      onPrompt: async (prompt) => {
+        throw new Error(
+          `Manual OAuth prompt not supported in OpenReelio helper: ${prompt.message}`,
+        );
+      },
+      onProgress: (message) => {
+        if (message) {
+          process.stderr.write(`${message}\n`);
+        }
+      },
+    });
+
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        oauth: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: credentials.access,
+          refresh: credentials.refresh,
+          expires: credentials.expires,
+          ...(credentials.accountId ? { accountId: credentials.accountId } : {}),
+        },
+        source: "browser_oauth",
       }),
     );
     return;

--- a/scripts/codex-auth-exchange.mjs
+++ b/scripts/codex-auth-exchange.mjs
@@ -1,0 +1,225 @@
+import { Buffer } from "node:buffer";
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { getOAuthApiKey } from "@mariozechner/pi-ai/oauth";
+
+const CODEX_CLI_AUTH_FILENAME = "auth.json";
+
+function resolveUserPath(input) {
+  if (!input) return input;
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+function resolveCodexHomePath() {
+  const configured = process.env.CODEX_HOME;
+  const home = configured ? resolveUserPath(configured) : resolveUserPath("~/.codex");
+  try {
+    return fs.realpathSync.native(home);
+  } catch {
+    return home;
+  }
+}
+
+function resolveCodexCliAuthPath() {
+  return path.join(resolveCodexHomePath(), CODEX_CLI_AUTH_FILENAME);
+}
+
+function computeCodexKeychainAccount(codexHome) {
+  const hash = createHash("sha256").update(codexHome).digest("hex");
+  return `cli|${hash.slice(0, 16)}`;
+}
+
+function decodeJwtExpiryMs(token) {
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payloadRaw = Buffer.from(parts[1], "base64url").toString("utf8");
+    const payload = JSON.parse(payloadRaw);
+    return typeof payload.exp === "number" && Number.isFinite(payload.exp) && payload.exp > 0
+      ? payload.exp * 1000
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readCodexKeychainCredentials() {
+  if (process.platform !== "darwin") return null;
+  const codexHome = resolveCodexHomePath();
+  const account = computeCodexKeychainAccount(codexHome);
+  try {
+    const secret = execSync(`security find-generic-password -s "Codex Auth" -a "${account}" -w`, {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    const parsed = JSON.parse(secret);
+    return normalizeCodexJson(parsed, "keychain");
+  } catch {
+    return null;
+  }
+}
+
+function normalizeCodexJson(data, source) {
+  if (!data || typeof data !== "object") return null;
+  const tokens = data.tokens;
+  const access = tokens?.access_token;
+  const refresh = tokens?.refresh_token;
+  const openaiApiKey = typeof data.OPENAI_API_KEY === "string" ? data.OPENAI_API_KEY.trim() : "";
+  const accountId = typeof tokens?.account_id === "string" ? tokens.account_id : undefined;
+
+  const result = {
+    source,
+    hasAuthFile: source === "file",
+    hasAccessToken: typeof access === "string" && access.length > 0,
+    hasRefreshToken: typeof refresh === "string" && refresh.length > 0,
+    hasOpenaiApiKey: openaiApiKey.length > 0,
+    openaiApiKey: openaiApiKey || null,
+    oauth: null,
+  };
+
+  if (typeof access === "string" && access && typeof refresh === "string" && refresh) {
+    let fallbackExpiry = Date.now() + 60 * 60 * 1000;
+    if (source === "file") {
+      try {
+        fallbackExpiry = fs.statSync(resolveCodexCliAuthPath()).mtimeMs + 60 * 60 * 1000;
+      } catch {
+        // keep default
+      }
+    } else {
+      const lastRefreshRaw = data.last_refresh;
+      const lastRefresh =
+        typeof lastRefreshRaw === "string" || typeof lastRefreshRaw === "number"
+          ? new Date(lastRefreshRaw).getTime()
+          : Date.now();
+      if (Number.isFinite(lastRefresh)) {
+        fallbackExpiry = lastRefresh + 60 * 60 * 1000;
+      }
+    }
+
+    result.oauth = {
+      type: "oauth",
+      provider: "openai-codex",
+      access,
+      refresh,
+      expires: decodeJwtExpiryMs(access) ?? fallbackExpiry,
+      ...(accountId ? { accountId } : {}),
+    };
+  }
+
+  return result;
+}
+
+function readCodexFileCredentials() {
+  const authPath = resolveCodexCliAuthPath();
+  if (!fs.existsSync(authPath)) {
+    return null;
+  }
+  const parsed = readJsonFile(authPath);
+  return normalizeCodexJson(parsed, "file");
+}
+
+function readCodexCredentials() {
+  return readCodexKeychainCredentials() ?? readCodexFileCredentials();
+}
+
+async function main() {
+  const command = process.argv[2] ?? "status";
+  const creds = readCodexCredentials();
+
+  if (command === "status") {
+    const payload = creds ?? {
+      source: null,
+      hasAuthFile: fs.existsSync(resolveCodexCliAuthPath()),
+      hasAccessToken: false,
+      hasRefreshToken: false,
+      hasOpenaiApiKey: false,
+      openaiApiKey: null,
+      oauth: null,
+    };
+    process.stdout.write(
+      JSON.stringify({
+        hasAuthFile: payload.hasAuthFile,
+        hasAccessToken: payload.hasAccessToken,
+        hasRefreshToken: payload.hasRefreshToken,
+        hasOpenaiApiKey: payload.hasOpenaiApiKey,
+        canExchangeOauth: Boolean(payload.oauth),
+        source: payload.source,
+      }),
+    );
+    return;
+  }
+
+  if (command === "exchange") {
+    if (!creds) {
+      process.stdout.write(JSON.stringify({ ok: false, message: "Codex auth not found." }));
+      return;
+    }
+
+    if (creds.openaiApiKey) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: true,
+          mode: "api_key",
+          apiKey: creds.openaiApiKey,
+          source: creds.source,
+        }),
+      );
+      return;
+    }
+
+    if (!creds.oauth) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          message: "Codex auth did not include reusable OAuth credentials.",
+        }),
+      );
+      return;
+    }
+
+    const result = await getOAuthApiKey("openai-codex", { "openai-codex": creds.oauth });
+    if (!result?.apiKey) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          message: "Failed to exchange Codex OAuth credentials for an API key.",
+        }),
+      );
+      return;
+    }
+
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        mode: "oauth_exchange",
+        apiKey: result.apiKey,
+        source: creds.source,
+        newCredentials: result.newCredentials ?? null,
+      }),
+    );
+    return;
+  }
+
+  process.stderr.write(`Unknown command: ${command}\n`);
+  process.exit(2);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/src-tauri/src/core/ai/mod.rs
+++ b/src-tauri/src/core/ai/mod.rs
@@ -59,8 +59,8 @@ pub use provider::{
     TokenUsage,
 };
 pub use providers::{
-    create_provider, AnthropicProvider, GeminiProvider, LocalProvider, OpenAIProvider,
-    ProviderConfig, ProviderStatus, ProviderType,
+    create_provider, AnthropicProvider, GeminiProvider, LocalProvider, OpenAICodexProvider,
+    OpenAIProvider, ProviderConfig, ProviderStatus, ProviderType,
 };
 pub use streaming::{
     clear_streaming_provider_config, set_streaming_provider_config, StreamEvent, StreamMessage,

--- a/src-tauri/src/core/ai/providers/anthropic.rs
+++ b/src-tauri/src/core/ai/providers/anthropic.rs
@@ -375,9 +375,11 @@ mod tests {
         let config = ProviderConfig {
             provider_type: super::super::ProviderType::Anthropic,
             api_key: None,
+            oauth_credential: None,
             base_url: None,
             model: None,
             timeout_secs: None,
+            auth_mode: None,
         };
         let result = AnthropicProvider::new(config);
 

--- a/src-tauri/src/core/ai/providers/gemini.rs
+++ b/src-tauri/src/core/ai/providers/gemini.rs
@@ -559,9 +559,11 @@ mod tests {
         let config = ProviderConfig {
             provider_type: super::super::ProviderType::Gemini,
             api_key: None,
+            oauth_credential: None,
             base_url: None,
             model: None,
             timeout_secs: None,
+            auth_mode: None,
         };
         let result = GeminiProvider::new(config);
 

--- a/src-tauri/src/core/ai/providers/mod.rs
+++ b/src-tauri/src/core/ai/providers/mod.rs
@@ -6,11 +6,13 @@ mod anthropic;
 mod gemini;
 mod local;
 mod openai;
+mod openai_codex;
 
 pub use anthropic::AnthropicProvider;
 pub use gemini::GeminiProvider;
 pub use local::LocalProvider;
 pub use openai::OpenAIProvider;
+pub use openai_codex::OpenAICodexProvider;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -49,7 +51,7 @@ impl std::str::FromStr for ProviderType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "openai" => Ok(ProviderType::OpenAI),
+            "openai" | "openai-codex" => Ok(ProviderType::OpenAI),
             "anthropic" => Ok(ProviderType::Anthropic),
             "gemini" => Ok(ProviderType::Gemini),
             "local" | "ollama" => Ok(ProviderType::Local),
@@ -77,6 +79,13 @@ pub struct ProviderStatus {
 }
 
 /// Configuration for creating a provider
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAIAuthMode {
+    ApiKey,
+    CodexOauth,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderConfig {
@@ -84,12 +93,16 @@ pub struct ProviderConfig {
     pub provider_type: ProviderType,
     /// API key (for cloud providers)
     pub api_key: Option<String>,
+    /// Stored OAuth credential (for Codex-backed OpenAI flows)
+    pub oauth_credential: Option<String>,
     /// Base URL (for custom endpoints or local models)
     pub base_url: Option<String>,
     /// Default model to use
     pub model: Option<String>,
     /// Request timeout in seconds
     pub timeout_secs: Option<u64>,
+    /// Optional OpenAI auth mode override
+    pub auth_mode: Option<OpenAIAuthMode>,
 }
 
 impl ProviderConfig {
@@ -98,9 +111,24 @@ impl ProviderConfig {
         Self {
             provider_type: ProviderType::OpenAI,
             api_key: Some(api_key.to_string()),
+            oauth_credential: None,
             base_url: None,
-            model: Some("gpt-5.2".to_string()),
+            model: Some("gpt-5.4".to_string()),
             timeout_secs: Some(60),
+            auth_mode: Some(OpenAIAuthMode::ApiKey),
+        }
+    }
+
+    /// Creates a new OpenAI Codex OAuth-backed provider config
+    pub fn openai_codex(oauth_credential: &str) -> Self {
+        Self {
+            provider_type: ProviderType::OpenAI,
+            api_key: None,
+            oauth_credential: Some(oauth_credential.to_string()),
+            base_url: Some(OpenAICodexProvider::DEFAULT_BASE_URL.to_string()),
+            model: Some("gpt-5.4".to_string()),
+            timeout_secs: Some(60),
+            auth_mode: Some(OpenAIAuthMode::CodexOauth),
         }
     }
 
@@ -109,9 +137,11 @@ impl ProviderConfig {
         Self {
             provider_type: ProviderType::Anthropic,
             api_key: Some(api_key.to_string()),
+            oauth_credential: None,
             base_url: None,
             model: Some("claude-sonnet-4-5-20251015".to_string()),
             timeout_secs: Some(60),
+            auth_mode: None,
         }
     }
 
@@ -120,9 +150,11 @@ impl ProviderConfig {
         Self {
             provider_type: ProviderType::Gemini,
             api_key: Some(api_key.to_string()),
+            oauth_credential: None,
             base_url: None,
             model: Some("gemini-3-flash-preview".to_string()),
             timeout_secs: Some(120), // Longer timeout for large context
+            auth_mode: None,
         }
     }
 
@@ -131,9 +163,11 @@ impl ProviderConfig {
         Self {
             provider_type: ProviderType::Local,
             api_key: None,
+            oauth_credential: None,
             base_url: base_url.map(|s| s.to_string()),
             model: Some("llama3.2".to_string()),
             timeout_secs: Some(120),
+            auth_mode: None,
         }
     }
 
@@ -161,8 +195,13 @@ use crate::core::CoreResult;
 pub fn create_provider(config: ProviderConfig) -> CoreResult<Box<dyn AIProvider>> {
     match config.provider_type {
         ProviderType::OpenAI => {
-            let provider = OpenAIProvider::new(config)?;
-            Ok(Box::new(provider))
+            if config.auth_mode == Some(OpenAIAuthMode::CodexOauth) {
+                let provider = OpenAICodexProvider::new(config)?;
+                Ok(Box::new(provider))
+            } else {
+                let provider = OpenAIProvider::new(config)?;
+                Ok(Box::new(provider))
+            }
         }
         ProviderType::Anthropic => {
             let provider = AnthropicProvider::new(config)?;
@@ -191,6 +230,10 @@ mod tests {
     fn test_provider_type_parsing() {
         assert_eq!(
             "openai".parse::<ProviderType>().unwrap(),
+            ProviderType::OpenAI
+        );
+        assert_eq!(
+            "openai-codex".parse::<ProviderType>().unwrap(),
             ProviderType::OpenAI
         );
         assert_eq!(
@@ -224,7 +267,16 @@ mod tests {
         let config = ProviderConfig::openai("test-key").with_model("gpt-4.1");
         assert_eq!(config.provider_type, ProviderType::OpenAI);
         assert_eq!(config.api_key, Some("test-key".to_string()));
+        assert_eq!(config.auth_mode, Some(OpenAIAuthMode::ApiKey));
         assert_eq!(config.model, Some("gpt-4.1".to_string()));
+    }
+
+    #[test]
+    fn test_provider_config_openai_codex() {
+        let config = ProviderConfig::openai_codex("{\"type\":\"oauth\"}");
+        assert_eq!(config.provider_type, ProviderType::OpenAI);
+        assert_eq!(config.auth_mode, Some(OpenAIAuthMode::CodexOauth));
+        assert!(config.oauth_credential.is_some());
     }
 
     #[test]

--- a/src-tauri/src/core/ai/providers/openai.rs
+++ b/src-tauri/src/core/ai/providers/openai.rs
@@ -39,6 +39,7 @@ impl OpenAIProvider {
 
     /// Available GPT models (2026)
     pub const AVAILABLE_MODELS: &'static [&'static str] = &[
+        "gpt-5.4",
         "gpt-5.2",
         "gpt-5.1",
         "gpt-5-mini",
@@ -66,7 +67,7 @@ impl OpenAIProvider {
             .base_url
             .unwrap_or_else(|| Self::DEFAULT_BASE_URL.to_string());
 
-        let default_model = config.model.unwrap_or_else(|| "gpt-5.2".to_string());
+        let default_model = config.model.unwrap_or_else(|| "gpt-5.4".to_string());
         let timeout_secs = config.timeout_secs.unwrap_or(60);
 
         #[cfg(feature = "ai-providers")]
@@ -196,6 +197,18 @@ struct ApiErrorDetail {
     message: String,
     #[serde(rename = "type")]
     error_type: Option<String>,
+}
+
+#[cfg_attr(not(feature = "ai-providers"), allow(dead_code))]
+#[derive(Deserialize)]
+struct ModelsListResponse {
+    data: Vec<ModelDescriptor>,
+}
+
+#[cfg_attr(not(feature = "ai-providers"), allow(dead_code))]
+#[derive(Deserialize)]
+struct ModelDescriptor {
+    id: String,
 }
 
 // =============================================================================
@@ -416,6 +429,62 @@ impl AIProvider for OpenAIProvider {
     }
 }
 
+impl OpenAIProvider {
+    fn parse_available_models_response(body: &str) -> CoreResult<Vec<String>> {
+        let parsed = serde_json::from_str::<ModelsListResponse>(body).map_err(|e| {
+            CoreError::AIRequestFailed(format!("Failed to parse OpenAI models response: {}", e))
+        })?;
+
+        let mut models = parsed
+            .data
+            .into_iter()
+            .map(|model| model.id)
+            .filter(|id| {
+                id.starts_with("gpt-")
+                    || id.starts_with("o1")
+                    || id.starts_with("o3")
+                    || id.starts_with("o4")
+            })
+            .collect::<Vec<_>>();
+
+        models.sort();
+        models.dedup();
+
+        if models.is_empty() {
+            return Ok(Self::available_models());
+        }
+
+        Ok(models)
+    }
+
+    #[cfg(feature = "ai-providers")]
+    pub async fn fetch_available_models(&self) -> CoreResult<Vec<String>> {
+        let url = format!("{}/models", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+            .map_err(|e| CoreError::AIRequestFailed(format!("Failed to fetch models: {}", e)))?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| CoreError::AIRequestFailed(format!("Failed to read models response: {}", e)))?;
+
+        if !status.is_success() {
+            return Err(CoreError::AIRequestFailed(format!(
+                "OpenAI models request failed ({}): {}",
+                status, body
+            )));
+        }
+
+        Self::parse_available_models_response(&body)
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -446,9 +515,11 @@ mod tests {
         let config = ProviderConfig {
             provider_type: super::super::ProviderType::OpenAI,
             api_key: None,
+            oauth_credential: None,
             base_url: None,
             model: None,
             timeout_secs: None,
+            auth_mode: None,
         };
         let result = OpenAIProvider::new(config);
 
@@ -475,7 +546,40 @@ mod tests {
     #[test]
     fn test_available_models() {
         let models = OpenAIProvider::available_models();
-        assert!(models.contains(&"gpt-5.2".to_string()));
+        assert!(models.contains(&"gpt-5.4".to_string()));
         assert!(models.contains(&"gpt-4.1".to_string()));
+    }
+
+    #[test]
+    fn test_parse_available_models_response_filters_and_dedupes() {
+        let models = OpenAIProvider::parse_available_models_response(
+            r#"{
+              "data": [
+                {"id": "gpt-5.4"},
+                {"id": "o4-mini"},
+                {"id": "whisper-1"},
+                {"id": "gpt-5.4"}
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(models, vec!["gpt-5.4".to_string(), "o4-mini".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_available_models_response_falls_back_when_no_supported_models() {
+        let models = OpenAIProvider::parse_available_models_response(
+            r#"{
+              "data": [
+                {"id": "whisper-1"},
+                {"id": "text-embedding-3-large"}
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(models.contains(&"gpt-5.4".to_string()));
+        assert!(models.contains(&"o3".to_string()));
     }
 }

--- a/src-tauri/src/core/ai/providers/openai_codex.rs
+++ b/src-tauri/src/core/ai/providers/openai_codex.rs
@@ -1,0 +1,293 @@
+//! OpenAI Codex provider implementation.
+//!
+//! Uses the same Codex OAuth transport family as OpenClaw via
+//! `@mariozechner/pi-ai`'s `openai-codex-responses` runtime instead of
+//! forcing Codex OAuth through the standard OpenAI `/v1` API surface.
+
+use async_trait::async_trait;
+use serde::Serialize;
+
+use super::ProviderConfig;
+use crate::core::ai::provider::{AIProvider, CompletionRequest, CompletionResponse};
+use crate::core::ai::provider::{FinishReason, TokenUsage};
+use crate::core::credentials::{
+    run_codex_helper_json, run_codex_helper_json_with_input, CodexHelperCompletion,
+    CodexHelperModels, StoredCodexOauthCredential,
+};
+use crate::core::{CoreError, CoreResult};
+
+pub struct OpenAICodexProvider {
+    oauth: StoredCodexOauthCredential,
+    default_model: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexCompletionPayload {
+    oauth: StoredCodexOauthCredential,
+    request: CodexCompletionHelperRequest,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexCompletionHelperRequest {
+    system: Option<String>,
+    prompt: String,
+    messages: Option<Vec<CodexConversationMessage>>,
+    max_tokens: Option<u32>,
+    temperature: Option<f32>,
+    model: Option<String>,
+    json_mode: bool,
+}
+
+#[derive(Serialize)]
+struct CodexConversationMessage {
+    role: String,
+    content: String,
+}
+
+impl OpenAICodexProvider {
+    pub const DEFAULT_BASE_URL: &'static str = "https://chatgpt.com/backend-api";
+
+    pub const AVAILABLE_MODELS: &'static [&'static str] = &[
+        "gpt-5.4",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex-max",
+    ];
+
+    pub fn new(config: ProviderConfig) -> CoreResult<Self> {
+        let oauth_json = config.oauth_credential.ok_or_else(|| {
+            CoreError::ValidationError("Codex OAuth credential is required".to_string())
+        })?;
+
+        let oauth = serde_json::from_str::<StoredCodexOauthCredential>(&oauth_json).map_err(|e| {
+            CoreError::ValidationError(format!(
+                "Stored Codex OAuth credential could not be parsed: {}",
+                e
+            ))
+        })?;
+
+        if oauth.access.trim().is_empty() || oauth.refresh.trim().is_empty() {
+            return Err(CoreError::ValidationError(
+                "Stored Codex OAuth credential is missing required token fields".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            oauth,
+            default_model: config.model.unwrap_or_else(|| "gpt-5.4".to_string()),
+        })
+    }
+
+    pub fn available_models() -> Vec<String> {
+        Self::AVAILABLE_MODELS
+            .iter()
+            .map(|model| (*model).to_string())
+            .collect()
+    }
+
+    pub fn supports_model(model: &str) -> bool {
+        let trimmed = model.trim().to_ascii_lowercase();
+        Self::AVAILABLE_MODELS
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(&trimmed))
+    }
+
+    pub async fn fetch_available_models(&self) -> CoreResult<Vec<String>> {
+        let result = tokio::task::spawn_blocking(|| run_codex_helper_json::<CodexHelperModels>("list-models"))
+            .await
+            .map_err(|e| CoreError::Internal(format!("Failed to join Codex models task: {}", e)))?
+            .map_err(|e| CoreError::AIRequestFailed(format!("Failed to list Codex models: {}", e)))?;
+
+        if !result.ok {
+            return Err(CoreError::AIRequestFailed(
+                result
+                    .message
+                    .unwrap_or_else(|| "Codex helper failed to list models".to_string()),
+            ));
+        }
+
+        let mut models = result.models.unwrap_or_default();
+        if models.is_empty() {
+            models = Self::available_models();
+        }
+        models.sort();
+        models.dedup();
+        Ok(models)
+    }
+
+    async fn complete_via_helper(
+        &self,
+        request: CompletionRequest,
+    ) -> CoreResult<(CodexHelperCompletion, Option<String>)> {
+        let oauth = self.oauth.clone();
+        let helper_request = CodexCompletionHelperRequest {
+            system: request.system.clone(),
+            prompt: request.prompt.clone(),
+            messages: request.messages.as_ref().map(|messages| {
+                messages
+                    .iter()
+                    .filter(|message| message.role != "system")
+                    .map(|message| CodexConversationMessage {
+                        role: message.role.clone(),
+                        content: message.content.clone(),
+                    })
+                    .collect()
+            }),
+            max_tokens: request.max_tokens,
+            temperature: request.temperature,
+            model: request.model.clone().or_else(|| Some(self.default_model.clone())),
+            json_mode: request.json_mode,
+        };
+
+        let payload = CodexCompletionPayload {
+            oauth,
+            request: helper_request,
+        };
+
+        let result = tokio::task::spawn_blocking(move || {
+            run_codex_helper_json_with_input::<CodexHelperCompletion, _>("complete-oauth-stdin", &payload)
+        })
+        .await
+        .map_err(|e| CoreError::Internal(format!("Failed to join Codex completion task: {}", e)))?
+        .map_err(|e| CoreError::AIRequestFailed(format!("Codex helper completion failed: {}", e)))?;
+
+        let refreshed_oauth = result
+            .new_credentials
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| CoreError::Internal(format!("Failed to serialize refreshed Codex OAuth: {}", e)))?;
+
+        Ok((result, refreshed_oauth))
+    }
+}
+
+impl std::fmt::Debug for OpenAICodexProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAICodexProvider")
+            .field("oauth", &"***REDACTED***")
+            .field("default_model", &self.default_model)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl AIProvider for OpenAICodexProvider {
+    fn name(&self) -> &str {
+        "openai-codex"
+    }
+
+    async fn complete(&self, request: CompletionRequest) -> CoreResult<CompletionResponse> {
+        let requested_model = request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.default_model.clone());
+        let (result, _refreshed_oauth) = self.complete_via_helper(request).await?;
+
+        if !result.ok {
+            return Err(CoreError::AIRequestFailed(
+                result
+                    .message
+                    .or(result.error_message)
+                    .unwrap_or_else(|| "OpenAI Codex request failed".to_string()),
+            ));
+        }
+
+        let finish_reason = match result.stop_reason.as_deref() {
+            Some("length") => FinishReason::Length,
+            Some("toolUse") => FinishReason::ToolCalls,
+            Some("error") => FinishReason::ContentFilter,
+            _ => FinishReason::Stop,
+        };
+
+        let usage = result
+            .usage
+            .map(|usage| {
+                let _ = usage.cost.input
+                    + usage.cost.output
+                    + usage.cost.cache_read
+                    + usage.cost.cache_write
+                    + usage.cost.total;
+                let _ = usage.cache_read + usage.cache_write;
+                TokenUsage {
+                    prompt_tokens: usage.input,
+                    completion_tokens: usage.output,
+                    total_tokens: usage.total_tokens,
+                }
+            })
+            .unwrap_or_default();
+
+        Ok(CompletionResponse {
+            text: result.text.unwrap_or_default(),
+            model: result.model.unwrap_or(requested_model),
+            usage,
+            finish_reason,
+        })
+    }
+
+    async fn embed(&self, _texts: Vec<String>) -> CoreResult<Vec<Vec<f32>>> {
+        Err(CoreError::NotSupported(
+            "Embeddings are not supported over OpenAI Codex OAuth".to_string(),
+        ))
+    }
+
+    async fn health_check(&self) -> CoreResult<()> {
+        let request = CompletionRequest::new("Reply with exactly OK.")
+            .with_model(&self.default_model)
+            .with_max_tokens(8)
+            .with_temperature(0.0);
+        let (result, _) = self.complete_via_helper(request).await?;
+
+        if !result.ok {
+            return Err(CoreError::AIRequestFailed(
+                result
+                    .message
+                    .or(result.error_message)
+                    .unwrap_or_else(|| "OpenAI Codex health check failed".to_string()),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn is_available(&self) -> bool {
+        !self.oauth.access.trim().is_empty() && !self.oauth.refresh.trim().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_oauth_json() -> String {
+        serde_json::json!({
+            "type": "oauth",
+            "provider": "openai-codex",
+            "access": "access-token",
+            "refresh": "refresh-token",
+            "expires": 1234567890_i64
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_openai_codex_provider_creation() {
+        let provider = OpenAICodexProvider::new(ProviderConfig::openai_codex(&sample_oauth_json()))
+            .unwrap();
+        assert_eq!(provider.name(), "openai-codex");
+        assert!(provider.is_available());
+    }
+
+    #[test]
+    fn test_openai_codex_supports_expected_models() {
+        assert!(OpenAICodexProvider::supports_model("gpt-5.4"));
+        assert!(OpenAICodexProvider::supports_model("gpt-5.3-codex"));
+        assert!(!OpenAICodexProvider::supports_model("o3"));
+    }
+}

--- a/src-tauri/src/core/credentials/mod.rs
+++ b/src-tauri/src/core/credentials/mod.rs
@@ -33,6 +33,7 @@ use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
@@ -188,6 +189,8 @@ pub struct CodexAuthStatus {
     pub has_auth_file: bool,
     pub has_openai_api_key: bool,
     pub has_access_token: bool,
+    pub has_refresh_token: bool,
+    pub can_exchange_oauth: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -200,6 +203,38 @@ struct CodexAuthFile {
 #[derive(Debug, Deserialize)]
 struct CodexTokens {
     access_token: Option<String>,
+    refresh_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexHelperStatus {
+    #[serde(rename = "hasAuthFile")]
+    has_auth_file: bool,
+    #[serde(rename = "hasOpenaiApiKey")]
+    has_openai_api_key: bool,
+    #[serde(rename = "hasAccessToken")]
+    has_access_token: bool,
+    #[serde(rename = "hasRefreshToken")]
+    has_refresh_token: bool,
+    #[serde(rename = "canExchangeOauth")]
+    can_exchange_oauth: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexHelperExchange {
+    ok: bool,
+    #[serde(rename = "apiKey")]
+    api_key: Option<String>,
+    mode: Option<String>,
+    source: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexResolvedApiKey {
+    pub api_key: String,
+    pub mode: String,
+    pub source: Option<String>,
 }
 
 /// Returns the default local Codex auth file path.
@@ -212,12 +247,49 @@ pub fn codex_auth_path() -> PathBuf {
 
 /// Reads the local Codex auth file status without exposing any token values.
 pub fn codex_auth_status() -> CodexAuthStatus {
+    if let Ok(Some(status)) = codex_helper_status() {
+        return CodexAuthStatus {
+            has_auth_file: status.has_auth_file,
+            has_openai_api_key: status.has_openai_api_key,
+            has_access_token: status.has_access_token,
+            has_refresh_token: status.has_refresh_token,
+            can_exchange_oauth: status.can_exchange_oauth,
+        };
+    }
     codex_auth_status_at(&codex_auth_path())
 }
 
 /// Reads an OpenAI API key from the local Codex auth file when one is present.
 pub fn codex_openai_api_key() -> CredentialResult<Option<String>> {
     codex_openai_api_key_at(&codex_auth_path())
+}
+
+pub fn codex_exchange_api_key() -> CredentialResult<Option<CodexResolvedApiKey>> {
+    let Some(result) = codex_helper_exchange()? else {
+        return Ok(None);
+    };
+
+    if !result.ok {
+        return Ok(None);
+    }
+
+    let api_key = result
+        .api_key
+        .and_then(|value| {
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() { None } else { Some(trimmed) }
+        })
+        .ok_or_else(|| {
+            CredentialError::SerializationError(
+                "Codex helper reported success without an API key".to_string(),
+            )
+        })?;
+
+    Ok(Some(CodexResolvedApiKey {
+        api_key,
+        mode: result.mode.unwrap_or_else(|| "unknown".to_string()),
+        source: result.source,
+    }))
 }
 
 fn codex_auth_status_at(path: &Path) -> CodexAuthStatus {
@@ -237,6 +309,21 @@ fn codex_auth_status_at(path: &Path) -> CodexAuthStatus {
             .as_ref()
             .and_then(|tokens| tokens.access_token.as_deref())
             .is_some_and(|value| !value.trim().is_empty()),
+        has_refresh_token: auth
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.refresh_token.as_deref())
+            .is_some_and(|value| !value.trim().is_empty()),
+        can_exchange_oauth: auth
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.access_token.as_deref())
+            .is_some_and(|value| !value.trim().is_empty())
+            && auth
+                .tokens
+                .as_ref()
+                .and_then(|tokens| tokens.refresh_token.as_deref())
+                .is_some_and(|value| !value.trim().is_empty()),
     }
 }
 
@@ -263,6 +350,60 @@ fn load_codex_auth(path: &Path) -> CredentialResult<Option<CodexAuthFile>> {
     let data = std::fs::read(path)?;
     let parsed = serde_json::from_slice::<CodexAuthFile>(&data)
         .map_err(|e| CredentialError::SerializationError(format!("Failed to parse Codex auth.json: {}", e)))?;
+    Ok(Some(parsed))
+}
+
+fn codex_helper_script_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("scripts")
+        .join("codex-auth-exchange.mjs")
+}
+
+fn run_codex_helper(command: &str) -> CredentialResult<String> {
+    let script_path = codex_helper_script_path();
+    if !script_path.exists() {
+        return Err(CredentialError::NotFound(format!(
+            "Codex helper script not found: {}",
+            script_path.display()
+        )));
+    }
+
+    let output = Command::new("node")
+        .arg(script_path)
+        .arg(command)
+        .output()
+        .map_err(|e| CredentialError::InitializationFailed(format!("Failed to execute Codex helper: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(CredentialError::InitializationFailed(if stderr.is_empty() {
+            format!("Codex helper exited with status {}", output.status)
+        } else {
+            format!("Codex helper failed: {}", stderr)
+        }));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| CredentialError::SerializationError(format!("Codex helper output was not UTF-8: {}", e)))
+}
+
+fn codex_helper_status() -> CredentialResult<Option<CodexHelperStatus>> {
+    let stdout = run_codex_helper("status")?;
+    let parsed = serde_json::from_str::<CodexHelperStatus>(&stdout).map_err(|e| {
+        CredentialError::SerializationError(format!("Failed to parse Codex helper status: {}", e))
+    })?;
+    Ok(Some(parsed))
+}
+
+fn codex_helper_exchange() -> CredentialResult<Option<CodexHelperExchange>> {
+    let stdout = run_codex_helper("exchange")?;
+    let parsed = serde_json::from_str::<CodexHelperExchange>(&stdout).map_err(|e| {
+        CredentialError::SerializationError(format!("Failed to parse Codex helper exchange: {}", e))
+    })?;
+    if !parsed.ok && parsed.message.is_none() {
+        return Ok(None);
+    }
     Ok(Some(parsed))
 }
 
@@ -985,6 +1126,8 @@ mod tests {
         assert!(status.has_auth_file);
         assert!(status.has_openai_api_key);
         assert!(status.has_access_token);
+        assert!(!status.has_refresh_token);
+        assert!(!status.can_exchange_oauth);
 
         let imported = codex_openai_api_key_at(&auth_path).unwrap();
         assert_eq!(imported.as_deref(), Some("sk-test-codex"));
@@ -1010,6 +1153,8 @@ mod tests {
         assert!(status.has_auth_file);
         assert!(!status.has_openai_api_key);
         assert!(status.has_access_token);
+        assert!(!status.has_refresh_token);
+        assert!(!status.can_exchange_oauth);
 
         let imported = codex_openai_api_key_at(&auth_path).unwrap();
         assert!(imported.is_none());

--- a/src-tauri/src/core/credentials/mod.rs
+++ b/src-tauri/src/core/credentials/mod.rs
@@ -30,10 +30,12 @@ use chacha20poly1305::{
     XChaCha20Poly1305, XNonce,
 };
 use rand::rngs::OsRng;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
@@ -45,6 +47,8 @@ use tracing::{debug, info, warn};
 pub enum CredentialType {
     /// OpenAI API key (sk-...)
     OpenaiApiKey,
+    /// Stored Codex/OpenAI OAuth credentials used to mint runtime bearer tokens
+    OpenaiCodexOauth,
     /// Anthropic API key (sk-ant-...)
     AnthropicApiKey,
     /// Google AI API key (AIza...)
@@ -56,10 +60,20 @@ pub enum CredentialType {
 }
 
 impl CredentialType {
+    fn max_value_len(&self) -> usize {
+        match self {
+            // Codex/OpenAI OAuth exchanges can yield JWT-style bearer tokens that are
+            // substantially longer than traditional `sk-*` API keys.
+            Self::OpenaiApiKey | Self::OpenaiCodexOauth => 4096,
+            _ => 1024,
+        }
+    }
+
     /// Returns the key name used in the vault
     pub fn vault_key(&self) -> &'static str {
         match self {
             Self::OpenaiApiKey => "openai_api_key",
+            Self::OpenaiCodexOauth => "openai_codex_oauth",
             Self::AnthropicApiKey => "anthropic_api_key",
             Self::GoogleApiKey => "google_api_key",
             Self::SeedanceApiKey => "seedance_api_key",
@@ -73,17 +87,25 @@ impl CredentialType {
             return Err(CredentialError::EmptyValue);
         }
 
-        if value.len() > 1024 {
+        if value.len() > self.max_value_len() {
             return Err(CredentialError::ValueTooLong);
         }
 
         // Basic format validation (not exhaustive - APIs will reject invalid keys)
         match self {
             Self::OpenaiApiKey => {
-                if !value.starts_with("sk-") && !value.starts_with("sess-") {
+                if !value.starts_with("sk-")
+                    && !value.starts_with("sess-")
+                    && !value.starts_with("eyJ")
+                {
                     warn!(
-                        "OpenAI API key does not match expected format (sk-* or sess-*), proceeding anyway"
+                        "OpenAI credential does not match expected format (sk-*, sess-*, or JWT bearer token), proceeding anyway"
                     );
+                }
+            }
+            Self::OpenaiCodexOauth => {
+                if serde_json::from_str::<StoredCodexOauthCredential>(value).is_err() {
+                    warn!("Codex OAuth credential did not parse as expected JSON, proceeding anyway");
                 }
             }
             Self::AnthropicApiKey => {
@@ -131,6 +153,7 @@ impl std::str::FromStr for CredentialType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "openai_api_key" | "openai" => Ok(Self::OpenaiApiKey),
+            "openai_codex_oauth" | "codex_oauth" | "openai_codex" => Ok(Self::OpenaiCodexOauth),
             "anthropic_api_key" | "anthropic" => Ok(Self::AnthropicApiKey),
             "google_api_key" | "google" | "gemini" => Ok(Self::GoogleApiKey),
             "seedance_api_key" | "seedance" => Ok(Self::SeedanceApiKey),
@@ -155,7 +178,7 @@ pub enum CredentialError {
     #[error("Credential value is empty")]
     EmptyValue,
 
-    #[error("Credential value too long (max 1024 bytes)")]
+    #[error("Credential value too long for this provider")]
     ValueTooLong,
 
     #[error("Invalid credential type: {0}")]
@@ -227,7 +250,80 @@ struct CodexHelperExchange {
     api_key: Option<String>,
     mode: Option<String>,
     source: Option<String>,
+    #[serde(rename = "newCredentials")]
+    new_credentials: Option<StoredCodexOauthCredential>,
     message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexHelperOauthExport {
+    ok: bool,
+    oauth: Option<StoredCodexOauthCredential>,
+    #[allow(dead_code)]
+    source: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CodexHelperModels {
+    pub ok: bool,
+    pub models: Option<Vec<String>>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CodexHelperUsageCost {
+    pub input: f64,
+    pub output: f64,
+    #[serde(rename = "cacheRead")]
+    pub cache_read: f64,
+    #[serde(rename = "cacheWrite")]
+    pub cache_write: f64,
+    pub total: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CodexHelperUsage {
+    pub input: u32,
+    pub output: u32,
+    #[serde(rename = "cacheRead")]
+    pub cache_read: u32,
+    #[serde(rename = "cacheWrite")]
+    pub cache_write: u32,
+    #[serde(rename = "totalTokens")]
+    pub total_tokens: u32,
+    pub cost: CodexHelperUsageCost,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CodexHelperCompletion {
+    pub ok: bool,
+    #[allow(dead_code)]
+    pub provider: Option<String>,
+    #[allow(dead_code)]
+    pub api: Option<String>,
+    pub model: Option<String>,
+    pub text: Option<String>,
+    #[serde(rename = "stopReason")]
+    pub stop_reason: Option<String>,
+    #[serde(rename = "errorMessage")]
+    pub error_message: Option<String>,
+    pub usage: Option<CodexHelperUsage>,
+    #[serde(rename = "newCredentials")]
+    pub new_credentials: Option<StoredCodexOauthCredential>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredCodexOauthCredential {
+    #[serde(rename = "type")]
+    pub credential_type: String,
+    pub provider: String,
+    pub access: String,
+    pub refresh: String,
+    pub expires: i64,
+    #[serde(rename = "accountId")]
+    pub account_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,6 +331,7 @@ pub struct CodexResolvedApiKey {
     pub api_key: String,
     pub mode: String,
     pub source: Option<String>,
+    pub updated_oauth: Option<String>,
 }
 
 /// Returns the default local Codex auth file path.
@@ -289,6 +386,82 @@ pub fn codex_exchange_api_key() -> CredentialResult<Option<CodexResolvedApiKey>>
         api_key,
         mode: result.mode.unwrap_or_else(|| "unknown".to_string()),
         source: result.source,
+        updated_oauth: result
+            .new_credentials
+            .map(|oauth| serde_json::to_string(&oauth))
+            .transpose()
+            .map_err(|e| {
+                CredentialError::SerializationError(format!(
+                    "Failed to serialize refreshed Codex OAuth credentials: {}",
+                    e
+                ))
+            })?,
+    }))
+}
+
+pub fn codex_local_oauth() -> CredentialResult<Option<String>> {
+    let Some(result) = codex_helper_export_oauth()? else {
+        return Ok(None);
+    };
+
+    if !result.ok {
+        return Ok(None);
+    }
+
+    result
+        .oauth
+        .map(|oauth| {
+            serde_json::to_string(&oauth).map_err(|e| {
+                CredentialError::SerializationError(format!(
+                    "Failed to serialize Codex OAuth credential: {}",
+                    e
+                ))
+            })
+        })
+        .transpose()
+}
+
+pub fn codex_exchange_stored_oauth(
+    stored_oauth_json: &str,
+) -> CredentialResult<Option<CodexResolvedApiKey>> {
+    let oauth = serde_json::from_str::<StoredCodexOauthCredential>(stored_oauth_json).map_err(
+        |e| CredentialError::SerializationError(format!("Failed to parse stored Codex OAuth credential: {}", e)),
+    )?;
+
+    let Some(result) = codex_helper_exchange_oauth(&oauth)? else {
+        return Ok(None);
+    };
+
+    if !result.ok {
+        return Ok(None);
+    }
+
+    let api_key = result
+        .api_key
+        .and_then(|value| {
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() { None } else { Some(trimmed) }
+        })
+        .ok_or_else(|| {
+            CredentialError::SerializationError(
+                "Codex helper reported success without an API key".to_string(),
+            )
+        })?;
+
+    Ok(Some(CodexResolvedApiKey {
+        api_key,
+        mode: result.mode.unwrap_or_else(|| "oauth_exchange".to_string()),
+        source: result.source,
+        updated_oauth: result
+            .new_credentials
+            .map(|updated| serde_json::to_string(&updated))
+            .transpose()
+            .map_err(|e| {
+                CredentialError::SerializationError(format!(
+                    "Failed to serialize refreshed stored Codex OAuth credential: {}",
+                    e
+                ))
+            })?,
     }))
 }
 
@@ -354,6 +527,12 @@ fn load_codex_auth(path: &Path) -> CredentialResult<Option<CodexAuthFile>> {
 }
 
 fn codex_helper_script_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("OPENREELIO_CODEX_HELPER_PATH") {
+        let candidate = PathBuf::from(path);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("scripts")
@@ -361,6 +540,10 @@ fn codex_helper_script_path() -> PathBuf {
 }
 
 fn run_codex_helper(command: &str) -> CredentialResult<String> {
+    run_codex_helper_with_input(command, None)
+}
+
+fn run_codex_helper_with_input(command: &str, input: Option<&str>) -> CredentialResult<String> {
     let script_path = codex_helper_script_path();
     if !script_path.exists() {
         return Err(CredentialError::NotFound(format!(
@@ -369,11 +552,27 @@ fn run_codex_helper(command: &str) -> CredentialResult<String> {
         )));
     }
 
-    let output = Command::new("node")
+    let mut child = Command::new("node")
         .arg(script_path)
         .arg(command)
-        .output()
+        .stdin(if input.is_some() { Stdio::piped() } else { Stdio::null() })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| CredentialError::InitializationFailed(format!("Failed to execute Codex helper: {}", e)))?;
+
+    if let Some(input) = input {
+        let stdin = child.stdin.as_mut().ok_or_else(|| {
+            CredentialError::InitializationFailed("Failed to open Codex helper stdin".to_string())
+        })?;
+        stdin
+            .write_all(input.as_bytes())
+            .map_err(|e| CredentialError::InitializationFailed(format!("Failed to write Codex helper stdin: {}", e)))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| CredentialError::InitializationFailed(format!("Failed to wait for Codex helper: {}", e)))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -388,19 +587,70 @@ fn run_codex_helper(command: &str) -> CredentialResult<String> {
         .map_err(|e| CredentialError::SerializationError(format!("Codex helper output was not UTF-8: {}", e)))
 }
 
-fn codex_helper_status() -> CredentialResult<Option<CodexHelperStatus>> {
-    let stdout = run_codex_helper("status")?;
-    let parsed = serde_json::from_str::<CodexHelperStatus>(&stdout).map_err(|e| {
-        CredentialError::SerializationError(format!("Failed to parse Codex helper status: {}", e))
+pub(crate) fn run_codex_helper_json<T>(command: &str) -> CredentialResult<T>
+where
+    T: DeserializeOwned,
+{
+    let stdout = run_codex_helper(command)?;
+    serde_json::from_str::<T>(&stdout).map_err(|e| {
+        CredentialError::SerializationError(format!(
+            "Failed to parse Codex helper {} response: {}",
+            command, e
+        ))
+    })
+}
+
+pub(crate) fn run_codex_helper_json_with_input<T, P>(
+    command: &str,
+    payload: &P,
+) -> CredentialResult<T>
+where
+    T: DeserializeOwned,
+    P: Serialize,
+{
+    let input = serde_json::to_string(payload).map_err(|e| {
+        CredentialError::SerializationError(format!(
+            "Failed to serialize Codex helper {} payload: {}",
+            command, e
+        ))
     })?;
+    let stdout = run_codex_helper_with_input(command, Some(&input))?;
+    serde_json::from_str::<T>(&stdout).map_err(|e| {
+        CredentialError::SerializationError(format!(
+            "Failed to parse Codex helper {} response: {}",
+            command, e
+        ))
+    })
+}
+
+fn codex_helper_status() -> CredentialResult<Option<CodexHelperStatus>> {
+    let parsed = run_codex_helper_json::<CodexHelperStatus>("status")?;
     Ok(Some(parsed))
 }
 
 fn codex_helper_exchange() -> CredentialResult<Option<CodexHelperExchange>> {
-    let stdout = run_codex_helper("exchange")?;
-    let parsed = serde_json::from_str::<CodexHelperExchange>(&stdout).map_err(|e| {
-        CredentialError::SerializationError(format!("Failed to parse Codex helper exchange: {}", e))
-    })?;
+    let parsed = run_codex_helper_json::<CodexHelperExchange>("exchange")?;
+    if !parsed.ok && parsed.message.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(parsed))
+}
+
+fn codex_helper_export_oauth() -> CredentialResult<Option<CodexHelperOauthExport>> {
+    let parsed = run_codex_helper_json::<CodexHelperOauthExport>("export-oauth")?;
+    if !parsed.ok && parsed.message.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(parsed))
+}
+
+fn codex_helper_exchange_oauth(
+    oauth: &StoredCodexOauthCredential,
+) -> CredentialResult<Option<CodexHelperExchange>> {
+    let parsed = run_codex_helper_json_with_input::<CodexHelperExchange, _>(
+        "exchange-oauth-stdin",
+        oauth,
+    )?;
     if !parsed.ok && parsed.message.is_none() {
         return Ok(None);
     }
@@ -864,6 +1114,12 @@ mod tests {
         assert!(CredentialType::OpenaiApiKey
             .validate("sk-test1234567890")
             .is_ok());
+        assert!(CredentialType::OpenaiApiKey
+            .validate(&"e".repeat(1889))
+            .is_ok());
+        assert!(CredentialType::OpenaiCodexOauth
+            .validate(r#"{"type":"oauth","provider":"openai-codex","access":"a","refresh":"b","expires":1,"accountId":"acct"}"#)
+            .is_ok());
 
         // Empty value
         assert!(matches!(
@@ -871,10 +1127,17 @@ mod tests {
             Err(CredentialError::EmptyValue)
         ));
 
-        // Too long
+        // Too long for OpenAI
+        let openai_long_value = "x".repeat(5000);
+        assert!(matches!(
+            CredentialType::OpenaiApiKey.validate(&openai_long_value),
+            Err(CredentialError::ValueTooLong)
+        ));
+
+        // Too long for providers that still use the default limit
         let long_value = "x".repeat(2000);
         assert!(matches!(
-            CredentialType::OpenaiApiKey.validate(&long_value),
+            CredentialType::AnthropicApiKey.validate(&long_value),
             Err(CredentialError::ValueTooLong)
         ));
     }
@@ -896,6 +1159,10 @@ mod tests {
         assert_eq!(
             "anthropic_api_key".parse::<CredentialType>().unwrap(),
             CredentialType::AnthropicApiKey
+        );
+        assert_eq!(
+            "openai_codex_oauth".parse::<CredentialType>().unwrap(),
+            CredentialType::OpenaiCodexOauth
         );
         assert_eq!(
             "gemini".parse::<CredentialType>().unwrap(),

--- a/src-tauri/src/core/credentials/mod.rs
+++ b/src-tauri/src/core/credentials/mod.rs
@@ -182,6 +182,90 @@ pub enum CredentialError {
 /// Result type for credential operations
 pub type CredentialResult<T> = Result<T, CredentialError>;
 
+/// Minimal status for a local Codex auth store.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CodexAuthStatus {
+    pub has_auth_file: bool,
+    pub has_openai_api_key: bool,
+    pub has_access_token: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexAuthFile {
+    #[serde(rename = "OPENAI_API_KEY")]
+    openai_api_key: Option<String>,
+    tokens: Option<CodexTokens>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexTokens {
+    access_token: Option<String>,
+}
+
+/// Returns the default local Codex auth file path.
+pub fn codex_auth_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("~"))
+        .join(".codex")
+        .join("auth.json")
+}
+
+/// Reads the local Codex auth file status without exposing any token values.
+pub fn codex_auth_status() -> CodexAuthStatus {
+    codex_auth_status_at(&codex_auth_path())
+}
+
+/// Reads an OpenAI API key from the local Codex auth file when one is present.
+pub fn codex_openai_api_key() -> CredentialResult<Option<String>> {
+    codex_openai_api_key_at(&codex_auth_path())
+}
+
+fn codex_auth_status_at(path: &Path) -> CodexAuthStatus {
+    let auth = match load_codex_auth(path) {
+        Ok(Some(auth)) => auth,
+        Ok(None) | Err(_) => return CodexAuthStatus::default(),
+    };
+
+    CodexAuthStatus {
+        has_auth_file: true,
+        has_openai_api_key: auth
+            .openai_api_key
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
+        has_access_token: auth
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.access_token.as_deref())
+            .is_some_and(|value| !value.trim().is_empty()),
+    }
+}
+
+fn codex_openai_api_key_at(path: &Path) -> CredentialResult<Option<String>> {
+    let Some(auth) = load_codex_auth(path)? else {
+        return Ok(None);
+    };
+
+    Ok(auth.openai_api_key.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }))
+}
+
+fn load_codex_auth(path: &Path) -> CredentialResult<Option<CodexAuthFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let data = std::fs::read(path)?;
+    let parsed = serde_json::from_slice::<CodexAuthFile>(&data)
+        .map_err(|e| CredentialError::SerializationError(format!("Failed to parse Codex auth.json: {}", e)))?;
+    Ok(Some(parsed))
+}
+
 /// Secure credential vault using encryption at rest
 ///
 /// This implementation uses a layered security approach:
@@ -879,5 +963,55 @@ mod tests {
             .await
             .unwrap();
         assert!(value.starts_with("sk-test-"));
+    }
+
+    #[test]
+    fn test_codex_auth_status_with_api_key() {
+        let temp_dir = TempDir::new().unwrap();
+        let auth_path = temp_dir.path().join("auth.json");
+
+        std::fs::write(
+            &auth_path,
+            r#"{
+              "OPENAI_API_KEY": "sk-test-codex",
+              "tokens": {
+                "access_token": "access-token"
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let status = codex_auth_status_at(&auth_path);
+        assert!(status.has_auth_file);
+        assert!(status.has_openai_api_key);
+        assert!(status.has_access_token);
+
+        let imported = codex_openai_api_key_at(&auth_path).unwrap();
+        assert_eq!(imported.as_deref(), Some("sk-test-codex"));
+    }
+
+    #[test]
+    fn test_codex_auth_status_with_token_only() {
+        let temp_dir = TempDir::new().unwrap();
+        let auth_path = temp_dir.path().join("auth.json");
+
+        std::fs::write(
+            &auth_path,
+            r#"{
+              "OPENAI_API_KEY": null,
+              "tokens": {
+                "access_token": "access-token"
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let status = codex_auth_status_at(&auth_path);
+        assert!(status.has_auth_file);
+        assert!(!status.has_openai_api_key);
+        assert!(status.has_access_token);
+
+        let imported = codex_openai_api_key_at(&auth_path).unwrap();
+        assert!(imported.is_none());
     }
 }

--- a/src-tauri/src/core/settings/mod.rs
+++ b/src-tauri/src/core/settings/mod.rs
@@ -671,7 +671,7 @@ fn default_primary_model() -> String {
 
 fn default_model_for_provider(provider: ProviderType) -> String {
     match provider {
-        ProviderType::OpenAI => "gpt-5.2".to_string(),
+        ProviderType::OpenAI => "gpt-5.4".to_string(),
         ProviderType::Anthropic => "claude-sonnet-4-5-20251015".to_string(),
         ProviderType::Gemini => "gemini-3-flash-preview".to_string(),
         ProviderType::Local => "llama3.2".to_string(),
@@ -765,6 +765,12 @@ impl AISettings {
         self.primary_model = self.primary_model.trim().to_string();
         if self.primary_model.is_empty() {
             self.primary_model = default_model_for_provider(self.primary_provider);
+        } else if self.primary_provider == ProviderType::OpenAI
+            && self.primary_model == "gpt-5.2"
+        {
+            // Migrate the old OpenAI default forward without overriding
+            // deliberate user selections.
+            self.primary_model = "gpt-5.4".to_string();
         } else if let Some(inferred) = infer_provider_from_model_name(&self.primary_model) {
             if inferred != self.primary_provider {
                 warn!(
@@ -1209,7 +1215,20 @@ mod tests {
 
         ai_settings.normalize();
 
-        assert_eq!(ai_settings.primary_model, "gpt-5.2");
+        assert_eq!(ai_settings.primary_model, "gpt-5.4");
+    }
+
+    #[test]
+    fn test_ai_settings_normalization_migrates_old_openai_default() {
+        let mut ai_settings = AISettings {
+            primary_provider: ProviderType::OpenAI,
+            primary_model: "gpt-5.2".to_string(),
+            ..Default::default()
+        };
+
+        ai_settings.normalize();
+
+        assert_eq!(ai_settings.primary_model, "gpt-5.4");
     }
 
     #[test]

--- a/src-tauri/src/ipc/commands/ai_legacy.rs
+++ b/src-tauri/src/ipc/commands/ai_legacy.rs
@@ -2016,20 +2016,6 @@ pub async fn sync_ai_from_vault(
     let api_key = if let Some(cred_type) = credential_type {
         let vault_path = app_data_dir.join("credentials.vault");
 
-        if !vault_path.exists() {
-            tracing::warn!("Credential vault does not exist, provider not configured");
-            return Ok(ProviderStatusDto {
-                provider_type: Some(ai_provider_type.to_string()),
-                is_configured: false,
-                is_available: false,
-                current_model: Some(model),
-                available_models: vec![],
-                error_message: Some(
-                    "No API key configured. Please set your API key in Settings.".to_string(),
-                ),
-            });
-        }
-
         let mut guard = state.credential_vault.lock().await;
         if guard.is_none() {
             *guard = Some(
@@ -2041,8 +2027,31 @@ pub async fn sync_ai_from_vault(
             .as_ref()
             .ok_or_else(|| "Credential vault unavailable".to_string())?;
 
+        if cred_type == CredentialType::OpenaiApiKey && !vault.exists(cred_type).await {
+            if let Some(imported_api_key) = crate::core::credentials::codex_openai_api_key()
+                .map_err(|e| format!("Failed to read Codex auth: {}", e))?
+            {
+                vault
+                    .store(cred_type, &imported_api_key)
+                    .await
+                    .map_err(|e| format!("Failed to import Codex credential: {}", e))?;
+                tracing::info!("Imported OpenAI API key from Codex during provider sync");
+            }
+        }
+
         // Check if credential exists
         if !vault.exists(cred_type).await {
+            let error_message = if cred_type == CredentialType::OpenaiApiKey {
+                let codex_status = crate::core::credentials::codex_auth_status();
+                if codex_status.has_access_token && !codex_status.has_openai_api_key {
+                    "Codex is signed in, but auth.json only contains a session token. OpenReelio still needs an OpenAI API key for api.openai.com.".to_string()
+                } else {
+                    "No API key configured. Please set your API key in Settings.".to_string()
+                }
+            } else {
+                "No API key configured. Please set your API key in Settings.".to_string()
+            };
+
             tracing::warn!("No API key found in vault for provider {:?}", provider_type);
             return Ok(ProviderStatusDto {
                 provider_type: Some(ai_provider_type.to_string()),
@@ -2050,9 +2059,7 @@ pub async fn sync_ai_from_vault(
                 is_available: false,
                 current_model: Some(model),
                 available_models: vec![],
-                error_message: Some(
-                    "No API key configured. Please set your API key in Settings.".to_string(),
-                ),
+                error_message: Some(error_message),
             });
         }
 

--- a/src-tauri/src/ipc/commands/ai_legacy.rs
+++ b/src-tauri/src/ipc/commands/ai_legacy.rs
@@ -2028,14 +2028,17 @@ pub async fn sync_ai_from_vault(
             .ok_or_else(|| "Credential vault unavailable".to_string())?;
 
         if cred_type == CredentialType::OpenaiApiKey && !vault.exists(cred_type).await {
-            if let Some(imported_api_key) = crate::core::credentials::codex_openai_api_key()
+            if let Some(resolved) = crate::core::credentials::codex_exchange_api_key()
                 .map_err(|e| format!("Failed to read Codex auth: {}", e))?
             {
                 vault
-                    .store(cred_type, &imported_api_key)
+                    .store(cred_type, &resolved.api_key)
                     .await
                     .map_err(|e| format!("Failed to import Codex credential: {}", e))?;
-                tracing::info!("Imported OpenAI API key from Codex during provider sync");
+                tracing::info!(
+                    "Imported OpenAI API key from Codex during provider sync via {}",
+                    resolved.mode
+                );
             }
         }
 
@@ -2043,8 +2046,10 @@ pub async fn sync_ai_from_vault(
         if !vault.exists(cred_type).await {
             let error_message = if cred_type == CredentialType::OpenaiApiKey {
                 let codex_status = crate::core::credentials::codex_auth_status();
-                if codex_status.has_access_token && !codex_status.has_openai_api_key {
-                    "Codex is signed in, but auth.json only contains a session token. OpenReelio still needs an OpenAI API key for api.openai.com.".to_string()
+                if codex_status.can_exchange_oauth {
+                    "Codex auth was detected, but OpenReelio could not exchange it into a usable OpenAI runtime key.".to_string()
+                } else if codex_status.has_access_token {
+                    "Codex auth.json contains an access token but no reusable refresh token or API key.".to_string()
                 } else {
                     "No API key configured. Please set your API key in Settings.".to_string()
                 }

--- a/src-tauri/src/ipc/commands/ai_legacy.rs
+++ b/src-tauri/src/ipc/commands/ai_legacy.rs
@@ -1857,6 +1857,8 @@ pub async fn configure_ai_provider(
 
     // Run a real connectivity/auth check.
     let provider_name = provider.name().to_string();
+    let provider_type_label =
+        effective_provider_type_label(&provider_name, &provider_type.to_string());
     let is_configured = provider.is_available();
     let (is_available, error_message) = match provider.health_check().await {
         Ok(()) => (true, None),
@@ -1877,7 +1879,7 @@ pub async fn configure_ai_provider(
         .set_provider_boxed_with_status(
             provider,
             ProviderRuntimeStatus {
-                provider_type: Some(provider_type.to_string()),
+                provider_type: Some(provider_type_label.clone()),
                 is_configured,
                 is_available,
                 current_model: requested_model.clone(),
@@ -1897,7 +1899,7 @@ pub async fn configure_ai_provider(
     let streaming_model = requested_model
         .clone()
         .unwrap_or_else(|| match provider_type {
-            ProviderType::OpenAI => "gpt-5.2".to_string(),
+            ProviderType::OpenAI => "gpt-5.4".to_string(),
             ProviderType::Anthropic => "claude-sonnet-4-5-20251015".to_string(),
             ProviderType::Gemini => "gemini-3-flash-preview".to_string(),
             ProviderType::Local => "llama3.2".to_string(),
@@ -1923,7 +1925,7 @@ pub async fn configure_ai_provider(
     );
 
     Ok(ProviderStatusDto {
-        provider_type: Some(provider_type.to_string()),
+        provider_type: Some(provider_type_label),
         is_configured,
         is_available,
         current_model: requested_model,
@@ -1961,6 +1963,160 @@ pub async fn clear_ai_provider(state: State<'_, AppState>) -> Result<(), String>
 
     tracing::info!("Cleared AI provider");
     Ok(())
+}
+
+fn is_direct_openai_api_key(value: &str) -> bool {
+    value.trim().starts_with("sk-")
+}
+
+fn effective_provider_type_label(provider_name: &str, fallback: &str) -> String {
+    match provider_name {
+        "openai-codex" => "openai-codex".to_string(),
+        _ => fallback.to_string(),
+    }
+}
+
+async fn ensure_stored_codex_oauth(
+    vault: &crate::core::credentials::CredentialVault,
+) -> Result<Option<String>, String> {
+    use crate::core::credentials::CredentialType;
+
+    if vault.exists(CredentialType::OpenaiCodexOauth).await {
+        return vault
+            .retrieve(CredentialType::OpenaiCodexOauth)
+            .await
+            .map(Some)
+            .map_err(|e| format!("Failed to retrieve stored Codex OAuth credential: {}", e));
+    }
+
+    if let Some(stored_oauth) = crate::core::credentials::codex_local_oauth()
+        .map_err(|e| format!("Failed to read local Codex OAuth: {}", e))?
+    {
+        vault
+            .store(CredentialType::OpenaiCodexOauth, &stored_oauth)
+            .await
+            .map_err(|e| format!("Failed to store Codex OAuth credential: {}", e))?;
+        tracing::info!("Imported local Codex OAuth into vault during OpenAI credential resolution");
+        return Ok(Some(stored_oauth));
+    }
+
+    Ok(None)
+}
+
+async fn ensure_direct_openai_api_key(
+    vault: &crate::core::credentials::CredentialVault,
+) -> Result<Option<String>, String> {
+    use crate::core::credentials::CredentialType;
+
+    if vault.exists(CredentialType::OpenaiApiKey).await {
+        let stored = vault
+            .retrieve(CredentialType::OpenaiApiKey)
+            .await
+            .map_err(|e| format!("Failed to retrieve OpenAI API key: {}", e))?;
+        if is_direct_openai_api_key(&stored) {
+            return Ok(Some(stored));
+        }
+    }
+
+    let Some(imported_api_key) = crate::core::credentials::codex_openai_api_key()
+        .map_err(|e| format!("Failed to read Codex auth: {}", e))?
+    else {
+        return Ok(None);
+    };
+
+    if !is_direct_openai_api_key(&imported_api_key) {
+        return Ok(None);
+    }
+
+    vault
+        .store(CredentialType::OpenaiApiKey, &imported_api_key)
+        .await
+        .map_err(|e| format!("Failed to import OpenAI API key from Codex: {}", e))?;
+    tracing::info!("Imported OpenAI API key from local Codex auth into vault");
+    Ok(Some(imported_api_key))
+}
+
+async fn resolve_openai_provider_config(
+    vault: &crate::core::credentials::CredentialVault,
+    model: &str,
+) -> Result<Option<crate::core::ai::ProviderConfig>, String> {
+    let direct_api_key = ensure_direct_openai_api_key(vault).await?;
+    let stored_oauth = ensure_stored_codex_oauth(vault).await?;
+
+    if let Some(oauth_json) = stored_oauth {
+        if crate::core::ai::OpenAICodexProvider::supports_model(model) {
+            return Ok(Some(
+                crate::core::ai::ProviderConfig::openai_codex(&oauth_json).with_model(model),
+            ));
+        }
+    }
+
+    if let Some(api_key) = direct_api_key {
+        return Ok(Some(
+            crate::core::ai::ProviderConfig::openai(&api_key).with_model(model),
+        ));
+    }
+
+    Ok(None)
+}
+
+async fn resolve_openai_available_models(
+    vault: &crate::core::credentials::CredentialVault,
+) -> Result<Vec<String>, String> {
+    if let Some(stored_oauth) = ensure_stored_codex_oauth(vault).await? {
+        let provider = crate::core::ai::OpenAICodexProvider::new(
+            crate::core::ai::ProviderConfig::openai_codex(&stored_oauth),
+        )
+        .map_err(|e| e.to_ipc_error())?;
+        return provider
+            .fetch_available_models()
+            .await
+            .map_err(|e| e.to_ipc_error());
+    }
+
+    if let Some(api_key) = ensure_direct_openai_api_key(vault).await? {
+        let provider =
+            crate::core::ai::OpenAIProvider::new(crate::core::ai::ProviderConfig::openai(&api_key))
+                .map_err(|e| e.to_ipc_error())?;
+        return provider
+            .fetch_available_models()
+            .await
+            .map_err(|e| e.to_ipc_error());
+    }
+
+    Ok(crate::core::ai::OpenAIProvider::available_models())
+}
+
+async fn openai_missing_configuration_message(
+    vault: &crate::core::credentials::CredentialVault,
+    model: &str,
+) -> String {
+    use crate::core::credentials::CredentialType;
+
+    let has_stored_codex_oauth = vault.exists(CredentialType::OpenaiCodexOauth).await;
+    let has_direct_api_key = vault.exists(CredentialType::OpenaiApiKey).await;
+    let codex_status = crate::core::credentials::codex_auth_status();
+
+    if has_stored_codex_oauth && !crate::core::ai::OpenAICodexProvider::supports_model(model) {
+        return format!(
+            "OpenAI via Codex OAuth is connected, but model {} requires a direct OpenAI API key.",
+            model
+        );
+    }
+
+    if has_stored_codex_oauth || codex_status.can_exchange_oauth {
+        return "Codex auth is available. Select a Codex-supported GPT-5 model or add a direct OpenAI API key for standard /v1 models.".to_string();
+    }
+
+    if codex_status.has_access_token {
+        return "Codex auth.json contains an access token but no reusable refresh token or direct OpenAI API key.".to_string();
+    }
+
+    if has_direct_api_key {
+        return "Stored OpenAI credential is not a reusable direct API key. Replace it with an sk-* key or connect Codex OAuth.".to_string();
+    }
+
+    "No OpenAI credential configured. Connect Codex OAuth or add a direct OpenAI API key.".to_string()
 }
 
 /// Syncs AI provider configuration from settings and encrypted vault
@@ -2012,6 +2168,8 @@ pub async fn sync_ai_from_vault(
         crate::core::settings::ProviderType::Local => ProviderType::Local,
     };
 
+    let mut resolved_provider_config: Option<ProviderConfig> = None;
+
     // Get API key from vault (if needed)
     let api_key = if let Some(cred_type) = credential_type {
         let vault_path = app_data_dir.join("credentials.vault");
@@ -2027,37 +2185,26 @@ pub async fn sync_ai_from_vault(
             .as_ref()
             .ok_or_else(|| "Credential vault unavailable".to_string())?;
 
-        if cred_type == CredentialType::OpenaiApiKey && !vault.exists(cred_type).await {
-            if let Some(resolved) = crate::core::credentials::codex_exchange_api_key()
-                .map_err(|e| format!("Failed to read Codex auth: {}", e))?
-            {
+        let resolved_credential = if cred_type == CredentialType::OpenaiApiKey {
+            resolved_provider_config = resolve_openai_provider_config(vault, &model).await?;
+            resolved_provider_config
+                .as_ref()
+                .and_then(|config| config.api_key.clone())
+        } else if vault.exists(cred_type).await {
+            Some(
                 vault
-                    .store(cred_type, &resolved.api_key)
+                    .retrieve(cred_type)
                     .await
-                    .map_err(|e| format!("Failed to import Codex credential: {}", e))?;
-                tracing::info!(
-                    "Imported OpenAI API key from Codex during provider sync via {}",
-                    resolved.mode
-                );
-            }
-        }
+                    .map_err(|e| format!("Failed to retrieve credential: {}", e))?,
+            )
+        } else {
+            None
+        };
 
-        // Check if credential exists
-        if !vault.exists(cred_type).await {
-            let error_message = if cred_type == CredentialType::OpenaiApiKey {
-                let codex_status = crate::core::credentials::codex_auth_status();
-                if codex_status.can_exchange_oauth {
-                    "Codex auth was detected, but OpenReelio could not exchange it into a usable OpenAI runtime key.".to_string()
-                } else if codex_status.has_access_token {
-                    "Codex auth.json contains an access token but no reusable refresh token or API key.".to_string()
-                } else {
-                    "No API key configured. Please set your API key in Settings.".to_string()
-                }
-            } else {
-                "No API key configured. Please set your API key in Settings.".to_string()
-            };
+        if resolved_credential.is_none() && resolved_provider_config.is_none() && cred_type == CredentialType::OpenaiApiKey {
+            let error_message = openai_missing_configuration_message(vault, &model).await;
 
-            tracing::warn!("No API key found in vault for provider {:?}", provider_type);
+            tracing::warn!("No compatible OpenAI credential found for model {}", model);
             return Ok(ProviderStatusDto {
                 provider_type: Some(ai_provider_type.to_string()),
                 is_configured: false,
@@ -2068,67 +2215,98 @@ pub async fn sync_ai_from_vault(
             });
         }
 
-        // Retrieve the API key
-        Some(
-            vault
-                .retrieve(cred_type)
-                .await
-                .map_err(|e| format!("Failed to retrieve credential: {}", e))?,
-        )
+        if resolved_credential.is_none() && cred_type != CredentialType::OpenaiApiKey {
+            tracing::warn!("No API key found in vault for provider {:?}", provider_type);
+            return Ok(ProviderStatusDto {
+                provider_type: Some(ai_provider_type.to_string()),
+                is_configured: false,
+                is_available: false,
+                current_model: Some(model),
+                available_models: vec![],
+                error_message: Some("No API key configured. Please set your API key in Settings.".to_string()),
+            });
+        }
+
+        resolved_credential
     } else {
         None
     };
 
     let streaming_api_key = api_key.clone().unwrap_or_default();
-    let streaming_base_url = match ai_provider_type {
-        ProviderType::OpenAI => crate::core::ai::OpenAIProvider::DEFAULT_BASE_URL.to_string(),
-        ProviderType::Anthropic => crate::core::ai::AnthropicProvider::DEFAULT_BASE_URL.to_string(),
-        ProviderType::Gemini => crate::core::ai::GeminiProvider::DEFAULT_BASE_URL.to_string(),
-        ProviderType::Local => settings
-            .ai
-            .ollama_url
-            .clone()
-            .unwrap_or_else(|| crate::core::ai::LocalProvider::DEFAULT_BASE_URL.to_string()),
+
+    let provider_config = if let Some(provider_config) = resolved_provider_config.clone() {
+        provider_config
+    } else {
+        match ai_provider_type {
+            ProviderType::OpenAI => {
+                let key = api_key.ok_or_else(|| "API key required for OpenAI".to_string())?;
+                ProviderConfig::openai(&key).with_model(&model)
+            }
+            ProviderType::Anthropic => {
+                let key = api_key.ok_or_else(|| "API key required for Anthropic".to_string())?;
+                ProviderConfig::anthropic(&key).with_model(&model)
+            }
+            ProviderType::Gemini => {
+                let key = api_key.ok_or_else(|| "API key required for Gemini".to_string())?;
+                ProviderConfig::gemini(&key).with_model(&model)
+            }
+            ProviderType::Local => {
+                let base_url = settings
+                    .ai
+                    .ollama_url
+                    .as_deref()
+                    .unwrap_or("http://localhost:11434");
+                ProviderConfig::local(Some(base_url)).with_model(&model)
+            }
+        }
     };
 
-    // Build provider config
-    let provider_config = match ai_provider_type {
-        ProviderType::OpenAI => {
-            let key = api_key.ok_or_else(|| "API key required for OpenAI".to_string())?;
-            ProviderConfig::openai(&key).with_model(&model)
-        }
-        ProviderType::Anthropic => {
-            let key = api_key.ok_or_else(|| "API key required for Anthropic".to_string())?;
-            ProviderConfig::anthropic(&key).with_model(&model)
-        }
-        ProviderType::Gemini => {
-            let key = api_key.ok_or_else(|| "API key required for Gemini".to_string())?;
-            ProviderConfig::gemini(&key).with_model(&model)
-        }
-        ProviderType::Local => {
-            let base_url = settings
+    let streaming_base_url = match provider_config.base_url.clone() {
+        Some(url) => url,
+        None => match ai_provider_type {
+            ProviderType::OpenAI => crate::core::ai::OpenAIProvider::DEFAULT_BASE_URL.to_string(),
+            ProviderType::Anthropic => crate::core::ai::AnthropicProvider::DEFAULT_BASE_URL.to_string(),
+            ProviderType::Gemini => crate::core::ai::GeminiProvider::DEFAULT_BASE_URL.to_string(),
+            ProviderType::Local => settings
                 .ai
                 .ollama_url
-                .as_deref()
-                .unwrap_or("http://localhost:11434");
-            ProviderConfig::local(Some(base_url)).with_model(&model)
-        }
+                .clone()
+                .unwrap_or_else(|| crate::core::ai::LocalProvider::DEFAULT_BASE_URL.to_string()),
+        },
     };
 
     // Create the provider
-    let provider = create_provider(provider_config).map_err(|e| e.to_ipc_error())?;
+    let provider = create_provider(provider_config.clone()).map_err(|e| e.to_ipc_error())?;
 
     // Run a real connectivity/auth check
     let provider_name = provider.name().to_string();
+    let provider_type_label =
+        effective_provider_type_label(&provider_name, &ai_provider_type.to_string());
     let is_configured = provider.is_available();
     let (is_available, error_message) = match provider.health_check().await {
         Ok(()) => (true, None),
         Err(e) => (false, Some(e.to_string())),
     };
 
-    // Get available models based on provider type
     let available_models = match ai_provider_type {
-        ProviderType::OpenAI => crate::core::ai::OpenAIProvider::available_models(),
+        ProviderType::OpenAI => {
+            let vault_path = app_data_dir.join("credentials.vault");
+            if !vault_path.exists() {
+                crate::core::ai::OpenAIProvider::available_models()
+            } else {
+                let mut guard = state.credential_vault.lock().await;
+                if guard.is_none() {
+                    *guard = Some(
+                        crate::core::credentials::CredentialVault::new(vault_path)
+                            .map_err(|e| format!("Failed to initialize credential vault: {}", e))?,
+                    );
+                }
+                let vault = guard
+                    .as_ref()
+                    .ok_or_else(|| "Credential vault unavailable".to_string())?;
+                resolve_openai_available_models(vault).await?
+            }
+        }
         ProviderType::Anthropic => crate::core::ai::AnthropicProvider::available_models(),
         ProviderType::Gemini => crate::core::ai::GeminiProvider::available_models(),
         ProviderType::Local => crate::core::ai::LocalProvider::common_models(),
@@ -2140,7 +2318,7 @@ pub async fn sync_ai_from_vault(
         .set_provider_boxed_with_status(
             provider,
             ProviderRuntimeStatus {
-                provider_type: Some(ai_provider_type.to_string()),
+                provider_type: Some(provider_type_label.clone()),
                 is_configured,
                 is_available,
                 current_model: Some(model.clone()),
@@ -2150,17 +2328,19 @@ pub async fn sync_ai_from_vault(
         )
         .await;
 
-    crate::core::ai::set_streaming_provider_config(crate::core::ai::StreamingProviderConfig {
-        provider_type: ai_provider_type,
-        api_key: if ai_provider_type == ProviderType::Local {
-            String::new()
-        } else {
-            streaming_api_key
-        },
-        base_url: streaming_base_url,
-        model: model.clone(),
-    })
-    .await;
+    if provider_name != "openai-codex" {
+        crate::core::ai::set_streaming_provider_config(crate::core::ai::StreamingProviderConfig {
+            provider_type: ai_provider_type,
+            api_key: if ai_provider_type == ProviderType::Local {
+                String::new()
+            } else {
+                streaming_api_key
+            },
+            base_url: streaming_base_url,
+            model: model.clone(),
+        })
+        .await;
+    }
 
     tracing::info!(
         "Synced AI provider from vault: {} (configured: {}, available: {})",
@@ -2170,7 +2350,7 @@ pub async fn sync_ai_from_vault(
     );
 
     Ok(ProviderStatusDto {
-        provider_type: Some(ai_provider_type.to_string()),
+        provider_type: Some(provider_type_label),
         is_configured,
         is_available,
         current_model: Some(model),
@@ -2519,13 +2699,38 @@ pub async fn generate_edit_script_with_ai(
 /// Gets available AI models for a provider type
 #[tauri::command]
 #[specta::specta]
-pub async fn get_available_ai_models(provider_type: String) -> Result<Vec<String>, String> {
+pub async fn get_available_ai_models(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    provider_type: String,
+) -> Result<Vec<String>, String> {
     use crate::core::ai::ProviderType;
 
     let ptype: ProviderType = provider_type.parse().map_err(|e: String| e)?;
 
     let models = match ptype {
-        ProviderType::OpenAI => crate::core::ai::OpenAIProvider::available_models(),
+        ProviderType::OpenAI => {
+            let app_data_dir = super::system::get_app_data_dir(&app)?;
+            let vault_path = app_data_dir.join("credentials.vault");
+
+            if !vault_path.exists() {
+                crate::core::ai::OpenAIProvider::available_models()
+            } else {
+                {
+                    let mut guard = state.credential_vault.lock().await;
+                    if guard.is_none() {
+                        *guard = Some(
+                            crate::core::credentials::CredentialVault::new(vault_path)
+                                .map_err(|e| format!("Failed to initialize credential vault: {}", e))?,
+                        );
+                    }
+                    let vault = guard
+                        .as_ref()
+                        .ok_or_else(|| "Credential vault unavailable".to_string())?;
+                    resolve_openai_available_models(vault).await?
+                }
+            }
+        }
         ProviderType::Anthropic => crate::core::ai::AnthropicProvider::available_models(),
         ProviderType::Gemini => crate::core::ai::GeminiProvider::available_models(),
         ProviderType::Local => crate::core::ai::LocalProvider::common_models(),

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -473,6 +473,8 @@ pub struct CodexAuthStatusDto {
     pub has_auth_file: bool,
     pub has_openai_api_key: bool,
     pub has_access_token: bool,
+    pub has_refresh_token: bool,
+    pub can_exchange_oauth: bool,
 }
 
 /// Result of attempting to import OpenAI credentials from Codex.
@@ -483,6 +485,8 @@ pub struct ImportCodexAuthResultDto {
     pub has_auth_file: bool,
     pub has_openai_api_key: bool,
     pub has_access_token: bool,
+    pub has_refresh_token: bool,
+    pub can_exchange_oauth: bool,
     pub message: String,
 }
 
@@ -933,6 +937,8 @@ pub async fn get_codex_auth_status() -> Result<CodexAuthStatusDto, String> {
         has_auth_file: status.has_auth_file,
         has_openai_api_key: status.has_openai_api_key,
         has_access_token: status.has_access_token,
+        has_refresh_token: status.has_refresh_token,
+        can_exchange_oauth: status.can_exchange_oauth,
     })
 }
 
@@ -952,6 +958,8 @@ pub async fn import_codex_auth(
             has_auth_file: false,
             has_openai_api_key: false,
             has_access_token: false,
+            has_refresh_token: false,
+            can_exchange_oauth: false,
             message: format!(
                 "Codex auth file not found at {}.",
                 codex_path.display()
@@ -959,13 +967,15 @@ pub async fn import_codex_auth(
         });
     }
 
-    let Some(api_key) = crate::core::credentials::codex_openai_api_key()
-        .map_err(|e| format!("Failed to read Codex auth: {}", e))?
+    let Some(resolved) = crate::core::credentials::codex_exchange_api_key()
+        .map_err(|e| format!("Failed to resolve Codex auth: {}", e))?
     else {
-        let message = if status.has_access_token {
-            "Codex auth.json contains a session token but no OpenAI API key. OpenReelio's OpenAI provider still requires an API key for api.openai.com."
+        let message = if status.can_exchange_oauth {
+            "Codex auth was detected but OpenReelio could not exchange it into a usable OpenAI runtime key."
+        } else if status.has_access_token {
+            "Codex auth.json contains an access token but no reusable refresh token or API key."
         } else {
-            "Codex auth.json does not contain an OpenAI API key."
+            "Codex auth.json does not contain reusable OpenAI credentials."
         };
 
         return Ok(ImportCodexAuthResultDto {
@@ -973,6 +983,8 @@ pub async fn import_codex_auth(
             has_auth_file: true,
             has_openai_api_key: false,
             has_access_token: status.has_access_token,
+            has_refresh_token: status.has_refresh_token,
+            can_exchange_oauth: status.can_exchange_oauth,
             message: message.to_string(),
         });
     };
@@ -992,19 +1004,23 @@ pub async fn import_codex_auth(
         .ok_or_else(|| "Credential vault unavailable".to_string())?;
 
     vault
-        .store(CredentialType::OpenaiApiKey, &api_key)
+        .store(CredentialType::OpenaiApiKey, &resolved.api_key)
         .await
         .map_err(|e| format!("Failed to store imported Codex credential: {}", e))?;
 
-    tracing::info!("Imported OpenAI API key from Codex auth.json");
+    tracing::info!("Imported OpenAI API key from Codex auth via {}", resolved.mode);
 
     Ok(ImportCodexAuthResultDto {
         imported: true,
         has_auth_file: true,
-        has_openai_api_key: true,
+        has_openai_api_key: status.has_openai_api_key,
         has_access_token: status.has_access_token,
-        message: "Imported OpenAI API key from Codex into the encrypted credential vault."
-            .to_string(),
+        has_refresh_token: status.has_refresh_token,
+        can_exchange_oauth: status.can_exchange_oauth,
+        message: format!(
+            "Imported OpenAI credential from Codex into the encrypted credential vault via {}.",
+            resolved.mode
+        ),
     })
 }
 

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -466,6 +466,26 @@ pub struct CredentialStatusDto {
     pub seedance: bool,
 }
 
+/// Status of local Codex auth availability.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexAuthStatusDto {
+    pub has_auth_file: bool,
+    pub has_openai_api_key: bool,
+    pub has_access_token: bool,
+}
+
+/// Result of attempting to import OpenAI credentials from Codex.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportCodexAuthResultDto {
+    pub imported: bool,
+    pub has_auth_file: bool,
+    pub has_openai_api_key: bool,
+    pub has_access_token: bool,
+    pub message: String,
+}
+
 // =============================================================================
 // Update DTOs
 // =============================================================================
@@ -901,6 +921,90 @@ pub async fn get_credential_status(app: tauri::AppHandle) -> Result<CredentialSt
         anthropic: vault.exists(CredentialType::AnthropicApiKey).await,
         google: vault.exists(CredentialType::GoogleApiKey).await,
         seedance: vault.exists(CredentialType::SeedanceApiKey).await,
+    })
+}
+
+/// Gets the status of a local Codex auth store.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_codex_auth_status() -> Result<CodexAuthStatusDto, String> {
+    let status = crate::core::credentials::codex_auth_status();
+    Ok(CodexAuthStatusDto {
+        has_auth_file: status.has_auth_file,
+        has_openai_api_key: status.has_openai_api_key,
+        has_access_token: status.has_access_token,
+    })
+}
+
+/// Imports an OpenAI API key from the local Codex auth store into the encrypted vault.
+#[tauri::command]
+#[specta::specta]
+pub async fn import_codex_auth(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ImportCodexAuthResultDto, String> {
+    let codex_path = crate::core::credentials::codex_auth_path();
+    let status = crate::core::credentials::codex_auth_status();
+
+    if !status.has_auth_file {
+        return Ok(ImportCodexAuthResultDto {
+            imported: false,
+            has_auth_file: false,
+            has_openai_api_key: false,
+            has_access_token: false,
+            message: format!(
+                "Codex auth file not found at {}.",
+                codex_path.display()
+            ),
+        });
+    }
+
+    let Some(api_key) = crate::core::credentials::codex_openai_api_key()
+        .map_err(|e| format!("Failed to read Codex auth: {}", e))?
+    else {
+        let message = if status.has_access_token {
+            "Codex auth.json contains a session token but no OpenAI API key. OpenReelio's OpenAI provider still requires an API key for api.openai.com."
+        } else {
+            "Codex auth.json does not contain an OpenAI API key."
+        };
+
+        return Ok(ImportCodexAuthResultDto {
+            imported: false,
+            has_auth_file: true,
+            has_openai_api_key: false,
+            has_access_token: status.has_access_token,
+            message: message.to_string(),
+        });
+    };
+
+    let app_data_dir = get_app_data_dir(&app)?;
+    let vault_path = app_data_dir.join("credentials.vault");
+
+    let mut guard = state.credential_vault.lock().await;
+    if guard.is_none() {
+        *guard = Some(
+            CredentialVault::new(vault_path)
+                .map_err(|e| format!("Failed to initialize credential vault: {}", e))?,
+        );
+    }
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| "Credential vault unavailable".to_string())?;
+
+    vault
+        .store(CredentialType::OpenaiApiKey, &api_key)
+        .await
+        .map_err(|e| format!("Failed to store imported Codex credential: {}", e))?;
+
+    tracing::info!("Imported OpenAI API key from Codex auth.json");
+
+    Ok(ImportCodexAuthResultDto {
+        imported: true,
+        has_auth_file: true,
+        has_openai_api_key: true,
+        has_access_token: status.has_access_token,
+        message: "Imported OpenAI API key from Codex into the encrypted credential vault."
+            .to_string(),
     })
 }
 

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -12,6 +12,10 @@ use tauri::{Manager, State};
 use crate::core::settings::{AppSettings, SettingsManager};
 use crate::AppState;
 
+fn is_direct_openai_api_key(value: &str) -> bool {
+    value.trim().starts_with("sk-")
+}
+
 // =============================================================================
 // App Lifecycle DTOs
 // =============================================================================
@@ -461,6 +465,8 @@ impl From<AppSettingsDto> for AppSettings {
 #[serde(rename_all = "camelCase")]
 pub struct CredentialStatusDto {
     pub openai: bool,
+    pub openai_api_key: bool,
+    pub openai_codex_oauth: bool,
     pub anthropic: bool,
     pub google: bool,
     pub seedance: bool,
@@ -902,6 +908,8 @@ pub async fn get_credential_status(app: tauri::AppHandle) -> Result<CredentialSt
     if !vault_path.exists() {
         return Ok(CredentialStatusDto {
             openai: false,
+            openai_api_key: false,
+            openai_codex_oauth: false,
             anthropic: false,
             google: false,
             seedance: false,
@@ -920,8 +928,21 @@ pub async fn get_credential_status(app: tauri::AppHandle) -> Result<CredentialSt
         .as_ref()
         .ok_or_else(|| "Credential vault unavailable".to_string())?;
 
+    let openai_api_key = if vault.exists(CredentialType::OpenaiApiKey).await {
+        vault
+            .retrieve(CredentialType::OpenaiApiKey)
+            .await
+            .map(|value| is_direct_openai_api_key(&value))
+            .unwrap_or(false)
+    } else {
+        false
+    };
+    let openai_codex_oauth = vault.exists(CredentialType::OpenaiCodexOauth).await;
+
     Ok(CredentialStatusDto {
-        openai: vault.exists(CredentialType::OpenaiApiKey).await,
+        openai: openai_api_key || openai_codex_oauth,
+        openai_api_key,
+        openai_codex_oauth,
         anthropic: vault.exists(CredentialType::AnthropicApiKey).await,
         google: vault.exists(CredentialType::GoogleApiKey).await,
         seedance: vault.exists(CredentialType::SeedanceApiKey).await,
@@ -967,11 +988,54 @@ pub async fn import_codex_auth(
         });
     }
 
-    let Some(resolved) = crate::core::credentials::codex_exchange_api_key()
-        .map_err(|e| format!("Failed to resolve Codex auth: {}", e))?
+    if let Some(stored_oauth) = crate::core::credentials::codex_local_oauth()
+        .map_err(|e| format!("Failed to read Codex OAuth: {}", e))?
+    {
+        let app_data_dir = get_app_data_dir(&app)?;
+        let vault_path = app_data_dir.join("credentials.vault");
+
+        let mut guard = state.credential_vault.lock().await;
+        if guard.is_none() {
+            *guard = Some(
+                CredentialVault::new(vault_path)
+                    .map_err(|e| format!("Failed to initialize credential vault: {}", e))?,
+            );
+        }
+        let vault = guard
+            .as_ref()
+            .ok_or_else(|| "Credential vault unavailable".to_string())?;
+
+        vault
+            .store(CredentialType::OpenaiCodexOauth, &stored_oauth)
+            .await
+            .map_err(|e| format!("Failed to store imported Codex OAuth credential: {}", e))?;
+
+        if vault.exists(CredentialType::OpenaiApiKey).await {
+            if let Ok(existing) = vault.retrieve(CredentialType::OpenaiApiKey).await {
+                if !is_direct_openai_api_key(&existing) {
+                    let _ = vault.delete(CredentialType::OpenaiApiKey).await;
+                }
+            }
+        }
+
+        tracing::info!("Stored Codex OAuth credential for OpenAI in encrypted vault");
+
+        return Ok(ImportCodexAuthResultDto {
+            imported: true,
+            has_auth_file: true,
+            has_openai_api_key: status.has_openai_api_key,
+            has_access_token: status.has_access_token,
+            has_refresh_token: status.has_refresh_token,
+            can_exchange_oauth: status.can_exchange_oauth,
+            message: "Connected Codex OAuth for OpenAI. OpenReelio will exchange it into a runtime credential when needed.".to_string(),
+        });
+    }
+
+    let Some(api_key) = crate::core::credentials::codex_openai_api_key()
+        .map_err(|e| format!("Failed to read Codex auth: {}", e))?
     else {
         let message = if status.can_exchange_oauth {
-            "Codex auth was detected but OpenReelio could not exchange it into a usable OpenAI runtime key."
+            "Codex auth was detected but OpenReelio could not store reusable Codex OAuth credentials."
         } else if status.has_access_token {
             "Codex auth.json contains an access token but no reusable refresh token or API key."
         } else {
@@ -1004,11 +1068,11 @@ pub async fn import_codex_auth(
         .ok_or_else(|| "Credential vault unavailable".to_string())?;
 
     vault
-        .store(CredentialType::OpenaiApiKey, &resolved.api_key)
+        .store(CredentialType::OpenaiApiKey, &api_key)
         .await
         .map_err(|e| format!("Failed to store imported Codex credential: {}", e))?;
 
-    tracing::info!("Imported OpenAI API key from Codex auth via {}", resolved.mode);
+    tracing::info!("Imported OpenAI API key from Codex auth");
 
     Ok(ImportCodexAuthResultDto {
         imported: true,
@@ -1017,10 +1081,8 @@ pub async fn import_codex_auth(
         has_access_token: status.has_access_token,
         has_refresh_token: status.has_refresh_token,
         can_exchange_oauth: status.can_exchange_oauth,
-        message: format!(
-            "Imported OpenAI credential from Codex into the encrypted credential vault via {}.",
-            resolved.mode
-        ),
+        message: "Imported OpenAI API key from Codex into the encrypted credential vault."
+            .to_string(),
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -920,6 +920,8 @@ mod tauri_app {
                 $crate::ipc::has_credential,
                 $crate::ipc::delete_credential,
                 $crate::ipc::get_credential_status,
+                $crate::ipc::get_codex_auth_status,
+                $crate::ipc::import_codex_auth,
                 // Video Generation
                 $crate::ipc::submit_video_generation,
                 $crate::ipc::poll_generation_job,
@@ -1293,6 +1295,8 @@ mod tauri_app {
             ipc::has_credential,
             ipc::delete_credential,
             ipc::get_credential_status,
+            ipc::get_codex_auth_status,
+            ipc::import_codex_auth,
             // Video Generation
             ipc::submit_video_generation,
             ipc::poll_generation_job,

--- a/src/agents/engine/core/modelRegistry.ts
+++ b/src/agents/engine/core/modelRegistry.ts
@@ -44,6 +44,15 @@ const MODEL_REGISTRY: Record<string, ModelTokenLimits> = {
   'gpt-4o': { contextWindow: 128_000, maxOutputTokens: 16_384 },
   'gpt-4o-mini': { contextWindow: 128_000, maxOutputTokens: 16_384 },
   'gpt-4o-2024-11-20': { contextWindow: 128_000, maxOutputTokens: 16_384 },
+  // OpenAI — GPT-5 family
+  'gpt-5.4': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.3-codex': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.3-codex-spark': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.2': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.2-codex': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.1-codex': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.1-codex-mini': { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.1-codex-max': { contextWindow: 400_000, maxOutputTokens: 128_000 },
   // OpenAI — o-series reasoning
   'o1': { contextWindow: 200_000, maxOutputTokens: 100_000 },
   'o1-mini': { contextWindow: 128_000, maxOutputTokens: 65_536 },
@@ -65,6 +74,7 @@ const MODEL_REGISTRY: Record<string, ModelTokenLimits> = {
 const PROVIDER_DEFAULTS: Record<string, ModelTokenLimits> = {
   anthropic: { contextWindow: 200_000, maxOutputTokens: 8_192 },
   openai: { contextWindow: 128_000, maxOutputTokens: 16_384 },
+  'openai-codex': { contextWindow: 400_000, maxOutputTokens: 128_000 },
   gemini: { contextWindow: 1_048_576, maxOutputTokens: 8_192 },
   local: { contextWindow: 32_000, maxOutputTokens: 4_096 },
 };

--- a/src/agents/engine/core/types.ts
+++ b/src/agents/engine/core/types.ts
@@ -813,7 +813,15 @@ export function createEmptyContext(projectId: string): AgentContext {
  * Merge partial config with defaults
  */
 export function mergeConfig(partial?: PartialEngineConfig): AgenticEngineConfig {
-  return { ...DEFAULT_ENGINE_CONFIG, ...partial };
+  if (!partial) {
+    return { ...DEFAULT_ENGINE_CONFIG };
+  }
+
+  const definedEntries = Object.entries(partial).filter(([, value]) => value !== undefined);
+  return {
+    ...DEFAULT_ENGINE_CONFIG,
+    ...Object.fromEntries(definedEntries),
+  } as AgenticEngineConfig;
 }
 
 /**

--- a/src/agents/engine/phases/Planner.ts
+++ b/src/agents/engine/phases/Planner.ts
@@ -180,7 +180,7 @@ export class Planner {
         // and non-ASCII prompts (Korean, Japanese, etc.) that consume
         // 2-3× more tokens per character.  Compact retry keeps the same
         // output budget since it already saves tokens on the input side.
-        const plan = await this.executeWithTimeout(
+        const rawPlan = await this.executeWithTimeout(
           () =>
             this.llm.generateStructured<Plan>(messages, schema, {
               maxTokens: this.config.maxOutputTokens ?? 16384,
@@ -189,6 +189,7 @@ export class Planner {
           timeoutMs,
         );
 
+        const plan = this.normalizePlan(rawPlan, thought);
         this.validatePlan(plan, context);
         return plan;
       } catch (error) {
@@ -280,7 +281,8 @@ export class Planner {
 
       // Parse the accumulated streaming output as structured JSON
       // instead of making a second LLM call
-      const plan = this.parseAccumulatedPlan<Plan>(accumulated);
+      const rawPlan = this.parseAccumulatedPlan<Plan>(accumulated);
+      const plan = this.normalizePlan(rawPlan, thought);
 
       this.validatePlan(plan, context);
       return plan;
@@ -900,6 +902,68 @@ export class Planner {
     }
 
     return normalized as Record<string, unknown>;
+  }
+
+  private normalizePlan(plan: unknown, thought: Thought): Plan {
+    const source = plan && typeof plan === 'object' ? (plan as Record<string, unknown>) : {};
+    const rawSteps = Array.isArray(source.steps) ? source.steps : [];
+
+    const steps = rawSteps.map((step, index) => {
+      const raw = step && typeof step === 'object' ? (step as Record<string, unknown>) : {};
+      const riskLevel = ['low', 'medium', 'high', 'critical'].includes(raw.riskLevel as string)
+        ? (raw.riskLevel as PlanStep['riskLevel'])
+        : 'low';
+
+      return {
+        id:
+          typeof raw.id === 'string' && raw.id.trim().length > 0
+            ? raw.id
+            : `step-${index + 1}`,
+        tool: typeof raw.tool === 'string' ? raw.tool : '',
+        args:
+          raw.args && typeof raw.args === 'object' && !Array.isArray(raw.args)
+            ? (raw.args as Record<string, unknown>)
+            : {},
+        description:
+          typeof raw.description === 'string' && raw.description.trim().length > 0
+            ? raw.description
+            : `Execute step ${index + 1}`,
+        riskLevel,
+        estimatedDuration:
+          typeof raw.estimatedDuration === 'number' && Number.isFinite(raw.estimatedDuration)
+            ? raw.estimatedDuration
+            : 1000,
+        dependsOn: Array.isArray(raw.dependsOn)
+          ? raw.dependsOn.filter((value): value is string => typeof value === 'string')
+          : undefined,
+      };
+    });
+
+    const estimatedTotalDuration =
+      typeof source.estimatedTotalDuration === 'number' && Number.isFinite(source.estimatedTotalDuration)
+        ? source.estimatedTotalDuration
+        : steps.reduce((sum, step) => sum + step.estimatedDuration, 0);
+
+    const requiresApproval =
+      typeof source.requiresApproval === 'boolean'
+        ? source.requiresApproval
+        : steps.some((step) => step.riskLevel === 'high' || step.riskLevel === 'critical');
+
+    const rollbackStrategy =
+      typeof source.rollbackStrategy === 'string' && source.rollbackStrategy.trim().length > 0
+        ? source.rollbackStrategy
+        : 'Undo completed steps in reverse order when possible.';
+
+    return {
+      goal:
+        typeof source.goal === 'string' && source.goal.trim().length > 0
+          ? source.goal
+          : thought.understanding,
+      steps,
+      estimatedTotalDuration,
+      requiresApproval,
+      rollbackStrategy,
+    };
   }
 
   private validateStepReferences(steps: PlanStep[]): string[] {

--- a/src/agents/engine/phases/Thinker.ts
+++ b/src/agents/engine/phases/Thinker.ts
@@ -15,7 +15,7 @@
 
 import type { ILLMClient, LLMMessage } from '../ports/ILLMClient';
 import type { AgentContext, LanguagePolicy, Thought } from '../core/types';
-import { ThinkingTimeoutError, UnderstandingError } from '../core/errors';
+import { SessionAbortedError, ThinkingTimeoutError, UnderstandingError } from '../core/errors';
 
 // =============================================================================
 // Types
@@ -97,11 +97,12 @@ export class Thinker {
     const schema = this.buildThoughtSchema();
 
     try {
-      const thought = await this.executeWithTimeout(
+      const rawThought = await this.executeWithTimeout(
         () => this.llm.generateStructured<Thought>(messages, schema),
         this.config.timeout,
       );
 
+      const thought = this.normalizeThought(rawThought);
       this.validateThought(thought);
       return thought;
     } catch (error) {
@@ -149,7 +150,8 @@ export class Thinker {
 
       // Then get the structured result
       const schema = this.buildThoughtSchema();
-      const thought = await this.llm.generateStructured<Thought>(messages, schema);
+      const rawThought = await this.llm.generateStructured<Thought>(messages, schema);
+      const thought = this.normalizeThought(rawThought);
 
       this.validateThought(thought);
       return thought;
@@ -176,6 +178,57 @@ export class Thinker {
   // ===========================================================================
   // Private Methods
   // ===========================================================================
+
+  /**
+   * Normalize partially valid model output into a full Thought object.
+   */
+  private normalizeThought(thought: unknown): Thought {
+    const source =
+      thought && typeof thought === 'object' ? (thought as Record<string, unknown>) : {};
+
+    const understanding =
+      typeof source.understanding === 'string' && source.understanding.trim().length > 0
+        ? source.understanding
+        : 'The user wants help with a video editing task.';
+
+    const requirements = Array.isArray(source.requirements)
+      ? source.requirements.filter((value): value is string => typeof value === 'string')
+      : [];
+
+    const uncertainties = Array.isArray(source.uncertainties)
+      ? source.uncertainties.filter((value): value is string => typeof value === 'string')
+      : [];
+
+    const explicitClarificationQuestion =
+      typeof source.clarificationQuestion === 'string' && source.clarificationQuestion.trim().length > 0
+        ? source.clarificationQuestion
+        : undefined;
+
+    const needsMoreInfo =
+      typeof source.needsMoreInfo === 'boolean'
+        ? source.needsMoreInfo
+        : Boolean(explicitClarificationQuestion) || uncertainties.length > 0;
+
+    const clarificationQuestion =
+      explicitClarificationQuestion
+      ?? (needsMoreInfo ? 'Could you clarify your request so I can proceed?' : undefined);
+
+    const approach =
+      typeof source.approach === 'string' && source.approach.trim().length > 0
+        ? source.approach
+        : needsMoreInfo
+          ? 'Ask one concise follow-up question to gather the missing information.'
+          : 'Proceed with a safe, minimal editing strategy using the available context and tools.';
+
+    return {
+      understanding,
+      requirements,
+      uncertainties,
+      approach,
+      needsMoreInfo,
+      clarificationQuestion,
+    };
+  }
 
   /**
    * Build messages for LLM including system prompt, optional history, and user input
@@ -345,30 +398,31 @@ export class Thinker {
         }
       }, timeout);
 
-      const abortHandler = () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timeoutId);
-          reject(new ThinkingTimeoutError(timeout));
-        }
-      };
-
-      if (this.abortController?.signal.aborted) {
-        clearTimeout(timeoutId);
-        reject(new ThinkingTimeoutError(timeout));
-        return;
-      }
-
       const signal = this.abortController?.signal;
-      if (signal) {
-        signal.addEventListener('abort', abortHandler);
-      }
-
       const cleanup = () => {
         if (signal) {
           signal.removeEventListener('abort', abortHandler);
         }
       };
+
+      const abortHandler = () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeoutId);
+          cleanup();
+          reject(new SessionAbortedError('Thinking aborted', 'thinking'));
+        }
+      };
+
+      if (this.abortController?.signal.aborted) {
+        clearTimeout(timeoutId);
+        cleanup();
+        reject(new SessionAbortedError('Thinking aborted', 'thinking'));
+        return;
+      }
+      if (signal) {
+        signal.addEventListener('abort', abortHandler);
+      }
 
       operation()
         .then((result) => {

--- a/src/components/features/agent/AgenticChat.tsx
+++ b/src/components/features/agent/AgenticChat.tsx
@@ -163,6 +163,10 @@ export const AgenticChat = forwardRef<AgenticChatHandle, AgenticChatProps>(funct
     const userInput = input.trim();
     setInput('');
 
+    // Create the session eagerly so the sidebar session list and persistence
+    // become visible before the first agent round-trip starts.
+    await useConversationStore.getState().ensureSession('editor');
+
     addUserMessage(userInput);
     onSubmit?.(userInput);
 

--- a/src/components/features/ai/AISidebar.tsx
+++ b/src/components/features/ai/AISidebar.tsx
@@ -136,6 +136,19 @@ export function AISidebar({
     return 'bg-green-500';
   };
 
+  const runtimeProviderLabel =
+    providerStatus.providerType === 'openai-codex'
+      ? 'Codex'
+      : providerStatus.providerType === 'openai'
+        ? 'OpenAI'
+        : providerStatus.providerType === 'anthropic'
+          ? 'Anthropic'
+          : providerStatus.providerType === 'gemini'
+            ? 'Gemini'
+            : providerStatus.providerType === 'local'
+              ? 'Local'
+              : null;
+
   return (
     <aside
       data-testid="ai-sidebar"
@@ -182,6 +195,14 @@ export function AISidebar({
             <Zap className="w-2.5 h-2.5" />
             Agent
           </span>
+          {runtimeProviderLabel && (
+            <span
+              className="px-1.5 py-0.5 text-[10px] font-medium bg-editor-surface text-editor-text-muted rounded"
+              title={`Runtime provider: ${runtimeProviderLabel}`}
+            >
+              {runtimeProviderLabel}
+            </span>
+          )}
           <div
             data-testid="provider-status"
             className={`w-2 h-2 rounded-full ${getProviderStatusColor()} ring-2 ring-offset-1 ring-offset-editor-sidebar/50 ring-transparent`}

--- a/src/components/features/settings/sections/AISettingsSection.tsx
+++ b/src/components/features/settings/sections/AISettingsSection.tsx
@@ -15,7 +15,11 @@ import React, { useCallback, useState, useEffect } from 'react';
 import type { AISettings, ProviderType, ProposalReviewMode } from '@/stores/settingsStore';
 import { CostControlPanel } from './CostControlPanel';
 import { useAIModels, getDefaultModel } from '@/hooks/useAIModels';
-import { useCredentials, type CredentialProvider } from '@/hooks/useCredentials';
+import {
+  useCredentials,
+  type CodexAuthStatus,
+  type CredentialProvider,
+} from '@/hooks/useCredentials';
 import { isVideoGenerationEnabled } from '@/config/featureFlags';
 
 // =============================================================================
@@ -348,6 +352,90 @@ const SecureApiKeyInput: React.FC<SecureApiKeyInputProps> = ({
   );
 };
 
+interface CodexImportHintProps {
+  disabled?: boolean;
+}
+
+const CodexImportHint: React.FC<CodexImportHintProps> = ({ disabled }) => {
+  const { getCodexAuthStatus, importCodexAuth, isSaving } = useCredentials();
+  const [status, setStatus] = useState<CodexAuthStatus | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setIsChecking(true);
+        const nextStatus = await getCodexAuthStatus();
+        if (!cancelled) {
+          setStatus(nextStatus);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setMessage(err instanceof Error ? err.message : 'Failed to inspect Codex auth');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsChecking(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [getCodexAuthStatus]);
+
+  if (isChecking) {
+    return <p className="text-xs text-editor-text-muted">Checking for Codex auth…</p>;
+  }
+
+  if (!status?.hasAuthFile) {
+    return <p className="text-xs text-editor-text-muted">No local Codex auth file detected.</p>;
+  }
+
+  const handleImport = async () => {
+    try {
+      const result = await importCodexAuth();
+      setMessage(result.message);
+      setStatus({
+        hasAuthFile: result.hasAuthFile,
+        hasOpenaiApiKey: result.hasOpenaiApiKey,
+        hasAccessToken: result.hasAccessToken,
+      });
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : 'Failed to import Codex auth');
+    }
+  };
+
+  return (
+    <div className="mt-2 rounded border border-editor-border bg-editor-bg px-3 py-2 space-y-2">
+      <p className="text-xs text-editor-text-muted">
+        Codex auth detected.
+        {status.hasOpenaiApiKey
+          ? ' An OpenAI API key is available for import.'
+          : status.hasAccessToken
+            ? ' Only a Codex session token is available, which OpenReelio cannot use directly with api.openai.com.'
+            : ' No OpenAI API key was found in the Codex auth file.'}
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleImport}
+          disabled={disabled || isSaving || !status.hasOpenaiApiKey}
+          className="px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text hover:bg-editor-bg-hover disabled:opacity-50"
+        >
+          {isSaving ? 'Importing...' : 'Import from Codex'}
+        </button>
+      </div>
+      {message && <p className="text-xs text-editor-text-muted">{message}</p>}
+    </div>
+  );
+};
+
 // =============================================================================
 // Main Component
 // =============================================================================
@@ -481,6 +569,7 @@ export const AISettingsSection: React.FC<AISettingsSectionProps> = ({
           placeholder={placeholder}
           disabled={disabled}
         />
+        {credentialProvider === 'openai' && <CodexImportHint disabled={disabled} />}
       </div>
     );
   };

--- a/src/components/features/settings/sections/AISettingsSection.tsx
+++ b/src/components/features/settings/sections/AISettingsSection.tsx
@@ -405,6 +405,8 @@ const CodexImportHint: React.FC<CodexImportHintProps> = ({ disabled }) => {
         hasAuthFile: result.hasAuthFile,
         hasOpenaiApiKey: result.hasOpenaiApiKey,
         hasAccessToken: result.hasAccessToken,
+        hasRefreshToken: result.hasRefreshToken,
+        canExchangeOauth: result.canExchangeOauth,
       });
     } catch (err) {
       setMessage(err instanceof Error ? err.message : 'Failed to import Codex auth');
@@ -417,15 +419,17 @@ const CodexImportHint: React.FC<CodexImportHintProps> = ({ disabled }) => {
         Codex auth detected.
         {status.hasOpenaiApiKey
           ? ' An OpenAI API key is available for import.'
-          : status.hasAccessToken
-            ? ' Only a Codex session token is available, which OpenReelio cannot use directly with api.openai.com.'
+          : status.canExchangeOauth
+            ? ' Codex CLI OAuth can be exchanged into a reusable OpenAI runtime key and imported.'
+            : status.hasAccessToken
+            ? ' Codex auth exists, but it does not include a reusable refresh token or API key.'
             : ' No OpenAI API key was found in the Codex auth file.'}
       </p>
       <div className="flex items-center gap-2">
         <button
           type="button"
           onClick={handleImport}
-          disabled={disabled || isSaving || !status.hasOpenaiApiKey}
+          disabled={disabled || isSaving || (!status.hasOpenaiApiKey && !status.canExchangeOauth)}
           className="px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text hover:bg-editor-bg-hover disabled:opacity-50"
         >
           {isSaving ? 'Importing...' : 'Import from Codex'}

--- a/src/components/features/settings/sections/AISettingsSection.tsx
+++ b/src/components/features/settings/sections/AISettingsSection.tsx
@@ -40,7 +40,7 @@ export interface AISettingsSectionProps {
 // =============================================================================
 
 const PROVIDER_OPTIONS: Array<{ value: ProviderType; label: string; description: string }> = [
-  { value: 'openai', label: 'OpenAI', description: 'GPT-5, O3 models for advanced reasoning' },
+  { value: 'openai', label: 'OpenAI', description: 'GPT-5.4 and O-series models for advanced reasoning' },
   {
     value: 'anthropic',
     label: 'Anthropic',
@@ -159,7 +159,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   onChange,
   disabled,
 }) => {
-  const { models, isLoading, error } = useAIModels(provider);
+  const { models, isLoading, error, refreshModels } = useAIModels(provider);
 
   // Handle provider change - update to default model if current is not available
   useEffect(() => {
@@ -175,8 +175,20 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   if (isLoading) {
     return (
-      <div className="w-full px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text-muted">
-        Loading models...
+      <div className="space-y-2">
+        <div className="w-full px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text-muted">
+          Loading models...
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => void refreshModels()}
+            disabled={disabled}
+            className="px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text hover:bg-editor-bg-hover disabled:opacity-50"
+          >
+            Refresh models
+          </button>
+        </div>
       </div>
     );
   }
@@ -199,19 +211,35 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
   }
 
   return (
-    <select
-      id={id}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      disabled={disabled || models.length === 0}
-      className="w-full px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text focus:outline-none focus:border-primary-500 disabled:opacity-50"
-    >
-      {models.map((model) => (
-        <option key={model} value={model}>
-          {model}
-        </option>
-      ))}
-    </select>
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled || models.length === 0}
+          className="flex-1 px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text focus:outline-none focus:border-primary-500 disabled:opacity-50"
+        >
+          {models.map((model) => (
+            <option key={model} value={model}>
+              {model}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void refreshModels()}
+          disabled={disabled}
+          className="px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text hover:bg-editor-bg-hover disabled:opacity-50"
+        >
+          Refresh
+        </button>
+      </div>
+      <p className="text-xs text-editor-text-muted">
+        OpenAI models are fetched from the active transport. With Codex OAuth, Refresh reads the
+        Codex model catalog instead of OpenAI `/v1/models`.
+      </p>
+    </div>
   );
 };
 
@@ -222,6 +250,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
 interface SecureApiKeyInputProps {
   provider: CredentialProvider;
   placeholder: string;
+  isConfigured: boolean;
   disabled?: boolean;
   onSaved?: () => void;
 }
@@ -229,15 +258,14 @@ interface SecureApiKeyInputProps {
 const SecureApiKeyInput: React.FC<SecureApiKeyInputProps> = ({
   provider,
   placeholder,
+  isConfigured,
   disabled,
   onSaved,
 }) => {
-  const { status, storeCredential, deleteCredential, isSaving, isLoading } = useCredentials();
+  const { storeCredential, deleteCredential, isSaving, isLoading } = useCredentials();
   const [inputValue, setInputValue] = useState('');
   const [showInput, setShowInput] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-
-  const isConfigured = status[provider];
 
   const handleSave = async () => {
     if (!inputValue.trim()) return;
@@ -357,7 +385,7 @@ interface CodexImportHintProps {
 }
 
 const CodexImportHint: React.FC<CodexImportHintProps> = ({ disabled }) => {
-  const { getCodexAuthStatus, importCodexAuth, isSaving } = useCredentials();
+  const { getCodexAuthStatus, importCodexAuth, deleteCredential, status: credentialStatus, isSaving } = useCredentials();
   const [status, setStatus] = useState<CodexAuthStatus | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [isChecking, setIsChecking] = useState(true);
@@ -397,7 +425,7 @@ const CodexImportHint: React.FC<CodexImportHintProps> = ({ disabled }) => {
     return <p className="text-xs text-editor-text-muted">No local Codex auth file detected.</p>;
   }
 
-  const handleImport = async () => {
+  const handleConnect = async () => {
     try {
       const result = await importCodexAuth();
       setMessage(result.message);
@@ -413,27 +441,52 @@ const CodexImportHint: React.FC<CodexImportHintProps> = ({ disabled }) => {
     }
   };
 
+  const handleDelete = async () => {
+    try {
+      await deleteCredential('openai_codex_oauth');
+      setMessage('Removed stored Codex OAuth from the encrypted vault.');
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : 'Failed to remove Codex OAuth');
+    }
+  };
+
   return (
     <div className="mt-2 rounded border border-editor-border bg-editor-bg px-3 py-2 space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-editor-text-muted">OpenAI via Codex OAuth</p>
+        <StatusBadge isConfigured={credentialStatus.openaiCodexOauth} isLoading={isChecking} />
+      </div>
       <p className="text-xs text-editor-text-muted">
-        Codex auth detected.
-        {status.hasOpenaiApiKey
-          ? ' An OpenAI API key is available for import.'
+        {credentialStatus.openaiCodexOauth
+          ? ' Codex OAuth is stored separately in the encrypted vault and is used through the Codex transport for supported GPT-5 models.'
           : status.canExchangeOauth
-            ? ' Codex CLI OAuth can be exchanged into a reusable OpenAI runtime key and imported.'
-            : status.hasAccessToken
-            ? ' Codex auth exists, but it does not include a reusable refresh token or API key.'
-            : ' No OpenAI API key was found in the Codex auth file.'}
+            ? ' Local Codex CLI OAuth was found and can be connected as a separate OpenAI credential source.'
+            : status.hasOpenaiApiKey
+              ? ' Local Codex auth only exposes a direct API key on this machine.'
+              : status.hasAccessToken
+                ? ' Codex auth exists, but it does not include a reusable refresh token or API key.'
+                : ' No reusable Codex OAuth credential was found.'}
       </p>
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={handleImport}
-          disabled={disabled || isSaving || (!status.hasOpenaiApiKey && !status.canExchangeOauth)}
-          className="px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text hover:bg-editor-bg-hover disabled:opacity-50"
-        >
-          {isSaving ? 'Importing...' : 'Import from Codex'}
-        </button>
+        {credentialStatus.openaiCodexOauth ? (
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={disabled || isSaving}
+            className="px-3 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {isSaving ? 'Removing...' : 'Disconnect Codex'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleConnect}
+            disabled={disabled || isSaving || (!status.hasOpenaiApiKey && !status.canExchangeOauth)}
+            className="px-3 py-2 rounded bg-editor-bg border border-editor-border text-editor-text hover:bg-editor-bg-hover disabled:opacity-50"
+          >
+            {isSaving ? 'Connecting...' : 'Connect from Codex'}
+          </button>
+        )}
       </div>
       {message && <p className="text-xs text-editor-text-muted">{message}</p>}
     </div>
@@ -558,19 +611,23 @@ export const AISettingsSection: React.FC<AISettingsSectionProps> = ({
     if (!labelInfo) return null;
 
     const { label, placeholder } = labelInfo;
+    const providerConfigured =
+      credentialProvider === 'openai'
+        ? credentialStatus.openaiApiKey
+        : credentialProvider === 'anthropic'
+          ? credentialStatus.anthropic
+          : credentialStatus.google;
 
     return (
       <div>
         <div className="flex items-center justify-between mb-1">
           <label className="block text-sm font-medium text-editor-text-muted">{label}</label>
-          <StatusBadge
-            isConfigured={credentialStatus[credentialProvider]}
-            isLoading={credentialsLoading}
-          />
+          <StatusBadge isConfigured={providerConfigured} isLoading={credentialsLoading} />
         </div>
         <SecureApiKeyInput
           provider={credentialProvider}
           placeholder={placeholder}
+          isConfigured={providerConfigured}
           disabled={disabled}
         />
         {credentialProvider === 'openai' && <CodexImportHint disabled={disabled} />}
@@ -789,6 +846,7 @@ export const AISettingsSection: React.FC<AISettingsSectionProps> = ({
               <SecureApiKeyInput
                 provider="seedance"
                 placeholder="Enter your Seedance API key"
+                isConfigured={credentialStatus.seedance}
                 disabled={disabled}
               />
             </div>

--- a/src/hooks/useAIModels.ts
+++ b/src/hooks/useAIModels.ts
@@ -237,6 +237,7 @@ function getFallbackModels(provider: ProviderType): string[] {
   switch (provider) {
     case 'openai':
       return [
+        'gpt-5.4',
         'gpt-5.2',
         'gpt-5.1',
         'gpt-5-mini',
@@ -284,7 +285,7 @@ function getFallbackModels(provider: ProviderType): string[] {
 export function getDefaultModel(provider: ProviderType): string {
   switch (provider) {
     case 'openai':
-      return 'gpt-5.2';
+      return 'gpt-5.4';
     case 'anthropic':
       return 'claude-sonnet-4-5-20251015';
     case 'gemini':

--- a/src/hooks/useAgenticLoop.ts
+++ b/src/hooks/useAgenticLoop.ts
@@ -50,6 +50,7 @@ import { usePlaybackStore } from '@/stores/playbackStore';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { useProjectStore } from '@/stores';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useAIStore } from '@/stores/aiStore';
 import { globalToolRegistry } from '@/agents';
 import { clearPendingApprovals } from '@/hooks/useAgentApproval';
 import { registerAgentAbort, unregisterAgentAbort } from '@/agents/engine/core/agentCleanup';
@@ -57,6 +58,9 @@ import { createLogger } from '@/services/logger';
 
 const logger = createLogger('useAgenticLoop');
 const CONTEXT_HISTORY_LIMIT = 30;
+const CODEX_THINKING_TIMEOUT_MS = 180_000;
+const CODEX_PLANNING_TIMEOUT_MS = 240_000;
+const CODEX_OBSERVATION_TIMEOUT_MS = 45_000;
 
 // =============================================================================
 // Types
@@ -468,8 +472,8 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
     registerAgentAbort(abort);
     return () => {
       unregisterAgentAbort();
-      // Use the shared abort() to ensure resolver and approval cleanup
-      abort();
+      // Do not force-abort on component unmount. In dev, transient remounts can
+      // otherwise cancel an active run and surface as a misleading timeout/error.
     };
   }, [abort]);
 
@@ -613,6 +617,19 @@ export function useAgenticLoopWithStores(
   const aiMaxTokens = useSettingsStore((s) => s.settings.ai.maxTokens);
   const aiPrimaryModel = useSettingsStore((s) => s.settings.ai.primaryModel);
   const aiPrimaryProvider = useSettingsStore((s) => s.settings.ai.primaryProvider);
+  const runtimeProviderStatus = useAIStore((s) => s.providerStatus);
+
+  const runtimeProvider =
+    options.config?.activeProvider
+    ?? (runtimeProviderStatus.isConfigured
+      ? runtimeProviderStatus.providerType ?? aiPrimaryProvider
+      : aiPrimaryProvider);
+  const runtimeModel =
+    options.config?.activeModel
+    ?? (runtimeProviderStatus.isConfigured
+      ? runtimeProviderStatus.currentModel ?? aiPrimaryModel
+      : aiPrimaryModel);
+  const isCodexRuntime = runtimeProvider === 'openai-codex';
 
   return useAgenticLoop({
     ...options,
@@ -621,8 +638,17 @@ export function useAgenticLoopWithStores(
       ...options.config,
       contextRefresher,
       maxOutputTokens: options.config?.maxOutputTokens ?? aiMaxTokens,
-      activeModel: options.config?.activeModel ?? aiPrimaryModel,
-      activeProvider: options.config?.activeProvider ?? aiPrimaryProvider,
+      activeModel: runtimeModel,
+      activeProvider: runtimeProvider,
+      thinkingTimeout:
+        options.config?.thinkingTimeout
+        ?? (isCodexRuntime ? CODEX_THINKING_TIMEOUT_MS : undefined),
+      planningTimeout:
+        options.config?.planningTimeout
+        ?? (isCodexRuntime ? CODEX_PLANNING_TIMEOUT_MS : undefined),
+      observationTimeout:
+        options.config?.observationTimeout
+        ?? (isCodexRuntime ? CODEX_OBSERVATION_TIMEOUT_MS : undefined),
     },
   });
 }

--- a/src/hooks/useCredentials.ts
+++ b/src/hooks/useCredentials.ts
@@ -52,6 +52,8 @@ export interface CodexAuthStatus {
   hasAuthFile: boolean;
   hasOpenaiApiKey: boolean;
   hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  canExchangeOauth: boolean;
 }
 
 export interface ImportCodexAuthResult {
@@ -59,6 +61,8 @@ export interface ImportCodexAuthResult {
   hasAuthFile: boolean;
   hasOpenaiApiKey: boolean;
   hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  canExchangeOauth: boolean;
   message: string;
 }
 

--- a/src/hooks/useCredentials.ts
+++ b/src/hooks/useCredentials.ts
@@ -20,7 +20,12 @@ import { useAIStore } from '@/stores/aiStore';
 const logger = createLogger('useCredentials');
 
 /** Supported credential provider types */
-export type CredentialProvider = 'openai' | 'anthropic' | 'google' | 'seedance';
+export type CredentialProvider =
+  | 'openai'
+  | 'openai_codex_oauth'
+  | 'anthropic'
+  | 'google'
+  | 'seedance';
 
 /**
  * Maps credential provider to AI provider type for cache invalidation
@@ -28,6 +33,7 @@ export type CredentialProvider = 'openai' | 'anthropic' | 'google' | 'seedance';
 function mapProviderToAIProvider(provider: CredentialProvider): 'openai' | 'anthropic' | 'gemini' | undefined {
   switch (provider) {
     case 'openai':
+    case 'openai_codex_oauth':
       return 'openai';
     case 'anthropic':
       return 'anthropic';
@@ -43,6 +49,8 @@ function mapProviderToAIProvider(provider: CredentialProvider): 'openai' | 'anth
 /** Status of credentials for each provider */
 export interface CredentialStatus {
   openai: boolean;
+  openaiApiKey: boolean;
+  openaiCodexOauth: boolean;
   anthropic: boolean;
   google: boolean;
   seedance: boolean;
@@ -121,6 +129,8 @@ export type UseCredentialsReturn = UseCredentialsState & UseCredentialsActions;
 export function useCredentials(): UseCredentialsReturn {
   const [status, setStatus] = useState<CredentialStatus>({
     openai: false,
+    openaiApiKey: false,
+    openaiCodexOauth: false,
     anthropic: false,
     google: false,
     seedance: false,

--- a/src/hooks/useCredentials.ts
+++ b/src/hooks/useCredentials.ts
@@ -48,6 +48,20 @@ export interface CredentialStatus {
   seedance: boolean;
 }
 
+export interface CodexAuthStatus {
+  hasAuthFile: boolean;
+  hasOpenaiApiKey: boolean;
+  hasAccessToken: boolean;
+}
+
+export interface ImportCodexAuthResult {
+  imported: boolean;
+  hasAuthFile: boolean;
+  hasOpenaiApiKey: boolean;
+  hasAccessToken: boolean;
+  message: string;
+}
+
 /** Hook state */
 interface UseCredentialsState {
   /** Status of each credential */
@@ -68,6 +82,10 @@ interface UseCredentialsActions {
   hasCredential: (provider: CredentialProvider) => Promise<boolean>;
   /** Delete a credential */
   deleteCredential: (provider: CredentialProvider) => Promise<void>;
+  /** Read local Codex auth availability */
+  getCodexAuthStatus: () => Promise<CodexAuthStatus>;
+  /** Import OpenAI API key from local Codex auth */
+  importCodexAuth: () => Promise<ImportCodexAuthResult>;
   /** Refresh credential status */
   refreshStatus: () => Promise<void>;
   /** Clear any error */
@@ -228,6 +246,45 @@ export function useCredentials(): UseCredentialsReturn {
     [refreshStatus]
   );
 
+  const getCodexAuthStatus = useCallback(async (): Promise<CodexAuthStatus> => {
+    try {
+      return await invoke<CodexAuthStatus>('get_codex_auth_status');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Failed to read Codex auth status', { error: message });
+      throw new Error(message);
+    }
+  }, []);
+
+  const importCodexAuth = useCallback(async (): Promise<ImportCodexAuthResult> => {
+    try {
+      setIsSaving(true);
+      setError(null);
+
+      const result = await invoke<ImportCodexAuthResult>('import_codex_auth');
+      await refreshStatus();
+
+      if (result.imported) {
+        invalidateModelCache('openai');
+        try {
+          await useAIStore.getState().syncFromSettings();
+          logger.info('AI provider synced after Codex import');
+        } catch (syncError) {
+          logger.warn('Failed to sync AI provider after Codex import', { syncError });
+        }
+      }
+
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Failed to import Codex auth', { error: message });
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [refreshStatus]);
+
   /**
    * Clears the current error
    */
@@ -248,6 +305,8 @@ export function useCredentials(): UseCredentialsReturn {
     storeCredential,
     hasCredential,
     deleteCredential,
+    getCodexAuthStatus,
+    importCodexAuth,
     refreshStatus,
     clearError,
   };

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -31,7 +31,7 @@ const debouncedSaveChatHistory = createDebouncedSaver(1000);
 // =============================================================================
 
 /** Supported AI provider types */
-export type ProviderType = 'openai' | 'anthropic' | 'gemini' | 'local';
+export type ProviderType = 'openai' | 'openai-codex' | 'anthropic' | 'gemini' | 'local';
 
 /** AI provider status */
 export interface ProviderStatus {


### PR DESCRIPTION
## Summary
- detect local Codex auth using the same Codex CLI reuse pattern OpenClaw documents
- resolve Codex OAuth credentials into a usable OpenAI runtime credential instead of only reading `OPENAI_API_KEY`
- auto-bootstrap OpenAI provider sync from Codex-backed credentials when the vault is empty
- expose the Codex import path in Settings with status that distinguishes direct API key, exchangeable OAuth, and incomplete auth

## Why
OpenClaw already supports reusing Codex CLI auth from `~/.codex/auth.json`, and users expect the same behavior here. On this machine, Codex auth does not contain `OPENAI_API_KEY`, but it does contain reusable OAuth credentials that can be exchanged into a runtime key. That makes the earlier API-key-only import behavior incomplete.

## What changed
- added a small Node helper script that mirrors OpenClaw's Codex CLI credential discovery approach:
  - check macOS keychain for `Codex Auth`
  - fall back to `~/.codex/auth.json`
  - detect whether auth is directly importable or exchangeable
- added `@mariozechner/pi-ai` and used `getOAuthApiKey("openai-codex", ...)` to exchange reusable Codex OAuth credentials into a runtime OpenAI key
- updated backend credential status/import commands to report refresh-token and exchange availability
- updated OpenAI provider sync to attempt Codex OAuth exchange before reporting the provider as unconfigured
- updated Settings UI messaging and button enablement to reflect exchangeable Codex auth

## Verification
- `node scripts/codex-auth-exchange.mjs status`
- `node scripts/codex-auth-exchange.mjs exchange`
- `npm run type-check`
- `npm run lint` (repo has existing warnings only)
- `cargo test core::credentials -- --nocapture`

Refs #510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import OpenAI credentials from local Codex auth with an "Import from Codex" hint and status check; new runtime "Codex" provider option and model refresh UI.
  * Frontend/back-end endpoints to check Codex auth and perform imports; helper CLI enables OAuth ↔ API-key exchanges and Codex-backed completions.

* **Bug Fixes**
  * Clearer credential messaging and provider-aware resolution when keys or auth are missing.

* **Tests**
  * Unit tests for Codex auth parsing, import flow, and credential length/format checks.

* **Chores**
  * Added a small runtime helper dependency and model default updated to gpt-5.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->