### PR TITLE
fix(ai): harden persisted checkpoint cleanup and observer retries

### DIFF
--- a/src/agents/engine/core/types.test.ts
+++ b/src/agents/engine/core/types.test.ts
@@ -211,7 +211,7 @@ describe('types', () => {
       expect(DEFAULT_ENGINE_CONFIG.thinkingTimeout).toBe(60000);
       expect(DEFAULT_ENGINE_CONFIG.planningTimeout).toBe(90000);
       expect(DEFAULT_ENGINE_CONFIG.executionTimeout).toBe(60000);
-      expect(DEFAULT_ENGINE_CONFIG.observationTimeout).toBe(15000);
+      expect(DEFAULT_ENGINE_CONFIG.observationTimeout).toBe(30000);
       expect(DEFAULT_ENGINE_CONFIG.enableStreaming).toBe(true);
       expect(DEFAULT_ENGINE_CONFIG.enableMemory).toBe(true);
       expect(DEFAULT_ENGINE_CONFIG.enableCheckpoints).toBe(true);

--- a/src/agents/engine/core/types.ts
+++ b/src/agents/engine/core/types.ts
@@ -599,7 +599,7 @@ export interface AgenticEngineConfig {
   planningTimeout: number;
   /** Timeout for execution phase in ms (default: 60000) */
   executionTimeout: number;
-  /** Timeout for observation phase in ms (default: 15000) */
+  /** Timeout for observation phase in ms (default: 30000) */
   observationTimeout: number;
 
   /** Enable streaming output (default: true) */
@@ -724,7 +724,7 @@ export const DEFAULT_ENGINE_CONFIG: AgenticEngineConfig = {
   thinkingTimeout: 60000,
   planningTimeout: 90000,
   executionTimeout: 60000,
-  observationTimeout: 15000,
+  observationTimeout: 30000,
   enableStreaming: true,
   enableMemory: true,
   enableCheckpoints: true,

--- a/src/agents/engine/phases/Observer.test.ts
+++ b/src/agents/engine/phases/Observer.test.ts
@@ -4,7 +4,7 @@
  * Tests for the Observe phase of the agentic loop.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Observer, createObserver } from './Observer';
 import { createMockLLMAdapter, type MockLLMAdapter } from '../adapters/llm/MockLLMAdapter';
 import {
@@ -15,7 +15,7 @@ import {
   createEmptyContext,
 } from '../core/types';
 import type { ExecutionResult } from './Executor';
-import { ObservationTimeoutError } from '../core/errors';
+import { ObservationError, ObservationTimeoutError } from '../core/errors';
 
 describe('Observer', () => {
   let observer: Observer;
@@ -314,6 +314,7 @@ describe('Observer', () => {
 
     it('should retry observation after a timeout', async () => {
       const retryingObserver = createObserver(mockLLM, { timeout: 10, maxRetries: 1 });
+      const structuredSpy = vi.spyOn(mockLLM, 'generateStructured');
 
       mockLLM.setStructuredResponse({
         structured: {
@@ -332,6 +333,91 @@ describe('Observer', () => {
         goalAchieved: true,
         summary: 'Done after retry',
       });
+      expect(structuredSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should preserve caller timeout on retry when timeout exceeds retry cap', async () => {
+      vi.useFakeTimers();
+
+      try {
+        let callCount = 0;
+
+        mockLLM.generateStructured = async <T>(): Promise<T> => {
+          callCount += 1;
+
+          if (callCount === 1) {
+            throw new Error('Failed to parse structured response');
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 95000));
+
+          return {
+            goalAchieved: true,
+            stateChanges: [],
+            summary: 'Recovered after long retry',
+            confidence: 0.9,
+            needsIteration: false,
+          } as T;
+        };
+
+        const longTimeoutObserver = createObserver(mockLLM, {
+          timeout: 120000,
+          maxRetries: 1,
+          retryBackoffMs: 0,
+        });
+
+        const promise = longTimeoutObserver.observe(successfulPlan, successfulExecution, context);
+
+        await vi.advanceTimersByTimeAsync(95000);
+
+        await expect(promise).resolves.toMatchObject({
+          goalAchieved: true,
+          summary: 'Recovered after long retry',
+        });
+        expect(callCount).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should abort without starting another retry attempt during backoff', async () => {
+      vi.useFakeTimers();
+
+      try {
+        let callCount = 0;
+
+        mockLLM.generateStructured = async <T>(): Promise<T> => {
+          callCount += 1;
+
+          if (callCount === 1) {
+            throw new Error('Network timeout while observing execution');
+          }
+
+          return {
+            goalAchieved: true,
+            stateChanges: [],
+            summary: 'Should not retry after abort',
+            confidence: 0.9,
+            needsIteration: false,
+          } as T;
+        };
+
+        const abortingObserver = createObserver(mockLLM, {
+          timeout: 100,
+          maxRetries: 1,
+          retryBackoffMs: 100,
+        });
+
+        const promise = abortingObserver.observe(successfulPlan, successfulExecution, context);
+
+        await vi.advanceTimersByTimeAsync(0);
+        abortingObserver.abort();
+
+        await expect(promise).rejects.toThrow(ObservationError);
+        expect(callCount).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should handle LLM error gracefully', async () => {

--- a/src/agents/engine/phases/Observer.test.ts
+++ b/src/agents/engine/phases/Observer.test.ts
@@ -294,7 +294,7 @@ describe('Observer', () => {
 
   describe('error handling', () => {
     it('should throw ObservationTimeoutError on timeout', async () => {
-      const shortTimeoutObserver = createObserver(mockLLM, { timeout: 10 });
+      const shortTimeoutObserver = createObserver(mockLLM, { timeout: 10, maxRetries: 0 });
 
       mockLLM.setStructuredResponse({
         structured: {
@@ -310,6 +310,28 @@ describe('Observer', () => {
       await expect(
         shortTimeoutObserver.observe(successfulPlan, successfulExecution, context),
       ).rejects.toThrow(ObservationTimeoutError);
+    });
+
+    it('should retry observation after a timeout', async () => {
+      const retryingObserver = createObserver(mockLLM, { timeout: 10, maxRetries: 1 });
+
+      mockLLM.setStructuredResponse({
+        structured: {
+          goalAchieved: true,
+          stateChanges: [],
+          summary: 'Done after retry',
+          confidence: 0.9,
+          needsIteration: false,
+        },
+        delay: 100,
+      });
+
+      await expect(
+        retryingObserver.observe(successfulPlan, successfulExecution, context),
+      ).resolves.toMatchObject({
+        goalAchieved: true,
+        summary: 'Done after retry',
+      });
     });
 
     it('should handle LLM error gracefully', async () => {

--- a/src/agents/engine/phases/Observer.test.ts
+++ b/src/agents/engine/phases/Observer.test.ts
@@ -234,6 +234,40 @@ describe('Observer', () => {
       expect(hasResult).toBe(true);
     });
 
+    it('should preserve falsy execution results in analysis', async () => {
+      const falsyExecution: ExecutionResult = {
+        ...successfulExecution,
+        completedSteps: [
+          {
+            ...successfulExecution.completedSteps[0],
+            result: {
+              success: true,
+              data: 0,
+              duration: 50,
+            },
+          },
+        ],
+      };
+
+      mockLLM.setStructuredResponse({
+        structured: {
+          goalAchieved: true,
+          stateChanges: [],
+          summary: 'Done',
+          confidence: 0.9,
+          needsIteration: false,
+        } as Observation,
+      });
+
+      await observer.observe(successfulPlan, falsyExecution, context);
+
+      const request = mockLLM.getLastRequest();
+      const hasFalsyResult = request?.messages.some((message) =>
+        message.content.includes('Result: 0'),
+      );
+      expect(hasFalsyResult).toBe(true);
+    });
+
     it('should include language policy instructions in observer system prompt', async () => {
       context.languagePolicy = createLanguagePolicy('en', {
         outputLanguage: 'ja',

--- a/src/agents/engine/phases/Observer.ts
+++ b/src/agents/engine/phases/Observer.ts
@@ -29,6 +29,10 @@ export interface ObserverConfig {
   timeout?: number;
   /** Maximum iterations before stopping */
   maxIterations?: number;
+  /** Maximum retries on transient observation failures */
+  maxRetries?: number;
+  /** Backoff in milliseconds between retries */
+  retryBackoffMs?: number;
   /** Custom system prompt override */
   systemPromptOverride?: string;
   /** Additional project prompt sections appended to the base phase prompt */
@@ -41,9 +45,13 @@ export interface ObserverConfig {
 const DEFAULT_CONFIG: Required<ObserverConfig> = {
   timeout: 30000, // 30 seconds
   maxIterations: 5,
+  maxRetries: 1,
+  retryBackoffMs: 400,
   systemPromptOverride: '',
   projectPromptAddendum: '',
 };
+
+const MAX_RESULT_CHARS = 2000;
 
 // =============================================================================
 // Observer Class
@@ -100,37 +108,50 @@ export class Observer {
     execution: ExecutionResult,
     context: AgentContext,
   ): Promise<Observation> {
-    this.abortController = new AbortController();
-
-    const messages = this.buildMessages(plan, execution, context);
     const schema = this.buildObservationSchema();
 
-    try {
-      const observation = await this.executeWithTimeout(
-        () => this.llm.generateStructured<Observation>(messages, schema),
-        this.config.timeout,
-      );
+    const maxAttempts = this.config.maxRetries + 1;
 
-      // Validate the observation
-      this.validateObservation(observation);
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      this.abortController = new AbortController();
 
-      // Apply iteration limit
-      const finalObservation = this.applyIterationLimit(observation, context);
+      const messages = this.buildMessages(plan, execution, context);
+      const timeoutMs = this.resolveTimeoutForAttempt(attempt);
 
-      return finalObservation;
-    } catch (error) {
-      if (error instanceof ObservationTimeoutError) {
-        throw error;
+      try {
+        const observation = await this.executeWithTimeout(
+          () => this.llm.generateStructured<Observation>(messages, schema),
+          timeoutMs,
+        );
+
+        this.validateObservation(observation);
+        return this.applyIterationLimit(observation, context);
+      } catch (error) {
+        const aborted =
+          !(error instanceof ObservationTimeoutError) &&
+          (this.abortController?.signal.aborted ?? false);
+        const shouldRetry = this.shouldRetryObservation(error, aborted, attempt, maxAttempts);
+
+        if (shouldRetry) {
+          await this.delay(this.config.retryBackoffMs * (attempt + 1));
+          continue;
+        }
+
+        if (error instanceof ObservationTimeoutError) {
+          throw error;
+        }
+        if (error instanceof ObservationError) {
+          throw error;
+        }
+        throw new ObservationError(
+          `Failed to analyze execution: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      } finally {
+        this.abortController = null;
       }
-      if (error instanceof ObservationError) {
-        throw error;
-      }
-      throw new ObservationError(
-        `Failed to analyze execution: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    } finally {
-      this.abortController = null;
     }
+
+    throw new ObservationError('Failed to analyze execution');
   }
 
   /**
@@ -320,7 +341,7 @@ ${languageSection}${projectPromptAddendum}`;
     ];
 
     if (step.result.data) {
-      lines.push(`  Result: ${JSON.stringify(step.result.data)}`);
+      lines.push(`  Result: ${this.serializeResultData(step.result.data)}`);
     }
 
     if (step.result.error) {
@@ -449,6 +470,55 @@ ${languageSection}${projectPromptAddendum}`;
     return observation;
   }
 
+  private serializeResultData(data: unknown): string {
+    try {
+      const serialized = JSON.stringify(data);
+
+      if (serialized.length <= MAX_RESULT_CHARS) {
+        return serialized;
+      }
+
+      const head = serialized.slice(0, Math.floor(MAX_RESULT_CHARS * 0.75));
+      const tail = serialized.slice(-Math.floor(MAX_RESULT_CHARS * 0.15));
+      return `${head}...[truncated ${serialized.length - MAX_RESULT_CHARS} chars]...${tail}`;
+    } catch {
+      return '[unserializable result]';
+    }
+  }
+
+  private resolveTimeoutForAttempt(attempt: number): number {
+    if (attempt === 0) {
+      return this.config.timeout;
+    }
+
+    const expanded = Math.max(this.config.timeout + 15000, Math.round(this.config.timeout * 1.5));
+    return Math.min(expanded, 90000);
+  }
+
+  private shouldRetryObservation(
+    error: unknown,
+    aborted: boolean,
+    attempt: number,
+    maxAttempts: number,
+  ): boolean {
+    if (aborted || attempt >= maxAttempts - 1) {
+      return false;
+    }
+
+    if (error instanceof ObservationTimeoutError) {
+      return true;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return /timeout|timed out|rate limit|429|503|network|temporar|service unavailable|failed to parse structured response|invalid json|unterminated string/i.test(
+      message,
+    );
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
   // ===========================================================================
   // Private Methods - Execution
   // ===========================================================================
@@ -460,39 +530,50 @@ ${languageSection}${projectPromptAddendum}`;
     return new Promise<T>((resolve, reject) => {
       let settled = false;
 
-      const timeoutId = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          this.abort();
-          reject(new ObservationTimeoutError(timeout));
-        }
-      }, timeout);
-
-      const abortHandler = () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timeoutId);
-          reject(new ObservationTimeoutError(timeout));
-        }
-      };
-
-      if (this.abortController?.signal.aborted) {
-        settled = true;
-        clearTimeout(timeoutId);
-        reject(new ObservationTimeoutError(timeout));
-        return;
-      }
-
       const signal = this.abortController?.signal;
-      if (signal) {
-        signal.addEventListener('abort', abortHandler);
-      }
-
       const cleanup = () => {
         if (signal) {
           signal.removeEventListener('abort', abortHandler);
         }
       };
+
+      const failAsAborted = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutId);
+        cleanup();
+        reject(new ObservationError('Observation aborted'));
+      };
+
+      const failAsTimeout = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutId);
+        cleanup();
+        this.llm.abort();
+        reject(new ObservationTimeoutError(timeout));
+      };
+
+      const timeoutId = setTimeout(() => {
+        failAsTimeout();
+      }, timeout);
+
+      const abortHandler = () => {
+        failAsAborted();
+      };
+
+      if (this.abortController?.signal.aborted) {
+        failAsAborted();
+        return;
+      }
+
+      if (signal) {
+        signal.addEventListener('abort', abortHandler);
+      }
 
       operation()
         .then((result) => {

--- a/src/agents/engine/phases/Observer.ts
+++ b/src/agents/engine/phases/Observer.ts
@@ -133,7 +133,10 @@ export class Observer {
         const shouldRetry = this.shouldRetryObservation(error, aborted, attempt, maxAttempts);
 
         if (shouldRetry) {
-          await this.delay(this.config.retryBackoffMs * (attempt + 1));
+          await this.delay(
+            this.config.retryBackoffMs * (attempt + 1),
+            this.abortController?.signal,
+          );
           continue;
         }
 
@@ -492,7 +495,7 @@ ${languageSection}${projectPromptAddendum}`;
     }
 
     const expanded = Math.max(this.config.timeout + 15000, Math.round(this.config.timeout * 1.5));
-    return Math.min(expanded, 90000);
+    return Math.max(this.config.timeout, Math.min(expanded, 90000));
   }
 
   private shouldRetryObservation(
@@ -515,8 +518,43 @@ ${languageSection}${projectPromptAddendum}`;
     );
   }
 
-  private delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  private delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new ObservationError('Observation aborted'));
+        return;
+      }
+
+      let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanup = () => {
+        signal?.removeEventListener('abort', abortHandler);
+      };
+
+      const abortHandler = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        cleanup();
+        reject(new ObservationError('Observation aborted'));
+      };
+
+      timeoutId = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve();
+      }, ms);
+
+      signal?.addEventListener('abort', abortHandler);
+    });
   }
 
   // ===========================================================================

--- a/src/agents/engine/phases/Observer.ts
+++ b/src/agents/engine/phases/Observer.ts
@@ -343,7 +343,7 @@ ${languageSection}${projectPromptAddendum}`;
       `  Retries: ${step.retryCount}`,
     ];
 
-    if (step.result.data) {
+    if (step.result.data !== undefined) {
       lines.push(`  Result: ${this.serializeResultData(step.result.data)}`);
     }
 

--- a/src/hooks/agentRuntimePersistence.ts
+++ b/src/hooks/agentRuntimePersistence.ts
@@ -278,6 +278,7 @@ export async function startPersistedRun(input: {
   context: AgentContext;
   checkpointController: ResumeCheckpointController;
   persistedRunIdRef: PersistedRunIdRef;
+  safeCheckpointIdRef: CheckpointIdRef;
   logger: WarnLogger;
   loggerLabel: string;
 }): Promise<string | null> {
@@ -292,6 +293,7 @@ export async function startPersistedRun(input: {
     context,
     checkpointController,
     persistedRunIdRef,
+    safeCheckpointIdRef,
     logger,
     loggerLabel,
   } = input;
@@ -307,7 +309,7 @@ export async function startPersistedRun(input: {
     });
 
     persistedRunIdRef.current = persistedRun.id;
-    await checkpointController.persistCheckpoint({
+    safeCheckpointIdRef.current = await checkpointController.persistCheckpoint({
       sessionId,
       runId: persistedRun.id,
       runtimeKind,
@@ -321,6 +323,7 @@ export async function startPersistedRun(input: {
     return persistedRun.id;
   } catch (error) {
     persistedRunIdRef.current = null;
+    safeCheckpointIdRef.current = null;
     logger.warn(`Failed to create persisted ${loggerLabel} run`, {
       sessionId,
       error: error instanceof Error ? error.message : String(error),

--- a/src/hooks/useAgentLoop.test.ts
+++ b/src/hooks/useAgentLoop.test.ts
@@ -467,6 +467,11 @@ describe('useAgentLoop', () => {
       }),
     );
     expect(vi.mocked(commands.consumeAgentResumeCheckpoint)).toHaveBeenCalled();
+    expect(sessionState.activeCheckpointId).toBeNull();
+    expect(
+      persistedCheckpoints.find((checkpoint) => checkpoint.checkpointKind === 'safe_resume_point')
+        ?.status,
+    ).toBe('consumed');
     expect(vi.mocked(commands.updateAgentRunPhase)).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 'run-fast-1',

--- a/src/hooks/useAgentLoop.ts
+++ b/src/hooks/useAgentLoop.ts
@@ -141,6 +141,7 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
   } | null>(null);
   const bootstrappedCheckpointIdRef = useRef<string | null>(null);
   const persistedRunIdRef = useRef<string | null>(null);
+  const safeCheckpointIdRef = useRef<string | null>(null);
   const optionsRef = useRef(options);
 
   useEffect(() => {
@@ -180,6 +181,7 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
       }
       runGuardRef.current = true;
       persistedRunIdRef.current = null;
+      safeCheckpointIdRef.current = null;
 
       // Reset state
       setIsRunning(true);
@@ -372,6 +374,7 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
         context,
         checkpointController,
         persistedRunIdRef,
+        safeCheckpointIdRef,
         logger,
         loggerLabel: 'agent loop',
       });
@@ -629,7 +632,9 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
         }
       } finally {
         const persistedRunId = persistedRunIdRef.current;
+        const safeCheckpointId = safeCheckpointIdRef.current;
         persistedRunIdRef.current = null;
+        safeCheckpointIdRef.current = null;
         if (persistedRunId) {
           await finalizePersistedRun({
             sessionId: storeSessionId,
@@ -649,6 +654,7 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
             loggerLabel: 'agent loop',
           });
         }
+        await checkpointController.consumeCheckpoint(safeCheckpointId);
         if (!traceToWrite) {
           traceToWrite = finalizeRuntimeTrace(
             persistedFinalPhase === 'completed',
@@ -695,6 +701,8 @@ export function useAgentLoop(options: UseAgentLoopOptions): UseAgentLoopReturn {
     loopRef.current = null;
     toolPermissionResolverRef.current = null;
     bootstrappedCheckpointIdRef.current = null;
+    persistedRunIdRef.current = null;
+    safeCheckpointIdRef.current = null;
     abortNotifiedRef.current = false;
     setPhase('idle');
     setIsRunning(false);

--- a/src/hooks/useAgenticLoop.test.ts
+++ b/src/hooks/useAgenticLoop.test.ts
@@ -625,6 +625,11 @@ describe('useAgenticLoop', () => {
       }),
     );
     expect(vi.mocked(commands.consumeAgentResumeCheckpoint)).toHaveBeenCalled();
+    expect(sessionState.activeCheckpointId).toBeNull();
+    expect(
+      persistedCheckpoints.find((checkpoint) => checkpoint.checkpointKind === 'safe_resume_point')
+        ?.status,
+    ).toBe('consumed');
     expect(vi.mocked(commands.updateAgentRunPhase)).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 'run-tpao-1',

--- a/src/hooks/useAgenticLoop.ts
+++ b/src/hooks/useAgenticLoop.ts
@@ -194,6 +194,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
   const bootstrappedCheckpointIdRef = useRef<string | null>(null);
   const memoryStoreRef = useRef<IMemoryStore | null>(null);
   const persistedRunIdRef = useRef<string | null>(null);
+  const safeCheckpointIdRef = useRef<string | null>(null);
   const latestPlanRef = useRef<Plan | null>(null);
 
   if (!memoryStoreRef.current && config?.enableMemory !== false) {
@@ -324,6 +325,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
       }
       runGuardRef.current = true;
       persistedRunIdRef.current = null;
+      safeCheckpointIdRef.current = null;
 
       // Reset state
       setIsRunning(true);
@@ -494,6 +496,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
         context,
         checkpointController,
         persistedRunIdRef,
+        safeCheckpointIdRef,
         logger,
         loggerLabel: 'agentic',
       });
@@ -748,7 +751,9 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
         throw error;
       } finally {
         const persistedRunId = persistedRunIdRef.current;
+        const safeCheckpointId = safeCheckpointIdRef.current;
         persistedRunIdRef.current = null;
+        safeCheckpointIdRef.current = null;
         if (persistedRunId) {
           await finalizePersistedRun({
             sessionId: executionContext.sessionId,
@@ -764,6 +769,7 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
             loggerLabel: 'agentic',
           });
         }
+        await checkpointController.consumeCheckpoint(safeCheckpointId);
         if (traceToWrite) {
           traceToWrite = {
             ...traceToWrite,
@@ -813,6 +819,8 @@ export function useAgenticLoop(options: UseAgenticLoopOptions): UseAgenticLoopRe
     approvalResolverRef.current = null;
     clearPendingApprovals();
     bootstrappedCheckpointIdRef.current = null;
+    persistedRunIdRef.current = null;
+    safeCheckpointIdRef.current = null;
     setPhase('idle');
     setIsRunning(false);
     setEvents([]);


### PR DESCRIPTION
### **User description**
## Description

Improve AI runtime reliability by consuming safe resume checkpoints after persisted runs finish and making the observer phase more tolerant of transient timeouts and structured-response failures.

## Related Issue

Closes #603, closes #604

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Track the persisted safe-resume checkpoint ID in both AI runtime loops and consume it during finalization and cleanup.
- Add assertions that consumed safe checkpoints clear `activeCheckpointId` and move the checkpoint status to `consumed`.
- Increase observer timeout resilience with retry/backoff handling, bounded result serialization, and regression coverage for retry-on-timeout behavior.

## Screenshots / Videos

N/A

## Testing

Targeted Vitest coverage was run for both logical change groups, and the commit hook also ran repository version sync checks, TypeScript type-checking, and ESLint.

### Test Environment

- OS: Windows 11
- Node.js version: v22.19.0
- Rust version: rustc 1.92.0 (ded5c06cf 2025-12-08)

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Executed test commands:
- `npm run test:run -- src/hooks/useAgentLoop.test.ts src/hooks/useAgenticLoop.test.ts`
- `npm run test:run -- src/agents/engine/core/types.test.ts src/agents/engine/phases/Observer.test.ts`

The pre-commit hook also ran `npx tsx scripts/sync-version.ts --check`, `tsc --noEmit`, and `eslint . --ext .js,.jsx,.ts,.tsx --fix` successfully. The repository still reports pre-existing ESLint warnings in unrelated files, but this branch did not add new warning locations.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Implements retry logic and backoff for observer phase.

- Increases default observation timeout to 30 seconds.

- Ensures safe resume checkpoints are consumed upon completion.

- Adds bounded serialization for large observation result payloads.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Observer Phase
    A["Execute Observation"] -- "Timeout/Transient Error" --> B["Retry with Backoff"]
    B -- "Success" --> C["Validate & Return"]
    A -- "Success" --> C
  end
  subgraph Runtime Lifecycle
    D["Start Persisted Run"] -- "Create" --> E["Safe Checkpoint"]
    F["Finalize Run"] -- "Consume" --> E
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>Increase default observation timeout to 30 seconds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-910f85c522d3d5da272e50bee94ca72395ea315ba41153ef62ce1fa49cb02144">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Observer.ts</strong><dd><code>Implement retry logic and result truncation in Observer</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-016e3f22a493c4c74594d460333ed76d4c41c5d8a23736efc0da9cee7ef1625e">+125/-44</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>agentRuntimePersistence.ts</strong><dd><code>Track safe checkpoint ID during run initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-d7b157f2867080f31a5d6aa5090b283a979d44befd0755d83ee9aee2b7f56fb9">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgentLoop.ts</strong><dd><code>Consume safe checkpoints in standard agent loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-1cf9c7dcf563f63b4df0f5717427a94869736f02281238a5f42c87f7667ad9b4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgenticLoop.ts</strong><dd><code>Consume safe checkpoints in agentic engine loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-077855c4f6949a53263679547c8d1f576639dcd85168dff8f6d532fc06557013">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>Observer.test.ts</strong><dd><code>Add regression tests for observation timeout retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-2c05f622e29eef08659f8bcbe8993a0f34231f2a4353823c717c28fd55393ae7">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgentLoop.test.ts</strong><dd><code>Verify checkpoint consumption in agent loop tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-d5ecdb0e828c3795b60b22a27f59be29793cdddeb5f5dcd5213a2b1d1acc9d45">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAgenticLoop.test.ts</strong><dd><code>Verify checkpoint consumption in agentic loop tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-faafa224851e67e7d3839f3dffbba5800bfd5a27ee5e3cfa6c38a298ae60fec6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.test.ts</strong><dd><code>Update default config assertions for observation timeout</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/605/files#diff-73449f0b921f34874b0e949692abb420e4d1be8158f6095e5848b7040ed1b577">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retries with backoff for observation attempts.
  * Result-size protection to safely handle large outputs.
  * Safer checkpoint tracking and consumption during runs.

* **Bug Fixes**
  * Improved retry/abort behavior to avoid duplicate attempts and ensure proper failure reporting.

* **Chores**
  * Increased default observation timeout from 15s to 30s.

* **Tests**
  * Expanded test coverage for retries, timeouts, aborts, and checkpoint consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->