### PR TITLE
feat(ai): add interval split workflow and harden mutating plans

### DIFF
--- a/src/agents/ToolRegistry.ts
+++ b/src/agents/ToolRegistry.ts
@@ -7,6 +7,7 @@
 
 import { createLogger } from '@/services/logger';
 import { canonicalizeToolNameCandidate, normalizeToolNameCandidate } from './toolNameNormalization';
+import type { ToolOutputContract } from './toolOutputContracts';
 
 // =============================================================================
 // Shared Types (formerly from Agent.ts)
@@ -86,6 +87,8 @@ export interface ToolDefinition {
   isAvailable?: () => Promise<boolean>;
   /** Optional compatibility aliases accepted at lookup time */
   aliases?: string[];
+  /** Optional output contract for step-reference consumers and prompt docs */
+  outputContract?: ToolOutputContract;
 }
 
 /** Result of executing a tool */

--- a/src/agents/engine/AgenticEngine.test.ts
+++ b/src/agents/engine/AgenticEngine.test.ts
@@ -510,6 +510,8 @@ describe('AgenticEngine', () => {
 
       expect(result.success).toBe(true);
       expect(result.iterations).toBe(1);
+      expect(mockToolExecutor.wasToolCalled('get_track_clips')).toBe(false);
+      expect(mockToolExecutor.wasToolCalled('get_timeline_info')).toBe(false);
       expect(mockToolExecutor.wasToolCalled('split_clip')).toBe(true);
     });
 

--- a/src/agents/engine/AgenticEngine.test.ts
+++ b/src/agents/engine/AgenticEngine.test.ts
@@ -432,6 +432,87 @@ describe('AgenticEngine', () => {
       expect(events.some((e) => e.type === 'session_complete')).toBe(true);
     });
 
+    it('should recover when planning first returns a read-only edit plan', async () => {
+      const analysisOnlyThought: Thought = {
+        understanding: 'The user wants the timeline split into 1-second segments',
+        requirements: ['Track clip list', 'Timeline duration'],
+        uncertainties: [],
+        approach: 'First inspect the timeline, then execute split operations.',
+        needsMoreInfo: false,
+      };
+
+      const analysisOnlyPlan: Plan = {
+        goal: 'Split the timeline into 1-second segments',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'get_track_clips',
+            args: { trackId: 'track-1' },
+            description: 'Inspect clips on the target track',
+            riskLevel: 'low',
+            estimatedDuration: 50,
+          },
+          {
+            id: 'step-2',
+            tool: 'get_timeline_info',
+            args: { sequenceId: 'sequence-1' },
+            description: 'Inspect timeline duration',
+            riskLevel: 'low',
+            estimatedDuration: 50,
+          },
+        ],
+        estimatedTotalDuration: 100,
+        requiresApproval: false,
+        rollbackStrategy: 'None needed for analysis',
+      };
+
+      const executionPlan: Plan = {
+        goal: 'Perform the first timeline split',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'split_clip',
+            args: { clipId: 'clip-1', position: 1 },
+            description: 'Split the first clip at 1 second',
+            riskLevel: 'low',
+            estimatedDuration: 100,
+          },
+        ],
+        estimatedTotalDuration: 100,
+        requiresApproval: false,
+        rollbackStrategy: 'Undo split',
+      };
+
+      const executionObservation: Observation = {
+        goalAchieved: true,
+        stateChanges: [
+          { type: 'clip_created', target: 'clip-2', details: { splitFrom: 'clip-1' } },
+        ],
+        summary: 'Split the clip at 1 second.',
+        confidence: 0.95,
+        needsIteration: false,
+      };
+
+      let callCount = 0;
+      vi.spyOn(mockLLM, 'generateStructured').mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) return analysisOnlyThought;
+        if (callCount === 2) return analysisOnlyPlan;
+        if (callCount === 3) return executionPlan;
+        return executionObservation;
+      });
+
+      const result = await engine.run(
+        'Split the video every 1 second',
+        agentContext,
+        executionContext,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.iterations).toBe(1);
+      expect(mockToolExecutor.wasToolCalled('split_clip')).toBe(true);
+    });
+
     it('should handle clarification needed', async () => {
       const clarificationThought: Thought = {
         understanding: 'User wants to do something with a clip',

--- a/src/agents/engine/AgenticEngine.ts
+++ b/src/agents/engine/AgenticEngine.ts
@@ -2138,7 +2138,15 @@ export class AgenticEngine {
       return true;
     }
 
-    return hasMutationIntentText(input, thought?.understanding, thought?.approach, plan.goal);
+    const intentSignals = [plan.goal, thought?.understanding].filter(
+      (value): value is string => typeof value === 'string' && value.trim().length > 0,
+    );
+
+    if (intentSignals.length === 0) {
+      return hasMutationIntentText(input);
+    }
+
+    return hasMutationIntentText(...intentSignals);
   }
 
   private isMutatingTool(toolName: string): boolean {

--- a/src/agents/engine/AgenticEngine.ts
+++ b/src/agents/engine/AgenticEngine.ts
@@ -19,6 +19,7 @@ import type {
   AgentPhase,
   AgentState,
   AgenticEngineConfig,
+  CorrectionRecord,
   ExecutionRecord,
   Observation,
   Plan,
@@ -51,10 +52,12 @@ import { Observer, createObserver } from './phases/Observer';
 import {
   detectImmediateTerminalFailure,
   detectRepeatedTerminalFailure,
+  didExecutionMutateState,
   type TerminalFailureGuidance,
 } from './phases/executionFailureUtils';
 import { TraceRecorder, type AgentTrace } from './core/traceRecorder';
 import { writeTrace } from './core/traceWriter';
+import { hasMutationIntentText, isMutatingToolName } from './core/toolSemantics';
 import { buildProjectPromptAddendum } from './prompts/system';
 import { createLogger } from '@/services/logger';
 
@@ -822,6 +825,20 @@ export class AgenticEngine {
           observation = this.applyTerminalFailureGuard(observation, terminalFailureGuard);
         }
 
+        const mutationGuard = this.enforceMutationExpectation(
+          state.input,
+          state.thought ?? undefined,
+          plan,
+          executionResult,
+          observation,
+          iteration,
+        );
+        observation = mutationGuard.observation;
+        if (mutationGuard.correction) {
+          contextWithTools = this.appendCorrection(contextWithTools, mutationGuard.correction);
+          state.context = { ...contextWithTools, currentIteration: iteration };
+        }
+
         lastObservation = observation;
         tracer?.endPhase();
         this.emitEvent(onEvent, {
@@ -1305,6 +1322,20 @@ export class AgenticEngine {
         observation = this.applyTerminalFailureGuard(observation, terminalFailureGuard);
       }
 
+      const resumedApprovalGuard = this.enforceMutationExpectation(
+        state.input,
+        state.thought ?? undefined,
+        plan,
+        executionResult,
+        observation,
+        1,
+      );
+      observation = resumedApprovalGuard.observation;
+      if (resumedApprovalGuard.correction) {
+        contextWithTools = this.appendCorrection(contextWithTools, resumedApprovalGuard.correction);
+        state.context = { ...contextWithTools, currentIteration: 1 };
+      }
+
       tracer?.endPhase();
       this.emitEvent(onEvent, {
         type: 'observation_complete',
@@ -1736,6 +1767,20 @@ export class AgenticEngine {
       observation = this.applyTerminalFailureGuard(observation, terminalFailureGuard);
     }
 
+    const resumedPermissionGuard = this.enforceMutationExpectation(
+      state.input,
+      state.thought ?? undefined,
+      plan,
+      executionResult,
+      observation,
+      1,
+    );
+    observation = resumedPermissionGuard.observation;
+    if (resumedPermissionGuard.correction) {
+      contextWithTools = this.appendCorrection(contextWithTools, resumedPermissionGuard.correction);
+      state.context = { ...contextWithTools, currentIteration: 1 };
+    }
+
     tracer?.endPhase();
     this.emitEvent(onEvent, {
       type: 'observation_complete',
@@ -2027,6 +2072,95 @@ export class AgenticEngine {
       suggestedAction: hasSuggestedAction ? observation.suggestedAction : guidance.suggestedAction,
       summary,
       confidence: Math.max(observation.confidence, 0.9),
+    };
+  }
+
+  private enforceMutationExpectation(
+    input: string,
+    thought: Thought | undefined,
+    plan: Plan,
+    execution: ExecutionResult,
+    observation: Observation,
+    iteration: number,
+  ): { observation: Observation; correction?: CorrectionRecord } {
+    if (
+      !this.requiresMutationToSatisfyGoal(input, thought, plan) ||
+      didExecutionMutateState(execution)
+    ) {
+      return { observation };
+    }
+
+    const executedToolNames = execution.completedSteps.map((step) => step.tool);
+    const reason =
+      'The request requires an actual edit, but the last execution only gathered information and did not run a mutating tool.';
+    const summary = observation.summary.includes(reason)
+      ? observation.summary
+      : `${observation.summary} ${reason}`.trim();
+    const shouldRetry = iteration < this.config.maxIterations;
+
+    logger.warn('Preventing false success after read-only execution for edit intent', {
+      goal: plan.goal,
+      iteration,
+      executedToolNames,
+    });
+
+    return {
+      observation: {
+        ...observation,
+        goalAchieved: false,
+        needsIteration: shouldRetry,
+        iterationReason: reason,
+        suggestedAction:
+          'Plan and execute the required mutating tools. If analysis is needed first, use those results to drive edit steps instead of stopping after queries.',
+        summary,
+        confidence: Math.min(observation.confidence, 0.4),
+      },
+      correction: shouldRetry
+        ? {
+            original: plan.goal,
+            corrected:
+              'Do not stop after read-only analysis for an edit request. The next plan must execute the mutating tools needed to fulfill the requested change.',
+            context:
+              executedToolNames.length > 0
+                ? `Iteration ${iteration} only executed read-only tools: ${executedToolNames.join(', ')}`
+                : `Iteration ${iteration} executed no tools`,
+          }
+        : undefined,
+    };
+  }
+
+  private requiresMutationToSatisfyGoal(
+    input: string,
+    thought: Thought | undefined,
+    plan: Plan,
+  ): boolean {
+    if (plan.steps.some((step) => this.isMutatingTool(step.tool))) {
+      return true;
+    }
+
+    return hasMutationIntentText(input, thought?.understanding, thought?.approach, plan.goal);
+  }
+
+  private isMutatingTool(toolName: string): boolean {
+    const category = this.toolExecutor.getToolDefinition(toolName)?.category?.trim().toLowerCase();
+    return isMutatingToolName(toolName, category);
+  }
+
+  private appendCorrection(context: AgentContext, correction: CorrectionRecord): AgentContext {
+    const alreadyPresent = context.corrections.some(
+      (entry) =>
+        entry.original === correction.original &&
+        entry.corrected === correction.corrected &&
+        entry.context === correction.context,
+    );
+
+    if (alreadyPresent) {
+      return context;
+    }
+
+    return {
+      ...context,
+      corrections: [...context.corrections, correction],
     };
   }
 

--- a/src/agents/engine/__tests__/golden/backend-atomic.golden.test.ts
+++ b/src/agents/engine/__tests__/golden/backend-atomic.golden.test.ts
@@ -16,12 +16,7 @@ import {
 } from '../../adapters/tools/MockToolExecutor';
 import type { ExecutionContext } from '../../ports/IToolExecutor';
 import { useProjectStore } from '@/stores/projectStore';
-import {
-  createMockAsset,
-  createMockClip,
-  createMockSequence,
-  createMockTrack,
-} from '@/test/mocks';
+import { createMockAsset, createMockClip, createMockSequence, createMockTrack } from '@/test/mocks';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
@@ -32,6 +27,16 @@ vi.mock('@tauri-apps/api/event', () => ({
 }));
 
 const mockInvoke = vi.mocked(invoke);
+
+function buildBackendProjectState() {
+  const project = useProjectStore.getState();
+  return {
+    assets: Array.from(project.assets.values()),
+    sequences: Array.from(project.sequences.values()),
+    effects: Array.from(project.effects.values()),
+    activeSequenceId: project.activeSequenceId,
+  };
+}
 
 function seedActiveProjectState(): void {
   const clip1 = createMockClip({
@@ -83,6 +88,13 @@ describe('Golden: backend-atomic', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     seedActiveProjectState();
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'get_project_state') {
+        return buildBackendProjectState();
+      }
+
+      throw new Error(`Unexpected invoke: ${command}`);
+    });
     mockToolExecutor = createMockToolExecutor();
 
     // Register editing tools (category: 'clip' → backend route)
@@ -203,7 +215,7 @@ describe('Golden: backend-atomic', () => {
     expect(result.failureCount).toBe(0);
 
     // Single IPC call containing all 3 steps
-    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
     expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
       plan: expect.objectContaining({
         steps: [
@@ -295,27 +307,42 @@ describe('Golden: backend-atomic', () => {
     // Mixed batches execute per-tool in order (not partitioned) to preserve
     // the caller's intended execution sequence.
     // Backend tools are routed individually via execute() calls.
-    mockInvoke.mockResolvedValueOnce({
-      planId: 'single-1',
-      success: true,
-      totalSteps: 1,
-      stepsCompleted: 1,
-      stepResults: [
-        { stepId: 'step-1', success: true, data: { newClipId: 'clip-2' }, durationMs: 20 },
-      ],
-      operationIds: ['op-1'],
-      executionTimeMs: 20,
-    });
-    mockInvoke.mockResolvedValueOnce({
-      planId: 'single-2',
-      success: true,
-      totalSteps: 1,
-      stepsCompleted: 1,
-      stepResults: [
-        { stepId: 'step-1', success: true, data: { moved: true }, durationMs: 15 },
-      ],
-      operationIds: ['op-2'],
-      executionTimeMs: 15,
+    const backendPlanResults = [
+      {
+        planId: 'single-1',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { newClipId: 'clip-2' }, durationMs: 20 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 20,
+      },
+      {
+        planId: 'single-2',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [{ stepId: 'step-1', success: true, data: { moved: true }, durationMs: 15 }],
+        operationIds: ['op-2'],
+        executionTimeMs: 15,
+      },
+    ];
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'get_project_state') {
+        return buildBackendProjectState();
+      }
+
+      if (command === 'execute_agent_plan') {
+        const nextResult = backendPlanResults.shift();
+        if (!nextResult) {
+          throw new Error('Unexpected execute_agent_plan call');
+        }
+        return nextResult;
+      }
+
+      throw new Error(`Unexpected invoke: ${command}`);
     });
 
     const result = await backendExecutor.executeBatch(
@@ -339,7 +366,7 @@ describe('Golden: backend-atomic', () => {
     expect(result.results[2].tool).toBe('get_timeline_info');
 
     // Backend IPC: 2 separate single-tool plans (not one combined plan)
-    expect(mockInvoke).toHaveBeenCalledTimes(2);
+    expect(mockInvoke).toHaveBeenCalledTimes(4);
 
     // Frontend executor handled the analysis tool
     expect(mockToolExecutor.wasToolCalled('get_timeline_info')).toBe(true);

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -276,6 +276,16 @@ function seedActiveProjectState(
   });
 }
 
+function buildBackendProjectState() {
+  const project = useProjectStore.getState();
+  return {
+    assets: Array.from(project.assets.values()),
+    sequences: Array.from(project.sequences.values()),
+    effects: Array.from(project.effects.values()),
+    activeSequenceId: project.activeSequenceId,
+  };
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -287,6 +297,13 @@ describe('BackendToolExecutor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     seedActiveProjectState();
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'get_project_state') {
+        return buildBackendProjectState();
+      }
+
+      throw new Error(`Unexpected invoke: ${command}`);
+    });
     frontend = createMockFrontendExecutor(TOOL_DEFS);
     backend = createBackendToolExecutor(frontend);
   });
@@ -924,6 +941,7 @@ describe('BackendToolExecutor', () => {
         operationIds: ['op-1'],
         executionTimeMs: 5,
       });
+      mockInvoke.mockResolvedValueOnce(buildBackendProjectState());
       mockInvoke.mockResolvedValueOnce({
         planId: 'single-2',
         success: true,
@@ -933,6 +951,7 @@ describe('BackendToolExecutor', () => {
         operationIds: ['op-2'],
         executionTimeMs: 5,
       });
+      mockInvoke.mockResolvedValueOnce(buildBackendProjectState());
 
       const result = await backend.executeBatch(
         {
@@ -1206,13 +1225,128 @@ describe('BackendToolExecutor', () => {
 
       // Editing tool → backend
       await backend.execute('split_clip', { clipId: 'c1', atTimelineSec: 5 }, CONTEXT);
-      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
       expect(frontend.execute).not.toHaveBeenCalled();
 
       // Analysis tool → frontend
       await backend.execute('analyze_video', { assetId: 'a1' }, CONTEXT);
       expect(frontend.execute).toHaveBeenCalledTimes(1);
-      expect(mockInvoke).toHaveBeenCalledTimes(1); // Still just the 1 call from editing
+      expect(mockInvoke).toHaveBeenCalledTimes(2); // execute_agent_plan + get_project_state
+    });
+
+    it('should sync backend-created clip ids into store for chained split steps', async () => {
+      seedActiveProjectState({ clipIds: ['clip-1'] });
+
+      const firstRefreshState = {
+        assets: [
+          createMockAsset({ id: 'asset-clip-1', name: 'clip-1.mp4', kind: 'video' }),
+          createMockAsset({ id: 'asset-clip-new', name: 'clip-new.mp4', kind: 'video' }),
+        ],
+        sequences: [
+          createMockSequence({
+            id: 'seq-1',
+            name: 'Test Sequence',
+            tracks: [
+              createMockTrack({
+                id: 'track-1',
+                kind: 'video',
+                name: 'Video 1',
+                clips: [
+                  createMockClip({ id: 'clip-1', assetId: 'asset-clip-1' }),
+                  createMockClip({ id: 'clip-new', assetId: 'asset-clip-new' }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        effects: [],
+        activeSequenceId: 'seq-1',
+      };
+
+      const secondRefreshState = {
+        assets: [
+          createMockAsset({ id: 'asset-clip-1', name: 'clip-1.mp4', kind: 'video' }),
+          createMockAsset({ id: 'asset-clip-new', name: 'clip-new.mp4', kind: 'video' }),
+          createMockAsset({ id: 'asset-clip-new-2', name: 'clip-new-2.mp4', kind: 'video' }),
+        ],
+        sequences: [
+          createMockSequence({
+            id: 'seq-1',
+            name: 'Test Sequence',
+            tracks: [
+              createMockTrack({
+                id: 'track-1',
+                kind: 'video',
+                name: 'Video 1',
+                clips: [
+                  createMockClip({ id: 'clip-1', assetId: 'asset-clip-1' }),
+                  createMockClip({ id: 'clip-new', assetId: 'asset-clip-new' }),
+                  createMockClip({ id: 'clip-new-2', assetId: 'asset-clip-new-2' }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        effects: [],
+        activeSequenceId: 'seq-1',
+      };
+
+      mockInvoke
+        .mockResolvedValueOnce({
+          planId: 'plan-1',
+          success: true,
+          totalSteps: 1,
+          stepsCompleted: 1,
+          stepResults: [
+            {
+              stepId: 'step-1',
+              success: true,
+              data: { createdIds: ['clip-new'] },
+              durationMs: 5,
+            },
+          ],
+          operationIds: ['op-1'],
+          executionTimeMs: 5,
+        })
+        .mockResolvedValueOnce(firstRefreshState)
+        .mockResolvedValueOnce({
+          planId: 'plan-2',
+          success: true,
+          totalSteps: 1,
+          stepsCompleted: 1,
+          stepResults: [
+            {
+              stepId: 'step-1',
+              success: true,
+              data: { createdIds: ['clip-new-2'] },
+              durationMs: 5,
+            },
+          ],
+          operationIds: ['op-2'],
+          executionTimeMs: 5,
+        })
+        .mockResolvedValueOnce(secondRefreshState);
+
+      const firstResult = await backend.execute(
+        'split_clip',
+        { clipId: 'clip-1', splitTime: 1 },
+        CONTEXT,
+      );
+      const secondResult = await backend.execute(
+        'split_clip',
+        { clipId: 'clip-new', splitTime: 2 },
+        CONTEXT,
+      );
+
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(useProjectStore.getState().stateVersion).toBeGreaterThan(8);
+      expect(
+        useProjectStore
+          .getState()
+          .getActiveSequence?.()
+          ?.tracks[0]?.clips.some((clip) => clip.id === 'clip-new'),
+      ).toBe(true);
     });
   });
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -1348,6 +1348,39 @@ describe('BackendToolExecutor', () => {
           ?.tracks[0]?.clips.some((clip) => clip.id === 'clip-new'),
       ).toBe(true);
     });
+
+    it('should poison the session after backend sync failure and block later mutations', async () => {
+      mockInvoke
+        .mockResolvedValueOnce({
+          planId: 'plan-1',
+          success: true,
+          totalSteps: 1,
+          stepsCompleted: 1,
+          stepResults: [{ stepId: 'step-1', success: true, data: { ok: true }, durationMs: 5 }],
+          operationIds: ['op-1'],
+          executionTimeMs: 5,
+        })
+        .mockRejectedValueOnce(new Error('refresh failed'));
+
+      const firstResult = await backend.execute(
+        'split_clip',
+        { clipId: 'clip-1', splitTime: 1 },
+        CONTEXT,
+      );
+      expect(firstResult.success).toBe(true);
+      expect(firstResult.data).toEqual(expect.objectContaining({ syncWarning: 'refresh failed' }));
+
+      const callCountAfterFirstMutation = mockInvoke.mock.calls.length;
+      const secondResult = await backend.execute(
+        'split_clip',
+        { clipId: 'clip-1', splitTime: 2 },
+        CONTEXT,
+      );
+
+      expect(secondResult.success).toBe(false);
+      expect(secondResult.error).toContain('SESSION_SYNC_FAILED');
+      expect(mockInvoke.mock.calls.length).toBe(callCountAfterFirstMutation);
+    });
   });
 
   // ===========================================================================

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -237,6 +237,7 @@ function normalizeBackendSingleStepData(
  */
 export class BackendToolExecutor implements IToolExecutor {
   private readonly sessionStateVersions = new Map<string, number>();
+  private readonly poisonedSessions = new Set<string>();
 
   constructor(private readonly frontendExecutor: IToolExecutor) {}
 
@@ -279,6 +280,13 @@ export class BackendToolExecutor implements IToolExecutor {
     args: Record<string, unknown>,
     context: ExecutionContext,
   ): string | null {
+    if (this.poisonedSessions.has(context.sessionId)) {
+      return (
+        'SESSION_SYNC_FAILED: a previous backend mutation succeeded but local state refresh failed. ' +
+        'Refresh context and re-plan before running more mutating steps.'
+      );
+    }
+
     const { error: revisionError, currentVersion } = validateMutationStateRevision(
       context,
       this.sessionStateVersions.get(context.sessionId),
@@ -1023,6 +1031,7 @@ export class BackendToolExecutor implements IToolExecutor {
 
   private rememberSessionStateVersion(sessionId: string, stateVersion: number): void {
     this.sessionStateVersions.set(sessionId, stateVersion);
+    this.poisonedSessions.delete(sessionId);
     if (this.sessionStateVersions.size <= 200) {
       return;
     }
@@ -1030,6 +1039,21 @@ export class BackendToolExecutor implements IToolExecutor {
     const oldest = this.sessionStateVersions.keys().next().value;
     if (typeof oldest === 'string') {
       this.sessionStateVersions.delete(oldest);
+      this.poisonedSessions.delete(oldest);
+    }
+  }
+
+  private poisonSession(sessionId: string): void {
+    this.sessionStateVersions.delete(sessionId);
+    this.poisonedSessions.add(sessionId);
+
+    if (this.poisonedSessions.size <= 200) {
+      return;
+    }
+
+    const oldest = this.poisonedSessions.values().next().value;
+    if (typeof oldest === 'string') {
+      this.poisonedSessions.delete(oldest);
     }
   }
 
@@ -1051,7 +1075,7 @@ export class BackendToolExecutor implements IToolExecutor {
         sessionId,
         error: message,
       });
-      this.rememberSessionStateVersion(sessionId, useProjectStore.getState().stateVersion);
+      this.poisonSession(sessionId);
       return message;
     }
   }

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -31,6 +31,7 @@ import { createLogger } from '@/services/logger';
 import { isMetaToolsEnabled } from '@/config/featureFlags';
 import { getVisibleMetaToolNames } from '@/agents/tools/metaTools';
 import { getWorkspaceToolNames } from '@/agents/tools/workspaceTools';
+import { useProjectStore } from '@/stores/projectStore';
 import {
   requiresProjectMutationPreflight,
   validateMutationPreconditions,
@@ -235,6 +236,8 @@ function normalizeBackendSingleStepData(
  * and delegates analysis/utility tools to the frontend fallback executor.
  */
 export class BackendToolExecutor implements IToolExecutor {
+  private readonly sessionStateVersions = new Map<string, number>();
+
   constructor(private readonly frontendExecutor: IToolExecutor) {}
 
   /**
@@ -276,8 +279,12 @@ export class BackendToolExecutor implements IToolExecutor {
     args: Record<string, unknown>,
     context: ExecutionContext,
   ): string | null {
-    const { error: revisionError } = validateMutationStateRevision(context);
+    const { error: revisionError, currentVersion } = validateMutationStateRevision(
+      context,
+      this.sessionStateVersions.get(context.sessionId),
+    );
     if (revisionError) {
+      this.rememberSessionStateVersion(context.sessionId, currentVersion);
       return revisionError;
     }
 
@@ -506,6 +513,9 @@ export class BackendToolExecutor implements IToolExecutor {
       const legacyRoute = this.tryBuildLegacyExecutePlanRoute(args, context);
       if (legacyRoute) {
         for (const step of legacyRoute.plan.steps) {
+          if ((step.dependsOn?.length ?? 0) > 0) {
+            continue;
+          }
           const preflightFailure = this.getMutationPreflightFailure(
             step.toolName.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`),
             step.params as Record<string, unknown>,
@@ -521,11 +531,17 @@ export class BackendToolExecutor implements IToolExecutor {
         });
 
         if (!execution.ok) {
+          this.rememberSessionStateVersion(
+            context.sessionId,
+            useProjectStore.getState().stateVersion,
+          );
           return createFailureResult(
             `Backend execution error: ${execution.error}`,
             execution.duration,
           );
         }
+
+        const syncWarning = await this.syncProjectState(context.sessionId);
 
         const stepResultById = new Map(
           execution.result.stepResults.map((stepResult) => [stepResult.stepId, stepResult]),
@@ -578,6 +594,7 @@ export class BackendToolExecutor implements IToolExecutor {
           data: {
             stepsExecuted: stepResults.length,
             stepResults,
+            ...(syncWarning ? { syncWarning } : {}),
           },
           duration: execution.duration,
           undoable: true,
@@ -600,7 +617,10 @@ export class BackendToolExecutor implements IToolExecutor {
           return createFailureResult(preflightFailure, 0);
         }
       }
-      return this.frontendExecutor.execute(toolName, args, context);
+
+      const frontendResult = await this.frontendExecutor.execute(toolName, args, context);
+      this.rememberSessionStateVersion(context.sessionId, useProjectStore.getState().stateVersion);
+      return frontendResult;
     }
 
     const preflightFailure = this.getMutationPreflightFailure(
@@ -667,8 +687,11 @@ export class BackendToolExecutor implements IToolExecutor {
       metaToolAction: executionTarget.metaAction ?? null,
     });
     if (!execution.ok) {
+      this.rememberSessionStateVersion(context.sessionId, useProjectStore.getState().stateVersion);
       return createFailureResult(`Backend execution error: ${execution.error}`, execution.duration);
     }
+
+    const syncWarning = await this.syncProjectState(context.sessionId);
 
     if (execution.result.success && execution.result.stepResults.length > 0) {
       // For compound tools, aggregate all step results into the data field
@@ -688,7 +711,7 @@ export class BackendToolExecutor implements IToolExecutor {
 
       return {
         success: true,
-        data,
+        data: this.appendSyncWarning(data, syncWarning),
         duration: execution.duration,
         undoable: true,
         undoOperation: {
@@ -759,24 +782,27 @@ export class BackendToolExecutor implements IToolExecutor {
 
       for (let i = 0; i < backendTools.length; i++) {
         const { requestTool, executionTarget } = backendTools[i];
-        const preflightFailure = this.getMutationPreflightFailure(
-          executionTarget.effectiveToolName,
-          executionTarget.params,
-          context,
-        );
-        if (preflightFailure) {
-          return {
-            success: false,
-            results: [
-              {
-                tool: requestTool.name,
-                result: createFailureResult(preflightFailure, performance.now() - start),
-              },
-            ],
-            totalDuration: performance.now() - start,
-            successCount: 0,
-            failureCount: 1,
-          };
+        const shouldPreflightNow = request.mode !== 'sequential' || i === 0;
+        if (shouldPreflightNow) {
+          const preflightFailure = this.getMutationPreflightFailure(
+            executionTarget.effectiveToolName,
+            executionTarget.params,
+            context,
+          );
+          if (preflightFailure) {
+            return {
+              success: false,
+              results: [
+                {
+                  tool: requestTool.name,
+                  result: createFailureResult(preflightFailure, performance.now() - start),
+                },
+              ],
+              totalDuration: performance.now() - start,
+              successCount: 0,
+              failureCount: 1,
+            };
+          }
         }
         const exp = compoundExpanders.get(executionTarget.effectiveToolName);
 
@@ -862,6 +888,7 @@ export class BackendToolExecutor implements IToolExecutor {
 
         try {
           const planResult = await invoke<AgentPlanResult>('execute_agent_plan', { plan });
+          const syncWarning = await this.syncProjectState(context.sessionId);
 
           // If the plan failed atomically (with rollback), all tools must be
           // reported as failed — individual step slices may look successful
@@ -893,12 +920,14 @@ export class BackendToolExecutor implements IToolExecutor {
                   tool: backendTools[mapping.toolIndex].requestTool.name,
                   result: {
                     success: true,
-                    data:
+                    data: this.appendSyncWarning(
                       mapping.stepCount > 1
                         ? {
                             steps: stepSlice.map((sr) => ({ success: sr.success, data: sr.data })),
                           }
                         : stepSlice[0].data,
+                      syncWarning,
+                    ),
                     duration: totalDuration,
                     undoable: true,
                   },
@@ -990,6 +1019,59 @@ export class BackendToolExecutor implements IToolExecutor {
 
   getToolsByRisk(maxRisk: RiskLevel): ToolInfo[] {
     return this.frontendExecutor.getToolsByRisk(maxRisk);
+  }
+
+  private rememberSessionStateVersion(sessionId: string, stateVersion: number): void {
+    this.sessionStateVersions.set(sessionId, stateVersion);
+    if (this.sessionStateVersions.size <= 200) {
+      return;
+    }
+
+    const oldest = this.sessionStateVersions.keys().next().value;
+    if (typeof oldest === 'string') {
+      this.sessionStateVersions.delete(oldest);
+    }
+  }
+
+  private async syncProjectState(sessionId: string): Promise<string | null> {
+    const projectState = useProjectStore.getState();
+    if (!projectState.isLoaded || !projectState.meta) {
+      this.rememberSessionStateVersion(sessionId, projectState.stateVersion);
+      return null;
+    }
+
+    try {
+      const nextStateVersion = await projectState.refreshFromBackendMutation();
+
+      this.rememberSessionStateVersion(sessionId, nextStateVersion);
+      return null;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn('Backend execution succeeded but frontend state refresh failed', {
+        sessionId,
+        error: message,
+      });
+      this.rememberSessionStateVersion(sessionId, useProjectStore.getState().stateVersion);
+      return message;
+    }
+  }
+
+  private appendSyncWarning(data: unknown, syncWarning: string | null): unknown {
+    if (!syncWarning) {
+      return data;
+    }
+
+    if (!isRecord(data)) {
+      return {
+        data,
+        syncWarning,
+      };
+    }
+
+    return {
+      ...data,
+      syncWarning,
+    };
   }
 }
 

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
@@ -408,6 +408,7 @@ export class ToolRegistryAdapter implements IToolExecutor {
       ...this.toToolInfo(tool),
       parameters: tool.parameters as unknown as Record<string, unknown>,
       required: (tool.parameters as { required?: string[] }).required,
+      outputContract: tool.outputContract,
     };
   }
 

--- a/src/agents/engine/adapters/tools/mutationPreflight.ts
+++ b/src/agents/engine/adapters/tools/mutationPreflight.ts
@@ -1,23 +1,8 @@
 import type { ExecutionContext } from '../../ports/IToolExecutor';
-import {
-  getAssetCatalogSnapshot,
-  getTimelineSnapshot,
-} from '@/agents/tools/storeAccessor';
+import { getAssetCatalogSnapshot, getTimelineSnapshot } from '@/agents/tools/storeAccessor';
 import { useProjectStore } from '@/stores/projectStore';
-
-const READ_ONLY_TOOL_PREFIXES = [
-  'get_',
-  'list_',
-  'find_',
-  'search_',
-  'analyze_',
-  'inspect_',
-  'query_',
-  'read_',
-  'check_',
-  'compare_',
-  'estimate_',
-];
+export { isReadOnlyToolName, requiresProjectMutationPreflight } from '../../core/toolSemantics';
+import { requiresProjectMutationPreflight } from '../../core/toolSemantics';
 
 const ID_PLACEHOLDER_PATTERNS: RegExp[] = [
   /(?:^|[_-])(placeholder|example|sample|dummy|temp|todo|tbd|unknown)(?:$|[_-])/i,
@@ -26,58 +11,6 @@ const ID_PLACEHOLDER_PATTERNS: RegExp[] = [
 ];
 
 const TRACK_ALIAS_PATTERNS: RegExp[] = [/^(video|audio)_[0-9]+$/i];
-
-const PROJECT_MUTATION_CATEGORIES = new Set([
-  'timeline',
-  'clip',
-  'track',
-  'effect',
-  'transition',
-  'audio',
-]);
-
-const PROJECT_MUTATION_UTILITY_TOOLS = new Set([
-  'add_caption',
-  'update_caption',
-  'delete_caption',
-  'style_caption',
-  'add_captions_from_transcription',
-  'import_captions_from_file',
-]);
-
-const READ_ONLY_EXACT_TOOL_NAMES = new Set([
-  'check_generation_status',
-  'estimate_generation_cost',
-]);
-
-export function isReadOnlyToolName(toolName: string, category?: string | null): boolean {
-  const normalized = toolName.trim().toLowerCase();
-  const normalizedCategory = category?.trim().toLowerCase() ?? null;
-
-  if (normalizedCategory === 'analysis' || READ_ONLY_EXACT_TOOL_NAMES.has(normalized)) {
-    return true;
-  }
-
-  return READ_ONLY_TOOL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
-}
-
-export function requiresProjectMutationPreflight(
-  toolName: string,
-  category?: string | null,
-): boolean {
-  const normalized = toolName.trim().toLowerCase();
-  const normalizedCategory = category?.trim().toLowerCase() ?? null;
-
-  if (normalized === 'execute_plan' || normalized === 'edit') {
-    return true;
-  }
-
-  if (PROJECT_MUTATION_UTILITY_TOOLS.has(normalized)) {
-    return true;
-  }
-
-  return normalizedCategory !== null && PROJECT_MUTATION_CATEGORIES.has(normalizedCategory);
-}
 
 export function validateMutationStateRevision(
   context: ExecutionContext,
@@ -95,8 +28,8 @@ export function validateMutationStateRevision(
     return {
       currentVersion,
       error:
-        `REV_CONFLICT: expected state version ${expectedVersion}, current version ${currentVersion}. `
-        + 'Refresh context and re-plan with current IDs.',
+        `REV_CONFLICT: expected state version ${expectedVersion}, current version ${currentVersion}. ` +
+        'Refresh context and re-plan with current IDs.',
     };
   }
 
@@ -179,8 +112,8 @@ function isPlaceholderId(value: string, key: string): boolean {
   }
 
   if (
-    key.toLowerCase().includes('track')
-    && TRACK_ALIAS_PATTERNS.some((pattern) => pattern.test(value))
+    key.toLowerCase().includes('track') &&
+    TRACK_ALIAS_PATTERNS.some((pattern) => pattern.test(value))
   ) {
     return true;
   }

--- a/src/agents/engine/core/orchestrationPlaybooks.test.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.test.ts
@@ -134,7 +134,8 @@ describe('buildOrchestrationPlaybook', () => {
 
   it('creates insert-and-segment playbook with chained split references', () => {
     const thought: Thought = {
-      understanding: "Insert '20240921_214806_1.mp4' into the timeline and split it into 5-second segments",
+      understanding:
+        "Insert '20240921_214806_1.mp4' into the timeline and split it into 5-second segments",
       requirements: ['insert asset', 'split into 5-second segments'],
       uncertainties: [],
       approach: 'Insert the named clip, then split each following 5-second boundary',
@@ -179,9 +180,36 @@ describe('buildOrchestrationPlaybook', () => {
     expect(thirdSplit?.dependsOn).toEqual(['playbook_split_segment_2']);
   });
 
+  it('creates timeline interval split playbook for whole-timeline video and audio segmentation', () => {
+    const thought: Thought = {
+      understanding: 'Split the video and audio on the timeline every 1 second',
+      requirements: ['timeline split', 'video', 'audio'],
+      uncertainties: [],
+      approach: 'Apply a regular 1-second split across the whole timeline',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['split_timeline_by_interval']);
+    const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
+
+    expect(match).not.toBeNull();
+    expect(match?.id).toBe('timeline_interval_split');
+    expect(match?.plan.steps).toHaveLength(1);
+    expect(match?.plan.steps[0]).toMatchObject({
+      tool: 'split_timeline_by_interval',
+      args: {
+        sequenceId: 'sequence-1',
+        intervalSeconds: 1,
+        includeVideo: true,
+        includeAudio: true,
+      },
+    });
+  });
+
   it('returns null for insert-and-segment requests when the target asset has no duration', () => {
     const thought: Thought = {
-      understanding: "Insert '20240921_214806_1.mp4' into the timeline and split it into 5-second segments",
+      understanding:
+        "Insert '20240921_214806_1.mp4' into the timeline and split it into 5-second segments",
       requirements: ['insert asset', 'split into 5-second segments'],
       uncertainties: [],
       approach: 'Insert the named clip, then split each following 5-second boundary',
@@ -445,7 +473,11 @@ describe('buildOrchestrationPlaybook', () => {
   it('should not match auto-caption when requirements include non-captioning analysis', () => {
     const thought: Thought = {
       understanding: 'Identify what is being said and shown in this video',
-      requirements: ['speech-to-text transcription', 'shot boundary detection', 'object recognition'],
+      requirements: [
+        'speech-to-text transcription',
+        'shot boundary detection',
+        'object recognition',
+      ],
       uncertainties: [],
       approach: 'Run multi-modal analysis pipeline',
       needsMoreInfo: false,

--- a/src/agents/engine/core/orchestrationPlaybooks.test.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.test.ts
@@ -206,6 +206,41 @@ describe('buildOrchestrationPlaybook', () => {
     });
   });
 
+  it('defaults to splitting both video and audio when the request targets the timeline without media qualifiers', () => {
+    const thought: Thought = {
+      understanding: 'Split the timeline every 1 second',
+      requirements: ['timeline split'],
+      uncertainties: [],
+      approach: 'Apply a regular 1-second split across the whole timeline',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['split_timeline_by_interval']);
+    const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
+
+    expect(match?.id).toBe('timeline_interval_split');
+    expect(match?.plan.steps[0]).toMatchObject({
+      args: {
+        includeVideo: true,
+        includeAudio: true,
+      },
+    });
+  });
+
+  it('does not match whole-timeline interval split for single-clip split wording', () => {
+    const thought: Thought = {
+      understanding: 'Split this video clip every 1 second',
+      requirements: ['split one clip'],
+      uncertainties: [],
+      approach: 'Segment the selected clip only',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['split_timeline_by_interval']);
+
+    expect(buildOrchestrationPlaybook(thought, createContext(), toolExecutor)).toBeNull();
+  });
+
   it('returns null for insert-and-segment requests when the target asset has no duration', () => {
     const thought: Thought = {
       understanding:

--- a/src/agents/engine/core/orchestrationPlaybooks.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.ts
@@ -87,16 +87,12 @@ const SEGMENT_KEYWORDS = [
 const TIMELINE_SPLIT_SCOPE_KEYWORDS = [
   /timeline/i,
   /all\s+(?:clips?|tracks?)/i,
-  /video\s*(?:and|&)\s*audio/i,
-  /audio\s*(?:and|&)\s*video/i,
-  /sound/i,
+  /(?:whole|entire)\s+(?:timeline|sequence)/i,
+  /(?:video|audio|sound)\s+(?:on|across)\s+(?:the\s+)?timeline/i,
+  /(?:all|every)\s+(?:video|audio|clips?|tracks?)/i,
   /타임라인/i,
-  /전체/i,
-  /모든/i,
-  /영상/i,
-  /비디오/i,
-  /오디오/i,
-  /소리/i,
+  /전체\s*(?:타임라인|클립|트랙)?/i,
+  /모든\s*(?:클립|트랙|영상|비디오|오디오)/i,
 ];
 
 const AUDIO_SCOPE_KEYWORDS = [/\baudio\b/i, /\bsound\b/i, /오디오/i, /소리/i, /음성/i];
@@ -223,14 +219,14 @@ export function buildOrchestrationPlaybook(
     return generateAndPlace;
   }
 
-  const timelineIntervalSplit = buildTimelineIntervalSplitPlaybook(playbookContext);
-  if (timelineIntervalSplit) {
-    return timelineIntervalSplit;
-  }
-
   const insertAndSegment = buildInsertAndSegmentPlaybook(playbookContext);
   if (insertAndSegment) {
     return insertAndSegment;
+  }
+
+  const timelineIntervalSplit = buildTimelineIntervalSplitPlaybook(playbookContext);
+  if (timelineIntervalSplit) {
+    return timelineIntervalSplit;
   }
 
   const brollMusicSubtitles = buildBrollMusicSubtitlesPlaybook(playbookContext);
@@ -382,8 +378,10 @@ function buildTimelineIntervalSplitPlaybook(
     return null;
   }
 
-  const includeAudio = matchesAny(text, AUDIO_SCOPE_KEYWORDS);
-  const includeVideo = matchesAny(text, VIDEO_SCOPE_KEYWORDS) || !includeAudio;
+  const mentionsAudio = matchesAny(text, AUDIO_SCOPE_KEYWORDS);
+  const mentionsVideo = matchesAny(text, VIDEO_SCOPE_KEYWORDS);
+  const includeAudio = mentionsAudio || (!mentionsAudio && !mentionsVideo);
+  const includeVideo = mentionsVideo || (!mentionsAudio && !mentionsVideo);
   const trackKinds = context.availableTracks.map((track) => track.type);
   const canSplitVideo = includeVideo && trackKinds.includes('video');
   const canSplitAudio = includeAudio && trackKinds.includes('audio');

--- a/src/agents/engine/core/orchestrationPlaybooks.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.ts
@@ -5,6 +5,7 @@ import type { StepValueReference } from './stepReferences';
 export type OrchestrationPlaybookId =
   | 'broll_music_subtitles'
   | 'generate_and_place'
+  | 'timeline_interval_split'
   | 'insert_and_segment'
   | 'stock_media_search'
   | 'auto_caption'
@@ -82,6 +83,24 @@ const SEGMENT_KEYWORDS = [
   /분할/i,
   /나누/i,
 ];
+
+const TIMELINE_SPLIT_SCOPE_KEYWORDS = [
+  /timeline/i,
+  /all\s+(?:clips?|tracks?)/i,
+  /video\s*(?:and|&)\s*audio/i,
+  /audio\s*(?:and|&)\s*video/i,
+  /sound/i,
+  /타임라인/i,
+  /전체/i,
+  /모든/i,
+  /영상/i,
+  /비디오/i,
+  /오디오/i,
+  /소리/i,
+];
+
+const AUDIO_SCOPE_KEYWORDS = [/\baudio\b/i, /\bsound\b/i, /오디오/i, /소리/i, /음성/i];
+const VIDEO_SCOPE_KEYWORDS = [/\bvideo\b/i, /\bclip\b/i, /영상/i, /비디오/i];
 
 const STOCK_KEYWORDS = [
   /\bstock\b/i,
@@ -204,6 +223,11 @@ export function buildOrchestrationPlaybook(
     return generateAndPlace;
   }
 
+  const timelineIntervalSplit = buildTimelineIntervalSplitPlaybook(playbookContext);
+  if (timelineIntervalSplit) {
+    return timelineIntervalSplit;
+  }
+
   const insertAndSegment = buildInsertAndSegmentPlaybook(playbookContext);
   if (insertAndSegment) {
     return insertAndSegment;
@@ -260,14 +284,22 @@ function buildInsertAndSegmentPlaybook(
   }
 
   const assetDuration = targetAsset.duration;
-  if (typeof assetDuration !== 'number' || !Number.isFinite(assetDuration) || assetDuration <= segmentDurationSec) {
+  if (
+    typeof assetDuration !== 'number' ||
+    !Number.isFinite(assetDuration) ||
+    assetDuration <= segmentDurationSec
+  ) {
     return null;
   }
 
   const MAX_SEGMENT_SPLITS = 50;
   const MIN_SEGMENT_TAIL_SECONDS = 0.05;
 
-  const splitBoundaries = buildSegmentBoundaries(assetDuration, segmentDurationSec, MIN_SEGMENT_TAIL_SECONDS);
+  const splitBoundaries = buildSegmentBoundaries(
+    assetDuration,
+    segmentDurationSec,
+    MIN_SEGMENT_TAIL_SECONDS,
+  );
   if (splitBoundaries.length === 0 || splitBoundaries.length > MAX_SEGMENT_SPLITS) {
     return null;
   }
@@ -325,6 +357,67 @@ function buildInsertAndSegmentPlaybook(
       requiresApproval: false,
       rollbackStrategy:
         'Undo the split operations in reverse order, then remove the inserted source clip if needed.',
+    },
+  };
+}
+
+function buildTimelineIntervalSplitPlaybook(
+  playbookContext: PlaybookContext,
+): OrchestrationPlaybookMatch | null {
+  const { text, context, toolExecutor } = playbookContext;
+
+  if (!matchesAny(text, SEGMENT_KEYWORDS) || !matchesAny(text, TIMELINE_SPLIT_SCOPE_KEYWORDS)) {
+    return null;
+  }
+
+  if (
+    matchesAny(text, INSERT_KEYWORDS) ||
+    !hasTools(toolExecutor, ['split_timeline_by_interval'])
+  ) {
+    return null;
+  }
+
+  const intervalSeconds = parseSegmentIntervalSeconds(text);
+  if (!intervalSeconds || !context.sequenceId) {
+    return null;
+  }
+
+  const includeAudio = matchesAny(text, AUDIO_SCOPE_KEYWORDS);
+  const includeVideo = matchesAny(text, VIDEO_SCOPE_KEYWORDS) || !includeAudio;
+  const trackKinds = context.availableTracks.map((track) => track.type);
+  const canSplitVideo = includeVideo && trackKinds.includes('video');
+  const canSplitAudio = includeAudio && trackKinds.includes('audio');
+
+  if (!canSplitVideo && !canSplitAudio) {
+    return null;
+  }
+
+  const steps: PlanStep[] = [
+    {
+      id: 'playbook_split_timeline_by_interval',
+      tool: 'split_timeline_by_interval',
+      args: {
+        sequenceId: context.sequenceId,
+        intervalSeconds,
+        includeVideo: canSplitVideo,
+        includeAudio: canSplitAudio,
+      },
+      description: `Split unlocked ${canSplitVideo && canSplitAudio ? 'video and audio' : canSplitAudio ? 'audio' : 'video'} clips every ${formatPlanSeconds(intervalSeconds)}`,
+      riskLevel: 'medium',
+      estimatedDuration: 1200,
+    },
+  ];
+
+  return {
+    id: 'timeline_interval_split',
+    confidence: 0.92,
+    plan: {
+      goal: `Split timeline clips every ${formatPlanSeconds(intervalSeconds)}`,
+      steps,
+      estimatedTotalDuration: estimateTotalDuration(steps),
+      requiresApproval: false,
+      rollbackStrategy:
+        'Undo the generated split operations from the edit history if the segmentation is not desired.',
     },
   };
 }

--- a/src/agents/engine/core/toolSemantics.ts
+++ b/src/agents/engine/core/toolSemantics.ts
@@ -1,0 +1,141 @@
+export const READ_ONLY_TOOL_PREFIXES = [
+  'get_',
+  'list_',
+  'find_',
+  'search_',
+  'analyze_',
+  'inspect_',
+  'query_',
+  'read_',
+  'check_',
+  'compare_',
+  'estimate_',
+];
+
+export const READ_ONLY_EXACT_TOOL_NAMES = new Set([
+  'check_generation_status',
+  'estimate_generation_cost',
+  'list_workspace_documents',
+  'read_workspace_document',
+]);
+
+const PROJECT_MUTATION_CATEGORIES = new Set([
+  'timeline',
+  'clip',
+  'track',
+  'effect',
+  'transition',
+  'audio',
+]);
+
+const PROJECT_MUTATION_UTILITY_TOOLS = new Set([
+  'add_caption',
+  'update_caption',
+  'delete_caption',
+  'style_caption',
+  'add_captions_from_transcription',
+  'import_captions_from_file',
+]);
+
+const MUTATING_TOOL_CATEGORIES = new Set([
+  ...PROJECT_MUTATION_CATEGORIES,
+  'editing',
+  'generation',
+  'project',
+]);
+
+const MUTATING_UTILITY_TOOLS = new Set([
+  ...PROJECT_MUTATION_UTILITY_TOOLS,
+  'write_workspace_document',
+  'replace_workspace_document_text',
+  'create_workspace_folder',
+  'rename_workspace_entry',
+  'move_workspace_entry',
+  'delete_workspace_entry',
+  'edit',
+  'audio',
+  'effects',
+  'text',
+  'execute_plan',
+]);
+
+export const MUTATION_INTENT_PATTERN = new RegExp(
+  [
+    '\\b(split|cut|trim|move|shift|delete|remove|insert|add|place|put|edit|update|change|replace|reorder|caption|subtitle|transcribe|mute|unmute|fade|normalize|speed|rename|create|write|apply)\\b',
+    '분할',
+    '쪼개',
+    '자르',
+    '잘라',
+    '삭제',
+    '제거',
+    '이동',
+    '옮기',
+    '삽입',
+    '추가',
+    '배치',
+    '편집',
+    '수정',
+    '변경',
+    '자막',
+    '속도',
+    '음소거',
+    '무음',
+    '페이드',
+    '생성',
+    '작성',
+    '적용',
+  ].join('|'),
+  'i',
+);
+
+export function isReadOnlyToolName(toolName: string, category?: string | null): boolean {
+  const normalizedToolName = toolName.trim().toLowerCase();
+  const normalizedCategory = category?.trim().toLowerCase() ?? null;
+
+  if (normalizedCategory === 'analysis' || READ_ONLY_EXACT_TOOL_NAMES.has(normalizedToolName)) {
+    return true;
+  }
+
+  return READ_ONLY_TOOL_PREFIXES.some((prefix) => normalizedToolName.startsWith(prefix));
+}
+
+export function requiresProjectMutationPreflight(
+  toolName: string,
+  category?: string | null,
+): boolean {
+  const normalizedToolName = toolName.trim().toLowerCase();
+  const normalizedCategory = category?.trim().toLowerCase() ?? null;
+
+  if (normalizedToolName === 'execute_plan' || normalizedToolName === 'edit') {
+    return true;
+  }
+
+  if (PROJECT_MUTATION_UTILITY_TOOLS.has(normalizedToolName)) {
+    return true;
+  }
+
+  return normalizedCategory !== null && PROJECT_MUTATION_CATEGORIES.has(normalizedCategory);
+}
+
+export function isMutatingToolName(toolName: string, category?: string | null): boolean {
+  const normalizedToolName = toolName.trim().toLowerCase();
+  const normalizedCategory = category?.trim().toLowerCase() ?? null;
+
+  if (isReadOnlyToolName(normalizedToolName, normalizedCategory)) {
+    return false;
+  }
+
+  if (MUTATING_UTILITY_TOOLS.has(normalizedToolName)) {
+    return true;
+  }
+
+  return normalizedCategory !== null && MUTATING_TOOL_CATEGORIES.has(normalizedCategory);
+}
+
+export function hasMutationIntentText(...values: Array<string | undefined>): boolean {
+  const text = values
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ');
+
+  return MUTATION_INTENT_PATTERN.test(text);
+}

--- a/src/agents/engine/phases/Planner.test.ts
+++ b/src/agents/engine/phases/Planner.test.ts
@@ -173,7 +173,15 @@ describe('Planner', () => {
 
       mockLLM.setStructuredResponse({ structured: mockPlan });
 
-      const result = await planner.plan(sampleThought, context);
+      const analysisThought: Thought = {
+        understanding: 'User wants to analyze the current timeline',
+        requirements: ['Timeline info', 'Audio analysis'],
+        uncertainties: [],
+        approach: 'Collect read-only analysis in parallel',
+        needsMoreInfo: false,
+      };
+
+      const result = await planner.plan(analysisThought, context);
 
       expect(result.goal).toBe('Split the clip at 5 seconds');
       expect(result.steps).toHaveLength(1);
@@ -200,7 +208,15 @@ describe('Planner', () => {
 
       mockLLM.setStructuredResponse({ structured: mockPlan });
 
-      const result = await planner.plan(sampleThought, context);
+      const analysisThought: Thought = {
+        understanding: 'User wants to analyze the current timeline',
+        requirements: ['Timeline info', 'Audio analysis'],
+        uncertainties: [],
+        approach: 'Collect read-only analysis in parallel',
+        needsMoreInfo: false,
+      };
+
+      const result = await planner.plan(analysisThought, context);
 
       expect(result.steps[0].tool).toBe('split_clip');
     });
@@ -245,7 +261,15 @@ describe('Planner', () => {
 
       mockLLM.setStructuredResponse({ structured: mockPlan });
 
-      const result = await planner.plan(sampleThought, context);
+      const analysisThought: Thought = {
+        understanding: 'User wants to analyze the current timeline',
+        requirements: ['Timeline info', 'Audio analysis'],
+        uncertainties: [],
+        approach: 'Collect read-only analysis in parallel',
+        needsMoreInfo: false,
+      };
+
+      const result = await planner.plan(analysisThought, context);
 
       expect(result.steps[0].tool).toBe('add_caption');
     });
@@ -1308,7 +1332,15 @@ describe('Planner', () => {
 
       mockLLM.setStructuredResponse({ structured: mockPlan });
 
-      const result = await planner.plan(sampleThought, context);
+      const analysisThought: Thought = {
+        understanding: 'User wants to analyze the current timeline',
+        requirements: ['Timeline info', 'Audio analysis'],
+        uncertainties: [],
+        approach: 'Collect read-only analysis in parallel',
+        needsMoreInfo: false,
+      };
+
+      const result = await planner.plan(analysisThought, context);
 
       // Both steps are parallelizable and have no dependencies
       const step1 = result.steps.find((s) => s.id === 'step-1');
@@ -1397,6 +1429,29 @@ describe('Planner', () => {
     it('should reject read-only plans for edit intents', async () => {
       const mockPlan: Plan = {
         goal: 'Split the timeline every 1 second',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'get_timeline_info',
+            args: { sequenceId: 'seq-1' },
+            description: 'Inspect timeline info',
+            riskLevel: 'low',
+            estimatedDuration: 50,
+          },
+        ],
+        estimatedTotalDuration: 50,
+        requiresApproval: false,
+        rollbackStrategy: 'N/A',
+      };
+
+      mockLLM.setStructuredResponse({ structured: mockPlan });
+
+      await expect(planner.plan(sampleThought, context)).rejects.toThrow(PlanValidationError);
+    });
+
+    it('should reject read-only plans when mutation intent only appears in thought context', async () => {
+      const mockPlan: Plan = {
+        goal: 'Continue the task',
         steps: [
           {
             id: 'step-1',

--- a/src/agents/engine/phases/Planner.test.ts
+++ b/src/agents/engine/phases/Planner.test.ts
@@ -96,6 +96,42 @@ describe('Planner', () => {
 
     mockToolExecutor.registerTool({
       info: {
+        name: 'get_track_clips',
+        description: 'Get clips on a track',
+        category: 'analysis',
+        riskLevel: 'low',
+        supportsUndo: false,
+        parallelizable: true,
+      },
+      parameters: {
+        type: 'object',
+        properties: {
+          trackId: { type: 'string' },
+        },
+      },
+      required: ['trackId'],
+    });
+
+    mockToolExecutor.registerTool({
+      info: {
+        name: 'get_clips_at_time',
+        description: 'Get clips at a time point',
+        category: 'analysis',
+        riskLevel: 'low',
+        supportsUndo: false,
+        parallelizable: true,
+      },
+      parameters: {
+        type: 'object',
+        properties: {
+          time: { type: 'number' },
+        },
+      },
+      required: ['time'],
+    });
+
+    mockToolExecutor.registerTool({
+      info: {
         name: 'insert_clip',
         description: 'Insert an asset clip into timeline',
         category: 'editing',
@@ -875,6 +911,8 @@ describe('Planner', () => {
       expect(systemMessage?.content).toContain('file');
       expect(systemMessage?.content).toContain('data.clipId');
       expect(systemMessage?.content).toContain('data.newClipId');
+      expect(systemMessage?.content).toContain('data.clips[n].id');
+      expect(systemMessage?.content).toContain('data[n].id');
       expect(systemMessage?.content).toContain('timelineIn');
       expect(systemMessage?.content).toContain('atTimelineSec');
       expect(systemMessage?.content).toContain('filePath');
@@ -1568,6 +1606,41 @@ describe('Planner', () => {
           },
         ],
         estimatedTotalDuration: 200,
+        requiresApproval: false,
+        rollbackStrategy: 'Undo',
+      };
+
+      mockLLM.setStructuredResponse({ structured: mockPlan });
+
+      await expect(planner.plan(sampleThought, context)).rejects.toThrow(PlanValidationError);
+    });
+
+    it('should reject invalid output paths for get_clips_at_time references', async () => {
+      const mockPlan: Plan = {
+        goal: 'Split the clip at 3 seconds',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'get_clips_at_time',
+            args: { time: 3 },
+            description: 'Find clips at 3 seconds',
+            riskLevel: 'low',
+            estimatedDuration: 50,
+          },
+          {
+            id: 'step-2',
+            tool: 'split_clip',
+            args: {
+              clipId: { $fromStep: 'step-1', $path: 'data[0].clipId' },
+              position: 3,
+            },
+            description: 'Split the clip at 3 seconds',
+            riskLevel: 'low',
+            estimatedDuration: 100,
+            dependsOn: ['step-1'],
+          },
+        ],
+        estimatedTotalDuration: 150,
         requiresApproval: false,
         rollbackStrategy: 'Undo',
       };

--- a/src/agents/engine/phases/Planner.test.ts
+++ b/src/agents/engine/phases/Planner.test.ts
@@ -1394,6 +1394,29 @@ describe('Planner', () => {
       await expect(planner.plan(sampleThought, context)).rejects.toThrow(PlanValidationError);
     });
 
+    it('should reject read-only plans for edit intents', async () => {
+      const mockPlan: Plan = {
+        goal: 'Split the timeline every 1 second',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'get_timeline_info',
+            args: { sequenceId: 'seq-1' },
+            description: 'Inspect timeline info',
+            riskLevel: 'low',
+            estimatedDuration: 50,
+          },
+        ],
+        estimatedTotalDuration: 50,
+        requiresApproval: false,
+        rollbackStrategy: 'N/A',
+      };
+
+      mockLLM.setStructuredResponse({ structured: mockPlan });
+
+      await expect(planner.plan(sampleThought, context)).rejects.toThrow(PlanValidationError);
+    });
+
     it('should reject placeholder-like IDs in plan arguments', async () => {
       context.sequenceId = 'seq_active';
       context.availableTracks = [

--- a/src/agents/engine/phases/Planner.ts
+++ b/src/agents/engine/phases/Planner.ts
@@ -26,6 +26,7 @@ import {
   normalizeReferencesForValidation,
 } from '../core/stepReferences';
 import { buildOrchestrationPlaybook } from '../core/orchestrationPlaybooks';
+import { getToolOutputContract } from '@/agents/toolOutputContracts';
 
 const logger = createLogger('Planner');
 
@@ -488,6 +489,9 @@ export class Planner {
     );
     parts.push(
       '13. Match near-synonyms to the exact available tool or action name. Example: splitClip -> split_clip, add_subtitle -> add_caption, remove_clip -> delete_clip.',
+    );
+    parts.push(
+      '14. When the target track is known, prefer get_track_clips(trackId) over get_clips_at_time(time) so later steps can reference data.clips[n].id without cross-track ambiguity.',
     );
     parts.push('');
     parts.push(...ORCHESTRATION_PLAYBOOK_LINES);
@@ -988,6 +992,7 @@ export class Planner {
   private validateStepReferences(steps: PlanStep[]): string[] {
     const errors: string[] = [];
     const knownStepIds = new Set(steps.map((step) => step.id));
+    const stepById = new Map(steps.map((step) => [step.id, step]));
 
     steps.forEach((step, index) => {
       const references = collectStepValueReferences(step.args);
@@ -1024,11 +1029,47 @@ export class Planner {
           errors.push(
             `Step ${index}: reference at '${occurrence.sourcePath}' must read from 'data.*' to use tool output contracts.`,
           );
+          continue;
+        }
+
+        const sourceStep = stepById.get(reference.$fromStep);
+        if (!sourceStep) {
+          continue;
+        }
+
+        const contractError = this.validateToolOutputReferencePath(
+          index,
+          occurrence.sourcePath,
+          sourceStep.tool,
+          reference.$path,
+        );
+        if (contractError) {
+          errors.push(contractError);
         }
       }
     });
 
     return errors;
+  }
+
+  private validateToolOutputReferencePath(
+    index: number,
+    sourcePath: string,
+    toolName: string,
+    rawReferencePath: string,
+  ): string | null {
+    const referencePath = rawReferencePath.trim().replace(/^\$\.?/, '');
+    const contract =
+      this.toolExecutor.getToolDefinition(toolName)?.outputContract ??
+      getToolOutputContract(toolName);
+    if (!contract?.validatePath || contract.validatePath(referencePath)) {
+      return null;
+    }
+
+    return (
+      `Step ${index}: reference at '${sourcePath}' uses invalid output path '${rawReferencePath}' for tool '${toolName}'. ` +
+      `Use one of: ${contract.examples.join(', ')}`
+    );
   }
 
   private isPlaceholderId(value: string, key: string): boolean {

--- a/src/agents/engine/phases/Planner.ts
+++ b/src/agents/engine/phases/Planner.ts
@@ -1072,8 +1072,9 @@ export class Planner {
 
   private validateMutationCoverage(goal: string, steps: PlanStep[], thought?: Thought): string[] {
     const normalizedGoal = goal.trim();
-    const intentSignals =
-      normalizedGoal.length > 0 ? [normalizedGoal] : [thought?.understanding, thought?.approach];
+    const intentSignals = [normalizedGoal, thought?.understanding].filter(
+      (value): value is string => typeof value === 'string' && value.trim().length > 0,
+    );
 
     if (!hasMutationIntentText(...intentSignals) || steps.length === 0) {
       return [];

--- a/src/agents/engine/phases/Planner.ts
+++ b/src/agents/engine/phases/Planner.ts
@@ -26,6 +26,7 @@ import {
   normalizeReferencesForValidation,
 } from '../core/stepReferences';
 import { buildOrchestrationPlaybook } from '../core/orchestrationPlaybooks';
+import { hasMutationIntentText, isReadOnlyToolName } from '../core/toolSemantics';
 import { getToolOutputContract } from '@/agents/toolOutputContracts';
 
 const logger = createLogger('Planner');
@@ -154,7 +155,7 @@ export class Planner {
   async plan(thought: Thought, context: AgentContext, history?: LLMMessage[]): Promise<Plan> {
     const playbookMatch = buildOrchestrationPlaybook(thought, context, this.toolExecutor);
     if (playbookMatch) {
-      this.validatePlan(playbookMatch.plan, context);
+      this.validatePlan(playbookMatch.plan, context, thought);
       return playbookMatch.plan;
     }
 
@@ -193,7 +194,7 @@ export class Planner {
           timeoutMs,
         );
 
-        this.validatePlan(plan, context);
+        this.validatePlan(plan, context, thought);
         return plan;
       } catch (error) {
         const aborted = this.abortController?.signal.aborted ?? false;
@@ -264,7 +265,7 @@ export class Planner {
     const playbookMatch = buildOrchestrationPlaybook(thought, context, this.toolExecutor);
     if (playbookMatch) {
       onProgress(`Using deterministic orchestration playbook: ${playbookMatch.id}`);
-      this.validatePlan(playbookMatch.plan, context);
+      this.validatePlan(playbookMatch.plan, context, thought);
       return playbookMatch.plan;
     }
 
@@ -300,7 +301,7 @@ export class Planner {
       // instead of making a second LLM call
       const plan = this.parseAccumulatedPlan<Plan>(accumulated);
 
-      this.validatePlan(plan, context);
+      this.validatePlan(plan, context, thought);
       return plan;
     } catch (error) {
       if (error instanceof PlanValidationError) {
@@ -491,7 +492,13 @@ export class Planner {
       '13. Match near-synonyms to the exact available tool or action name. Example: splitClip -> split_clip, add_subtitle -> add_caption, remove_clip -> delete_clip.',
     );
     parts.push(
-      '14. When the target track is known, prefer get_track_clips(trackId) over get_clips_at_time(time) so later steps can reference data.clips[n].id without cross-track ambiguity.',
+      '14. If the user asked to change the timeline, project, captions, audio, or workspace, do not stop at read-only inspection steps. Include the actual mutating steps required to fulfill the request unless the task is explicitly informational.',
+    );
+    parts.push(
+      '15. Do not arbitrarily narrow scope (for example, only the first 10 seconds or only one track) unless the user explicitly requested that limit or the active selection clearly defines it.',
+    );
+    parts.push(
+      '16. When the target track is known, prefer get_track_clips(trackId) over get_clips_at_time(time) so later steps can reference data.clips[n].id without cross-track ambiguity.',
     );
     parts.push('');
     parts.push(...ORCHESTRATION_PLAYBOOK_LINES);
@@ -754,7 +761,11 @@ export class Planner {
   /**
    * Validate the generated plan
    */
-  private validatePlan(plan: unknown, context: AgentContext): asserts plan is Plan {
+  private validatePlan(
+    plan: unknown,
+    context: AgentContext,
+    thought?: Thought,
+  ): asserts plan is Plan {
     const errors: string[] = [];
 
     // Basic structure validation
@@ -802,6 +813,13 @@ export class Planner {
 
     const stepReferenceErrors = this.validateStepReferences(steps as PlanStep[]);
     errors.push(...stepReferenceErrors);
+
+    const mutationCoverageErrors = this.validateMutationCoverage(
+      p.goal as string,
+      steps as PlanStep[],
+      thought,
+    );
+    errors.push(...mutationCoverageErrors);
 
     if (errors.length > 0) {
       throw new PlanValidationError('Step validation failed', errors);
@@ -1050,6 +1068,29 @@ export class Planner {
     });
 
     return errors;
+  }
+
+  private validateMutationCoverage(goal: string, steps: PlanStep[], thought?: Thought): string[] {
+    const normalizedGoal = goal.trim();
+    const intentSignals =
+      normalizedGoal.length > 0 ? [normalizedGoal] : [thought?.understanding, thought?.approach];
+
+    if (!hasMutationIntentText(...intentSignals) || steps.length === 0) {
+      return [];
+    }
+
+    if (steps.some((step) => !this.isReadOnlyTool(step.tool))) {
+      return [];
+    }
+
+    return [
+      'Plan contains only read-only/query steps even though the goal is an edit request. Include the actual mutating steps needed to complete the edit or ask for clarification if execution should not proceed.',
+    ];
+  }
+
+  private isReadOnlyTool(toolName: string): boolean {
+    const category = this.toolExecutor.getToolDefinition(toolName)?.category?.trim().toLowerCase();
+    return isReadOnlyToolName(toolName, category);
   }
 
   private validateToolOutputReferencePath(

--- a/src/agents/engine/ports/IToolExecutor.ts
+++ b/src/agents/engine/ports/IToolExecutor.ts
@@ -6,6 +6,7 @@
  */
 
 import type { RiskLevel, SideEffect, ValidationResult } from '../core/types';
+import type { ToolOutputContract } from '@/agents/toolOutputContracts';
 
 // =============================================================================
 // Types
@@ -94,6 +95,8 @@ export interface ToolDefinition extends ToolInfo {
     description: string;
     args: Record<string, unknown>;
   }>;
+  /** Optional output contract for downstream step references */
+  outputContract?: ToolOutputContract;
 }
 
 /**

--- a/src/agents/engine/prompts/agentPrompts.ts
+++ b/src/agents/engine/prompts/agentPrompts.ts
@@ -46,7 +46,7 @@ You prepare execution strategies for video editing work before any timeline muta
 - Prepare implementation notes for downstream editing agents
 
 ## Behavior Guidelines
-- You are READ-ONLY. Never modify the timeline or project state.
+- You must not execute timeline mutations yourself, but you may and should plan mutating steps when the user requested an edit.
 - Optimize for actionable plans, not generic advice.
 - Prefer concrete clip, track, asset, and file references when available.
 - Call out dependencies, approvals, or destructive steps before execution.

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -11,6 +11,8 @@
  * Token budget: ~700 tokens full, ~200-300 for specialized roles.
  */
 
+import { buildToolOutputContractSection } from '@/agents/toolOutputContracts';
+
 // =============================================================================
 // Role type (duplicated from system.ts to avoid circular dependency)
 // =============================================================================
@@ -27,7 +29,8 @@ const QUERY_ACTIONS = `## Query Actions (meta-tool: query)
 - list_tracks → all tracks with type, clip count, lock/mute status
 - get_clip_info(clipId) → detailed clip: position, duration, speed, effects, source range
 - get_track_clips(trackId) → all clips on one track
-- get_clips_at_time(time) → clips spanning a specific time point
+- get_clips_at_time(time) → clips spanning a specific time point across tracks
+- prefer get_track_clips(trackId) for track-specific edits because step references cannot filter cross-track results
 - get_selected_clips → currently selected clips (full detail)
 - get_playhead_position → current playhead seconds + total duration
 - find_clips_by_asset(assetId) → clips using a specific asset
@@ -111,6 +114,16 @@ const WORKSPACE_TOOLS = `## Workspace Tools (always available, not behind meta-t
 - replace_workspace_document_text / create_workspace_folder
 - rename_workspace_entry / move_workspace_entry / delete_workspace_entry`;
 
+const TOOL_OUTPUT_CONTRACTS = buildToolOutputContractSection([
+  'get_timeline_info',
+  'get_track_clips',
+  'get_clips_at_time',
+  'get_selected_clips',
+  'insert_clip',
+  'insert_clip_from_file',
+  'split_clip',
+]);
+
 const EDITING_CONCEPTS = `## Editing Concepts
 - Ripple: trim + shift subsequent clips to fill/accommodate
 - Roll: move cut point between adjacent clips (total duration unchanged)
@@ -125,7 +138,9 @@ const COMMON_WORKFLOWS = `## Common Workflows
 3. Remove silence: find_gaps → delete_clips_in_range or manual split+delete
 4. Speed ramp: split_clip at boundaries → change_clip_speed on middle segment
 5. Multi-step edit: issue ordered edit actions only when needed; backend-safe edit actions may be fused into one atomic backend plan
-6. Segment an inserted clip: insert_clip → split_clip using data.clipId for the first cut → later split_clip steps use the previous split's data.newClipId`;
+6. Segment an inserted clip: insert_clip → split_clip using data.clipId for the first cut → later split_clip steps use the previous split's data.newClipId
+7. Track-specific clip lookup: get_track_clips(trackId) → reference clip IDs via data.clips[n].id
+8. Time-based clip lookup across tracks: get_clips_at_time(time) → reference clip IDs via data[n].id (never data[n].clipId)`;
 
 const CLI_REFERENCE = `## CLI (headless alternative)
 openreelio-cli <group> <command> --path <dir> [--args]
@@ -143,6 +158,7 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
     case 'editor':
       return [
         QUERY_ACTIONS,
+        TOOL_OUTPUT_CONTRACTS,
         EDIT_ACTIONS,
         AUDIO_ACTIONS,
         EFFECTS_ACTIONS,
@@ -155,6 +171,7 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
     case 'planner':
       return [
         QUERY_ACTIONS,
+        TOOL_OUTPUT_CONTRACTS,
         EDIT_ACTIONS,
         AUDIO_ACTIONS,
         EFFECTS_ACTIONS,
@@ -165,13 +182,20 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
         CLI_REFERENCE,
       ];
     case 'analyst':
-      return [QUERY_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
+      return [QUERY_ACTIONS, TOOL_OUTPUT_CONTRACTS, WORKSPACE_TOOLS, CLI_REFERENCE];
     case 'colorist':
-      return [QUERY_ACTIONS, EFFECTS_ACTIONS, WORKSPACE_TOOLS, EDITING_CONCEPTS, CLI_REFERENCE];
+      return [
+        QUERY_ACTIONS,
+        TOOL_OUTPUT_CONTRACTS,
+        EFFECTS_ACTIONS,
+        WORKSPACE_TOOLS,
+        EDITING_CONCEPTS,
+        CLI_REFERENCE,
+      ];
     case 'audio':
-      return [QUERY_ACTIONS, AUDIO_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
+      return [QUERY_ACTIONS, TOOL_OUTPUT_CONTRACTS, AUDIO_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
     case 'captioner':
-      return [QUERY_ACTIONS, TEXT_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
+      return [QUERY_ACTIONS, TOOL_OUTPUT_CONTRACTS, TEXT_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
   }
 }
 

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -65,6 +65,7 @@ const EDIT_ACTIONS = `## Edit Actions (meta-tool: edit, all require sequenceId)
 - move_clip(trackId, clipId, newTimelineIn, newTrackId?) → reposition or cross-track move
 - trim_clip(trackId, clipId, newSourceIn?, newSourceOut?) → adjust source boundaries
 - split_clip(trackId, clipId, splitTime) → divide into two clips at time point; result exposes data.newClipId for the right-hand segment
+- split_timeline_by_interval(intervalSeconds, includeVideo?, includeAudio?, startTime?, endTime?) → split unlocked timeline clips at regular boundaries across video and/or audio tracks
 - delete_clip(trackId, clipId) → remove clip from timeline
 - delete_clips_in_range(startTime, endTime, trackId?) → bulk remove by time range
 - change_clip_speed(trackId, clipId, speed) → speed 0.1–10.0, duration auto-adjusts

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -1,0 +1,163 @@
+export interface ToolOutputContract {
+  summary: string;
+  examples: string[];
+  validatePath?: (path: string) => boolean;
+}
+
+const CLIP_OUTPUT_FIELDS = [
+  'id',
+  'assetId',
+  'trackId',
+  'timelineIn',
+  'duration',
+  'sourceIn',
+  'sourceOut',
+  'speed',
+  'opacity',
+  'hasEffects',
+  'effectCount',
+  'label',
+] as const;
+
+const TRACK_OUTPUT_FIELDS = [
+  'id',
+  'name',
+  'kind',
+  'clipCount',
+  'muted',
+  'locked',
+  'visible',
+  'volume',
+] as const;
+
+const TIMELINE_INFO_FIELDS = [
+  'stateVersion',
+  'sequenceId',
+  'name',
+  'duration',
+  'trackCount',
+  'clipCount',
+  'playheadPosition',
+] as const;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function matchesArrayItemPath(
+  path: string,
+  base: string,
+  allowedFields: readonly string[],
+): boolean {
+  const fieldPattern = allowedFields.join('|');
+  return new RegExp(`^${escapeRegex(base)}(?:\\[\\d+\\])?(?:\\.(?:${fieldPattern}))?$`).test(path);
+}
+
+function matchesTrackClipsPath(path: string): boolean {
+  const trackFieldPattern = TRACK_OUTPUT_FIELDS.join('|');
+  const clipFieldPattern = CLIP_OUTPUT_FIELDS.join('|');
+
+  return (
+    path === 'data' ||
+    path === 'data.track' ||
+    path === 'data.clips' ||
+    new RegExp(`^data\\.track\\.(?:${trackFieldPattern})$`).test(path) ||
+    new RegExp(`^data\\.clips\\[\\d+\\](?:\\.(?:${clipFieldPattern}))?$`).test(path)
+  );
+}
+
+function matchesTimelineInfoPath(path: string): boolean {
+  const infoFieldPattern = TIMELINE_INFO_FIELDS.join('|');
+  return (
+    path === 'data' ||
+    new RegExp(`^data\\.(?:${infoFieldPattern})$`).test(path) ||
+    /^data\.selectedClipIds(?:\[\d+\])?$/.test(path) ||
+    /^data\.selectedTrackIds(?:\[\d+\])?$/.test(path)
+  );
+}
+
+function matchesInsertClipPath(path: string): boolean {
+  return (
+    path === 'data' ||
+    path === 'data.clipId' ||
+    path === 'data.operationId' ||
+    path === 'data.createdIds' ||
+    /^data\.createdIds\[\d+\]$/.test(path)
+  );
+}
+
+function matchesSplitClipPath(path: string): boolean {
+  return (
+    matchesInsertClipPath(path) ||
+    path === 'data.newClipId' ||
+    path === 'data.sourceClipId' ||
+    path === 'data.deletedIds' ||
+    /^data\.deletedIds\[\d+\]$/.test(path)
+  );
+}
+
+export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
+  get_timeline_info: {
+    summary:
+      'returns timeline metadata under data.* including sequenceId, duration, trackCount, clipCount, playheadPosition, selectedClipIds[n], and selectedTrackIds[n]',
+    examples: ['data.sequenceId', 'data.duration', 'data.selectedTrackIds[0]'],
+    validatePath: matchesTimelineInfoPath,
+  },
+  get_track_clips: {
+    summary:
+      'returns one track summary under data.track.* and track-scoped clips under data.clips[n].*',
+    examples: ['data.track.id', 'data.clips[0].id', 'data.clips[0].timelineIn'],
+    validatePath: matchesTrackClipsPath,
+  },
+  get_clips_at_time: {
+    summary: 'returns clips across tracks under data[n].*',
+    examples: ['data[0].id', 'data[0].trackId', 'data[0].timelineIn'],
+    validatePath: (path) => matchesArrayItemPath(path, 'data', CLIP_OUTPUT_FIELDS),
+  },
+  get_selected_clips: {
+    summary: 'returns selected clips under data[n].*',
+    examples: ['data[0].id', 'data[0].trackId', 'data[0].timelineIn'],
+    validatePath: (path) => matchesArrayItemPath(path, 'data', CLIP_OUTPUT_FIELDS),
+  },
+  insert_clip: {
+    summary:
+      'returns newly created timeline clip identifiers under data.clipId and data.createdIds[0]',
+    examples: ['data.clipId', 'data.createdIds[0]'],
+    validatePath: matchesInsertClipPath,
+  },
+  insert_clip_from_file: {
+    summary:
+      'returns newly created timeline clip identifiers under data.clipId and data.createdIds[0]',
+    examples: ['data.clipId', 'data.createdIds[0]'],
+    validatePath: matchesInsertClipPath,
+  },
+  split_clip: {
+    summary:
+      'returns split result fields under data.* including data.newClipId for the newly created right-hand segment',
+    examples: ['data.newClipId', 'data.sourceClipId', 'data.createdIds[0]'],
+    validatePath: matchesSplitClipPath,
+  },
+};
+
+export function getToolOutputContract(toolName: string): ToolOutputContract | null {
+  return TOOL_OUTPUT_CONTRACTS[toolName.trim().toLowerCase()] ?? null;
+}
+
+export function buildToolOutputContractSection(toolNames: string[]): string {
+  const lines = toolNames
+    .map((toolName) => {
+      const contract = getToolOutputContract(toolName);
+      if (!contract) {
+        return null;
+      }
+
+      return `- ${toolName} -> ${contract.summary}; examples: ${contract.examples.join(', ')}`;
+    })
+    .filter((line): line is string => Boolean(line));
+
+  if (lines.length === 0) {
+    return '';
+  }
+
+  return ['## Tool Output Contracts', ...lines].join('\n');
+}

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -10,6 +10,7 @@
  */
 
 import { globalToolRegistry, type ToolDefinition } from '../ToolRegistry';
+import { getToolOutputContract } from '../toolOutputContracts';
 import { createLogger } from '@/services/logger';
 import { invoke } from '@tauri-apps/api/core';
 import type {
@@ -2668,6 +2669,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
     description:
       'Get general information about the current timeline/sequence including duration, track count, clip count, and playhead position',
     category: 'analysis',
+    outputContract: getToolOutputContract('get_timeline_info') ?? undefined,
     parameters: {
       type: 'object',
       properties: {},
@@ -2900,6 +2902,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
     name: 'get_clips_at_time',
     description: 'Find all clips that span a specific time point on the timeline',
     category: 'analysis',
+    outputContract: getToolOutputContract('get_clips_at_time') ?? undefined,
     parameters: {
       type: 'object',
       properties: {
@@ -2934,6 +2937,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
     name: 'get_selected_clips',
     description: 'Get full details of all currently selected clips',
     category: 'analysis',
+    outputContract: getToolOutputContract('get_selected_clips') ?? undefined,
     parameters: {
       type: 'object',
       properties: {},
@@ -2998,6 +3002,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
     name: 'get_track_clips',
     description: 'Get all clips on a specific track',
     category: 'analysis',
+    outputContract: getToolOutputContract('get_track_clips') ?? undefined,
     parameters: {
       type: 'object',
       properties: {

--- a/src/agents/tools/editingTools.test.ts
+++ b/src/agents/tools/editingTools.test.ts
@@ -363,6 +363,194 @@ describe('editingTools — extended tools', () => {
         },
       ]);
     });
+
+    it('should reject invalid interval values', async () => {
+      vi.mocked(useProjectStore.getState).mockReturnValue({
+        isLoaded: true,
+        meta: { id: 'project-1', name: 'Test' },
+        sequences: new Map(),
+      } as unknown as ReturnType<typeof useProjectStore.getState>);
+
+      const tool = globalToolRegistry.get('split_timeline_by_interval');
+      const result = await tool!.handler(
+        {
+          sequenceId: 'seq-1',
+          intervalSeconds: 0,
+        },
+        CTX,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('positive number');
+    });
+
+    it('should reject requests when both media flags are disabled', async () => {
+      vi.mocked(useProjectStore.getState).mockReturnValue({
+        isLoaded: true,
+        meta: { id: 'project-1', name: 'Test' },
+        sequences: new Map(),
+      } as unknown as ReturnType<typeof useProjectStore.getState>);
+
+      const tool = globalToolRegistry.get('split_timeline_by_interval');
+      const result = await tool!.handler(
+        {
+          sequenceId: 'seq-1',
+          intervalSeconds: 1,
+          includeVideo: false,
+          includeAudio: false,
+        },
+        CTX,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('At least one');
+    });
+
+    it('should skip locked tracks and zero-length ranges', async () => {
+      const executeCommand = vi.fn();
+
+      vi.mocked(useProjectStore.getState).mockReturnValue({
+        isLoaded: true,
+        meta: { id: 'project-1', name: 'Test' },
+        executeCommand,
+        sequences: new Map([
+          [
+            'seq-1',
+            {
+              id: 'seq-1',
+              name: 'Main',
+              format: '16:9',
+              fps: 30,
+              sampleRate: 48000,
+              tracks: [
+                {
+                  id: 'track-video-locked',
+                  kind: 'video',
+                  name: 'Video Locked',
+                  clips: [
+                    {
+                      id: 'clip-video-locked',
+                      assetId: 'asset-video-locked',
+                      place: { timelineInSec: 0, durationSec: 5 },
+                      range: { sourceInSec: 0, sourceOutSec: 5 },
+                      speed: 1,
+                      opacity: 1,
+                      effects: [],
+                    },
+                  ],
+                  blendMode: 'normal',
+                  muted: false,
+                  locked: true,
+                  visible: true,
+                  volume: 1,
+                },
+                {
+                  id: 'track-audio-1',
+                  kind: 'audio',
+                  name: 'Audio 1',
+                  clips: [
+                    {
+                      id: 'clip-audio-zero',
+                      assetId: 'asset-audio-zero',
+                      place: { timelineInSec: 2, durationSec: 0 },
+                      range: { sourceInSec: 0, sourceOutSec: 0 },
+                      speed: 1,
+                      opacity: 1,
+                      effects: [],
+                    },
+                  ],
+                  blendMode: 'normal',
+                  muted: false,
+                  locked: false,
+                  visible: true,
+                  volume: 1,
+                },
+              ],
+              markers: [],
+            },
+          ],
+        ]),
+      } as unknown as ReturnType<typeof useProjectStore.getState>);
+
+      const tool = globalToolRegistry.get('split_timeline_by_interval');
+      const result = await tool!.handler(
+        {
+          sequenceId: 'seq-1',
+          intervalSeconds: 1,
+          includeVideo: true,
+          includeAudio: true,
+        },
+        CTX,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual(
+        expect.objectContaining({
+          operationsExecuted: 0,
+        }),
+      );
+      expect(executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('should fail when the requested split count exceeds the safety cap', async () => {
+      const executeCommand = vi.fn();
+
+      vi.mocked(useProjectStore.getState).mockReturnValue({
+        isLoaded: true,
+        meta: { id: 'project-1', name: 'Test' },
+        executeCommand,
+        sequences: new Map([
+          [
+            'seq-1',
+            {
+              id: 'seq-1',
+              name: 'Main',
+              format: '16:9',
+              fps: 30,
+              sampleRate: 48000,
+              tracks: [
+                {
+                  id: 'track-video-1',
+                  kind: 'video',
+                  name: 'Video 1',
+                  clips: [
+                    {
+                      id: 'clip-video-long',
+                      assetId: 'asset-video-long',
+                      place: { timelineInSec: 0, durationSec: 6001 },
+                      range: { sourceInSec: 0, sourceOutSec: 6001 },
+                      speed: 1,
+                      opacity: 1,
+                      effects: [],
+                    },
+                  ],
+                  blendMode: 'normal',
+                  muted: false,
+                  locked: false,
+                  visible: true,
+                  volume: 1,
+                },
+              ],
+              markers: [],
+            },
+          ],
+        ]),
+      } as unknown as ReturnType<typeof useProjectStore.getState>);
+
+      const tool = globalToolRegistry.get('split_timeline_by_interval');
+      const result = await tool!.handler(
+        {
+          sequenceId: 'seq-1',
+          intervalSeconds: 1,
+          includeVideo: true,
+        },
+        CTX,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('safety limit');
+      expect(executeCommand).not.toHaveBeenCalled();
+    });
   });
 
   describe('freeze_frame', () => {

--- a/src/agents/tools/editingTools.test.ts
+++ b/src/agents/tools/editingTools.test.ts
@@ -220,6 +220,151 @@ describe('editingTools — extended tools', () => {
     });
   });
 
+  describe('split_timeline_by_interval', () => {
+    it('should split unlocked video and audio clips from the end toward the start', async () => {
+      const executeCommand = vi
+        .fn()
+        .mockResolvedValue({ opId: 'op-split', success: true, createdIds: ['clip-new'] });
+
+      vi.mocked(useProjectStore.getState).mockReturnValue({
+        isLoaded: true,
+        meta: { id: 'project-1', name: 'Test' },
+        executeCommand,
+        sequences: new Map([
+          [
+            'seq-1',
+            {
+              id: 'seq-1',
+              name: 'Main',
+              format: '16:9',
+              fps: 30,
+              sampleRate: 48000,
+              tracks: [
+                {
+                  id: 'track-video-1',
+                  kind: 'video',
+                  name: 'Video 1',
+                  clips: [
+                    {
+                      id: 'clip-video-1',
+                      assetId: 'asset-video-1',
+                      place: { timelineInSec: 0, durationSec: 3.2 },
+                      range: { sourceInSec: 0, sourceOutSec: 3.2 },
+                      speed: 1,
+                      opacity: 1,
+                      effects: [],
+                    },
+                  ],
+                  blendMode: 'normal',
+                  muted: false,
+                  locked: false,
+                  visible: true,
+                  volume: 1,
+                },
+                {
+                  id: 'track-audio-1',
+                  kind: 'audio',
+                  name: 'Audio 1',
+                  clips: [
+                    {
+                      id: 'clip-audio-1',
+                      assetId: 'asset-audio-1',
+                      place: { timelineInSec: 0, durationSec: 3.2 },
+                      range: { sourceInSec: 0, sourceOutSec: 3.2 },
+                      speed: 1,
+                      opacity: 1,
+                      effects: [],
+                    },
+                  ],
+                  blendMode: 'normal',
+                  muted: false,
+                  locked: false,
+                  visible: true,
+                  volume: 1,
+                },
+              ],
+              markers: [],
+            },
+          ],
+        ]),
+      } as unknown as ReturnType<typeof useProjectStore.getState>);
+
+      const tool = globalToolRegistry.get('split_timeline_by_interval');
+      const result = await tool!.handler(
+        {
+          sequenceId: 'seq-1',
+          intervalSeconds: 1,
+          includeVideo: true,
+          includeAudio: true,
+        },
+        CTX,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual(
+        expect.objectContaining({
+          operationsExecuted: 6,
+        }),
+      );
+      expect(executeCommand.mock.calls.map((call) => call[0])).toEqual([
+        {
+          type: 'SplitClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'track-audio-1',
+            clipId: 'clip-audio-1',
+            splitTime: 3,
+          },
+        },
+        {
+          type: 'SplitClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'track-video-1',
+            clipId: 'clip-video-1',
+            splitTime: 3,
+          },
+        },
+        {
+          type: 'SplitClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'track-audio-1',
+            clipId: 'clip-audio-1',
+            splitTime: 2,
+          },
+        },
+        {
+          type: 'SplitClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'track-video-1',
+            clipId: 'clip-video-1',
+            splitTime: 2,
+          },
+        },
+        {
+          type: 'SplitClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'track-audio-1',
+            clipId: 'clip-audio-1',
+            splitTime: 1,
+          },
+        },
+        {
+          type: 'SplitClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'track-video-1',
+            clipId: 'clip-video-1',
+            splitTime: 1,
+          },
+        },
+      ]);
+    });
+  });
+
   describe('freeze_frame', () => {
     it('should be registered with category clip', () => {
       const tool = globalToolRegistry.get('freeze_frame');

--- a/src/agents/tools/editingTools.ts
+++ b/src/agents/tools/editingTools.ts
@@ -29,6 +29,7 @@ const logger = createLogger('EditingTools');
 const DEFAULT_INSERT_CLIP_DURATION_SEC = 10;
 const DEFAULT_FREEZE_FRAME_RATE = 30;
 const SPLIT_TIME_EPSILON = 1e-6;
+const MAX_INTERVAL_SPLIT_OPERATIONS = 5000;
 
 const MARKER_COLOR_PRESETS: Record<string, Color> = {
   red: { r: 1, g: 0, b: 0 },
@@ -141,6 +142,57 @@ function buildTimelineIntervalSplitOperations(
   });
 
   return operations;
+}
+
+function estimateTimelineIntervalSplitOperations(
+  sequence: Sequence,
+  options: {
+    intervalSeconds: number;
+    includeVideo: boolean;
+    includeAudio: boolean;
+    startTime: number;
+    endTime: number;
+  },
+): number {
+  const { intervalSeconds, includeVideo, includeAudio, startTime, endTime } = options;
+  let estimatedOperations = 0;
+
+  for (const track of sequence.tracks) {
+    if (track.locked) {
+      continue;
+    }
+
+    const includeTrack =
+      (track.kind === 'video' && includeVideo) || (track.kind === 'audio' && includeAudio);
+    if (!includeTrack) {
+      continue;
+    }
+
+    for (const clip of track.clips) {
+      const clipStart = clip.place.timelineInSec;
+      const clipEnd = clipStart + clip.place.durationSec;
+      const effectiveStart = Math.max(clipStart, startTime);
+      const effectiveEnd = Math.min(clipEnd, endTime);
+
+      if (effectiveEnd - effectiveStart <= SPLIT_TIME_EPSILON) {
+        continue;
+      }
+
+      const firstBoundary =
+        Math.ceil((effectiveStart + SPLIT_TIME_EPSILON) / intervalSeconds) * intervalSeconds;
+      const availableSpan = effectiveEnd - SPLIT_TIME_EPSILON - firstBoundary;
+      if (availableSpan < 0) {
+        continue;
+      }
+
+      estimatedOperations += Math.floor(availableSpan / intervalSeconds) + 1;
+      if (estimatedOperations > MAX_INTERVAL_SPLIT_OPERATIONS) {
+        return estimatedOperations;
+      }
+    }
+  }
+
+  return estimatedOperations;
 }
 
 function parseHexMarkerColor(input: string): Color | undefined {
@@ -691,6 +743,22 @@ const EDITING_TOOLS: ToolDefinition[] = [
           typeof args.endTime === 'number' ? args.endTime : Number.POSITIVE_INFINITY;
         const startTime = typeof args.startTime === 'number' ? Math.max(0, args.startTime) : 0;
         const endTime = Math.max(startTime, timelineEnd);
+        const estimatedOperations = estimateTimelineIntervalSplitOperations(sequence, {
+          intervalSeconds,
+          includeVideo,
+          includeAudio,
+          startTime,
+          endTime,
+        });
+        if (estimatedOperations > MAX_INTERVAL_SPLIT_OPERATIONS) {
+          return {
+            success: false,
+            error:
+              `split_timeline_by_interval would execute ${estimatedOperations} split operations, ` +
+              `which exceeds the safety limit of ${MAX_INTERVAL_SPLIT_OPERATIONS}`,
+          };
+        }
+
         const operations = buildTimelineIntervalSplitOperations(sequence, {
           intervalSeconds,
           includeVideo,

--- a/src/agents/tools/editingTools.ts
+++ b/src/agents/tools/editingTools.ts
@@ -28,6 +28,7 @@ import type { AgentPlanResult, StylePlanResult } from '@/bindings';
 const logger = createLogger('EditingTools');
 const DEFAULT_INSERT_CLIP_DURATION_SEC = 10;
 const DEFAULT_FREEZE_FRAME_RATE = 30;
+const SPLIT_TIME_EPSILON = 1e-6;
 
 const MARKER_COLOR_PRESETS: Record<string, Color> = {
   red: { r: 1, g: 0, b: 0 },
@@ -41,6 +42,106 @@ const MARKER_COLOR_PRESETS: Record<string, Color> = {
   white: { r: 1, g: 1, b: 1 },
   black: { r: 0, g: 0, b: 0 },
 };
+
+type IntervalSplitOperation = {
+  trackId: string;
+  trackKind: Track['kind'];
+  clipId: string;
+  splitTime: number;
+};
+
+function roundSplitTime(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function buildIntervalBoundaries(
+  clipStart: number,
+  clipEnd: number,
+  intervalSeconds: number,
+  startTime: number,
+  endTime: number,
+): number[] {
+  const effectiveStart = Math.max(clipStart, startTime);
+  const effectiveEnd = Math.min(clipEnd, endTime);
+  if (effectiveEnd - effectiveStart <= SPLIT_TIME_EPSILON) {
+    return [];
+  }
+
+  const boundaries: number[] = [];
+  const firstBoundary =
+    Math.ceil((effectiveStart + SPLIT_TIME_EPSILON) / intervalSeconds) * intervalSeconds;
+
+  for (
+    let boundary = firstBoundary;
+    boundary < effectiveEnd - SPLIT_TIME_EPSILON;
+    boundary += intervalSeconds
+  ) {
+    if (boundary <= clipStart + SPLIT_TIME_EPSILON) {
+      continue;
+    }
+
+    boundaries.push(roundSplitTime(boundary));
+  }
+
+  return boundaries;
+}
+
+function buildTimelineIntervalSplitOperations(
+  sequence: Sequence,
+  options: {
+    intervalSeconds: number;
+    includeVideo: boolean;
+    includeAudio: boolean;
+    startTime: number;
+    endTime: number;
+  },
+): IntervalSplitOperation[] {
+  const { intervalSeconds, includeVideo, includeAudio, startTime, endTime } = options;
+  const operations: IntervalSplitOperation[] = [];
+
+  for (const track of sequence.tracks) {
+    if (track.locked) {
+      continue;
+    }
+
+    const includeTrack =
+      (track.kind === 'video' && includeVideo) || (track.kind === 'audio' && includeAudio);
+    if (!includeTrack) {
+      continue;
+    }
+
+    for (const clip of track.clips) {
+      const clipStart = clip.place.timelineInSec;
+      const clipEnd = clipStart + clip.place.durationSec;
+      const boundaries = buildIntervalBoundaries(
+        clipStart,
+        clipEnd,
+        intervalSeconds,
+        startTime,
+        endTime,
+      );
+
+      for (const splitTime of boundaries) {
+        operations.push({
+          trackId: track.id,
+          trackKind: track.kind,
+          clipId: clip.id,
+          splitTime,
+        });
+      }
+    }
+  }
+
+  operations.sort((left, right) => {
+    if (right.splitTime !== left.splitTime) {
+      return right.splitTime - left.splitTime;
+    }
+
+    return left.trackId.localeCompare(right.trackId);
+  });
+
+  return operations;
+}
 
 function parseHexMarkerColor(input: string): Color | undefined {
   const normalized = input.trim().replace(/^#/, '');
@@ -519,6 +620,120 @@ const EDITING_TOOLS: ToolDefinition[] = [
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.error('split_clip failed', { error: message });
+        return { success: false, error: message };
+      }
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // Split Timeline By Interval
+  // -------------------------------------------------------------------------
+  {
+    name: 'split_timeline_by_interval',
+    description:
+      'Split timeline clips at regular interval boundaries across unlocked video and/or audio tracks',
+    category: 'timeline',
+    parameters: {
+      type: 'object',
+      properties: {
+        sequenceId: {
+          type: 'string',
+          description: 'The ID of the sequence to process',
+        },
+        intervalSeconds: {
+          type: 'number',
+          description: 'Split interval in seconds',
+        },
+        includeVideo: {
+          type: 'boolean',
+          description: 'Whether to split video tracks',
+        },
+        includeAudio: {
+          type: 'boolean',
+          description: 'Whether to split audio tracks',
+        },
+        startTime: {
+          type: 'number',
+          description: 'Optional inclusive start time for splitting',
+        },
+        endTime: {
+          type: 'number',
+          description: 'Optional exclusive end time for splitting',
+        },
+      },
+      required: ['sequenceId', 'intervalSeconds'],
+    },
+    handler: async (args) => {
+      try {
+        const sequenceId = args.sequenceId as string;
+        const intervalSeconds = Number(args.intervalSeconds);
+        const includeVideo = args.includeVideo !== false;
+        const includeAudio = args.includeAudio === true;
+
+        if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
+          return { success: false, error: 'intervalSeconds must be a positive number' };
+        }
+
+        if (!includeVideo && !includeAudio) {
+          return {
+            success: false,
+            error: 'At least one of includeVideo or includeAudio must be true',
+          };
+        }
+
+        const project = useProjectStore.getState();
+        const sequence = project.sequences.get(sequenceId);
+        if (!sequence) {
+          return { success: false, error: `Sequence '${sequenceId}' not found` };
+        }
+
+        const timelineEnd =
+          typeof args.endTime === 'number' ? args.endTime : Number.POSITIVE_INFINITY;
+        const startTime = typeof args.startTime === 'number' ? Math.max(0, args.startTime) : 0;
+        const endTime = Math.max(startTime, timelineEnd);
+        const operations = buildTimelineIntervalSplitOperations(sequence, {
+          intervalSeconds,
+          includeVideo,
+          includeAudio,
+          startTime,
+          endTime,
+        });
+
+        const executedOperations: Array<
+          Pick<IntervalSplitOperation, 'trackId' | 'trackKind' | 'clipId' | 'splitTime'>
+        > = [];
+
+        for (const operation of operations) {
+          await executeAgentCommand('SplitClip', {
+            sequenceId,
+            trackId: operation.trackId,
+            clipId: operation.clipId,
+            splitTime: operation.splitTime,
+          });
+          executedOperations.push(operation);
+        }
+
+        logger.debug('split_timeline_by_interval executed', {
+          sequenceId,
+          intervalSeconds,
+          operationCount: executedOperations.length,
+        });
+        return {
+          success: true,
+          result: {
+            sequenceId,
+            intervalSeconds,
+            includeVideo,
+            includeAudio,
+            startTime,
+            endTime,
+            operationsExecuted: executedOperations.length,
+            operations: executedOperations,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error('split_timeline_by_interval failed', { error: message });
         return { success: false, error: message };
       }
     },

--- a/src/agents/tools/editingTools.ts
+++ b/src/agents/tools/editingTools.ts
@@ -6,6 +6,7 @@
  */
 
 import { globalToolRegistry, type ToolDefinition } from '../ToolRegistry';
+import { getToolOutputContract } from '../toolOutputContracts';
 import { createLogger } from '@/services/logger';
 import { invoke } from '@tauri-apps/api/core';
 import { getTimelineSnapshot, findWorkspaceFile } from './storeAccessor';
@@ -473,6 +474,7 @@ const EDITING_TOOLS: ToolDefinition[] = [
     name: 'split_clip',
     description: 'Split a clip at a specific time point, creating two separate clips',
     category: 'clip',
+    outputContract: getToolOutputContract('split_clip') ?? undefined,
     parameters: {
       type: 'object',
       properties: {
@@ -680,6 +682,7 @@ const EDITING_TOOLS: ToolDefinition[] = [
     name: 'insert_clip',
     description: 'Insert a new clip from an asset onto the timeline',
     category: 'clip',
+    outputContract: getToolOutputContract('insert_clip') ?? undefined,
     parameters: {
       type: 'object',
       properties: {
@@ -774,6 +777,7 @@ const EDITING_TOOLS: ToolDefinition[] = [
     description:
       'Insert a clip from a workspace file by its relative path or name. Automatically registers the file as a project asset if not already registered, then inserts it onto the timeline. This is the preferred way to add workspace files to the timeline.',
     category: 'clip',
+    outputContract: getToolOutputContract('insert_clip_from_file') ?? undefined,
     parameters: {
       type: 'object',
       properties: {
@@ -1730,8 +1734,7 @@ const EDITING_TOOLS: ToolDefinition[] = [
               applyProjectState(draft, freshState);
             });
           } catch (syncError) {
-            const syncMessage =
-              syncError instanceof Error ? syncError.message : String(syncError);
+            const syncMessage = syncError instanceof Error ? syncError.message : String(syncError);
             syncWarning = syncMessage;
             logger.warn('apply_editing_style executed but state refresh failed', {
               error: syncMessage,

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -138,6 +138,7 @@ interface ProjectState {
 
   // Command execution
   executeCommand: (command: Command) => Promise<CommandResult>;
+  refreshFromBackendMutation: () => Promise<number>;
   undo: () => Promise<UndoRedoResult>;
   redo: () => Promise<UndoRedoResult>;
   jumpToHistoryState: (targetIndex: number) => Promise<UndoRedoResult>;
@@ -685,6 +686,53 @@ export const useProjectStore = create<ProjectState>()(
           }
         }, `executeCommand:${command.type}`),
       );
+    },
+
+    refreshFromBackendMutation: async () => {
+      return commandQueue.enqueue(async () => {
+        const versionBefore = get().stateVersion;
+
+        try {
+          logger.debug('Refreshing store after backend mutation', { version: versionBefore });
+          const freshState = await refreshProjectState();
+
+          let concurrentModificationDetected = false;
+          let nextStateVersion = versionBefore;
+          set((state) => {
+            if (state.stateVersion !== versionBefore) {
+              concurrentModificationDetected = true;
+              logger.error('Concurrent modification detected during backend mutation refresh', {
+                expectedVersion: versionBefore,
+                actualVersion: state.stateVersion,
+              });
+              return;
+            }
+
+            state.isDirty = true;
+            state.stateVersion += 1;
+            nextStateVersion = state.stateVersion;
+            state.error = null;
+            applyProjectState(state, freshState);
+          });
+
+          if (concurrentModificationDetected) {
+            throw new Error(
+              'Concurrent modification detected during backend mutation refresh. Please retry the operation.',
+            );
+          }
+
+          logger.debug('Backend mutation refresh completed', { newVersion: nextStateVersion });
+          return nextStateVersion;
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          logger.error('Backend mutation refresh failed', { error: errorMessage });
+
+          set((state) => {
+            state.error = errorMessage;
+          });
+          throw error;
+        }
+      }, 'refreshFromBackendMutation');
     },
 
     /**


### PR DESCRIPTION
### **User description**
## Description

Add a reliable interval-based timeline split workflow for the agent and harden planner/execution behavior so mutating requests produce real edits with synchronized frontend state.

## Related Issue

Closes #606

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `split_timeline_by_interval`, deterministic interval-split playbook matching, and related prompt/tool reference updates for whole-timeline segmentation requests.
- Add tool output contracts and planner validation for step-reference paths so chained agent plans use valid tool outputs.
- Prevent read-only plans from satisfying mutating requests and refresh project state after backend mutations so chained edits can see newly created IDs.

## Screenshots / Videos

N/A

## Testing

Ran targeted agent/timeline Vitest suites and the pre-commit hook checks used by this repository.

### Test Environment

- OS: Microsoft Windows 11 Pro
- Node.js version: v22.19.0
- Rust version: cargo 1.92.0 (344c4567c 2025-10-21)

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Targeted tests run:
- `npm run test:run -- src/agents/tools/editingTools.test.ts src/agents/engine/core/orchestrationPlaybooks.test.ts`
- `npm run test:run -- src/agents/engine/phases/Planner.test.ts src/agents/engine/AgenticEngine.test.ts`
- `npm run test:run -- src/agents/engine/adapters/tools/BackendToolExecutor.test.ts`
- Pre-commit hook checks: `npm run version:check`, `npm run type-check`, `npm run lint`

The lint step still reports pre-existing warnings in unrelated files, so the warnings checklist item remains unchecked.


___

### **PR Type**
Enhancement, Bug fix, Refactoring, Tests


___

### **Description**
- Added `split_timeline_by_interval` tool for efficient timeline-wide segmentation.

- Implemented tool output contracts to ensure reliable step-referencing in agent plans.

- Hardened planner to prevent read-only plans from satisfying mutation requests.

- Added automatic project state synchronization after backend mutations to update clip IDs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UserRequest["User Request"] -- "Mutation Intent" --> Planner["Planner (Hardened)"]
  Planner -- "Interval Split Playbook" --> ToolExecutor["Backend Tool Executor"]
  ToolExecutor -- "Execute Mutation" --> Backend["Backend Engine"]
  Backend -- "New Clip IDs" --> Sync["State Sync (refreshFromBackendMutation)"]
  Sync -- "Update Store" --> FrontendStore["Frontend Project Store"]
  FrontendStore -- "Updated IDs" --> NextStep["Chained Agent Steps"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>editingTools.ts</strong><dd><code>Add `split_timeline_by_interval` tool and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-feff783abcf967fed37830f7fe4794b447012a538bea6a9d96f778cd37b01c7d">+220/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BackendToolExecutor.ts</strong><dd><code>Sync project state after backend mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-a3aff75bdd811b11db7655a08b69d97087140aed6185e0824612b7f32326f54a">+104/-22</a></td>

</tr>

<tr>
  <td><strong>toolOutputContracts.ts</strong><dd><code>Define schemas for tool output data paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-2fe279e63827a652ff07a52579998fb029ad15e9604be67586e5659c39ddc75f">+163/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>orchestrationPlaybooks.ts</strong><dd><code>Add deterministic playbook for timeline interval splitting</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-1ee42f69433d7f5b0ae2ed0d4266e876c367fb882e94916bc493082e13145990">+95/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>projectStore.ts</strong><dd><code>Add `refreshFromBackendMutation` to synchronize state</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-82dd55495e23fa081a4509b6e3a3279b0127026f9b690f7e0442a769f74ee6b9">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Planner.ts</strong><dd><code>Validate mutation coverage and tool output references</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-1e5ea3140bf5195731831d1f841eab96267fb69ecd723c29629de81b92fca9e6">+87/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistry.ts</strong><dd><code>Add `outputContract` to `ToolDefinition`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-33b448915f16ba7fb666139fa3841361de9019f553c37151b40d7f31cfbe5122">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistryAdapter.ts</strong><dd><code>Map output contracts in registry adapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-f3778719dba36a355947514a6c8186918dff8be145ee79c8d149f111af997316">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IToolExecutor.ts</strong><dd><code>Update interface with tool output contracts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-f663051ff7342dd222589aab3be4e94478f5a8d8363be63a24e4d3d832ec61d1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysisTools.ts</strong><dd><code>Attach output contracts to analysis tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-717609a79d522c08834e29f962677b6c063796dd112f1c4bf93d697292f48a4a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AgenticEngine.ts</strong><dd><code>Enforce mutation expectations and prevent false successes</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-011b0b20aad60192a33ef841f0b1bf7d1d84d5b0ec950fc02f6d93c899a35246">+134/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>toolSemantics.ts</strong><dd><code>Centralize logic for identifying mutating vs read-only tools</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-3fdd608949cbaa8fbb6897adce1b947150bf08ee9688d837030708d946bed5ee">+141/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mutationPreflight.ts</strong><dd><code>Delegate tool semantic checks to core logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-bcf949128db77c3b1833896f7c99140c151b973e257bad69dc0908d9387e21f8">+7/-74</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AgenticEngine.test.ts</strong><dd><code>Test recovery from read-only edit plans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-12e129047cd0aecc3068c400bff7d79f09f09b5ef7aa3d28dff33142d8ea1064">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>editingTools.test.ts</strong><dd><code>Test interval-based timeline splitting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-9f92ba18e18dbfb8a93af1997b34e47a21df27a0e799b611723cdd3b19539bbc">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BackendToolExecutor.test.ts</strong><dd><code>Test state synchronization after backend execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-8e592e61f08c2f6dd01675f9d5577677dfe5ee2cb85c6da9fb3a916b9bb413a0">+136/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>orchestrationPlaybooks.test.ts</strong><dd><code>Test interval split playbook matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-67d3eacb874ecec818bd0ce91121099f09ec003b88b4d925c6c196977bc37ece">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Planner.test.ts</strong><dd><code>Test validation of mutation coverage and output paths</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-d357bf23b75a715fbdeb045872fc02a50bcf24ad215c59efa9ee0fae1ec395e7">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>toolReference.ts</strong><dd><code>Update system prompts with output contracts and new tools</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+31/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agentPrompts.ts</strong><dd><code>Adjust planner behavior guidelines for mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/607/files#diff-2615ba60043ade4efae32193316508b690dcb3aa86452dfe388abacdb9c9fc5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline interval split tool: split timelines at regular intervals with selectable audio/video targets.

* **Improvements**
  * Planner now validates and enforces that requested edits result in actual mutations.
  * Backend mutation flows now sync project state with per-session versioning to reduce desyncs.
  * Step-reference validation tightened to ensure tool outputs are referenced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->