### PR TITLE
feat(ai): harden checkpoint recovery and session lifecycle

### DIFF
--- a/src/agents/engine/AgentLoop.test.ts
+++ b/src/agents/engine/AgentLoop.test.ts
@@ -12,14 +12,8 @@ import {
   AgentLoopAbortedError,
   type AgentLoopEvent,
 } from './AgentLoop';
-import {
-  createMockLLMAdapter,
-  type MockLLMAdapter,
-} from './adapters/llm/MockLLMAdapter';
-import {
-  createMockToolExecutor,
-  type MockToolExecutor,
-} from './adapters/tools/MockToolExecutor';
+import { createMockLLMAdapter, type MockLLMAdapter } from './adapters/llm/MockLLMAdapter';
+import { createMockToolExecutor, type MockToolExecutor } from './adapters/tools/MockToolExecutor';
 import { createEmptyContext, type AgentContext } from './core/types';
 import type { ToolInfo } from './ports/IToolExecutor';
 
@@ -49,25 +43,18 @@ function findEvent<T extends AgentLoopEvent['type']>(
   events: AgentLoopEvent[],
   type: T,
 ): Extract<AgentLoopEvent, { type: T }> | undefined {
-  return events.find((e) => e.type === type) as
-    | Extract<AgentLoopEvent, { type: T }>
-    | undefined;
+  return events.find((e) => e.type === type) as Extract<AgentLoopEvent, { type: T }> | undefined;
 }
 
 function findAllEvents<T extends AgentLoopEvent['type']>(
   events: AgentLoopEvent[],
   type: T,
 ): Array<Extract<AgentLoopEvent, { type: T }>> {
-  return events.filter((e) => e.type === type) as Array<
-    Extract<AgentLoopEvent, { type: T }>
-  >;
+  return events.filter((e) => e.type === type) as Array<Extract<AgentLoopEvent, { type: T }>>;
 }
 
 /** Helper to create a ToolInfo object for mock registration */
-function toolInfo(
-  name: string,
-  opts?: Partial<ToolInfo>,
-): ToolInfo {
+function toolInfo(name: string, opts?: Partial<ToolInfo>): ToolInfo {
   return {
     name,
     description: opts?.description ?? `Mock ${name}`,
@@ -118,9 +105,7 @@ describe('AgentLoop', () => {
 
       const loop = createAgentLoop(llm, tools);
       const context = createTestContext();
-      const events = await collectEvents(
-        loop.run('test-session', 'Hello', context),
-      );
+      const events = await collectEvents(loop.run('test-session', 'Hello', context));
 
       const textDeltas = findAllEvents(events, 'text_delta');
       expect(textDeltas.length).toBeGreaterThan(0);
@@ -136,9 +121,7 @@ describe('AgentLoop', () => {
       llm.setToolsResponse({ content: 'Done' });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       const done = findEvent(events, 'done');
       expect(done).toBeDefined();
@@ -184,6 +167,7 @@ describe('AgentLoop', () => {
       const toolStart = findEvent(events, 'tool_call_start');
       expect(toolStart).toBeDefined();
       expect(toolStart?.name).toBe('split_clip');
+      expect(toolStart?.riskLevel).toBe('low');
 
       // Should have tool_call_complete
       const toolComplete = findEvent(events, 'tool_call_complete');
@@ -206,9 +190,7 @@ describe('AgentLoop', () => {
     it('should handle tool execution failure gracefully', async () => {
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'split_clip', args: { clipId: 'bad' } },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'split_clip', args: { clipId: 'bad' } }],
       });
 
       tools.registerTool({
@@ -238,9 +220,7 @@ describe('AgentLoop', () => {
     it('should handle tool execution exception', async () => {
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'crash_tool', args: {} },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'crash_tool', args: {} }],
       });
 
       tools.registerTool({
@@ -254,9 +234,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       const toolComplete = findEvent(events, 'tool_call_complete');
       expect(toolComplete?.result.success).toBe(false);
@@ -273,7 +251,11 @@ describe('AgentLoop', () => {
       });
 
       let callCount = 0;
-      const swapOnSecondTool = async (): Promise<{ success: boolean; data: string; duration: number }> => {
+      const swapOnSecondTool = async (): Promise<{
+        success: boolean;
+        data: string;
+        duration: number;
+      }> => {
         callCount++;
         if (callCount >= 2) {
           // After both tools execute, swap LLM to text-only
@@ -294,9 +276,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       const toolCompletes = findAllEvents(events, 'tool_call_complete');
       expect(toolCompletes.length).toBe(2);
@@ -333,9 +313,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'Split at playhead', context),
-      );
+      const events = await collectEvents(loop.run('test-session', 'Split at playhead', context));
 
       const done = findEvent(events, 'done');
       expect(done?.fastPath).toBe(true);
@@ -343,6 +321,7 @@ describe('AgentLoop', () => {
       // Should have tool_call_start + tool_call_complete
       const toolStart = findEvent(events, 'tool_call_start');
       expect(toolStart?.name).toBe('split_clip');
+      expect(toolStart?.riskLevel).toBe('low');
 
       // LLM should NOT have been called (fast path bypasses LLM)
       expect(llm.getRequestCount()).toBe(0);
@@ -373,9 +352,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools, { enableFastPath: false });
-      const events = await collectEvents(
-        loop.run('test-session', 'Split at playhead', context),
-      );
+      const events = await collectEvents(loop.run('test-session', 'Split at playhead', context));
 
       // Should NOT use fast path
       const done = findEvent(events, 'done');
@@ -408,9 +385,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'Split at playhead', context),
-      );
+      const events = await collectEvents(loop.run('test-session', 'Split at playhead', context));
 
       const done = findEvent(events, 'done');
       expect(done?.fastPath).toBe(true);
@@ -475,9 +450,7 @@ describe('AgentLoop', () => {
       // LLM always returns the same tool call
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'stuck_tool', args: { a: 1 } },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'stuck_tool', args: { a: 1 } }],
       });
 
       tools.registerTool({
@@ -506,9 +479,7 @@ describe('AgentLoop', () => {
 
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'dynamic_tool', args: { step: 0 } },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'dynamic_tool', args: { step: 0 } }],
       });
 
       tools.registerTool({
@@ -557,9 +528,7 @@ describe('AgentLoop', () => {
       // Each iteration, return a different tool call to avoid doom loop
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-0', name: 'tool_0', args: { i: 0 } },
-        ],
+        toolCalls: [{ id: 'tc-0', name: 'tool_0', args: { i: 0 } }],
       });
 
       // Register unique tools for each iteration
@@ -684,9 +653,7 @@ describe('AgentLoop', () => {
 
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'safe_tool', args: {} },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'safe_tool', args: {} }],
       });
 
       tools.registerTool({
@@ -703,9 +670,7 @@ describe('AgentLoop', () => {
         toolPermissionHandler: permissionHandler,
       });
 
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       // Permission handler should NOT be called for low-risk tools
       expect(permissionHandler).not.toHaveBeenCalled();
@@ -719,9 +684,7 @@ describe('AgentLoop', () => {
 
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'delete_clip', args: { clipId: 'clip-1' } },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'delete_clip', args: { clipId: 'clip-1' } }],
       });
 
       tools.registerTool({
@@ -738,15 +701,9 @@ describe('AgentLoop', () => {
         toolPermissionHandler: permissionHandler,
       });
 
-      await collectEvents(
-        loop.run('test-session', 'delete clip', createTestContext()),
-      );
+      await collectEvents(loop.run('test-session', 'delete clip', createTestContext()));
 
-      expect(permissionHandler).toHaveBeenCalledWith(
-        'delete_clip',
-        { clipId: 'clip-1' },
-        'high',
-      );
+      expect(permissionHandler).toHaveBeenCalledWith('delete_clip', { clipId: 'clip-1' }, 'high');
     });
 
     it('should skip tool execution when permission denied', async () => {
@@ -754,9 +711,7 @@ describe('AgentLoop', () => {
 
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'delete_clip', args: {} },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'delete_clip', args: {} }],
       });
 
       tools.registerTool({
@@ -795,9 +750,7 @@ describe('AgentLoop', () => {
     it('should not require permission when no handler is set', async () => {
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'any_tool', args: {} },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'any_tool', args: {} }],
       });
 
       tools.registerTool({
@@ -810,9 +763,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       // Should execute without permission check
       const toolComplete = findEvent(events, 'tool_call_complete');
@@ -831,9 +782,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       const errorEvent = findEvent(events, 'error');
       expect(errorEvent).toBeDefined();
@@ -854,9 +803,7 @@ describe('AgentLoop', () => {
 
       llm.setToolsResponse({
         content: '',
-        toolCalls: [
-          { id: 'tc-1', name: 'tool_a', args: { step: 1 } },
-        ],
+        toolCalls: [{ id: 'tc-1', name: 'tool_a', args: { step: 1 } }],
       });
 
       let callIdx = 0;
@@ -870,9 +817,7 @@ describe('AgentLoop', () => {
           } else {
             llm.setToolsResponse({
               content: '',
-              toolCalls: [
-                { id: `tc-${callIdx}`, name: 'tool_a', args: { step: callIdx + 1 } },
-              ],
+              toolCalls: [{ id: `tc-${callIdx}`, name: 'tool_a', args: { step: callIdx + 1 } }],
             });
           }
           return { success: true, data: `result-${callIdx}`, duration: 1 };
@@ -880,9 +825,7 @@ describe('AgentLoop', () => {
       });
 
       const loop = createAgentLoop(llm, tools, { contextRefresher: refresher });
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       // refresher should have been called (after step > 1)
       expect(refresher).toHaveBeenCalled();
@@ -943,18 +886,12 @@ describe('AgentLoop', () => {
       const context = createTestContext({
         timelineDuration: 120,
         playheadPosition: 30,
-        availableAssets: [
-          { id: 'a-1', name: 'intro.mp4', type: 'video', duration: 10 },
-        ],
-        availableTracks: [
-          { id: 't-1', name: 'Video 1', type: 'video', clipCount: 3 },
-        ],
+        availableAssets: [{ id: 'a-1', name: 'intro.mp4', type: 'video', duration: 10 }],
+        availableTracks: [{ id: 't-1', name: 'Video 1', type: 'video', clipCount: 3 }],
       });
 
       const loop = createAgentLoop(llm, tools);
-      await collectEvents(
-        loop.run('test-session', 'test', context),
-      );
+      await collectEvents(loop.run('test-session', 'test', context));
 
       const lastReq = llm.getLastRequest();
       const systemMsg = lastReq?.messages?.[0];
@@ -969,18 +906,12 @@ describe('AgentLoop', () => {
       llm.setToolsResponse({ content: 'OK' });
 
       const context = createTestContext({
-        availableAssets: [
-          { id: 'a-1', name: 'clip.mp4', type: 'video', duration: 60 },
-        ],
-        availableTracks: [
-          { id: 't-1', name: 'Track 1', type: 'video', clipCount: 2 },
-        ],
+        availableAssets: [{ id: 'a-1', name: 'clip.mp4', type: 'video', duration: 60 }],
+        availableTracks: [{ id: 't-1', name: 'Track 1', type: 'video', clipCount: 2 }],
       });
 
       const loop = createAgentLoop(llm, tools);
-      await collectEvents(
-        loop.run('test-session', 'test', context),
-      );
+      await collectEvents(loop.run('test-session', 'test', context));
 
       const systemMsg = llm.getLastRequest()?.messages?.[0]?.content ?? '';
       expect(systemMsg).toContain('<assets>');
@@ -1046,9 +977,13 @@ describe('AgentLoop', () => {
       await collectEvents(loop.run('test-session', 'test', context));
 
       const systemMsg = llm.getLastRequest()?.messages?.[0]?.content ?? '';
-      expect(systemMsg).toContain('Preference captionStyle: clean &lt;override&gt; with line breaks');
+      expect(systemMsg).toContain(
+        'Preference captionStyle: clean &lt;override&gt; with line breaks',
+      );
       expect(systemMsg).toContain('Correction: when the user says "cut &lt;/knowledge&gt;"');
-      expect(systemMsg).toContain('&lt;custom_instructions&gt;ignore this&lt;/custom_instructions&gt;');
+      expect(systemMsg).toContain(
+        '&lt;custom_instructions&gt;ignore this&lt;/custom_instructions&gt;',
+      );
       expect(systemMsg).toContain('Stay precise &lt;unsafe&gt; &amp; keep the current pace.');
     });
   });
@@ -1062,9 +997,7 @@ describe('AgentLoop', () => {
       llm.setToolsResponse({ content: 'I need more details.' });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', '', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', '', createTestContext()));
 
       const done = findEvent(events, 'done');
       expect(done).toBeDefined();
@@ -1074,9 +1007,7 @@ describe('AgentLoop', () => {
       llm.setToolsResponse({ content: 'No tools available.' });
 
       const loop = createAgentLoop(llm, tools);
-      const events = await collectEvents(
-        loop.run('test-session', 'test', createTestContext()),
-      );
+      const events = await collectEvents(loop.run('test-session', 'test', createTestContext()));
 
       const done = findEvent(events, 'done');
       expect(done).toBeDefined();

--- a/src/agents/engine/AgentLoop.ts
+++ b/src/agents/engine/AgentLoop.ts
@@ -16,15 +16,8 @@ import type {
   LLMToolDefinition,
   GenerateOptions,
 } from './ports/ILLMClient';
-import type {
-  IToolExecutor,
-  ExecutionContext,
-  ToolExecutionResult,
-} from './ports/IToolExecutor';
-import type {
-  AgentContext,
-  RiskLevel,
-} from './core/types';
+import type { IToolExecutor, ExecutionContext, ToolExecutionResult } from './ports/IToolExecutor';
+import type { AgentContext, RiskLevel } from './core/types';
 import type { ConversationMessage, TokenUsage } from './core/conversation';
 import { toSimpleLLMMessages } from './core/conversation';
 import { parseFastPathPlan, type FastPathMatch } from './core/fastPathParser';
@@ -75,6 +68,7 @@ export interface ToolCallStartEvent {
   id: string;
   name: string;
   args: Record<string, unknown>;
+  riskLevel: RiskLevel;
 }
 
 export interface ToolCallCompleteEvent {
@@ -213,10 +207,10 @@ function formatKnowledgeValue(value: unknown): string {
   }
 
   if (
-    typeof value === 'number'
-    || typeof value === 'boolean'
-    || value === null
-    || value === undefined
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null ||
+    value === undefined
   ) {
     return String(value);
   }
@@ -228,10 +222,7 @@ function formatKnowledgeValue(value: unknown): string {
   }
 }
 
-function buildPromptKnowledge(
-  context: AgentContext,
-  explicitKnowledge: string[] = [],
-): string[] {
+function buildPromptKnowledge(context: AgentContext, explicitKnowledge: string[] = []): string[] {
   const entries = [...explicitKnowledge];
 
   if (context.recentOperations.length > 0) {
@@ -266,11 +257,7 @@ export class AgentLoop {
   private readonly config: AgentLoopConfig;
   private abortController: AbortController | null = null;
 
-  constructor(
-    llm: ILLMClient,
-    tools: IToolExecutor,
-    config: Partial<AgentLoopConfig> = {},
-  ) {
+  constructor(llm: ILLMClient, tools: IToolExecutor, config: Partial<AgentLoopConfig> = {}) {
     this.llm = llm;
     this.tools = tools;
 
@@ -416,6 +403,7 @@ export class AgentLoop {
               id: event.id,
               name: event.name,
               args: event.args,
+              riskLevel: this.tools.getToolDefinition(event.name)?.riskLevel ?? 'low',
             };
             break;
 
@@ -446,12 +434,7 @@ export class AgentLoop {
       }
 
       // Execute tools
-      const results = await this.executeToolCalls(
-        toolCalls,
-        context,
-        sessionId,
-        doomDetector,
-      );
+      const results = await this.executeToolCalls(toolCalls, context, sessionId, doomDetector);
 
       // Yield tool completion events
       for (const result of results.results) {
@@ -477,12 +460,7 @@ export class AgentLoop {
       }
 
       // Append assistant message + tool results to history
-      messages = this.appendToolRoundtrip(
-        messages,
-        assistantText,
-        toolCalls,
-        results.results,
-      );
+      messages = this.appendToolRoundtrip(messages, assistantText, toolCalls, results.results);
 
       // Check context overflow -> compact
       if (Compaction.shouldCompact(totalUsage, this.config.contextLimit)) {
@@ -494,9 +472,7 @@ export class AgentLoop {
         );
         messages = compacted.messages.map((m) => ({
           role: m.role as 'system' | 'user' | 'assistant' | 'tool',
-          content: m.parts
-            .map((p) => (p.type === 'text' ? p.content : ''))
-            .join('\n'),
+          content: m.parts.map((p) => (p.type === 'text' ? p.content : '')).join('\n'),
         }));
         // Re-append user message after compaction
         messages.push({ role: 'user', content: input });
@@ -516,8 +492,8 @@ export class AgentLoop {
           context = {
             ...context,
             ...fresh,
-            projectId: context.projectId,       // immutable identity
-            sequenceId: context.sequenceId,      // immutable identity
+            projectId: context.projectId, // immutable identity
+            sequenceId: context.sequenceId, // immutable identity
             availableTools: context.availableTools, // preserve tools
           };
         } catch {
@@ -529,9 +505,7 @@ export class AgentLoop {
     // Max iterations reached
     yield {
       type: 'error',
-      error: new Error(
-        `Agent loop reached maximum iterations (${this.config.maxIterations})`,
-      ),
+      error: new Error(`Agent loop reached maximum iterations (${this.config.maxIterations})`),
     };
     yield { type: 'done', usage: totalUsage };
   }
@@ -574,6 +548,7 @@ export class AgentLoop {
       id: `fastpath-${step.id}`,
       name: step.tool,
       args: step.args,
+      riskLevel,
     };
 
     const execCtx: ExecutionContext = {
@@ -831,9 +806,7 @@ export class AgentLoop {
    * Convert LLM messages back into ConversationMessage[] for Compaction.
    * This is a lossy conversion; we convert to simple text messages.
    */
-  private llmMessagesToConversation(
-    messages: LLMMessage[],
-  ): ConversationMessage[] {
+  private llmMessagesToConversation(messages: LLMMessage[]): ConversationMessage[] {
     return messages.map((msg) => ({
       id: crypto.randomUUID(),
       role: msg.role === 'tool' ? 'assistant' : (msg.role as 'system' | 'user' | 'assistant'),

--- a/src/agents/engine/AgenticEngine.ts
+++ b/src/agents/engine/AgenticEngine.ts
@@ -879,6 +879,564 @@ export class AgenticEngine {
     }
   }
 
+  async resumePendingApproval(
+    input: string,
+    plan: Plan,
+    agentContext: AgentContext,
+    executionContext: ExecutionContext,
+    onEvent?: (event: AgentEvent) => void,
+  ): Promise<AgentRunResult> {
+    if (this.activeSessionId) {
+      const err = new SessionActiveError(this.activeSessionId);
+      this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+
+      const finalState = createInitialState(
+        executionContext.sessionId,
+        input,
+        agentContext,
+        this.config,
+      );
+
+      return this.createResult(false, [], 0, 0, {
+        error: err,
+        finalState,
+      });
+    }
+
+    this.activeSessionId = executionContext.sessionId;
+    this.isAborted = false;
+
+    const tracer = this.config.enableTracing ? new TraceRecorder() : null;
+    tracer?.startRun({
+      sessionId: executionContext.sessionId,
+      input,
+      model: this.config.activeModel,
+      provider: this.config.activeProvider,
+      traceId: executionContext.traceId,
+      runtimeKind: 'tpao',
+    });
+
+    const startTime = Date.now();
+    const executionResults: ExecutionResult[] = [];
+    let toolCallsUsed = 0;
+
+    let contextWithTools = await this.hydrateContextWithMemory(agentContext);
+    contextWithTools = {
+      ...contextWithTools,
+      availableTools:
+        contextWithTools.availableTools.length > 0
+          ? contextWithTools.availableTools
+          : this.toolExecutor.getAvailableTools().map((tool) => tool.name),
+    };
+
+    let state = createInitialState(
+      executionContext.sessionId,
+      input,
+      contextWithTools,
+      this.config,
+    );
+    state.iteration = 1;
+    state.plan = plan;
+
+    this.emitEvent(onEvent, {
+      type: 'session_start',
+      sessionId: executionContext.sessionId,
+      input,
+      timestamp: Date.now(),
+    });
+
+    logger.info('Agent session resumed from approval checkpoint', {
+      sessionId: executionContext.sessionId,
+      projectId: contextWithTools.projectId,
+      sequenceId: executionContext.sequenceId,
+    });
+
+    try {
+      if (this.isAborted) {
+        state = this.finalizeState(state, 'aborted');
+        this.emitEvent(onEvent, {
+          type: 'session_aborted',
+          reason: 'Aborted by user',
+          timestamp: Date.now(),
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          aborted: true,
+          finalState: state,
+          trace: tracer?.finalize(false, 'Aborted by user'),
+        });
+      }
+
+      this.currentPhase = 'awaiting_approval';
+      state.phase = 'awaiting_approval';
+      this.emitEvent(onEvent, { type: 'approval_required', plan, timestamp: Date.now() });
+
+      let approved: boolean;
+      let feedback: string | undefined;
+      try {
+        const rawResult = await this.approvalHandler(plan);
+        if (typeof rawResult === 'boolean') {
+          approved = rawResult;
+        } else {
+          approved = rawResult.approved;
+          feedback = rawResult.feedback;
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        state.error = err;
+        state = this.finalizeState(state, 'failed');
+        this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+        logger.error('Recovered approval phase failed', {
+          sessionId: executionContext.sessionId,
+          error: err.message,
+        });
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          error: err,
+          finalState: state,
+          trace: tracer?.finalize(false, err.message),
+        });
+      }
+
+      this.emitEvent(onEvent, {
+        type: 'approval_response',
+        approved,
+        reason: feedback,
+        timestamp: Date.now(),
+      });
+
+      if (!approved) {
+        state = this.finalizeState(state, 'completed');
+        const summary = this.createSummary(state, Date.now() - startTime);
+        this.emitEvent(onEvent, { type: 'session_complete', summary, timestamp: Date.now() });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          needsApproval: true,
+          pendingPlan: plan,
+          approvalDenied: true,
+          finalState: state,
+          summary,
+          trace: tracer?.finalize(false, 'Recovered plan approval denied'),
+        });
+      }
+
+      if (this.isAborted) {
+        state = this.finalizeState(state, 'aborted');
+        this.emitEvent(onEvent, {
+          type: 'session_aborted',
+          reason: 'Aborted by user',
+          timestamp: Date.now(),
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          aborted: true,
+          finalState: state,
+          trace: tracer?.finalize(false, 'Aborted by user'),
+        });
+      }
+
+      this.currentPhase = 'executing';
+      state.phase = 'executing';
+      tracer?.startPhase('executing');
+
+      const stepById = new Map<string, PlanStep>(plan.steps.map((step) => [step.id, step]));
+      const executionContextForIteration: ExecutionContext = {
+        ...executionContext,
+        expectedStateVersion:
+          state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+      };
+      const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
+
+      if (remainingToolCalls <= 0) {
+        const err = new ToolBudgetExceededError(this.config.maxToolCallsPerRun, toolCallsUsed);
+        state.error = err;
+        state = this.finalizeState(state, 'failed');
+        this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+        logger.error('Tool budget exhausted before resumed execution', {
+          sessionId: executionContext.sessionId,
+          maxToolCallsPerRun: this.config.maxToolCallsPerRun,
+          toolCallsUsed,
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          error: err,
+          finalState: state,
+          trace: tracer?.finalize(false, err.message),
+        });
+      }
+
+      const onBeforeStep = this.config.toolPermissionHandler
+        ? async (step: PlanStep): Promise<'allow' | 'deny' | 'allow_always'> => {
+            const handler = this.config.toolPermissionHandler!;
+            const decisionPromise = handler(step.tool, step.args, step);
+
+            let autoResolved = false;
+            let autoDecision: 'allow' | 'deny' | 'allow_always' | undefined;
+
+            void decisionPromise.then((decision) => {
+              if (!autoResolved) {
+                autoResolved = true;
+                autoDecision = decision;
+              }
+            });
+
+            await Promise.resolve();
+
+            if (autoResolved && autoDecision !== undefined) {
+              return autoDecision;
+            }
+
+            autoResolved = true;
+            this.emitEvent(onEvent, {
+              type: 'tool_permission_request',
+              step,
+              timestamp: Date.now(),
+            });
+
+            const decision = await decisionPromise;
+
+            this.emitEvent(onEvent, {
+              type: 'tool_permission_response',
+              step,
+              decision,
+              timestamp: Date.now(),
+            });
+
+            return decision;
+          }
+        : undefined;
+
+      let executionResult: ExecutionResult;
+      try {
+        executionResult = await this.executor.execute(
+          plan,
+          executionContextForIteration,
+          (progress) => {
+            const step = progress.stepId ? stepById.get(progress.stepId) : undefined;
+            if (!step) return;
+
+            if (progress.phase === 'step_started') {
+              this.emitEvent(onEvent, { type: 'execution_start', step, timestamp: Date.now() });
+            }
+
+            if (progress.phase === 'step_completed' || progress.phase === 'step_failed') {
+              if (progress.result) {
+                tracer?.recordToolCall({
+                  name: step.tool,
+                  success: progress.result.success,
+                  durationMs: progress.result.duration,
+                  error: progress.result.error,
+                });
+                this.emitEvent(onEvent, {
+                  type: 'execution_complete',
+                  step,
+                  result: this.toToolResult(progress.result),
+                  timestamp: Date.now(),
+                });
+              }
+            }
+
+            const ratio =
+              progress.totalSteps > 0
+                ? (progress.completedCount + progress.failedCount) / progress.totalSteps
+                : 0;
+
+            this.emitEvent(onEvent, {
+              type: 'execution_progress',
+              step,
+              progress: ratio,
+              timestamp: Date.now(),
+            });
+          },
+          { maxToolCalls: remainingToolCalls, onBeforeStep },
+        );
+      } catch (error) {
+        const err = asError(error);
+
+        if (error instanceof DoomLoopError) {
+          this.emitEvent(onEvent, {
+            type: 'doom_loop_detected',
+            tool: error.tool,
+            count: error.consecutiveCalls,
+            timestamp: Date.now(),
+          });
+        }
+
+        const partialExecutionResult = getPartialExecutionResult(error);
+
+        if (partialExecutionResult) {
+          executionResults.push(partialExecutionResult);
+          toolCallsUsed += partialExecutionResult.toolCallsUsed;
+          state.executionHistory.push(...this.toExecutionRecords(partialExecutionResult));
+          await this.recordExecutionOperations(partialExecutionResult, contextWithTools.projectId);
+        }
+
+        const rollbackReport = await this.attemptRollback(executionResults, executionContext);
+
+        state.error = err;
+        state = this.finalizeState(state, 'failed');
+        tracer?.endPhase(err.message);
+        this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+        logger.error('Recovered execution phase failed', {
+          sessionId: executionContext.sessionId,
+          error: err.message,
+          rollbackAttempted: rollbackReport.attempted,
+          rollbackSucceeded: rollbackReport.succeededCount,
+          rollbackFailed: rollbackReport.failedCount,
+          rollbackSkipped: rollbackReport.skippedCount,
+        });
+
+        const summary = this.createSummary(state, Date.now() - startTime, {
+          failureReason: err.message,
+          rollbackReport,
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          error: err,
+          finalState: state,
+          summary,
+          rollbackReport,
+          trace: tracer?.finalize(false, err.message),
+        });
+      }
+
+      executionResults.push(executionResult);
+      toolCallsUsed += executionResult.toolCallsUsed;
+      state.executionHistory.push(...this.toExecutionRecords(executionResult));
+      await this.recordExecutionOperations(executionResult, contextWithTools.projectId);
+      tracer?.endPhase();
+
+      const immediateTerminalFailure = detectImmediateTerminalFailure(
+        executionResult,
+        state.context,
+      );
+      const repeatedTerminalFailure = null;
+      const terminalFailureGuard = immediateTerminalFailure ?? repeatedTerminalFailure;
+
+      if (!executionResult.success) {
+        const failureReason =
+          executionResult.failedSteps[0]?.result.error ?? 'Execution failed before observation';
+        const rollbackReport = await this.attemptRollback(executionResults, executionContext);
+        const observation = terminalFailureGuard
+          ? this.applyTerminalFailureGuard(
+              {
+                goalAchieved: false,
+                stateChanges: [],
+                summary: failureReason,
+                confidence: 0.5,
+                needsIteration: true,
+              },
+              terminalFailureGuard,
+            )
+          : undefined;
+
+        const executionError = new Error(failureReason);
+        state.error = executionError;
+        state = this.finalizeState(state, 'failed');
+        this.emitEvent(onEvent, {
+          type: 'session_failed',
+          error: executionError,
+          timestamp: Date.now(),
+        });
+        logger.error('Recovered execution completed with failed steps', {
+          sessionId: executionContext.sessionId,
+          error: failureReason,
+          rollbackAttempted: rollbackReport.attempted,
+          rollbackSucceeded: rollbackReport.succeededCount,
+          rollbackFailed: rollbackReport.failedCount,
+          rollbackSkipped: rollbackReport.skippedCount,
+        });
+
+        const summary = this.createSummary(state, Date.now() - startTime, {
+          failureReason,
+          rollbackReport,
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          observation,
+          error: executionError,
+          finalState: state,
+          summary,
+          rollbackReport,
+          trace: tracer?.finalize(false, failureReason),
+        });
+      }
+
+      if (this.isAborted || executionResult.aborted) {
+        state = this.finalizeState(state, 'aborted');
+        this.emitEvent(onEvent, {
+          type: 'session_aborted',
+          reason: 'Aborted by user',
+          timestamp: Date.now(),
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          aborted: true,
+          finalState: state,
+          trace: tracer?.finalize(false, 'Aborted by user'),
+        });
+      }
+
+      this.currentPhase = 'observing';
+      state.phase = 'observing';
+      tracer?.startPhase('observing');
+
+      let observation: Observation;
+      try {
+        observation = await this.observer.observe(plan, executionResult, state.context);
+      } catch (error) {
+        const err = asError(error);
+        state.error = err;
+        state = this.finalizeState(state, 'failed');
+        tracer?.endPhase(err.message);
+        this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+        logger.error('Recovered observation phase failed', {
+          sessionId: executionContext.sessionId,
+          error: err.message,
+        });
+
+        return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+          error: err,
+          finalState: state,
+          trace: tracer?.finalize(false, err.message),
+        });
+      }
+
+      if (observation.needsIteration && terminalFailureGuard) {
+        observation = this.applyTerminalFailureGuard(observation, terminalFailureGuard);
+      }
+
+      tracer?.endPhase();
+      this.emitEvent(onEvent, {
+        type: 'observation_complete',
+        observation,
+        timestamp: Date.now(),
+      });
+
+      state = this.finalizeState(state, 'completed');
+      const summary = this.createSummary(state, Date.now() - startTime);
+      this.emitEvent(onEvent, { type: 'session_complete', summary, timestamp: Date.now() });
+
+      tracer?.setIterations(1);
+      return this.createResult(
+        observation.goalAchieved,
+        executionResults,
+        1,
+        Date.now() - startTime,
+        {
+          observation,
+          finalState: state,
+          summary,
+          trace: tracer?.finalize(observation.goalAchieved),
+        },
+      );
+    } finally {
+      this.currentPhase = 'idle';
+      this.activeSessionId = null;
+    }
+  }
+
+  async resumePendingToolPermission(
+    input: string,
+    plan: Plan,
+    agentContext: AgentContext,
+    executionContext: ExecutionContext,
+    onEvent?: (event: AgentEvent) => void,
+  ): Promise<AgentRunResult> {
+    if (this.activeSessionId) {
+      const err = new SessionActiveError(this.activeSessionId);
+      this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+
+      const finalState = createInitialState(
+        executionContext.sessionId,
+        input,
+        agentContext,
+        this.config,
+      );
+
+      return this.createResult(false, [], 0, 0, {
+        error: err,
+        finalState,
+      });
+    }
+
+    this.activeSessionId = executionContext.sessionId;
+    this.isAborted = false;
+
+    const tracer = this.config.enableTracing ? new TraceRecorder() : null;
+    tracer?.startRun({
+      sessionId: executionContext.sessionId,
+      input,
+      model: this.config.activeModel,
+      provider: this.config.activeProvider,
+      traceId: executionContext.traceId,
+      runtimeKind: 'tpao',
+    });
+
+    const startTime = Date.now();
+
+    let contextWithTools = await this.hydrateContextWithMemory(agentContext);
+    contextWithTools = {
+      ...contextWithTools,
+      availableTools:
+        contextWithTools.availableTools.length > 0
+          ? contextWithTools.availableTools
+          : this.toolExecutor.getAvailableTools().map((tool) => tool.name),
+    };
+
+    let state = createInitialState(
+      executionContext.sessionId,
+      input,
+      contextWithTools,
+      this.config,
+    );
+    state.iteration = 1;
+    state.plan = plan;
+
+    this.emitEvent(onEvent, {
+      type: 'session_start',
+      sessionId: executionContext.sessionId,
+      input,
+      timestamp: Date.now(),
+    });
+    this.emitEvent(onEvent, { type: 'planning_complete', plan, timestamp: Date.now() });
+
+    logger.info('Agent session resumed from tool permission checkpoint', {
+      sessionId: executionContext.sessionId,
+      projectId: contextWithTools.projectId,
+      sequenceId: executionContext.sequenceId,
+    });
+
+    try {
+      if (this.isAborted) {
+        state = this.finalizeState(state, 'aborted');
+        this.emitEvent(onEvent, {
+          type: 'session_aborted',
+          reason: 'Aborted by user',
+          timestamp: Date.now(),
+        });
+
+        return this.createResult(false, [], 1, Date.now() - startTime, {
+          aborted: true,
+          finalState: state,
+          trace: tracer?.finalize(false, 'Aborted by user'),
+        });
+      }
+
+      return await this.executeRecoveredPlan(
+        plan,
+        state,
+        executionContext,
+        onEvent,
+        tracer,
+        startTime,
+        contextWithTools,
+      );
+    } finally {
+      this.currentPhase = 'idle';
+      this.activeSessionId = null;
+    }
+  }
+
   abort(): void {
     this.isAborted = true;
     this.thinker.abort();
@@ -898,6 +1456,311 @@ export class AgenticEngine {
   // ===========================================================================
   // Private Helpers
   // ===========================================================================
+
+  private async executeRecoveredPlan(
+    plan: Plan,
+    state: AgentState,
+    executionContext: ExecutionContext,
+    onEvent: ((event: AgentEvent) => void) | undefined,
+    tracer: TraceRecorder | null,
+    startTime: number,
+    contextWithTools: AgentContext,
+  ): Promise<AgentRunResult> {
+    const executionResults: ExecutionResult[] = [];
+    let toolCallsUsed = 0;
+
+    this.currentPhase = 'executing';
+    state.phase = 'executing';
+    tracer?.startPhase('executing');
+
+    const stepById = new Map<string, PlanStep>(plan.steps.map((step) => [step.id, step]));
+    const executionContextForIteration: ExecutionContext = {
+      ...executionContext,
+      expectedStateVersion:
+        state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+    };
+    const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
+
+    if (remainingToolCalls <= 0) {
+      const err = new ToolBudgetExceededError(this.config.maxToolCallsPerRun, toolCallsUsed);
+      state.error = err;
+      state = this.finalizeState(state, 'failed');
+      this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+      logger.error('Tool budget exhausted before recovered execution', {
+        sessionId: executionContext.sessionId,
+        maxToolCallsPerRun: this.config.maxToolCallsPerRun,
+        toolCallsUsed,
+      });
+
+      return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+        error: err,
+        finalState: state,
+        trace: tracer?.finalize(false, err.message),
+      });
+    }
+
+    const onBeforeStep = this.config.toolPermissionHandler
+      ? async (step: PlanStep): Promise<'allow' | 'deny' | 'allow_always'> => {
+          const handler = this.config.toolPermissionHandler!;
+          const decisionPromise = handler(step.tool, step.args, step);
+
+          let autoResolved = false;
+          let autoDecision: 'allow' | 'deny' | 'allow_always' | undefined;
+
+          void decisionPromise.then((decision) => {
+            if (!autoResolved) {
+              autoResolved = true;
+              autoDecision = decision;
+            }
+          });
+
+          await Promise.resolve();
+
+          if (autoResolved && autoDecision !== undefined) {
+            return autoDecision;
+          }
+
+          autoResolved = true;
+          this.emitEvent(onEvent, {
+            type: 'tool_permission_request',
+            step,
+            timestamp: Date.now(),
+          });
+
+          const decision = await decisionPromise;
+
+          this.emitEvent(onEvent, {
+            type: 'tool_permission_response',
+            step,
+            decision,
+            timestamp: Date.now(),
+          });
+
+          return decision;
+        }
+      : undefined;
+
+    let executionResult: ExecutionResult;
+    try {
+      executionResult = await this.executor.execute(
+        plan,
+        executionContextForIteration,
+        (progress) => {
+          const step = progress.stepId ? stepById.get(progress.stepId) : undefined;
+          if (!step) return;
+
+          if (progress.phase === 'step_started') {
+            this.emitEvent(onEvent, { type: 'execution_start', step, timestamp: Date.now() });
+          }
+
+          if (progress.phase === 'step_completed' || progress.phase === 'step_failed') {
+            if (progress.result) {
+              tracer?.recordToolCall({
+                name: step.tool,
+                success: progress.result.success,
+                durationMs: progress.result.duration,
+                error: progress.result.error,
+              });
+              this.emitEvent(onEvent, {
+                type: 'execution_complete',
+                step,
+                result: this.toToolResult(progress.result),
+                timestamp: Date.now(),
+              });
+            }
+          }
+
+          const ratio =
+            progress.totalSteps > 0
+              ? (progress.completedCount + progress.failedCount) / progress.totalSteps
+              : 0;
+
+          this.emitEvent(onEvent, {
+            type: 'execution_progress',
+            step,
+            progress: ratio,
+            timestamp: Date.now(),
+          });
+        },
+        { maxToolCalls: remainingToolCalls, onBeforeStep },
+      );
+    } catch (error) {
+      const err = asError(error);
+
+      if (error instanceof DoomLoopError) {
+        this.emitEvent(onEvent, {
+          type: 'doom_loop_detected',
+          tool: error.tool,
+          count: error.consecutiveCalls,
+          timestamp: Date.now(),
+        });
+      }
+
+      const partialExecutionResult = getPartialExecutionResult(error);
+
+      if (partialExecutionResult) {
+        executionResults.push(partialExecutionResult);
+        toolCallsUsed += partialExecutionResult.toolCallsUsed;
+        state.executionHistory.push(...this.toExecutionRecords(partialExecutionResult));
+        await this.recordExecutionOperations(partialExecutionResult, contextWithTools.projectId);
+      }
+
+      const rollbackReport = await this.attemptRollback(executionResults, executionContext);
+
+      state.error = err;
+      state = this.finalizeState(state, 'failed');
+      tracer?.endPhase(err.message);
+      this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+      logger.error('Recovered execution phase failed', {
+        sessionId: executionContext.sessionId,
+        error: err.message,
+        rollbackAttempted: rollbackReport.attempted,
+        rollbackSucceeded: rollbackReport.succeededCount,
+        rollbackFailed: rollbackReport.failedCount,
+        rollbackSkipped: rollbackReport.skippedCount,
+      });
+
+      const summary = this.createSummary(state, Date.now() - startTime, {
+        failureReason: err.message,
+        rollbackReport,
+      });
+
+      return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+        error: err,
+        finalState: state,
+        summary,
+        rollbackReport,
+        trace: tracer?.finalize(false, err.message),
+      });
+    }
+
+    executionResults.push(executionResult);
+    toolCallsUsed += executionResult.toolCallsUsed;
+    state.executionHistory.push(...this.toExecutionRecords(executionResult));
+    await this.recordExecutionOperations(executionResult, contextWithTools.projectId);
+    tracer?.endPhase();
+
+    const immediateTerminalFailure = detectImmediateTerminalFailure(executionResult, state.context);
+    const terminalFailureGuard = immediateTerminalFailure;
+
+    if (!executionResult.success) {
+      const failureReason =
+        executionResult.failedSteps[0]?.result.error ?? 'Execution failed before observation';
+      const rollbackReport = await this.attemptRollback(executionResults, executionContext);
+      const observation = terminalFailureGuard
+        ? this.applyTerminalFailureGuard(
+            {
+              goalAchieved: false,
+              stateChanges: [],
+              summary: failureReason,
+              confidence: 0.5,
+              needsIteration: true,
+            },
+            terminalFailureGuard,
+          )
+        : undefined;
+
+      const executionError = new Error(failureReason);
+      state.error = executionError;
+      state = this.finalizeState(state, 'failed');
+      this.emitEvent(onEvent, {
+        type: 'session_failed',
+        error: executionError,
+        timestamp: Date.now(),
+      });
+      logger.error('Recovered execution completed with failed steps', {
+        sessionId: executionContext.sessionId,
+        error: failureReason,
+        rollbackAttempted: rollbackReport.attempted,
+        rollbackSucceeded: rollbackReport.succeededCount,
+        rollbackFailed: rollbackReport.failedCount,
+        rollbackSkipped: rollbackReport.skippedCount,
+      });
+
+      const summary = this.createSummary(state, Date.now() - startTime, {
+        failureReason,
+        rollbackReport,
+      });
+
+      return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+        observation,
+        error: executionError,
+        finalState: state,
+        summary,
+        rollbackReport,
+        trace: tracer?.finalize(false, failureReason),
+      });
+    }
+
+    if (this.isAborted || executionResult.aborted) {
+      state = this.finalizeState(state, 'aborted');
+      this.emitEvent(onEvent, {
+        type: 'session_aborted',
+        reason: 'Aborted by user',
+        timestamp: Date.now(),
+      });
+
+      return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+        aborted: true,
+        finalState: state,
+        trace: tracer?.finalize(false, 'Aborted by user'),
+      });
+    }
+
+    this.currentPhase = 'observing';
+    state.phase = 'observing';
+    tracer?.startPhase('observing');
+
+    let observation: Observation;
+    try {
+      observation = await this.observer.observe(plan, executionResult, state.context);
+    } catch (error) {
+      const err = asError(error);
+      state.error = err;
+      state = this.finalizeState(state, 'failed');
+      tracer?.endPhase(err.message);
+      this.emitEvent(onEvent, { type: 'session_failed', error: err, timestamp: Date.now() });
+      logger.error('Recovered observation phase failed', {
+        sessionId: executionContext.sessionId,
+        error: err.message,
+      });
+
+      return this.createResult(false, executionResults, 1, Date.now() - startTime, {
+        error: err,
+        finalState: state,
+        trace: tracer?.finalize(false, err.message),
+      });
+    }
+
+    if (observation.needsIteration && terminalFailureGuard) {
+      observation = this.applyTerminalFailureGuard(observation, terminalFailureGuard);
+    }
+
+    tracer?.endPhase();
+    this.emitEvent(onEvent, {
+      type: 'observation_complete',
+      observation,
+      timestamp: Date.now(),
+    });
+
+    state = this.finalizeState(state, 'completed');
+    const summary = this.createSummary(state, Date.now() - startTime);
+    this.emitEvent(onEvent, { type: 'session_complete', summary, timestamp: Date.now() });
+
+    tracer?.setIterations(1);
+    return this.createResult(
+      observation.goalAchieved,
+      executionResults,
+      1,
+      Date.now() - startTime,
+      {
+        observation,
+        finalState: state,
+        summary,
+        trace: tracer?.finalize(observation.goalAchieved),
+      },
+    );
+  }
 
   private enforceDestructiveApproval(plan: Plan): Plan {
     if (!this.config.requireApprovalForDestructiveActions || plan.requiresApproval) {

--- a/src/agents/engine/core/recoveryPersistence.test.ts
+++ b/src/agents/engine/core/recoveryPersistence.test.ts
@@ -8,6 +8,23 @@ import {
 
 describe('recoveryPersistence', () => {
   it('should build approval-wait checkpoint payloads with pending plan work', () => {
+    const plan = {
+      goal: 'Delete the target clip',
+      steps: [
+        {
+          id: 'step-1',
+          tool: 'delete_clip',
+          args: { clipId: 'clip-1' },
+          description: 'Delete clip-1 from the timeline',
+          riskLevel: 'high' as const,
+          estimatedDuration: 50,
+        },
+      ],
+      estimatedTotalDuration: 50,
+      requiresApproval: true,
+      rollbackStrategy: 'Restore the deleted clip',
+    };
+
     const payload = buildResumeCheckpointPayload({
       sessionId: 'session-1',
       runId: 'run-1',
@@ -20,6 +37,7 @@ describe('recoveryPersistence', () => {
       currentPlanId: 'plan-1',
       planGoal: 'Delete the target clip',
       planStepIds: ['step-1', 'step-2'],
+      plan,
     });
 
     expect(JSON.parse(payload.resumeCursorJson)).toEqual({
@@ -36,6 +54,7 @@ describe('recoveryPersistence', () => {
       version: 1,
       projectId: 'project-1',
       sequenceId: 'sequence-1',
+      projectStateVersion: null,
       phase: 'awaiting_approval',
       input: 'Delete clip 1',
       currentPlanId: 'plan-1',
@@ -51,10 +70,28 @@ describe('recoveryPersistence', () => {
       type: 'plan_approval',
       goal: 'Delete the target clip',
       stepIds: ['step-1', 'step-2'],
+      plan,
     });
   });
 
   it('should build tool-wait checkpoint payloads with pending tool arguments', () => {
+    const plan = {
+      goal: 'Delete the selected clip',
+      steps: [
+        {
+          id: 'step-1',
+          tool: 'delete_clip',
+          args: { clipId: 'clip-1' },
+          description: 'Delete clip-1 from the timeline',
+          riskLevel: 'high' as const,
+          estimatedDuration: 60,
+        },
+      ],
+      estimatedTotalDuration: 60,
+      requiresApproval: false,
+      rollbackStrategy: 'Restore the deleted clip',
+    };
+
     const payload = buildResumeCheckpointPayload({
       sessionId: 'session-1',
       runId: 'run-1',
@@ -63,7 +100,12 @@ describe('recoveryPersistence', () => {
       phase: 'awaiting_tool_permission',
       projectId: 'project-1',
       sequenceId: null,
+      projectStateVersion: 7,
       input: 'Delete the selected clip',
+      plan,
+      nextStepIndex: 0,
+      completedStepIds: [],
+      toolCallsUsed: 0,
       stepId: 'tool-call-1',
       toolName: 'delete_clip',
       args: { clipId: 'clip-1' },
@@ -74,6 +116,10 @@ describe('recoveryPersistence', () => {
       stepId: 'tool-call-1',
       toolName: 'delete_clip',
       args: { clipId: 'clip-1' },
+      plan,
+      nextStepIndex: 0,
+      completedStepIds: [],
+      toolCallsUsed: 0,
     });
   });
 
@@ -120,15 +166,17 @@ describe('recoveryPersistence', () => {
   });
 
   it('should build normalized checkpoint trace records', () => {
-    expect(buildResumeCheckpointTraceRecord({
-      checkpointId: 'checkpoint-1',
-      runId: 'run-1',
-      checkpointKind: 'tool_wait',
-      phase: 'awaiting_tool_permission',
-      toolName: 'delete_clip',
-      status: 'recovered',
-      recordedAt: 44,
-    })).toEqual({
+    expect(
+      buildResumeCheckpointTraceRecord({
+        checkpointId: 'checkpoint-1',
+        runId: 'run-1',
+        checkpointKind: 'tool_wait',
+        phase: 'awaiting_tool_permission',
+        toolName: 'delete_clip',
+        status: 'recovered',
+        recordedAt: 44,
+      }),
+    ).toEqual({
       checkpointId: 'checkpoint-1',
       runId: 'run-1',
       checkpointKind: 'tool_wait',
@@ -142,18 +190,20 @@ describe('recoveryPersistence', () => {
   });
 
   it('should build normalized compaction trace records', () => {
-    expect(buildCompactionTraceRecord({
-      compactionId: 'compaction-1',
-      runId: 'run-1',
-      tier: 'summary',
-      trigger: 'auto',
-      summary: 'Compacted around delete flow',
-      sourceMessageCount: 12,
-      retainedMessageCount: 4,
-      estimatedTokensSaved: 3200,
-      status: 'persisted',
-      recordedAt: 55,
-    })).toEqual({
+    expect(
+      buildCompactionTraceRecord({
+        compactionId: 'compaction-1',
+        runId: 'run-1',
+        tier: 'summary',
+        trigger: 'auto',
+        summary: 'Compacted around delete flow',
+        sourceMessageCount: 12,
+        retainedMessageCount: 4,
+        estimatedTokensSaved: 3200,
+        status: 'persisted',
+        recordedAt: 55,
+      }),
+    ).toEqual({
       compactionId: 'compaction-1',
       runId: 'run-1',
       tier: 'summary',

--- a/src/agents/engine/core/recoveryPersistence.ts
+++ b/src/agents/engine/core/recoveryPersistence.ts
@@ -4,10 +4,8 @@ import type {
   CompactionTier,
   ResumeCheckpointKind,
 } from './agentSession';
-import type {
-  CheckpointTraceRecord,
-  CompactionTraceRecord,
-} from './traceRecorder';
+import type { Plan } from './types';
+import type { CheckpointTraceRecord, CompactionTraceRecord } from './traceRecorder';
 
 export interface RecoveryCheckpointPayloadInput {
   sessionId: string;
@@ -17,11 +15,16 @@ export interface RecoveryCheckpointPayloadInput {
   phase: string;
   projectId: string;
   sequenceId: string | null;
+  projectStateVersion?: number | null;
   input: string;
   currentPlanId?: string | null;
   pendingApprovalId?: string | null;
   planGoal?: string | null;
   planStepIds?: string[];
+  plan?: Plan | null;
+  nextStepIndex?: number | null;
+  completedStepIds?: string[] | null;
+  toolCallsUsed?: number | null;
   stepId?: string | null;
   toolName?: string | null;
   args?: Record<string, unknown> | null;
@@ -98,6 +101,7 @@ export function buildResumeCheckpointPayload(
     version: 1,
     projectId: input.projectId,
     sequenceId: input.sequenceId,
+    projectStateVersion: input.projectStateVersion ?? null,
     phase: input.phase,
     input: input.input,
     currentPlanId: input.currentPlanId ?? null,
@@ -116,6 +120,7 @@ export function buildResumeCheckpointPayload(
       type: 'plan_approval',
       goal: input.planGoal ?? null,
       stepIds: input.planStepIds ?? [],
+      plan: input.plan ?? null,
     });
   } else if (input.checkpointKind === 'tool_wait') {
     pendingWorkJson = JSON.stringify({
@@ -123,6 +128,10 @@ export function buildResumeCheckpointPayload(
       stepId: input.stepId ?? null,
       toolName: input.toolName ?? null,
       args: input.args ?? null,
+      plan: input.plan ?? null,
+      nextStepIndex: input.nextStepIndex ?? null,
+      completedStepIds: input.completedStepIds ?? null,
+      toolCallsUsed: input.toolCallsUsed ?? null,
     });
   } else if (input.checkpointKind === 'compaction_boundary') {
     pendingWorkJson = JSON.stringify({

--- a/src/components/features/agent/AgentLoopChat.tsx
+++ b/src/components/features/agent/AgentLoopChat.tsx
@@ -53,7 +53,7 @@ export const AgentLoopChat = forwardRef<AgentLoopChatHandle, AgentLoopChatProps>
     const activeSessionId = useConversationStore((state) => state.activeSessionId);
     const sessions = useConversationStore((state) => state.sessions);
 
-    const { handleEvent, handleAbort, reset } = useAgentLoopEventHandler();
+    const { bindSession, handleEvent, handleAbort, reset } = useAgentLoopEventHandler();
 
     const {
       run,
@@ -72,6 +72,7 @@ export const AgentLoopChat = forwardRef<AgentLoopChatHandle, AgentLoopChatProps>
       config,
       context,
       onEvent: handleEvent,
+      onSessionReady: bindSession,
       onComplete: (usage) => {
         onComplete?.(usage);
       },

--- a/src/components/features/agent/AgentRuntimeChatShell.test.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.test.tsx
@@ -297,6 +297,75 @@ describe('AgentRuntimeChatShell', () => {
     expect(screen.getByTestId('chat-input-disabled')).toHaveTextContent('true');
   });
 
+  it('aborts the active run when the user switches projects', async () => {
+    const abort = vi.fn();
+    const loadForProject = vi.fn((projectId: string) => {
+      useConversationStore.setState((state) => ({
+        ...state,
+        activeProjectId: projectId,
+        activeConversation: {
+          id: `draft-${projectId}`,
+          projectId,
+          messages: [],
+          createdAt: 200,
+          updatedAt: 200,
+        },
+      }));
+    });
+
+    act(() => {
+      useMessageQueueStore.getState().enqueue('queued prompt');
+      useConversationStore.setState((state) => ({
+        ...state,
+        loadForProject,
+      }));
+    });
+
+    render(
+      <AgentRuntimeChatShell
+        chatTestId="agent-runtime-shell"
+        executeMessage={vi.fn()}
+        abort={abort}
+        phase="executing"
+        isRunning={true}
+        isEnabled={true}
+        error={null}
+        runtimeSummary={{ startedTools: 1, completedTools: 0, latestIteration: 0 }}
+        plan={null}
+        pendingClarificationQuestion={null}
+        pendingToolPermissionRequest={null}
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRetry={() => {}}
+        onToolAllow={() => {}}
+        onToolAllowAlways={() => {}}
+        onToolDeny={() => {}}
+      />,
+    );
+
+    act(() => {
+      useProjectStore.setState((state) => ({
+        ...state,
+        meta: {
+          ...(state.meta ?? {
+            name: 'Test Project',
+            path: '/tmp/project',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            modifiedAt: '2026-01-01T00:00:00.000Z',
+          }),
+          id: 'project-2',
+        },
+      }));
+    });
+
+    await waitFor(() => {
+      expect(abort).toHaveBeenCalledTimes(1);
+      expect(loadForProject).toHaveBeenCalledWith('project-2');
+    });
+
+    expect(useMessageQueueStore.getState().queue).toHaveLength(0);
+  });
+
   it('clears artifact focus when the active conversation changes', async () => {
     const user = userEvent.setup();
 

--- a/src/components/features/agent/AgentRuntimeChatShell.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.tsx
@@ -135,6 +135,7 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
     const restorePanel = useWorkspaceLayoutStore((state) => state.restorePanel);
     const setActivePanel = useWorkspaceLayoutStore((state) => state.setActivePanel);
     const setZoneCollapsed = useWorkspaceLayoutStore((state) => state.setZoneCollapsed);
+    const previousProjectIdRef = useRef(currentProjectId);
 
     const artifactFocus = useMemo(() => {
       if (!artifactSelection.focus) {
@@ -216,13 +217,29 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
 
     useEffect(() => {
       const targetProjectId = currentProjectId ?? 'default';
+      const previousProjectId = previousProjectIdRef.current;
+      previousProjectIdRef.current = currentProjectId;
+
+      if (previousProjectId && previousProjectId !== currentProjectId && isRunning) {
+        clearQueue();
+        abort();
+      }
+
       if (activeProjectId !== targetProjectId) {
         if (clearQueueOnProjectSwitch) {
           clearQueue();
         }
         loadForProject(targetProjectId);
       }
-    }, [activeProjectId, clearQueue, clearQueueOnProjectSwitch, currentProjectId, loadForProject]);
+    }, [
+      abort,
+      activeProjectId,
+      clearQueue,
+      clearQueueOnProjectSwitch,
+      currentProjectId,
+      isRunning,
+      loadForProject,
+    ]);
 
     const prevIsRunningRef = useRef(isRunning);
     useEffect(() => {

--- a/src/components/features/agent/AgentSessionResumeHistoryPanel.test.tsx
+++ b/src/components/features/agent/AgentSessionResumeHistoryPanel.test.tsx
@@ -1,10 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type {
-  AgentSession,
-  CompactionRecord,
-  ResumeCheckpoint,
-} from '@/agents/engine';
+import type { AgentSession, CompactionRecord, ResumeCheckpoint } from '@/agents/engine';
 import { useConversationStore } from '@/stores/conversationStore';
 import {
   buildAgentSessionRecoveryFingerprint,
@@ -47,9 +43,7 @@ function createSession(overrides: Partial<AgentSession> = {}): AgentSession {
   };
 }
 
-function createCompactionRecord(
-  overrides: Partial<CompactionRecord> = {},
-): CompactionRecord {
+function createCompactionRecord(overrides: Partial<CompactionRecord> = {}): CompactionRecord {
   return {
     id: 'compaction-1',
     sessionId: 'session-1',
@@ -67,9 +61,7 @@ function createCompactionRecord(
   };
 }
 
-function createResumeCheckpoint(
-  overrides: Partial<ResumeCheckpoint> = {},
-): ResumeCheckpoint {
+function createResumeCheckpoint(overrides: Partial<ResumeCheckpoint> = {}): ResumeCheckpoint {
   return {
     id: 'checkpoint-1',
     sessionId: 'session-1',
@@ -107,8 +99,12 @@ function seedSessionKernel(input?: {
   compactions?: CompactionRecord[];
   checkpoints?: ResumeCheckpoint[];
   artifactsLastError?: string | null;
-  activeIssues?: ReturnType<typeof useAgentSessionStore.getState>['persistenceIssuesBySessionId'][string];
-  latchedIssues?: ReturnType<typeof useAgentSessionStore.getState>['persistenceLatchesBySessionId'][string];
+  activeIssues?: ReturnType<
+    typeof useAgentSessionStore.getState
+  >['persistenceIssuesBySessionId'][string];
+  latchedIssues?: ReturnType<
+    typeof useAgentSessionStore.getState
+  >['persistenceLatchesBySessionId'][string];
 }): AgentSession {
   const session = createSession(input?.sessionOverrides);
   const headerFingerprint = buildAgentSessionRecoveryFingerprint(session);
@@ -130,9 +126,7 @@ function seedSessionKernel(input?: {
         lastError: input?.artifactsLastError ?? null,
       },
     },
-    persistenceIssuesBySessionId: input?.activeIssues
-      ? { [session.id]: input.activeIssues }
-      : {},
+    persistenceIssuesBySessionId: input?.activeIssues ? { [session.id]: input.activeIssues } : {},
     persistenceLatchesBySessionId: input?.latchedIssues
       ? { [session.id]: input.latchedIssues }
       : {},
@@ -211,9 +205,7 @@ describe('AgentSessionResumeHistoryPanel', () => {
         /recovery will rebuild visible context from that summary instead of a linked checkpoint/i,
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/persisted recovery history refresh is partial/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/persisted recovery history refresh is partial/i)).toBeInTheDocument();
   });
 
   it('should render a cold conversation-log path when no durable boundary exists', () => {
@@ -224,6 +216,24 @@ describe('AgentSessionResumeHistoryPanel', () => {
     expect(screen.getByText('Cold')).toBeInTheDocument();
     expect(screen.getByText('Conversation log replay')).toBeInTheDocument();
     expect(screen.getByText('0 persisted checkpoints')).toBeInTheDocument();
+    expect(screen.getByText('0 persisted compactions')).toBeInTheDocument();
+  });
+
+  it('should stay cold when only header metadata hints at compaction but no persisted summary rows are loaded', () => {
+    seedSessionKernel({
+      sessionOverrides: {
+        latestSummaryMessageId: 'summary-1',
+        compactionVersion: 1,
+        lastCompactedAt: 700,
+      },
+      artifactsLastError: 'Failed to load compaction history: backend offline',
+    });
+
+    render(<AgentSessionResumeHistoryPanel />);
+
+    expect(screen.getByText('Cold')).toBeInTheDocument();
+    expect(screen.getByText('Conversation log replay')).toBeInTheDocument();
+    expect(screen.getByText(/persisted recovery history refresh is partial/i)).toBeInTheDocument();
     expect(screen.getByText('0 persisted compactions')).toBeInTheDocument();
   });
 

--- a/src/components/features/agent/AgenticChat.tsx
+++ b/src/components/features/agent/AgenticChat.tsx
@@ -32,6 +32,8 @@ export interface AgenticChatProps {
   onComplete?: UseAgenticLoopOptions['onComplete'];
   /** Called on error */
   onError?: UseAgenticLoopOptions['onError'];
+  /** Called when the active run is aborted */
+  onAbort?: UseAgenticLoopOptions['onAbort'];
   /** Placeholder text for input */
   placeholder?: string;
   /** Whether the chat is disabled */
@@ -66,6 +68,7 @@ export const AgenticChat = forwardRef<AgenticChatHandle, AgenticChatProps>(funct
     onSubmit,
     onComplete,
     onError,
+    onAbort,
     placeholder = 'Ask the AI to edit your video...',
     disabled = false,
     currentAgentName = 'Editor',
@@ -108,6 +111,9 @@ export const AgenticChat = forwardRef<AgenticChatHandle, AgenticChatProps>(funct
     onError: (err) => {
       addSystemMessage(`Error: ${err.message}`);
       onError?.(err);
+    },
+    onAbort: () => {
+      onAbort?.();
     },
     onApprovalRequired: () => {
       // Approval is handled through part renderers

--- a/src/components/features/agent/AgenticSidebarContent.test.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.test.tsx
@@ -600,6 +600,127 @@ describe('AgenticSidebarContent', () => {
     );
   });
 
+  it('marks an active child delegation as cancelled when the run aborts', async () => {
+    const updateDelegationRecord = vi.fn().mockResolvedValue({});
+
+    useConversationStore.setState((state) => ({
+      ...state,
+      activeSessionId: 'session-child',
+      activeConversation: {
+        id: 'session-child',
+        projectId: 'project-1',
+        messages: [
+          {
+            id: 'assistant-msg-cancel',
+            role: 'assistant',
+            parts: [{ type: 'text', content: 'Partial pacing analysis.' }],
+            timestamp: 2,
+          },
+        ],
+        createdAt: 2,
+        updatedAt: 2,
+      },
+      sessions: [
+        ...state.sessions,
+        {
+          id: 'session-child',
+          projectId: 'project-1',
+          title: 'Planner Session',
+          agent: 'planner',
+          modelProvider: null,
+          modelId: null,
+          createdAt: 2,
+          updatedAt: 2,
+          archived: false,
+          messageCount: 1,
+          lastMessagePreview: 'Partial pacing analysis.',
+        },
+      ],
+    }));
+    useAgentSessionStore.setState((state) => ({
+      ...state,
+      snapshotsById: {
+        ...state.snapshotsById,
+        'session-child': {
+          session: {
+            id: 'session-child',
+            projectId: 'project-1',
+            sequenceId: null,
+            title: 'Planner Session',
+            status: 'idle',
+            runtimeKind: 'subagent',
+            agentProfileId: 'planner',
+            sessionMode: 'child',
+            lineage: {
+              parentSessionId: 'session-1',
+              branchFromSessionId: null,
+              rootSessionId: 'session-1',
+            },
+            currentRunId: 'run-child',
+            currentPlanId: null,
+            pendingApprovalId: null,
+            activeCheckpointId: null,
+            permissionStateVersion: 0,
+            compactionVersion: 0,
+            resumeCursorVersion: 0,
+            latestSummaryMessageId: null,
+            lastCompactedAt: null,
+            lastResumedAt: null,
+            modelProvider: null,
+            modelId: null,
+            createdAt: 2,
+            updatedAt: 2,
+            completedAt: null,
+          },
+          runs: [],
+        },
+      },
+      activeSessionId: 'session-child',
+    }));
+    useAgentDelegationStore.setState((state) => ({
+      ...state,
+      recordsBySessionId: {
+        'session-child': [
+          {
+            id: 'delegation-1',
+            parentSessionId: 'session-1',
+            childSessionId: 'session-child',
+            parentRunId: 'run-parent',
+            agentProfileId: 'planner',
+            delegatedGoal: 'Review pacing',
+            contextPacketJson: '{}',
+            allowedToolsDeltaJson: null,
+            permissionSnapshotJson: null,
+            status: 'running',
+            mergeStatus: 'pending',
+            summaryMessageId: null,
+            resultJson: null,
+            errorMessage: null,
+            createdAt: 2,
+            updatedAt: 2,
+            completedAt: null,
+          },
+        ],
+      },
+      updateDelegationRecord,
+    }));
+
+    render(<AgenticSidebarContent />);
+
+    await act(async () => {
+      await (latestAgenticChatProps as { onAbort?: () => void }).onAbort?.();
+    });
+
+    expect(updateDelegationRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'delegation-1',
+        status: 'cancelled',
+        summaryMessageId: 'assistant-msg-cancel',
+        errorMessage: 'Cancelled by user.',
+      }),
+    );
+  });
+
   it('opens agent review for a delegated child result from the parent session', async () => {
     const user = userEvent.setup();
 

--- a/src/components/features/agent/AgenticSidebarContent.test.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.test.tsx
@@ -10,6 +10,8 @@ import { useAgentSessionStore } from '@/stores/agentSessionStore';
 import { useAgentDelegationStore } from '@/stores/agentDelegationStore';
 import { createDefaultLayout, useWorkspaceLayoutStore } from '@/stores/workspaceLayoutStore';
 import { loadProjectPromptContext } from '@/agents/engine/core/projectPromptContext';
+import { createToolRegistryAdapter } from '@/agents/engine/adapters/tools/ToolRegistryAdapter';
+import { createBackendToolExecutor } from '@/agents/engine/adapters/tools/BackendToolExecutor';
 import { AgenticSidebarContent } from './AgenticSidebarContent';
 
 let latestSessionListProps: Record<string, unknown> | null = null;
@@ -286,6 +288,22 @@ describe('AgenticSidebarContent', () => {
       screen.getByText('Enable `USE_AGENTIC_ENGINE` to restore the canonical TPAO runtime.'),
     ).toBeInTheDocument();
     expect(screen.queryByTestId('agentic-chat')).not.toBeInTheDocument();
+  });
+
+  it('reacts to backend tool flag changes without remounting the sidebar', async () => {
+    setFeatureFlag('USE_BACKEND_TOOLS', false);
+
+    render(<AgenticSidebarContent />);
+
+    expect(createToolRegistryAdapter).toHaveBeenCalledTimes(1);
+    expect(createBackendToolExecutor).not.toHaveBeenCalled();
+
+    await act(async () => {
+      setFeatureFlag('USE_BACKEND_TOOLS', true);
+    });
+
+    expect(createToolRegistryAdapter).toHaveBeenCalledTimes(2);
+    expect(createBackendToolExecutor).toHaveBeenCalledTimes(1);
   });
 
   it('shows a transition state while a new session is starting', async () => {

--- a/src/components/features/agent/AgenticSidebarContent.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.tsx
@@ -31,7 +31,7 @@ import {
   loadProjectPromptContext,
   type ProjectPromptContext,
 } from '@/agents/engine/core/projectPromptContext';
-import { resolveSidebarRuntimePolicy, isBackendToolsEnabled } from '@/config/featureFlags';
+import { useFeatureFlag, useSidebarRuntimePolicy } from '@/config/featureFlags';
 import { useConversationStore, useProjectStore } from '@/stores';
 import { useAgentArtifactReviewStore } from '@/stores/agentArtifactReviewStore';
 import { useAgentSessionStore } from '@/stores/agentSessionStore';
@@ -129,6 +129,8 @@ export function AgenticSidebarContent({
   // Adapters
   // ===========================================================================
 
+  const backendToolsEnabled = useFeatureFlag('USE_BACKEND_TOOLS');
+
   const llmClient = useMemo(() => {
     logger.info('Creating TauriLLMAdapter');
     return createTauriLLMAdapter();
@@ -136,20 +138,20 @@ export function AgenticSidebarContent({
 
   const toolExecutor = useMemo(() => {
     const frontend = createToolRegistryAdapter(globalToolRegistry);
-    if (isBackendToolsEnabled()) {
+    if (backendToolsEnabled) {
       logger.info('Creating BackendToolExecutor (editing tools → backend IPC)');
       return createBackendToolExecutor(frontend);
     }
     logger.info('Creating ToolRegistryAdapter (all tools → frontend)');
     return frontend;
-  }, []);
+  }, [backendToolsEnabled]);
 
   // ===========================================================================
   // Chat Handle Ref (for abort/isRunning access)
   // ===========================================================================
 
   const chatHandleRef = useRef<AgentRuntimeChatHandle>(null);
-  const runtimePolicy = resolveSidebarRuntimePolicy();
+  const runtimePolicy = useSidebarRuntimePolicy();
   const currentProjectId = useProjectStore((state) => state.meta?.id ?? null);
   const currentProjectPath = useProjectStore((state) => state.meta?.path ?? null);
   const activeSessionId = useConversationStore((state) => state.activeSessionId);

--- a/src/components/features/agent/AgenticSidebarContent.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.tsx
@@ -154,6 +154,7 @@ export function AgenticSidebarContent({
   const runtimePolicy = useSidebarRuntimePolicy();
   const currentProjectId = useProjectStore((state) => state.meta?.id ?? null);
   const currentProjectPath = useProjectStore((state) => state.meta?.path ?? null);
+  const previousProjectIdRef = useRef<string | null>(currentProjectId);
   const activeSessionId = useConversationStore((state) => state.activeSessionId);
   const sessions = useConversationStore((state) => state.sessions);
   const activeConversationMessages = useConversationStore(
@@ -166,6 +167,7 @@ export function AgenticSidebarContent({
   const getLastUserInput = useConversationStore((state) => state.getLastUserInput);
   const clearQueuedMessages = useMessageQueueStore((state) => state.clear);
   const setArtifactReviewSelection = useAgentArtifactReviewStore((state) => state.setSelection);
+  const clearArtifactReviewSelection = useAgentArtifactReviewStore((state) => state.clearSelection);
   const restorePanel = useWorkspaceLayoutStore((state) => state.restorePanel);
   const setActivePanel = useWorkspaceLayoutStore((state) => state.setActivePanel);
   const setZoneCollapsed = useWorkspaceLayoutStore((state) => state.setZoneCollapsed);
@@ -205,6 +207,21 @@ export function AgenticSidebarContent({
     clearQueuedMessages();
     chatHandleRef.current?.abort();
   }, [clearQueuedMessages]);
+
+  useEffect(() => {
+    const previousProjectId = previousProjectIdRef.current;
+    previousProjectIdRef.current = currentProjectId;
+
+    if (!previousProjectId || previousProjectId === currentProjectId) {
+      return;
+    }
+
+    abortCurrentSession();
+    clearArtifactReviewSelection();
+    setChatSurfaceKey((prev) => prev + 1);
+    setIsSessionTransitionPending(false);
+    setSessionTransitionLabel(null);
+  }, [abortCurrentSession, clearArtifactReviewSelection, currentProjectId]);
 
   const runSessionTransition = useCallback(
     async (label: 'new' | 'switch' | 'delegate', action: () => Promise<unknown>) => {
@@ -552,11 +569,16 @@ export function AgenticSidebarContent({
         (activeDelegationRecord.status === 'requested' ||
           activeDelegationRecord.status === 'running')
       ) {
-        const resultPayload = buildDelegationResultPayload(result, activeConversationMessages);
+        const liveMessages =
+          useConversationStore.getState().activeConversation?.id ===
+          activeDelegationRecord.childSessionId
+            ? (useConversationStore.getState().activeConversation?.messages ?? EMPTY_MESSAGES)
+            : activeConversationMessages;
+        const resultPayload = buildDelegationResultPayload(result, liveMessages);
         void updateDelegationRecord({
           id: activeDelegationRecord.id,
           status: 'completed',
-          summaryMessageId: resolveDelegationSummaryMessageId(activeConversationMessages),
+          summaryMessageId: resolveDelegationSummaryMessageId(liveMessages),
           resultJson: JSON.stringify(resultPayload),
           completedAt: Date.now(),
         }).catch((error) => {
@@ -571,6 +593,34 @@ export function AgenticSidebarContent({
     [activeConversationMessages, activeDelegationRecord, onSessionComplete, updateDelegationRecord],
   );
 
+  const handleAbort = useCallback(() => {
+    if (
+      !activeDelegationRecord ||
+      (activeDelegationRecord.status !== 'requested' && activeDelegationRecord.status !== 'running')
+    ) {
+      return;
+    }
+
+    const liveMessages =
+      useConversationStore.getState().activeConversation?.id ===
+      activeDelegationRecord.childSessionId
+        ? (useConversationStore.getState().activeConversation?.messages ?? EMPTY_MESSAGES)
+        : activeConversationMessages;
+
+    void updateDelegationRecord({
+      id: activeDelegationRecord.id,
+      status: 'cancelled',
+      summaryMessageId: resolveDelegationSummaryMessageId(liveMessages),
+      errorMessage: 'Cancelled by user.',
+      completedAt: Date.now(),
+    }).catch((error) => {
+      logger.warn('Failed to mark delegation cancelled', {
+        delegationId: activeDelegationRecord.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, [activeConversationMessages, activeDelegationRecord, updateDelegationRecord]);
+
   const handleError = useCallback(
     (error: Error) => {
       logger.error('Agentic session error', { error: error.message });
@@ -579,10 +629,15 @@ export function AgenticSidebarContent({
         (activeDelegationRecord.status === 'requested' ||
           activeDelegationRecord.status === 'running')
       ) {
+        const liveMessages =
+          useConversationStore.getState().activeConversation?.id ===
+          activeDelegationRecord.childSessionId
+            ? (useConversationStore.getState().activeConversation?.messages ?? EMPTY_MESSAGES)
+            : activeConversationMessages;
         void updateDelegationRecord({
           id: activeDelegationRecord.id,
           status: 'failed',
-          summaryMessageId: resolveDelegationSummaryMessageId(activeConversationMessages),
+          summaryMessageId: resolveDelegationSummaryMessageId(liveMessages),
           resultJson: JSON.stringify({
             success: false,
             aborted: false,
@@ -722,6 +777,7 @@ export function AgenticSidebarContent({
             config={chatPromptConfig}
             onSubmit={handleSubmit}
             onComplete={handleComplete}
+            onAbort={handleAbort}
             onError={handleError}
             placeholder={promptPlaceholder}
             disabled={isSessionTransitionPending}

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from 'react';
+
 /**
  * Feature Flags System
  *
@@ -97,6 +99,8 @@ export interface AgentSidebarRuntimePolicy {
  * localStorage key for storing feature flag overrides
  */
 const STORAGE_KEY = 'openreelio-feature-flags';
+const featureFlagListeners = new Set<() => void>();
+let cachedFeatureFlagsSnapshot: FeatureFlags | null = null;
 
 /**
  * Default values for all feature flags
@@ -177,6 +181,26 @@ function saveOverrides(overrides: Partial<FeatureFlags>): void {
   } catch {
     // localStorage full or other error - silently ignore
   }
+}
+
+function notifyFeatureFlagListeners(): void {
+  for (const listener of featureFlagListeners) {
+    listener();
+  }
+}
+
+function readFeatureFlagsSnapshot(): FeatureFlags {
+  const nextSnapshot = getAllFeatureFlags();
+
+  if (
+    cachedFeatureFlagsSnapshot &&
+    FEATURE_FLAG_KEYS.every((key) => cachedFeatureFlagsSnapshot?.[key] === nextSnapshot[key])
+  ) {
+    return cachedFeatureFlagsSnapshot;
+  }
+
+  cachedFeatureFlagsSnapshot = nextSnapshot;
+  return nextSnapshot;
 }
 
 /**
@@ -265,6 +289,7 @@ export function setFeatureFlag(flag: FeatureFlagKey, value: boolean): void {
   const overrides = getStoredOverrides();
   overrides[flag] = value;
   saveOverrides(overrides);
+  notifyFeatureFlagListeners();
 }
 
 /**
@@ -286,9 +311,52 @@ export function resetFeatureFlags(): void {
 
   try {
     localStorage.removeItem(STORAGE_KEY);
+    notifyFeatureFlagListeners();
   } catch {
     // Silently ignore errors
   }
+}
+
+export function subscribeFeatureFlags(listener: () => void): () => void {
+  featureFlagListeners.add(listener);
+  return () => {
+    featureFlagListeners.delete(listener);
+  };
+}
+
+export function useFeatureFlag(flag: FeatureFlagKey): boolean {
+  return useSyncExternalStore(
+    subscribeFeatureFlags,
+    () => getFeatureFlag(flag),
+    () => DEFAULT_FLAGS[flag],
+  );
+}
+
+export function useFeatureFlags(): FeatureFlags {
+  return useSyncExternalStore(subscribeFeatureFlags, readFeatureFlagsSnapshot, () => DEFAULT_FLAGS);
+}
+
+export function useSidebarRuntimePolicy(): AgentSidebarRuntimePolicy {
+  const flags = useFeatureFlags();
+  const compatibilityRuntimeEnabled = flags.USE_AGENT_LOOP;
+
+  if (flags.USE_AGENTIC_ENGINE) {
+    return {
+      canonicalRuntime: 'tpao',
+      selectedRuntime: 'tpao',
+      track: 'canonical',
+      compatibilityRuntime: compatibilityRuntimeEnabled ? 'fast' : null,
+      compatibilityRuntimeEnabled,
+    };
+  }
+
+  return {
+    canonicalRuntime: 'tpao',
+    selectedRuntime: 'disabled',
+    track: 'disabled',
+    compatibilityRuntime: compatibilityRuntimeEnabled ? 'fast' : null,
+    compatibilityRuntimeEnabled,
+  };
 }
 
 /**

--- a/src/hooks/agentRuntimePersistence.ts
+++ b/src/hooks/agentRuntimePersistence.ts
@@ -1,9 +1,11 @@
 import type {
   AgentContext,
+  AgentRunTrigger,
   AgentRunPhase,
   AgentRuntimeKind,
   CompactionRecord,
   ILLMClient,
+  Plan,
   ResumeCheckpoint,
   ShippingAgentRuntimeKind,
 } from '@/agents/engine';
@@ -47,6 +49,7 @@ type RecoveryBootstrapBoundary =
       boundaryId: string;
       message: string;
       kind: 'checkpoint';
+      checkpoint: ResumeCheckpoint;
       traceRecord: CheckpointTraceRecord;
     }
   | {
@@ -55,6 +58,27 @@ type RecoveryBootstrapBoundary =
       kind: 'summary';
       traceRecord: CompactionTraceRecord;
     };
+
+export interface RecoveredApprovalResume {
+  kind: 'approval_wait';
+  checkpointId: string;
+  runId: string | null;
+  input: string;
+  plan: Plan;
+}
+
+export interface RecoveredToolWaitResume {
+  kind: 'tool_wait';
+  checkpointId: string;
+  runId: string | null;
+  input: string;
+  plan: Plan;
+  stepId: string;
+  toolName: string | null;
+  projectStateVersion: number;
+}
+
+export type RecoveredExecutableResume = RecoveredApprovalResume | RecoveredToolWaitResume;
 
 export async function ensureConfiguredProvider(
   llmClient: ILLMClient,
@@ -246,6 +270,7 @@ export async function bootstrapPersistedAgentSession(input: {
 export async function startPersistedRun(input: {
   sessionId: string;
   runtimeKind: AgentRuntimeKind;
+  trigger?: AgentRunTrigger;
   maxIterations?: number;
   maxToolCalls?: number;
   traceId?: string | null;
@@ -259,6 +284,7 @@ export async function startPersistedRun(input: {
   const {
     sessionId,
     runtimeKind,
+    trigger = 'user',
     maxIterations,
     maxToolCalls,
     traceId,
@@ -274,7 +300,7 @@ export async function startPersistedRun(input: {
     const persistedRun = await useAgentSessionStore.getState().startRun({
       sessionId,
       runtimeKind,
-      trigger: 'user',
+      trigger,
       maxIterations,
       maxToolCalls,
       traceId,
@@ -366,7 +392,7 @@ export async function bootstrapRecoveredContextFromCheckpoint(input: {
   lastBootstrappedCheckpointIdRef: CheckpointIdRef;
   onCheckpointRecovered?: (record: CheckpointTraceRecord) => void;
   onCompactionRecovered?: (record: CompactionTraceRecord) => void;
-}): Promise<void> {
+}): Promise<RecoveredExecutableResume | null> {
   const {
     sessionId,
     addSystemMessage,
@@ -380,7 +406,7 @@ export async function bootstrapRecoveredContextFromCheckpoint(input: {
   const session = agentSessionStore.snapshotsById[sessionId]?.session;
 
   if (!session) {
-    return;
+    return null;
   }
 
   try {
@@ -392,7 +418,7 @@ export async function bootstrapRecoveredContextFromCheckpoint(input: {
       sessionId,
       error: error instanceof Error ? error.message : String(error),
     });
-    return;
+    return null;
   }
 
   const refreshedSession = useAgentSessionStore.getState().snapshotsById[sessionId]?.session;
@@ -405,12 +431,16 @@ export async function bootstrapRecoveredContextFromCheckpoint(input: {
     checkpoints,
     compactions,
   );
+  const recoveredExecutableResume =
+    bootstrapBoundary?.kind === 'checkpoint'
+      ? resolveRecoveredExecutableResume(bootstrapBoundary.checkpoint)
+      : null;
 
   if (
     !bootstrapBoundary ||
     bootstrapBoundary.boundaryId === lastBootstrappedCheckpointIdRef.current
   ) {
-    return;
+    return recoveredExecutableResume;
   }
 
   addSystemMessage(bootstrapBoundary.message);
@@ -420,6 +450,7 @@ export async function bootstrapRecoveredContextFromCheckpoint(input: {
     onCompactionRecovered?.(bootstrapBoundary.traceRecord);
   }
   lastBootstrappedCheckpointIdRef.current = bootstrapBoundary.boundaryId;
+  return recoveredExecutableResume;
 }
 
 export function getPersistedSessionTraceState(sessionId: string): {
@@ -466,6 +497,7 @@ function resolveRecoveryBootstrapBoundary(
     return {
       boundaryId: `checkpoint:${activeCheckpoint.id}`,
       kind: 'checkpoint',
+      checkpoint: activeCheckpoint,
       message,
       traceRecord: buildResumeCheckpointTraceRecord({
         checkpointId: activeCheckpoint.id,
@@ -557,7 +589,11 @@ function buildRecoveredCheckpointMessage(checkpoint: ResumeCheckpoint): string |
     const toolName = stringValue(pendingWork?.toolName) ?? stringValue(resumeCursor?.toolName);
     lines.push(`- Pending tool permission: ${toolName ?? 'unknown tool'}`);
   } else if (pendingType === 'plan_approval') {
-    lines.push('- Pending plan approval was recovered into visible context.');
+    lines.push(
+      planValue(pendingWork?.plan)
+        ? '- Pending plan approval can resume execution after approval.'
+        : '- Pending plan approval was recovered into visible context.',
+    );
   } else if (pendingType === 'compaction_resume') {
     lines.push('- Recovered compaction boundary for context rebuild.');
   }
@@ -568,7 +604,9 @@ function buildRecoveredCheckpointMessage(checkpoint: ResumeCheckpoint): string |
   }
 
   lines.push(
-    'Use this recovered context when continuing the conversation. Execution did not automatically resume.',
+    planValue(pendingWork?.plan)
+      ? 'Use this recovered context when continuing the conversation. Execution can resume from this approval checkpoint after you confirm the recovered plan.'
+      : 'Use this recovered context when continuing the conversation. Execution did not automatically resume.',
   );
 
   return lines.join('\n');
@@ -634,6 +672,110 @@ function parseJson<T>(raw: string | null, fallback: T | null = null): T | null {
 
 function stringValue(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function planValue(value: unknown): Plan | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Partial<Plan>;
+  if (
+    typeof candidate.goal !== 'string' ||
+    !Array.isArray(candidate.steps) ||
+    typeof candidate.estimatedTotalDuration !== 'number' ||
+    typeof candidate.requiresApproval !== 'boolean' ||
+    typeof candidate.rollbackStrategy !== 'string'
+  ) {
+    return null;
+  }
+
+  return candidate as Plan;
+}
+
+function resolveRecoveredExecutableResume(
+  checkpoint: ResumeCheckpoint,
+): RecoveredExecutableResume | null {
+  if (checkpoint.checkpointKind === 'approval_wait') {
+    return resolveRecoveredApprovalResume(checkpoint);
+  }
+
+  if (checkpoint.checkpointKind === 'tool_wait') {
+    return resolveRecoveredToolWaitResume(checkpoint);
+  }
+
+  return null;
+}
+
+function resolveRecoveredApprovalResume(
+  checkpoint: ResumeCheckpoint,
+): RecoveredApprovalResume | null {
+  if (checkpoint.checkpointKind !== 'approval_wait') {
+    return null;
+  }
+
+  const sessionState = parseJson<Record<string, unknown>>(checkpoint.sessionStateJson);
+  const pendingWork = parseJson<Record<string, unknown> | null>(checkpoint.pendingWorkJson, null);
+  const plan = planValue(pendingWork?.plan);
+  const input = stringValue(sessionState?.input);
+
+  if (!plan || !plan.requiresApproval || !input) {
+    return null;
+  }
+
+  return {
+    kind: 'approval_wait',
+    checkpointId: checkpoint.id,
+    runId: checkpoint.runId,
+    input,
+    plan,
+  };
+}
+
+function resolveRecoveredToolWaitResume(
+  checkpoint: ResumeCheckpoint,
+): RecoveredToolWaitResume | null {
+  if (checkpoint.checkpointKind !== 'tool_wait') {
+    return null;
+  }
+
+  const resumeCursor = parseJson<Record<string, unknown>>(checkpoint.resumeCursorJson);
+  const sessionState = parseJson<Record<string, unknown>>(checkpoint.sessionStateJson);
+  const pendingWork = parseJson<Record<string, unknown> | null>(checkpoint.pendingWorkJson, null);
+  const plan = planValue(pendingWork?.plan);
+  const input = stringValue(sessionState?.input);
+  const stepId = stringValue(pendingWork?.stepId) ?? stringValue(resumeCursor?.stepId);
+  const toolName = stringValue(pendingWork?.toolName) ?? stringValue(resumeCursor?.toolName);
+  const nextStepIndex = numberValue(pendingWork?.nextStepIndex);
+  const toolCallsUsed = numberValue(pendingWork?.toolCallsUsed);
+  const projectStateVersion = numberValue(sessionState?.projectStateVersion);
+  const completedStepIds = Array.isArray(pendingWork?.completedStepIds)
+    ? pendingWork.completedStepIds.filter((value): value is string => typeof value === 'string')
+    : null;
+
+  if (
+    !plan ||
+    !input ||
+    !stepId ||
+    nextStepIndex !== 0 ||
+    toolCallsUsed !== 0 ||
+    projectStateVersion === null ||
+    !completedStepIds ||
+    completedStepIds.length > 0
+  ) {
+    return null;
+  }
+
+  return {
+    kind: 'tool_wait',
+    checkpointId: checkpoint.id,
+    runId: checkpoint.runId,
+    input,
+    plan,
+    stepId,
+    toolName,
+    projectStateVersion,
+  };
 }
 
 function numberValue(value: unknown): number | null {

--- a/src/hooks/useAgentLoop.ts
+++ b/src/hooks/useAgentLoop.ts
@@ -76,6 +76,8 @@ export interface UseAgentLoopOptions {
 
   /** Called for each event from the loop */
   onEvent?: (event: AgentLoopEvent) => void;
+  /** Called once the run is bound to a persisted conversation session */
+  onSessionReady?: (sessionId: string) => void;
   /** Called when the loop completes */
   onComplete?: (usage?: TokenUsage) => void;
   /** Called on error */
@@ -225,6 +227,7 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
         runGuardRef.current = false;
         return;
       }
+      optionsRef.current.onSessionReady?.(storeSessionId);
 
       const projectId = store.activeProjectId ?? context.projectId;
       const agentSessionStore = useAgentSessionStore.getState();

--- a/src/hooks/useAgentLoopEventHandler.test.ts
+++ b/src/hooks/useAgentLoopEventHandler.test.ts
@@ -110,4 +110,51 @@ describe('useAgentLoopEventHandler', () => {
     ]);
     expect(state.isGenerating).toBe(false);
   });
+
+  it('should preserve the tool risk level for tool-call parts', () => {
+    const { result } = renderHook(() => useAgentLoopEventHandler());
+
+    act(() => {
+      result.current.handleEvent({
+        type: 'tool_call_start',
+        id: 'tool-call-1',
+        name: 'delete_clip',
+        args: { clipId: 'clip-1' },
+        riskLevel: 'high',
+      });
+    });
+
+    const message = useConversationStore.getState().activeConversation?.messages[0];
+    expect(message?.parts[0]).toMatchObject({
+      type: 'tool_call',
+      tool: 'delete_clip',
+      riskLevel: 'high',
+      status: 'running',
+    });
+  });
+
+  it('should drop stale events after the handler is bound to a different session', () => {
+    const { result } = renderHook(() => useAgentLoopEventHandler());
+
+    act(() => {
+      result.current.bindSession('session-1');
+      useConversationStore.setState((state) => ({
+        ...state,
+        activeSessionId: 'session-2',
+        activeConversation: {
+          id: 'conv-2',
+          projectId: 'project-1',
+          messages: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      }));
+      result.current.handleEvent({
+        type: 'text_delta',
+        content: 'late output',
+      });
+    });
+
+    expect(useConversationStore.getState().activeConversation?.messages).toHaveLength(0);
+  });
 });

--- a/src/hooks/useAgentLoopEventHandler.ts
+++ b/src/hooks/useAgentLoopEventHandler.ts
@@ -22,14 +22,19 @@ export function useAgentLoopEventHandler() {
   const messageIdRef = useRef<string | null>(null);
   const boundSessionIdRef = useRef<string | null>(null);
 
+  const bindSession = useCallback((sessionId: string | null): void => {
+    messageIdRef.current = null;
+    boundSessionIdRef.current = sessionId;
+  }, []);
+
   const getBoundMessageId = useCallback((): string | null => {
     const store = useConversationStore.getState();
     const activeSessionId = store.activeSessionId ?? null;
 
     if (
-      boundSessionIdRef.current
-      && activeSessionId
-      && activeSessionId !== boundSessionIdRef.current
+      boundSessionIdRef.current &&
+      activeSessionId &&
+      activeSessionId !== boundSessionIdRef.current
     ) {
       return null;
     }
@@ -43,11 +48,7 @@ export function useAgentLoopEventHandler() {
   }, []);
 
   const updateTrailingPart = useCallback(
-    (
-      messageId: string,
-      type: 'text' | 'reasoning',
-      appendContent: string,
-    ): void => {
+    (messageId: string, type: 'text' | 'reasoning', appendContent: string): void => {
       const store = useConversationStore.getState();
       const message = store.activeConversation?.messages.find((entry) => entry.id === messageId);
       if (!message) {
@@ -87,7 +88,8 @@ export function useAgentLoopEventHandler() {
       }
 
       const approvalIndex = message.parts.findIndex(
-        (part) => part.type === 'tool_approval' && part.stepId === stepId && part.status === 'pending',
+        (part) =>
+          part.type === 'tool_approval' && part.stepId === stepId && part.status === 'pending',
       );
       if (approvalIndex < 0) {
         return;
@@ -144,17 +146,21 @@ export function useAgentLoopEventHandler() {
             tool: event.name,
             args: event.args,
             description: `Execute ${event.name}`,
-            riskLevel: 'low',
+            riskLevel: event.riskLevel,
             status: 'running',
             startedAt: Date.now(),
           });
           break;
 
         case 'tool_call_complete': {
-          const message = store.activeConversation?.messages.find((entry) => entry.id === messageId);
-          const callIndex = message?.parts.findIndex(
-            (part) => part.type === 'tool_call' && part.stepId === event.id && part.status === 'running',
-          ) ?? -1;
+          const message = store.activeConversation?.messages.find(
+            (entry) => entry.id === messageId,
+          );
+          const callIndex =
+            message?.parts.findIndex(
+              (part) =>
+                part.type === 'tool_call' && part.stepId === event.id && part.status === 'running',
+            ) ?? -1;
 
           if (callIndex >= 0) {
             store.updatePart(messageId, callIndex, {
@@ -226,9 +232,12 @@ export function useAgentLoopEventHandler() {
     [finalizeBoundMessage, getBoundMessageId, updateToolApprovalStatus, updateTrailingPart],
   );
 
-  const handleAbort = useCallback((reason = 'Session aborted by user'): void => {
-    finalizeBoundMessage(reason);
-  }, [finalizeBoundMessage]);
+  const handleAbort = useCallback(
+    (reason = 'Session aborted by user'): void => {
+      finalizeBoundMessage(reason);
+    },
+    [finalizeBoundMessage],
+  );
 
   const reset = useCallback((): void => {
     messageIdRef.current = null;
@@ -236,6 +245,7 @@ export function useAgentLoopEventHandler() {
   }, []);
 
   return {
+    bindSession,
     handleEvent,
     handleAbort,
     reset,

--- a/src/hooks/useAgenticLoop.test.ts
+++ b/src/hooks/useAgenticLoop.test.ts
@@ -134,6 +134,56 @@ function createPersistedRecoveryCheckpoint(overrides: Record<string, unknown> = 
   };
 }
 
+function createPersistedToolWaitCheckpoint(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'checkpoint-recovery-tool-1',
+    sessionId: 'conversation-session-1',
+    runId: 'run-previous',
+    checkpointKind: 'tool_wait',
+    status: 'active',
+    resumeCursorJson: JSON.stringify({
+      checkpointKind: 'tool_wait',
+      phase: 'awaiting_tool_permission',
+      stepId: 'step-1',
+      toolName: 'delete_clip',
+    }),
+    sessionStateJson: JSON.stringify({
+      phase: 'awaiting_tool_permission',
+      input: 'Delete the intro clip',
+      planGoal: 'Delete the intro clip safely',
+      projectStateVersion: 7,
+    }),
+    pendingWorkJson: JSON.stringify({
+      type: 'tool_permission',
+      stepId: 'step-1',
+      toolName: 'delete_clip',
+      args: { clipId: 'clip-1' },
+      plan: {
+        goal: 'Delete the intro clip safely',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'delete_clip',
+            args: { clipId: 'clip-1' },
+            description: 'Delete the intro clip from the timeline',
+            riskLevel: 'high',
+            estimatedDuration: 75,
+          },
+        ],
+        estimatedTotalDuration: 75,
+        requiresApproval: false,
+        rollbackStrategy: 'Restore the deleted clip from undo history.',
+      },
+      nextStepIndex: 0,
+      completedStepIds: [],
+      toolCallsUsed: 0,
+    }),
+    createdAt: 97,
+    consumedAt: null,
+    ...overrides,
+  };
+}
+
 function createPersistedCompaction(overrides: Record<string, unknown> = {}) {
   return {
     id: 'compaction-summary-1',
@@ -1006,6 +1056,211 @@ describe('useAgenticLoop', () => {
     );
     expect(vi.mocked(commands.consumeAgentResumeCheckpoint)).not.toHaveBeenCalledWith(
       'checkpoint-recovery-1',
+    );
+  });
+
+  it('should resume a recovered approval checkpoint into execution with a resume-triggered run', async () => {
+    const llm = createMockLLMAdapter();
+    const tools = createMockToolExecutorWithVideoTools();
+    const recoveredPlan = {
+      goal: 'Delete the intro clip safely',
+      steps: [
+        {
+          id: 'step-1',
+          tool: 'delete_clip',
+          args: { clipId: 'clip-1' },
+          description: 'Delete the intro clip from the timeline',
+          riskLevel: 'high' as const,
+          estimatedDuration: 75,
+        },
+      ],
+      estimatedTotalDuration: 75,
+      requiresApproval: true,
+      rollbackStrategy: 'Restore the deleted clip from undo history.',
+    };
+
+    sessionState = {
+      ...createAgentSessionDto(),
+      activeCheckpointId: 'checkpoint-recovery-1',
+      resumeCursorVersion: 1,
+    };
+    persistedCheckpoints = [
+      createPersistedRecoveryCheckpoint({
+        pendingWorkJson: JSON.stringify({
+          type: 'plan_approval',
+          goal: recoveredPlan.goal,
+          stepIds: ['step-1'],
+          plan: recoveredPlan,
+        }),
+      }),
+    ];
+
+    const structuredSpy = vi.spyOn(llm, 'generateStructured').mockResolvedValue({
+      goalAchieved: true,
+      stateChanges: [
+        {
+          type: 'clip_deleted',
+          target: 'clip-1',
+          details: { deleted: true },
+        },
+      ],
+      summary: 'Deleted clip-1 after resume',
+      confidence: 0.96,
+      needsIteration: false,
+    });
+
+    const { result } = renderHook(() =>
+      useAgenticLoop({
+        llmClient: llm,
+        toolExecutor: tools,
+        context: {
+          projectId: 'project-1',
+          sequenceId: 'sequence-1',
+        },
+        config: {
+          enableFastPath: false,
+          enableMemory: false,
+          enableTracing: false,
+          toolPermissionHandler: async () => 'allow',
+        },
+      }),
+    );
+
+    let runPromise!: ReturnType<typeof result.current.run>;
+    act(() => {
+      runPromise = result.current.run('Continue the recovered edit');
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('awaiting_approval');
+      expect(result.current.plan?.goal).toBe('Delete the intro clip safely');
+    });
+
+    expect(structuredSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(commands.startAgentRun)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'conversation-session-1',
+        trigger: 'resume',
+      }),
+    );
+    expect(
+      vi
+        .mocked(commands.createAgentResumeCheckpoint)
+        .mock.calls.map(([input]) => input)
+        .filter((input) => input.checkpointKind === 'approval_wait'),
+    ).toHaveLength(0);
+
+    act(() => {
+      result.current.approvePlan();
+    });
+
+    await act(async () => {
+      await runPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('completed');
+    });
+
+    expect(structuredSpy).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(commands.consumeAgentResumeCheckpoint)).toHaveBeenCalledWith(
+      'checkpoint-recovery-1',
+    );
+    expect(vi.mocked(commands.updateAgentRunPhase)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-tpao-1',
+        phase: 'completed',
+      }),
+    );
+  });
+
+  it('should resume a recovered first-step tool permission checkpoint without replaying planning', async () => {
+    const llm = createMockLLMAdapter();
+    const tools = createMockToolExecutorWithVideoTools();
+
+    sessionState = {
+      ...createAgentSessionDto(),
+      activeCheckpointId: 'checkpoint-recovery-tool-1',
+      resumeCursorVersion: 1,
+    };
+    persistedCheckpoints = [createPersistedToolWaitCheckpoint()];
+
+    const structuredSpy = vi.spyOn(llm, 'generateStructured').mockResolvedValue({
+      goalAchieved: true,
+      stateChanges: [
+        {
+          type: 'clip_deleted',
+          target: 'clip-1',
+          details: { deleted: true },
+        },
+      ],
+      summary: 'Deleted clip-1 after resumed tool permission',
+      confidence: 0.97,
+      needsIteration: false,
+    });
+
+    const { result } = renderHook(() =>
+      useAgenticLoop({
+        llmClient: llm,
+        toolExecutor: tools,
+        context: {
+          projectId: 'project-1',
+          sequenceId: 'sequence-1',
+          projectStateVersion: 7,
+        },
+        config: {
+          enableFastPath: false,
+          enableMemory: false,
+          enableTracing: false,
+        },
+      }),
+    );
+
+    let runPromise!: ReturnType<typeof result.current.run>;
+    act(() => {
+      runPromise = result.current.run('Continue the recovered edit');
+    });
+
+    await waitFor(() => {
+      expect(result.current.pendingToolPermissionStep?.id).toBe('step-1');
+    });
+
+    expect(result.current.plan?.goal).toBe('Delete the intro clip safely');
+    expect(structuredSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(commands.startAgentRun)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'conversation-session-1',
+        trigger: 'resume',
+      }),
+    );
+    expect(
+      vi
+        .mocked(commands.createAgentResumeCheckpoint)
+        .mock.calls.map(([input]) => input)
+        .filter((input) => input.checkpointKind === 'tool_wait'),
+    ).toHaveLength(0);
+
+    act(() => {
+      result.current.approveToolPermission('allow');
+    });
+
+    await act(async () => {
+      await runPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('completed');
+    });
+
+    expect(structuredSpy).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(commands.consumeAgentResumeCheckpoint)).toHaveBeenCalledWith(
+      'checkpoint-recovery-tool-1',
+    );
+    expect(vi.mocked(commands.updateAgentRunPhase)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-tpao-1',
+        phase: 'completed',
+      }),
     );
   });
 

--- a/src/hooks/useAgenticLoop.test.ts
+++ b/src/hooks/useAgenticLoop.test.ts
@@ -873,11 +873,24 @@ describe('useAgenticLoop', () => {
         checkpointKind: 'approval_wait',
       }),
     );
-    expect(JSON.parse(approvalCheckpointCall?.pendingWorkJson ?? 'null')).toEqual({
-      type: 'plan_approval',
-      goal: 'Delete the target clip',
-      stepIds: ['step-approval-1'],
-    });
+    expect(JSON.parse(approvalCheckpointCall?.pendingWorkJson ?? 'null')).toEqual(
+      expect.objectContaining({
+        type: 'plan_approval',
+        goal: 'Delete the target clip',
+        stepIds: ['step-approval-1'],
+        plan: expect.objectContaining({
+          goal: 'Delete the target clip',
+          requiresApproval: true,
+          steps: [
+            expect.objectContaining({
+              id: 'step-approval-1',
+              tool: 'delete_clip',
+              args: { clipId: 'clip-1' },
+            }),
+          ],
+        }),
+      }),
+    );
 
     act(() => {
       result.current.approvePlan();

--- a/src/hooks/useAgenticLoop.ts
+++ b/src/hooks/useAgenticLoop.ts
@@ -194,6 +194,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
   const bootstrappedCheckpointIdRef = useRef<string | null>(null);
   const memoryStoreRef = useRef<IMemoryStore | null>(null);
   const persistedRunIdRef = useRef<string | null>(null);
+  const latestPlanRef = useRef<Plan | null>(null);
 
   if (!memoryStoreRef.current && config?.enableMemory !== false) {
     memoryStoreRef.current = createMemoryManagerAdapter();
@@ -242,6 +243,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
       case 'approval_required':
         setPhase('awaiting_approval');
         setPlan(event.plan);
+        latestPlanRef.current = event.plan;
         // Trigger callback and wait for response
         optionsRef.current.onApprovalRequired?.(event.plan);
         break;
@@ -264,6 +266,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
 
       case 'planning_complete':
         setPlan(event.plan);
+        latestPlanRef.current = event.plan;
         break;
 
       case 'execution_start':
@@ -328,6 +331,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
       setError(null);
       setThought(null);
       setPlan(null);
+      latestPlanRef.current = null;
       setPendingClarificationQuestion(null);
       setPendingToolPermissionStep(null);
       setPhase('thinking');
@@ -585,6 +589,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
               input,
               planGoal: plan.goal,
               planStepIds: plan.steps.map((step) => step.id),
+              plan,
             });
 
             try {
@@ -594,6 +599,10 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
             }
           },
           toolPermissionHandler: async (toolName, args, step) => {
+            const activePlan = latestPlanRef.current;
+            const stepIndex =
+              activePlan?.steps.findIndex((candidate) => candidate.id === step.id) ?? -1;
+
             const decisionPromise = baseToolPermissionHandler(toolName, args, step);
             let autoResolved = false;
             let autoDecision: 'allow' | 'deny' | 'allow_always' | undefined;
@@ -617,7 +626,12 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
                 phase: 'awaiting_tool_permission',
                 projectId: context.projectId,
                 sequenceId: context.sequenceId ?? null,
+                projectStateVersion: context.projectStateVersion ?? null,
                 input,
+                plan: activePlan,
+                nextStepIndex: stepIndex >= 0 ? stepIndex : null,
+                completedStepIds: stepIndex === 0 ? [] : null,
+                toolCallsUsed: stepIndex === 0 ? 0 : null,
                 stepId: typeof step.id === 'string' ? step.id : null,
                 toolName,
                 args,
@@ -767,6 +781,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
     setError(null);
     setThought(null);
     setPlan(null);
+    latestPlanRef.current = null;
     setPendingClarificationQuestion(null);
     setPendingToolPermissionStep(null);
     setSessionId(null);

--- a/src/hooks/useAgenticLoop.ts
+++ b/src/hooks/useAgenticLoop.ts
@@ -432,7 +432,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
         logger,
         loggerLabel: 'agentic',
       });
-      await bootstrapRecoveredContextFromCheckpoint({
+      const recoveredExecutableResume = await bootstrapRecoveredContextFromCheckpoint({
         sessionId: storeSessionId,
         addSystemMessage: convStore.addSystemMessage,
         logger,
@@ -441,6 +441,14 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
         onCheckpointRecovered: (record) => runtimeTraceRecorder?.recordCheckpointEvent(record),
         onCompactionRecovered: (record) => runtimeTraceRecorder?.recordCompactionEvent(record),
       });
+      const recoveredApprovalResume =
+        recoveredExecutableResume?.kind === 'approval_wait' ? recoveredExecutableResume : null;
+      const recoveredToolWaitResume =
+        recoveredExecutableResume?.kind === 'tool_wait' &&
+        typeof context.projectStateVersion === 'number' &&
+        recoveredExecutableResume.projectStateVersion === context.projectStateVersion
+          ? recoveredExecutableResume
+          : null;
 
       // Create execution context bound to the store session
       const executionContext = {
@@ -478,10 +486,11 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
       const startedRunId = await startPersistedRun({
         sessionId: executionContext.sessionId,
         runtimeKind: 'tpao',
+        trigger: recoveredApprovalResume || recoveredToolWaitResume ? 'resume' : 'user',
         maxIterations: config?.maxIterations,
         maxToolCalls: config?.maxToolCallsPerRun,
         traceId: persistedTraceId,
-        runInput: input,
+        runInput: recoveredApprovalResume?.input ?? recoveredToolWaitResume?.input ?? input,
         context,
         checkpointController,
         persistedRunIdRef,
@@ -578,6 +587,14 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
           writeTraceOnComplete: false,
           memoryStore: config?.memoryStore ?? memoryStoreRef.current ?? undefined,
           approvalHandler: async (plan) => {
+            if (recoveredApprovalResume?.checkpointId) {
+              try {
+                return await baseApprovalHandler(plan);
+              } finally {
+                await checkpointController.consumeCheckpoint(recoveredApprovalResume.checkpointId);
+              }
+            }
+
             const checkpointId = await checkpointController.persistCheckpoint({
               sessionId: storeSessionId,
               runId: persistedRunIdRef.current,
@@ -602,6 +619,17 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
             const activePlan = latestPlanRef.current;
             const stepIndex =
               activePlan?.steps.findIndex((candidate) => candidate.id === step.id) ?? -1;
+
+            if (
+              recoveredToolWaitResume?.checkpointId &&
+              step.id === recoveredToolWaitResume.stepId
+            ) {
+              try {
+                return await baseToolPermissionHandler(toolName, args, step);
+              } finally {
+                await checkpointController.consumeCheckpoint(recoveredToolWaitResume.checkpointId);
+              }
+            }
 
             const decisionPromise = baseToolPermissionHandler(toolName, args, step);
             let autoResolved = false;
@@ -655,13 +683,23 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
         const conversationHistory = trimDuplicatedTailUserMessageForContext(rawHistory, input);
 
         // Run engine with conversation history
-        const result = await engine.run(
-          input,
-          context,
-          executionContext,
-          handleEvent,
-          conversationHistory,
-        );
+        const result = recoveredApprovalResume
+          ? await engine.resumePendingApproval(
+              recoveredApprovalResume.input,
+              recoveredApprovalResume.plan,
+              context,
+              executionContext,
+              handleEvent,
+            )
+          : recoveredToolWaitResume
+            ? await engine.resumePendingToolPermission(
+                recoveredToolWaitResume.input,
+                recoveredToolWaitResume.plan,
+                context,
+                executionContext,
+                handleEvent,
+              )
+            : await engine.run(input, context, executionContext, handleEvent, conversationHistory);
 
         persistedFinalPhase =
           result.finalState.phase === 'aborted'

--- a/src/stores/agentSessionStore.test.ts
+++ b/src/stores/agentSessionStore.test.ts
@@ -89,9 +89,7 @@ function createSnapshot(
   };
 }
 
-function createPermissionDecision(
-  overrides: Partial<PermissionDecision> = {},
-): PermissionDecision {
+function createPermissionDecision(overrides: Partial<PermissionDecision> = {}): PermissionDecision {
   return {
     id: 'decision-1',
     sessionId: 'session-1',
@@ -107,9 +105,7 @@ function createPermissionDecision(
   };
 }
 
-function createCompactionRecord(
-  overrides: Partial<CompactionRecord> = {},
-): CompactionRecord {
+function createCompactionRecord(overrides: Partial<CompactionRecord> = {}): CompactionRecord {
   return {
     id: 'compaction-1',
     sessionId: 'session-1',
@@ -127,9 +123,7 @@ function createCompactionRecord(
   };
 }
 
-function createResumeCheckpoint(
-  overrides: Partial<ResumeCheckpoint> = {},
-): ResumeCheckpoint {
+function createResumeCheckpoint(overrides: Partial<ResumeCheckpoint> = {}): ResumeCheckpoint {
   return {
     id: 'checkpoint-1',
     sessionId: 'session-1',
@@ -151,11 +145,12 @@ describe('agentSessionStore', () => {
 
   beforeEach(() => {
     backend = {
-      createSession: async (input) => createSession({
-        id: input.id ?? 'session-1',
-        projectId: input.projectId,
-        title: input.title ?? 'New Agent Session',
-      }),
+      createSession: async (input) =>
+        createSession({
+          id: input.id ?? 'session-1',
+          projectId: input.projectId,
+          title: input.title ?? 'New Agent Session',
+        }),
       getSession: async (sessionId) => createSnapshot({ id: sessionId }),
       listPermissionDecisions: async () => [],
       listCompactions: async () => [],
@@ -608,20 +603,22 @@ describe('agentSessionStore', () => {
   });
 
   it('classifies permission replay and finalize misses as degraded', () => {
-    expect(summarizeAgentSessionPersistence([
-      {
-        sessionId: 'session-1',
-        stage: 'permission_replay',
-        message: 'failed to replay permissions',
-        occurredAt: 100,
-      },
-      {
-        sessionId: 'session-1',
-        stage: 'run_finalize',
-        message: 'failed to finalize run',
-        occurredAt: 200,
-      },
-    ])).toEqual({
+    expect(
+      summarizeAgentSessionPersistence([
+        {
+          sessionId: 'session-1',
+          stage: 'permission_replay',
+          message: 'failed to replay permissions',
+          occurredAt: 100,
+        },
+        {
+          sessionId: 'session-1',
+          stage: 'run_finalize',
+          message: 'failed to finalize run',
+          occurredAt: 200,
+        },
+      ]),
+    ).toEqual({
       status: 'degraded',
       label: 'Degraded',
       description:
@@ -631,14 +628,16 @@ describe('agentSessionStore', () => {
   });
 
   it('classifies session creation or run-start misses as ephemeral', () => {
-    expect(summarizeAgentSessionPersistence([
-      {
-        sessionId: 'session-1',
-        stage: 'run_start',
-        message: 'failed to start persisted run',
-        occurredAt: 100,
-      },
-    ])).toEqual({
+    expect(
+      summarizeAgentSessionPersistence([
+        {
+          sessionId: 'session-1',
+          stage: 'run_start',
+          message: 'failed to start persisted run',
+          occurredAt: 100,
+        },
+      ]),
+    ).toEqual({
       status: 'ephemeral',
       label: 'Ephemeral',
       description:
@@ -674,26 +673,28 @@ describe('agentSessionStore', () => {
       resumeCursorVersion: 4,
     });
 
-    expect(summarizeAgentSessionResumeHistory({
-      session,
-      artifacts: {
-        ...createEmptyAgentSessionRecoveryArtifacts(),
-        checkpoints: [
-          createResumeCheckpoint({
-            id: 'checkpoint-9',
-            checkpointKind: 'approval_wait',
-            status: 'active',
-            createdAt: 900,
-          }),
-        ],
-        compactions: [
-          createCompactionRecord({
-            id: 'compaction-9',
-            createdAt: 800,
-          }),
-        ],
-      },
-    })).toMatchObject({
+    expect(
+      summarizeAgentSessionResumeHistory({
+        session,
+        artifacts: {
+          ...createEmptyAgentSessionRecoveryArtifacts(),
+          checkpoints: [
+            createResumeCheckpoint({
+              id: 'checkpoint-9',
+              checkpointKind: 'approval_wait',
+              status: 'active',
+              createdAt: 900,
+            }),
+          ],
+          compactions: [
+            createCompactionRecord({
+              id: 'compaction-9',
+              createdAt: 800,
+            }),
+          ],
+        },
+      }),
+    ).toMatchObject({
       status: 'full',
       label: 'Context Available',
       restartBoundary: {
@@ -713,19 +714,21 @@ describe('agentSessionStore', () => {
       lastCompactedAt: 700,
     });
 
-    expect(summarizeAgentSessionResumeHistory({
-      session,
-      artifacts: {
-        ...createEmptyAgentSessionRecoveryArtifacts(),
-        checkpoints: [],
-        compactions: [
-          createCompactionRecord({
-            id: 'compaction-9',
-            createdAt: 700,
-          }),
-        ],
-      },
-    })).toMatchObject({
+    expect(
+      summarizeAgentSessionResumeHistory({
+        session,
+        artifacts: {
+          ...createEmptyAgentSessionRecoveryArtifacts(),
+          checkpoints: [],
+          compactions: [
+            createCompactionRecord({
+              id: 'compaction-9',
+              createdAt: 700,
+            }),
+          ],
+        },
+      }),
+    ).toMatchObject({
       status: 'degraded',
       label: 'Degraded',
       restartBoundary: {
@@ -740,10 +743,34 @@ describe('agentSessionStore', () => {
   });
 
   it('classifies restart as cold when no durable boundary is linked', () => {
-    expect(summarizeAgentSessionResumeHistory({
-      session: createSession(),
-      artifacts: createEmptyAgentSessionRecoveryArtifacts(),
-    })).toMatchObject({
+    expect(
+      summarizeAgentSessionResumeHistory({
+        session: createSession(),
+        artifacts: createEmptyAgentSessionRecoveryArtifacts(),
+      }),
+    ).toMatchObject({
+      status: 'cold',
+      label: 'Cold',
+      restartBoundary: {
+        kind: 'conversation_log',
+        title: 'Conversation log replay',
+      },
+      checkpointCount: 0,
+      compactionCount: 0,
+    });
+  });
+
+  it('stays cold when only session-header compaction metadata exists without persisted summary rows', () => {
+    expect(
+      summarizeAgentSessionResumeHistory({
+        session: createSession({
+          latestSummaryMessageId: 'summary-9',
+          lastCompactedAt: 700,
+          compactionVersion: 1,
+        }),
+        artifacts: createEmptyAgentSessionRecoveryArtifacts(),
+      }),
+    ).toMatchObject({
       status: 'cold',
       label: 'Cold',
       restartBoundary: {
@@ -756,28 +783,30 @@ describe('agentSessionStore', () => {
   });
 
   it('keeps restart mode ephemeral when a non-durable boundary was latched', () => {
-    expect(summarizeAgentSessionResumeHistory({
-      session: createSession({
-        activeCheckpointId: 'checkpoint-9',
-        resumeCursorVersion: 1,
-      }),
-      latchedIssues: [
-        {
-          sessionId: 'session-1',
-          stage: 'run_start',
-          message: 'failed to persist run start',
-          occurredAt: 100,
-        },
-      ],
-      artifacts: {
-        ...createEmptyAgentSessionRecoveryArtifacts(),
-        checkpoints: [
-          createResumeCheckpoint({
-            id: 'checkpoint-9',
-          }),
+    expect(
+      summarizeAgentSessionResumeHistory({
+        session: createSession({
+          activeCheckpointId: 'checkpoint-9',
+          resumeCursorVersion: 1,
+        }),
+        latchedIssues: [
+          {
+            sessionId: 'session-1',
+            stage: 'run_start',
+            message: 'failed to persist run start',
+            occurredAt: 100,
+          },
         ],
-      },
-    })).toMatchObject({
+        artifacts: {
+          ...createEmptyAgentSessionRecoveryArtifacts(),
+          checkpoints: [
+            createResumeCheckpoint({
+              id: 'checkpoint-9',
+            }),
+          ],
+        },
+      }),
+    ).toMatchObject({
       status: 'ephemeral',
       label: 'Ephemeral',
       restartBoundary: {
@@ -789,18 +818,20 @@ describe('agentSessionStore', () => {
   });
 
   it('ignores active checkpoint rows that are not linked from the session header', () => {
-    expect(summarizeAgentSessionResumeHistory({
-      session: createSession(),
-      artifacts: {
-        ...createEmptyAgentSessionRecoveryArtifacts(),
-        checkpoints: [
-          createResumeCheckpoint({
-            id: 'checkpoint-unlinked',
-            status: 'active',
-          }),
-        ],
-      },
-    })).toMatchObject({
+    expect(
+      summarizeAgentSessionResumeHistory({
+        session: createSession(),
+        artifacts: {
+          ...createEmptyAgentSessionRecoveryArtifacts(),
+          checkpoints: [
+            createResumeCheckpoint({
+              id: 'checkpoint-unlinked',
+              status: 'active',
+            }),
+          ],
+        },
+      }),
+    ).toMatchObject({
       status: 'cold',
       label: 'Cold',
       restartBoundary: {
@@ -816,17 +847,19 @@ describe('agentSessionStore', () => {
   });
 
   it('builds a stable recovery fingerprint from persisted session markers', () => {
-    expect(buildAgentSessionRecoveryFingerprint(createSession())).toBe(
-      'session-1||||0|0||',
-    );
-    expect(buildAgentSessionRecoveryFingerprint(createSession({
-      currentRunId: 'run-2',
-      activeCheckpointId: 'checkpoint-2',
-      latestSummaryMessageId: 'summary-2',
-      compactionVersion: 2,
-      resumeCursorVersion: 4,
-      lastCompactedAt: 600,
-      lastResumedAt: 700,
-    }))).toBe('session-1|run-2|checkpoint-2|summary-2|2|4|600|700');
+    expect(buildAgentSessionRecoveryFingerprint(createSession())).toBe('session-1||||0|0||');
+    expect(
+      buildAgentSessionRecoveryFingerprint(
+        createSession({
+          currentRunId: 'run-2',
+          activeCheckpointId: 'checkpoint-2',
+          latestSummaryMessageId: 'summary-2',
+          compactionVersion: 2,
+          resumeCursorVersion: 4,
+          lastCompactedAt: 600,
+          lastResumedAt: 700,
+        }),
+      ),
+    ).toBe('session-1|run-2|checkpoint-2|summary-2|2|4|600|700');
   });
 });

--- a/src/stores/agentSessionStore.ts
+++ b/src/stores/agentSessionStore.ts
@@ -15,8 +15,9 @@ import {
 } from '@/agents/engine';
 import type { CreateAgentSessionInput } from '@/agents/engine';
 
-export type AgentSessionStoreCreateInput =
-  Omit<CreateAgentSessionInput, 'projectId'> & { projectId?: string };
+export type AgentSessionStoreCreateInput = Omit<CreateAgentSessionInput, 'projectId'> & {
+  projectId?: string;
+};
 export type AgentSessionStoreEnsureInput = AgentSessionStoreCreateInput & { id: string };
 export type AgentSessionPersistenceStage =
   | 'session_ensure'
@@ -125,9 +126,7 @@ export interface AgentSessionStoreActions {
     options?: { headerFingerprint?: string | null },
   ): Promise<AgentSessionRecoveryArtifacts>;
   recordCompaction(input: CreatePersistedCompactionInput): Promise<CompactionRecord>;
-  createResumeCheckpoint(
-    input: CreatePersistedResumeCheckpointInput,
-  ): Promise<ResumeCheckpoint>;
+  createResumeCheckpoint(input: CreatePersistedResumeCheckpointInput): Promise<ResumeCheckpoint>;
   consumeResumeCheckpoint(checkpointId: string): Promise<ResumeCheckpoint>;
   reportPersistenceIssue: (input: {
     sessionId: string;
@@ -135,10 +134,7 @@ export interface AgentSessionStoreActions {
     error: unknown;
     occurredAt?: number;
   }) => AgentSessionPersistenceIssue;
-  clearPersistenceIssue: (
-    sessionId: string,
-    stage?: AgentSessionPersistenceStage,
-  ) => void;
+  clearPersistenceIssue: (sessionId: string, stage?: AgentSessionPersistenceStage) => void;
   createSession(input?: AgentSessionStoreCreateInput): Promise<AgentSession>;
   startRun(input: StartPersistedAgentRunInput): Promise<AgentRun>;
   updateRunPhase(input: UpdatePersistedAgentRunPhaseInput): Promise<AgentRun>;
@@ -211,10 +207,9 @@ function upsertPersistenceIssue(
   issues: AgentSessionPersistenceIssue[],
   nextIssue: AgentSessionPersistenceIssue,
 ): AgentSessionPersistenceIssue[] {
-  return [
-    ...issues.filter((issue) => issue.stage !== nextIssue.stage),
-    nextIssue,
-  ].sort((left, right) => left.occurredAt - right.occurredAt);
+  return [...issues.filter((issue) => issue.stage !== nextIssue.stage), nextIssue].sort(
+    (left, right) => left.occurredAt - right.occurredAt,
+  );
 }
 
 export function deriveAgentSessionPersistenceMode(
@@ -228,9 +223,7 @@ export function summarizeAgentSessionPersistenceView(
   latchedIssues?: AgentSessionPersistenceIssue[],
 ): AgentSessionPersistenceView {
   const hasActiveIssues = Boolean(activeIssues && activeIssues.length > 0);
-  const visibleIssues = hasActiveIssues
-    ? [...(activeIssues ?? [])]
-    : [...(latchedIssues ?? [])];
+  const visibleIssues = hasActiveIssues ? [...(activeIssues ?? [])] : [...(latchedIssues ?? [])];
   const summary = summarizeAgentSessionPersistence(visibleIssues);
 
   if (summary.status === 'healthy') {
@@ -287,15 +280,11 @@ export function buildAgentSessionRecoveryFingerprint(session: AgentSession): str
   ].join('|');
 }
 
-function sortCompactions(
-  compactions: CompactionRecord[],
-): CompactionRecord[] {
+function sortCompactions(compactions: CompactionRecord[]): CompactionRecord[] {
   return [...compactions].sort((left, right) => right.createdAt - left.createdAt);
 }
 
-function sortResumeCheckpoints(
-  checkpoints: ResumeCheckpoint[],
-): ResumeCheckpoint[] {
+function sortResumeCheckpoints(checkpoints: ResumeCheckpoint[]): ResumeCheckpoint[] {
   return [...checkpoints].sort((left, right) => right.createdAt - left.createdAt);
 }
 
@@ -329,7 +318,6 @@ function buildRestartBoundary(input: {
   session: AgentSession | null;
   activeCheckpoint: ResumeCheckpoint | null;
   latestSummaryCompaction: CompactionRecord | null;
-  latestCompaction: CompactionRecord | null;
 }): AgentSessionRestartBoundaryView {
   if (!input.session) {
     return {
@@ -349,12 +337,7 @@ function buildRestartBoundary(input: {
     };
   }
 
-  if (
-    input.latestSummaryCompaction
-    || input.latestCompaction
-    || input.session.latestSummaryMessageId
-    || input.session.lastCompactedAt
-  ) {
+  if (input.latestSummaryCompaction) {
     return {
       kind: 'summary_boundary',
       title: 'Persisted summary',
@@ -377,10 +360,7 @@ export function summarizeAgentSessionResumeHistory(input: {
   latchedIssues?: AgentSessionPersistenceIssue[];
   artifacts?: AgentSessionRecoveryArtifacts | null;
 }): AgentSessionResumeHistoryView {
-  const persistence = summarizeAgentSessionPersistenceView(
-    input.activeIssues,
-    input.latchedIssues,
-  );
+  const persistence = summarizeAgentSessionPersistenceView(input.activeIssues, input.latchedIssues);
   const checkpoints = sortResumeCheckpoints(input.artifacts?.checkpoints ?? []);
   const compactions = sortCompactions(input.artifacts?.compactions ?? []);
   const activeCheckpoint = input.session
@@ -388,13 +368,12 @@ export function summarizeAgentSessionResumeHistory(input: {
     : null;
   const latestCheckpoint = checkpoints[0] ?? null;
   const latestCompaction = compactions[0] ?? null;
-  const latestSummaryCompaction = compactions.find((compaction) => compaction.tier === 'summary')
-    ?? null;
+  const latestSummaryCompaction =
+    compactions.find((compaction) => compaction.tier === 'summary') ?? null;
   const restartBoundary = buildRestartBoundary({
     session: input.session,
     activeCheckpoint,
     latestSummaryCompaction,
-    latestCompaction,
   });
 
   let status: AgentSessionRecoveryMode = 'cold';
@@ -437,10 +416,7 @@ function findSessionIdForRun(
   runId: string,
 ): string | null {
   for (const snapshot of Object.values(snapshotsById)) {
-    if (
-      snapshot.runs.some((run) => run.id === runId)
-      || snapshot.session.currentRunId === runId
-    ) {
+    if (snapshot.runs.some((run) => run.id === runId) || snapshot.session.currentRunId === runId) {
       return snapshot.session.id;
     }
   }
@@ -583,8 +559,8 @@ export function createAgentSessionStore(
 
       refreshRecoveryArtifacts: async (sessionId: string, options) => {
         const current =
-          get().recoveryArtifactsBySessionId[sessionId]
-          ?? createEmptyAgentSessionRecoveryArtifacts();
+          get().recoveryArtifactsBySessionId[sessionId] ??
+          createEmptyAgentSessionRecoveryArtifacts();
 
         set((state) => {
           state.recoveryArtifactsBySessionId[sessionId] = {
@@ -599,16 +575,16 @@ export function createAgentSessionStore(
           backend.listCompactions(sessionId),
           backend.listResumeCheckpoints(sessionId),
         ]);
-        const nextCompactions = compactionsResult.status === 'fulfilled'
-          ? compactionsResult.value
-          : current.compactions;
-        const nextCheckpoints = checkpointsResult.status === 'fulfilled'
-          ? checkpointsResult.value
-          : current.checkpoints;
+        const nextCompactions =
+          compactionsResult.status === 'fulfilled' ? compactionsResult.value : current.compactions;
+        const nextCheckpoints =
+          checkpointsResult.status === 'fulfilled' ? checkpointsResult.value : current.checkpoints;
         const errors: string[] = [];
 
         if (compactionsResult.status === 'rejected') {
-          errors.push(`Failed to load compaction history: ${extractErrorMessage(compactionsResult.reason)}`);
+          errors.push(
+            `Failed to load compaction history: ${extractErrorMessage(compactionsResult.reason)}`,
+          );
         }
 
         if (checkpointsResult.status === 'rejected') {
@@ -684,8 +660,9 @@ export function createAgentSessionStore(
       },
 
       consumeResumeCheckpoint: async (checkpointId: string) => {
-        const checkpoints = Object.values(get().recoveryArtifactsBySessionId)
-          .flatMap((artifacts) => artifacts.checkpoints);
+        const checkpoints = Object.values(get().recoveryArtifactsBySessionId).flatMap(
+          (artifacts) => artifacts.checkpoints,
+        );
         const cachedCheckpoint = checkpoints.find((checkpoint) => checkpoint.id === checkpointId);
 
         try {
@@ -748,9 +725,7 @@ export function createAgentSessionStore(
             delete state.persistenceIssuesBySessionId[sessionId];
             remainingIssues = [];
           } else {
-            remainingIssues = currentIssues.filter(
-              (issue) => issue.stage !== stage,
-            );
+            remainingIssues = currentIssues.filter((issue) => issue.stage !== stage);
             if (remainingIssues.length === 0) {
               delete state.persistenceIssuesBySessionId[sessionId];
             } else {
@@ -759,9 +734,10 @@ export function createAgentSessionStore(
           }
 
           if (state.activeSessionId === sessionId) {
-            state.lastError = remainingIssues.length > 0
-              ? remainingIssues[remainingIssues.length - 1]?.message ?? null
-              : null;
+            state.lastError =
+              remainingIssues.length > 0
+                ? (remainingIssues[remainingIssues.length - 1]?.message ?? null)
+                : null;
           }
         });
       },
@@ -789,7 +765,8 @@ export function createAgentSessionStore(
 
           set((state) => {
             applySnapshot(state, snapshot);
-            state.recoveryArtifactsBySessionId[session.id] ??= createEmptyAgentSessionRecoveryArtifacts();
+            state.recoveryArtifactsBySessionId[session.id] ??=
+              createEmptyAgentSessionRecoveryArtifacts();
             state.isMutating = false;
           });
 
@@ -863,8 +840,8 @@ export function createAgentSessionStore(
           return run;
         } catch (error) {
           const message = extractErrorMessage(error);
-          const sessionId = findSessionIdForRun(get().snapshotsById, input.runId)
-            ?? get().activeSessionId;
+          const sessionId =
+            findSessionIdForRun(get().snapshotsById, input.runId) ?? get().activeSessionId;
           set((state) => {
             state.isMutating = false;
             state.lastError = message;


### PR DESCRIPTION
### **User description**
## Description

Harden the AI runtime recovery and session lifecycle so recovered checkpoints can resume execution, compatibility loop events stay bound to the correct session, and the sidebar aborts or refreshes cleanly across runtime and project changes.

## Related Issue

Closes #596, closes #595, closes #597

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added executable recovery resume support for canonical agent sessions by persisting richer checkpoint payloads, resuming approval and first-step tool-permission waits, and deriving resume history from persisted recovery rows only.
- Bound compatibility AgentLoop events to the session that started the run and preserved emitted tool risk metadata through the UI event handler path.
- Made the agent sidebar react to feature-flag changes, abort active runs on project switch, clear stale sidebar state, and cancel running delegated child sessions with the latest visible assistant summary.

## Screenshots / Videos

N/A

## Testing

Ran targeted Vitest suites covering recovery persistence, recovered execution, resume history classification, compatibility loop event handling, sidebar flag reactivity, and project-switch abort behavior.

### Test Environment

- OS: Windows 11
- Node.js version: v22.19.0
- Rust version: rustc 1.92.0 (ded5c06cf 2025-12-08)

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Targeted test commands run:
`npx vitest run src/agents/engine/core/recoveryPersistence.test.ts`
`npx vitest run src/hooks/useAgenticLoop.test.ts`
`npx vitest run src/stores/agentSessionStore.test.ts src/components/features/agent/AgentSessionResumeHistoryPanel.test.tsx`
`npx vitest run src/agents/engine/AgentLoop.test.ts src/hooks/useAgentLoopEventHandler.test.ts`
`npx vitest run src/config/featureFlags.test.ts src/components/features/agent/AgenticSidebarContent.test.tsx`
`npx vitest run src/components/features/agent/AgentRuntimeChatShell.test.tsx src/components/features/agent/AgenticSidebarContent.test.tsx`

Pre-commit hooks also ran `npx tsx scripts/sync-version.ts --check`, `tsc --noEmit`, and `eslint . --ext .js,.jsx,.ts,.tsx --fix`.
Existing repository-wide ESLint warnings remain in unrelated files; no new lint errors were introduced by this branch.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Resumes recovered agent checkpoints into execution.

- Aborts active runs on project switch.

- Binds compatibility events to specific sessions.

- Refreshes sidebar runtime on flag changes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AgenticEngine"] -- "resumePendingApproval" --> B["Execution Loop"]
  A -- "resumePendingToolPermission" --> B
  C["AgenticSidebarContent"] -- "Project Switch" --> D["Abort Session"]
  E["AgentLoop"] -- "Bind Session ID" --> F["Event Filtering"]
  G["Feature Flags"] -- "Subscription" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AgenticEngine.ts</strong><dd><code>Add resume methods for recovered agent checkpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-011b0b20aad60192a33ef841f0b1bf7d1d84d5b0ec950fc02f6d93c899a35246">+863/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agentRuntimePersistence.ts</strong><dd><code>Resolve executable resume state from checkpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-d7b157f2867080f31a5d6aa5090b283a979d44befd0755d83ee9aee2b7f56fb9">+149/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useAgenticLoop.ts</strong><dd><code>Wire recovered checkpoints into the runtime loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-077855c4f6949a53263679547c8d1f576639dcd85168dff8f6d532fc06557013">+62/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>featureFlags.ts</strong><dd><code>Add hooks for reactive feature flag access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-300c3a8852bbbdba304f8a2df27b16265f9bab69039559aff38ca211ec7f965a">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recoveryPersistence.ts</strong><dd><code>Enrich checkpoint payloads with plan state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-8e59d309cdb0282fe72e49988b7529d93cf896789586bcbcefa16593ca8e527d">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>AgenticSidebarContent.tsx</strong><dd><code>Harden sidebar lifecycle and project switch logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-31a5ed8d8fa2f4f532c6a9a1e0293c8235f7a0d2fc2283cc993b9d03cc347d00">+65/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentLoop.ts</strong><dd><code>Bind compatibility loop events to session IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-2713299672198d6cc9294c2d969d626bc95dcfd79b1ba8d987c5bb522dc34759">+18/-45</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agentSessionStore.ts</strong><dd><code>Refine resume history classification and persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-9e51a49800c3ecc75eca7c700d73b82a53cbff232ebd52b7a7159f70f9564831">+37/-60</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.tsx</strong><dd><code>Abort runs and clear queue on project switch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-cfbd011a7c5d0d30bcefdf80916bd1a897e3da724bc64d6bf16e4fc2430c9233">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>useAgenticLoop.test.ts</strong><dd><code>Test recovered approval and tool-wait resumption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-faafa224851e67e7d3839f3dffbba5800bfd5a27ee5e3cfa6c38a298ae60fec6">+273/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AgenticSidebarContent.test.tsx</strong><dd><code>Verify sidebar reactivity and delegation cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-77f56605bd10cfd30db19f8998584f0d71dd041b76724a023c5886a946699cc0">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AgentLoop.test.ts</strong><dd><code>Update compatibility loop tests for risk levels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-e2678327898dc7c9b28bc72a92e236f5d1a88e4046ca171b38030455d4757245">+50/-119</a></td>

</tr>

<tr>
  <td><strong>recoveryPersistence.test.ts</strong><dd><code>Test enriched recovery checkpoint payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-30aef0abc98ffade4f5eddcc1d96d6aed6a6e776a497e4579bb95e7dbd3241cb">+71/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agentSessionStore.test.ts</strong><dd><code>Validate resume history status classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-0374a19681c1a8bca69950dd53ddc7f9bd73fd8e8b8c195bfb19492ebdeadc50">+151/-118</a></td>

</tr>

<tr>
  <td><strong>AgentSessionResumeHistoryPanel.test.tsx</strong><dd><code>Test UI rendering of recovery boundaries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-557be227c781739caedd794ba89a68c0456745441cfb4c6f053c0dc93bb5a4aa">+29/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>AgentLoopChat.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-427a470a1c5842d262e826d440933fbeff578940d86ac329d6d0787356ceb2d1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-969b5e31db360c6d5fc816fb11979bd7020a7e0e24223f25032b805ca9b1bcac">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgenticChat.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-9d721667d1b11896d04ddbdf3613aa1fc8fe848eb16c949faa4ae96b47183709">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgentLoop.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-1cf9c7dcf563f63b4df0f5717427a94869736f02281238a5f42c87f7667ad9b4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgentLoopEventHandler.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-eaa0eb3eaab4e7c39dd003aa1c31183f93f64548f2b5c94ef4a156ae535a8498">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgentLoopEventHandler.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/598/files#diff-c1fb2886025b43206ef23029f005fb1f04ac6aa1cf4fb3b180b4af467afb3fdf">+27/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls now track and display risk levels for enhanced visibility
  * Resume interrupted workflows pending user approval or tool permissions
  * Agent runs automatically abort when switching projects
  * Enhanced session persistence with recovery checkpoints for interrupted states

* **Bug Fixes**
  * Improved handling of project transitions during active sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->