### PR TITLE
feat(ai): add canonical source analysis report workflow

### DIFF
--- a/src-tauri/src/core/analysis/mod.rs
+++ b/src-tauri/src/core/analysis/mod.rs
@@ -77,6 +77,8 @@ pub struct AnalysisJobRunner {
     project_dir: PathBuf,
     /// Path to FFmpeg binary (uses PATH if not set)
     ffmpeg_path: PathBuf,
+    /// Path to FFprobe binary (uses PATH if not set)
+    ffprobe_path: PathBuf,
 }
 
 impl AnalysisJobRunner {
@@ -85,12 +87,19 @@ impl AnalysisJobRunner {
         Self {
             project_dir: project_dir.to_path_buf(),
             ffmpeg_path: PathBuf::from("ffmpeg"),
+            ffprobe_path: PathBuf::from("ffprobe"),
         }
     }
 
     /// Creates a job runner with a custom FFmpeg path
     pub fn with_ffmpeg_path(mut self, ffmpeg_path: PathBuf) -> Self {
         self.ffmpeg_path = ffmpeg_path;
+        self
+    }
+
+    /// Creates a job runner with a custom FFprobe path
+    pub fn with_ffprobe_path(mut self, ffprobe_path: PathBuf) -> Self {
+        self.ffprobe_path = ffprobe_path;
         self
     }
 
@@ -440,6 +449,7 @@ impl AnalysisJobRunner {
 
         let config = ShotDetectorConfig {
             ffmpeg_path: Some(self.ffmpeg_path.clone()),
+            ffprobe_path: Some(self.ffprobe_path.clone()),
             ..Default::default()
         };
 

--- a/src-tauri/src/core/jobs/worker.rs
+++ b/src-tauri/src/core/jobs/worker.rs
@@ -501,16 +501,20 @@ impl JobProcessor {
             }
         }
 
-        let ffmpeg_path = {
+        let (ffmpeg_path, ffprobe_path) = {
             let ffmpeg_state = self.ffmpeg_state.read().await;
             let runner = ffmpeg_state.runner().ok_or("FFmpeg not available")?;
-            runner.info().ffmpeg_path.clone()
+            (
+                runner.info().ffmpeg_path.clone(),
+                runner.info().ffprobe_path.clone(),
+            )
         };
 
         self.emit_progress(&job.id, 0.05, Some("Queued analysis pipeline"));
 
         let runner = AnalysisJobRunner::new(std::path::Path::new(&payload.project_path))
-            .with_ffmpeg_path(ffmpeg_path);
+            .with_ffmpeg_path(ffmpeg_path)
+            .with_ffprobe_path(ffprobe_path);
         let input_path_string = input_path.to_string_lossy().to_string();
         let app_handle = self.app_handle.clone();
         let asset_id = payload.asset_id.clone();

--- a/src-tauri/src/core/workspace/service.rs
+++ b/src-tauri/src/core/workspace/service.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
-use crate::core::assets::{Asset, AssetKind, AudioInfo, MetadataExtractor, VideoInfo};
+use crate::core::assets::{Asset, AssetKind, MetadataExtractor};
 use crate::core::project::ProjectState;
 use crate::core::CoreResult;
 
@@ -86,7 +86,7 @@ fn build_workspace_asset(entry: &IndexEntry, absolute_path: &std::path::Path) ->
             extracted_metadata
                 .as_ref()
                 .and_then(|metadata| metadata.audio.clone())
-                .unwrap_or_else(AudioInfo::default),
+                .unwrap_or_default(),
         ),
         AssetKind::Image => {
             let (width, height) = extracted_metadata
@@ -106,7 +106,7 @@ fn build_workspace_asset(entry: &IndexEntry, absolute_path: &std::path::Path) ->
             extracted_metadata
                 .as_ref()
                 .and_then(|metadata| metadata.video.clone())
-                .unwrap_or_else(VideoInfo::default),
+                .unwrap_or_default(),
         ),
     };
 
@@ -565,7 +565,7 @@ fn get_direct_child_dir(prefix: &str, full_path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::assets::AssetKind;
+    use crate::core::assets::{AssetKind, AudioInfo};
 
     fn create_test_project(dir: &std::path::Path) {
         std::fs::create_dir_all(dir.join("footage")).unwrap();

--- a/src-tauri/src/core/workspace/service.rs
+++ b/src-tauri/src/core/workspace/service.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
-use crate::core::assets::{Asset, AssetKind, AudioInfo, VideoInfo};
+use crate::core::assets::{Asset, AssetKind, AudioInfo, MetadataExtractor, VideoInfo};
 use crate::core::project::ProjectState;
 use crate::core::CoreResult;
 
@@ -62,6 +62,101 @@ pub struct WorkspaceService {
     event_tx: mpsc::UnboundedSender<WorkspaceEvent>,
     event_rx: Option<mpsc::UnboundedReceiver<WorkspaceEvent>>,
     ignore_rules: Arc<IgnoreRules>,
+}
+
+fn build_workspace_asset(entry: &IndexEntry, absolute_path: &std::path::Path) -> Asset {
+    let uri = absolute_path.to_string_lossy().to_string();
+    let name = entry
+        .relative_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(&entry.relative_path);
+    let extracted_metadata = MetadataExtractor::extract(absolute_path).ok();
+
+    let resolved_file_size = extracted_metadata
+        .as_ref()
+        .map(|metadata| metadata.file_size)
+        .filter(|size| *size > 0)
+        .unwrap_or(entry.file_size);
+
+    let mut asset = match entry.kind {
+        AssetKind::Audio => Asset::new_audio(
+            name,
+            &uri,
+            extracted_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.audio.clone())
+                .unwrap_or_else(AudioInfo::default),
+        ),
+        AssetKind::Image => {
+            let (width, height) = extracted_metadata
+                .as_ref()
+                .and_then(|metadata| {
+                    metadata
+                        .video
+                        .as_ref()
+                        .map(|video| (video.width, video.height))
+                })
+                .unwrap_or((1920, 1080));
+            Asset::new_image(name, &uri, width, height)
+        }
+        _ => Asset::new_video(
+            name,
+            &uri,
+            extracted_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.video.clone())
+                .unwrap_or_else(VideoInfo::default),
+        ),
+    };
+
+    if let Some(metadata) = extracted_metadata.as_ref() {
+        if metadata.duration_sec > 0.0 {
+            asset = asset.with_duration(metadata.duration_sec);
+        }
+        if let Some(audio) = metadata.audio.clone() {
+            asset.audio = Some(audio);
+        }
+    }
+
+    asset.with_file_size(resolved_file_size)
+}
+
+fn refresh_existing_workspace_asset_metadata(
+    asset: &mut Asset,
+    entry: &IndexEntry,
+    absolute_path: &std::path::Path,
+) {
+    let needs_refresh = asset.duration_sec.is_none()
+        || asset.file_size == 0
+        || (matches!(asset.kind, AssetKind::Video)
+            && asset
+                .video
+                .as_ref()
+                .map(|video| video.codec.trim().is_empty())
+                .unwrap_or(true));
+
+    if !needs_refresh {
+        return;
+    }
+
+    let refreshed = build_workspace_asset(entry, absolute_path);
+    asset.duration_sec = asset.duration_sec.or(refreshed.duration_sec);
+    if refreshed.file_size > 0 {
+        asset.file_size = refreshed.file_size;
+    }
+    if asset.video.is_none()
+        || asset
+            .video
+            .as_ref()
+            .map(|video| video.codec.trim().is_empty())
+            .unwrap_or(true)
+    {
+        asset.video = refreshed.video;
+    }
+    if asset.audio.is_none() {
+        asset.audio = refreshed.audio;
+    }
 }
 
 impl WorkspaceService {
@@ -309,6 +404,10 @@ impl WorkspaceService {
                     .find(|a| a.relative_path.as_deref() == Some(&entry.relative_path))
                 {
                     let asset_id = asset.id.clone();
+                    if let Some(existing_asset) = state.assets.get_mut(&asset_id) {
+                        let abs_path = project_root.join(&entry.relative_path);
+                        refresh_existing_workspace_asset_metadata(existing_asset, entry, &abs_path);
+                    }
                     self.index
                         .mark_registered(&entry.relative_path, &asset_id)?;
                 }
@@ -316,38 +415,7 @@ impl WorkspaceService {
             }
 
             let abs_path = project_root.join(&entry.relative_path);
-            let uri = abs_path.to_string_lossy().to_string();
-
-            let asset = match entry.kind {
-                AssetKind::Audio => Asset::new_audio(
-                    entry
-                        .relative_path
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(&entry.relative_path),
-                    &uri,
-                    AudioInfo::default(),
-                ),
-                AssetKind::Image => Asset::new_image(
-                    entry
-                        .relative_path
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(&entry.relative_path),
-                    &uri,
-                    1920,
-                    1080,
-                ),
-                _ => Asset::new_video(
-                    entry
-                        .relative_path
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(&entry.relative_path),
-                    &uri,
-                    VideoInfo::default(),
-                ),
-            };
+            let asset = build_workspace_asset(entry, &abs_path);
 
             let asset = asset
                 .with_relative_path(&entry.relative_path)
@@ -368,18 +436,7 @@ impl WorkspaceService {
             if let Some(ref asset_id) = entry.asset_id {
                 if !state.assets.contains_key(asset_id) {
                     let abs_path = project_root.join(&entry.relative_path);
-                    let uri = abs_path.to_string_lossy().to_string();
-                    let name = entry
-                        .relative_path
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(&entry.relative_path);
-
-                    let mut asset = match entry.kind {
-                        AssetKind::Audio => Asset::new_audio(name, &uri, AudioInfo::default()),
-                        AssetKind::Image => Asset::new_image(name, &uri, 1920, 1080),
-                        _ => Asset::new_video(name, &uri, VideoInfo::default()),
-                    };
+                    let mut asset = build_workspace_asset(entry, &abs_path);
 
                     // Preserve the original asset_id from the index
                     asset.id = asset_id.clone();

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -33,7 +33,7 @@ use crate::core::analysis::{AnalysisBundle, AnalysisJobRunner, AnalysisOptions, 
 use crate::core::captions::audio::extract_audio_for_transcription_async;
 use crate::core::commands::AddEffectCommand;
 use crate::core::effects::{curve_points_to_json, CurvePoint, EffectType, ParamValue};
-use crate::core::ffmpeg::SharedFFmpegState;
+use crate::core::ffmpeg::{MediaInfo, SharedFFmpegState};
 use crate::core::jobs::{Job, JobStatus, JobType, Priority};
 use crate::AppState;
 
@@ -67,24 +67,66 @@ struct ResolvedAssetContext {
 async fn resolve_asset_context(
     asset_id: &str,
     state: &State<'_, AppState>,
+    ffmpeg_state: &State<'_, SharedFFmpegState>,
 ) -> Result<ResolvedAssetContext, String> {
-    let guard = state.project.lock().await;
-    let project = guard
-        .as_ref()
-        .ok_or_else(|| "No project is currently open".to_string())?;
+    let (project_path, asset_path, active_sequence_id, cached_metadata) = {
+        let guard = state.project.lock().await;
+        let project = guard
+            .as_ref()
+            .ok_or_else(|| "No project is currently open".to_string())?;
 
-    let asset = project
-        .state
-        .assets
-        .get(asset_id)
-        .ok_or_else(|| format!("Asset not found: {}", asset_id))?;
+        let asset = project
+            .state
+            .assets
+            .get(asset_id)
+            .ok_or_else(|| format!("Asset not found: {}", asset_id))?;
 
-    let duration = asset
-        .duration_sec
-        .ok_or_else(|| "Asset has no duration (not a video/audio file?)".to_string())?;
+        (
+            project.path.clone(),
+            asset.uri.clone(),
+            project.state.active_sequence_id.clone(),
+            asset.duration_sec.map(|duration| build_asset_video_metadata(duration, asset)),
+        )
+    };
 
+    if let Some(metadata) = cached_metadata {
+        return Ok(ResolvedAssetContext {
+            project_path,
+            asset_path,
+            metadata,
+            active_sequence_id,
+        });
+    }
+
+    let resolved_asset_path = resolve_asset_media_path(&project_path, &asset_path);
+    let probed = probe_missing_asset_metadata(&resolved_asset_path, ffmpeg_state).await?;
+    if probed.duration_sec <= 0.0 {
+        return Err("Asset has no duration (not a video/audio file?)".to_string());
+    }
+
+    Ok(ResolvedAssetContext {
+        project_path,
+        asset_path,
+        metadata: build_probe_video_metadata(&probed),
+        active_sequence_id,
+    })
+}
+
+fn resolve_asset_media_path(project_path: &PathBuf, asset_path: &str) -> PathBuf {
+    let path = PathBuf::from(asset_path);
+    if path.is_absolute() {
+        path
+    } else {
+        project_path.join(path)
+    }
+}
+
+fn build_asset_video_metadata(
+    duration: f64,
+    asset: &crate::core::assets::Asset,
+) -> VideoMetadata {
     let has_audio = asset.audio.is_some();
-    let metadata = asset.video.as_ref().map_or_else(
+    asset.video.as_ref().map_or_else(
         || VideoMetadata::new(duration).with_audio(has_audio),
         |video| {
             VideoMetadata::new(duration)
@@ -93,13 +135,35 @@ async fn resolve_asset_context(
                 .with_codec(&video.codec)
                 .with_audio(has_audio)
         },
-    );
+    )
+}
 
-    Ok(ResolvedAssetContext {
-        project_path: project.path.clone(),
-        asset_path: asset.uri.clone(),
-        metadata,
-        active_sequence_id: project.state.active_sequence_id.clone(),
+fn build_probe_video_metadata(probed: &MediaInfo) -> VideoMetadata {
+    let mut metadata = VideoMetadata::new(probed.duration_sec).with_audio(probed.audio.is_some());
+    if let Some(video) = probed.video.as_ref() {
+        metadata = metadata
+            .with_dimensions(video.width, video.height)
+            .with_fps(video.fps)
+            .with_codec(&video.codec);
+    }
+    metadata
+}
+
+async fn probe_missing_asset_metadata(
+    asset_path: &std::path::Path,
+    ffmpeg_state: &State<'_, SharedFFmpegState>,
+) -> Result<MediaInfo, String> {
+    let ffmpeg = ffmpeg_state.read().await;
+    let runner = ffmpeg
+        .runner()
+        .ok_or_else(|| "FFmpeg not available to probe missing asset metadata".to_string())?;
+
+    runner.probe(asset_path).await.map_err(|error| {
+        format!(
+            "Asset metadata is incomplete and probing failed for '{}': {}",
+            asset_path.display(),
+            error
+        )
     })
 }
 
@@ -171,13 +235,14 @@ async fn submit_analysis_job_and_wait(
 /// `{project}/.openreelio/analysis/{asset_id}/bundle.json`
 #[tauri::command]
 #[specta::specta]
-#[tracing::instrument(skip(state))]
+#[tracing::instrument(skip(state, ffmpeg_state))]
 pub async fn analyze_video_full(
     asset_id: String,
     options: AnalysisOptions,
     state: State<'_, AppState>,
+    ffmpeg_state: State<'_, SharedFFmpegState>,
 ) -> Result<AnalysisBundle, String> {
-    let asset_context = resolve_asset_context(&asset_id, &state).await?;
+    let asset_context = resolve_asset_context(&asset_id, &state, &ffmpeg_state).await?;
 
     submit_analysis_job_and_wait(
         &asset_id,
@@ -293,14 +358,15 @@ pub async fn import_diarization_json(
 /// Runs an external diarization runner and imports the resulting JSON into the cached bundle.
 #[tauri::command]
 #[specta::specta]
-#[tracing::instrument(skip(state, args), fields(asset_id = %asset_id, executable = %executable))]
+#[tracing::instrument(skip(state, args, ffmpeg_state), fields(asset_id = %asset_id, executable = %executable))]
 pub async fn run_external_diarization(
     asset_id: String,
     executable: String,
     args: Vec<String>,
     state: State<'_, AppState>,
+    ffmpeg_state: State<'_, SharedFFmpegState>,
 ) -> Result<ExternalDiarizationRunSummary, String> {
-    let asset_context = resolve_asset_context(&asset_id, &state).await?;
+    let asset_context = resolve_asset_context(&asset_id, &state, &ffmpeg_state).await?;
     let runner = AnalysisJobRunner::new(&asset_context.project_path);
     let bundle = runner
         .load_bundle_optional(&asset_id)
@@ -467,13 +533,14 @@ pub async fn delete_esd(esd_id: String, state: State<'_, AppState>) -> Result<bo
 /// dedicated track, inserts the source asset, and applies DTW-guided splits.
 #[tauri::command]
 #[specta::specta]
-#[tracing::instrument(skip(state), fields(esd_id = %esd_id, source_asset_id = %source_asset_id))]
+#[tracing::instrument(skip(state, ffmpeg_state), fields(esd_id = %esd_id, source_asset_id = %source_asset_id))]
 pub async fn apply_editing_style(
     esd_id: String,
     source_asset_id: String,
     state: State<'_, AppState>,
+    ffmpeg_state: State<'_, SharedFFmpegState>,
 ) -> Result<StylePlanResult, String> {
-    let asset_context = resolve_asset_context(&source_asset_id, &state).await?;
+    let asset_context = resolve_asset_context(&source_asset_id, &state, &ffmpeg_state).await?;
     let project_path = asset_context.project_path.clone();
     let sequence_id = asset_context
         .active_sequence_id
@@ -766,4 +833,80 @@ fn build_curves_params(correction: &ColorCorrection) -> HashMap<String, ParamVal
     params.insert("luma_vs_sat_curve".to_string(), ParamValue::String(flat));
 
     params
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::assets::{Asset, AudioInfo, VideoInfo};
+    use crate::core::ffmpeg::{AudioStreamInfo, VideoStreamInfo};
+    use crate::core::Ratio;
+
+    #[test]
+    fn build_asset_video_metadata_uses_asset_duration_and_streams() {
+        let mut asset = Asset::new_video(
+            "clip.mp4",
+            "/tmp/clip.mp4",
+            VideoInfo {
+                width: 1280,
+                height: 720,
+                fps: Ratio::new(30000, 1001),
+                codec: "h264".to_string(),
+                bitrate: Some(4_000_000),
+                has_alpha: false,
+                is_hdr: false,
+                color_transfer: None,
+            },
+        )
+        .with_duration(12.5);
+        asset.audio = Some(AudioInfo::default());
+
+        let metadata = build_asset_video_metadata(12.5, &asset);
+
+        assert_eq!(metadata.duration_sec, 12.5);
+        assert_eq!(metadata.width, Some(1280));
+        assert_eq!(metadata.height, Some(720));
+        assert_eq!(metadata.codec.as_deref(), Some("h264"));
+        assert!(metadata.has_audio);
+    }
+
+    #[test]
+    fn build_probe_video_metadata_uses_probed_duration_when_asset_metadata_is_missing() {
+        let metadata = build_probe_video_metadata(&MediaInfo {
+            duration_sec: 8.25,
+            video: Some(VideoStreamInfo {
+                width: 1920,
+                height: 1080,
+                fps: 23.976,
+                codec: "prores".to_string(),
+                pixel_format: "yuv422p10le".to_string(),
+                bitrate: Some(12_000_000),
+                is_hdr: false,
+                color_transfer: None,
+            }),
+            audio: Some(AudioStreamInfo {
+                sample_rate: 48_000,
+                channels: 2,
+                codec: "aac".to_string(),
+                bitrate: Some(192_000),
+            }),
+            format: "mov,mp4,m4a,3gp,3g2,mj2".to_string(),
+            size_bytes: 123,
+        });
+
+        assert_eq!(metadata.duration_sec, 8.25);
+        assert_eq!(metadata.width, Some(1920));
+        assert_eq!(metadata.height, Some(1080));
+        assert_eq!(metadata.codec.as_deref(), Some("prores"));
+        assert!(metadata.has_audio);
+    }
+
+    #[test]
+    fn resolve_asset_media_path_joins_relative_paths_to_project_root() {
+        let project_path = PathBuf::from("/project");
+        assert_eq!(
+            resolve_asset_media_path(&project_path, "media/clip.mp4"),
+            PathBuf::from("/project/media/clip.mp4")
+        );
+    }
 }

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -114,7 +114,7 @@ async fn resolve_asset_context(
     })
 }
 
-fn resolve_asset_media_path(project_path: &PathBuf, asset_path: &str) -> PathBuf {
+fn resolve_asset_media_path(project_path: &std::path::Path, asset_path: &str) -> PathBuf {
     let path = PathBuf::from(asset_path);
     if path.is_absolute() {
         path

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -85,7 +85,9 @@ async fn resolve_asset_context(
             project.path.clone(),
             asset.uri.clone(),
             project.state.active_sequence_id.clone(),
-            asset.duration_sec.map(|duration| build_asset_video_metadata(duration, asset)),
+            asset
+                .duration_sec
+                .map(|duration| build_asset_video_metadata(duration, asset)),
         )
     };
 
@@ -121,10 +123,7 @@ fn resolve_asset_media_path(project_path: &PathBuf, asset_path: &str) -> PathBuf
     }
 }
 
-fn build_asset_video_metadata(
-    duration: f64,
-    asset: &crate::core::assets::Asset,
-) -> VideoMetadata {
+fn build_asset_video_metadata(duration: f64, asset: &crate::core::assets::Asset) -> VideoMetadata {
     let has_audio = asset.audio.is_some();
     asset.video.as_ref().map_or_else(
         || VideoMetadata::new(duration).with_audio(has_audio),

--- a/src/agents/engine/core/orchestrationPlaybooks.test.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.test.ts
@@ -72,6 +72,60 @@ function createContext(overrides: Partial<AgentContext> = {}): AgentContext {
 }
 
 describe('buildOrchestrationPlaybook', () => {
+  it('creates a source-analysis-read playbook without requiring an active sequence', () => {
+    const thought: Thought = {
+      understanding: 'Analyze this source video and read the report for broll.mp4',
+      requirements: ['inspect source footage'],
+      uncertainties: [],
+      approach: 'Read the canonical source analysis report first',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['read_source_analysis_report']);
+    const match = buildOrchestrationPlaybook(
+      thought,
+      createContext({ sequenceId: undefined }),
+      toolExecutor,
+    );
+
+    expect(match).not.toBeNull();
+    expect(match?.id).toBe('source_analysis_read');
+    expect(match?.plan.steps[0]).toMatchObject({
+      tool: 'read_source_analysis_report',
+      args: { assetId: 'asset-video-fallback' },
+    });
+  });
+
+  it('does not use the source-analysis-read playbook for mutating edit requests', () => {
+    const thought: Thought = {
+      understanding: 'Analyze this source video and insert the best moments onto the timeline',
+      requirements: ['source analysis', 'timeline edit'],
+      uncertainties: [],
+      approach: 'Inspect the footage and then place the results on the timeline',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['read_source_analysis_report']);
+    const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
+
+    expect(match).toBeNull();
+  });
+
+  it('uses the source-analysis-read playbook for report-generation requests', () => {
+    const thought: Thought = {
+      understanding: 'Generate a source analysis report for broll.mp4',
+      requirements: ['source analysis report'],
+      uncertainties: [],
+      approach: 'Produce the canonical analysis report for the source video',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['read_source_analysis_report']);
+    const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
+
+    expect(match?.id).toBe('source_analysis_read');
+  });
+
   it('creates B-roll/music/subtitles playbook with step references', () => {
     const thought: Thought = {
       understanding: 'Please add B-roll with background music and subtitles',

--- a/src/agents/engine/core/orchestrationPlaybooks.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.ts
@@ -3,6 +3,7 @@ import type { AgentContext, Plan, PlanStep, Thought } from './types';
 import type { StepValueReference } from './stepReferences';
 
 export type OrchestrationPlaybookId =
+  | 'source_analysis_read'
   | 'broll_music_subtitles'
   | 'generate_and_place'
   | 'timeline_interval_split'
@@ -140,6 +141,52 @@ const AUTO_CAPTION_KEYWORDS = [
   /음성\s*인식/i,
 ];
 
+const SOURCE_ANALYSIS_READ_KEYWORDS = [
+  /\banaly[sz]e\b/i,
+  /\binspect\b/i,
+  /\breview\b/i,
+  /\bread\b/i,
+  /\bbreak\s*down\b/i,
+  /\breport\b/i,
+  /분석/i,
+  /검토/i,
+  /읽/i,
+  /리포트/i,
+];
+
+const SOURCE_MEDIA_KEYWORDS = [
+  /\bsource\b/i,
+  /\bfootage\b/i,
+  /\bmaterial\b/i,
+  /\bvideo\b/i,
+  /\bclip\b/i,
+  /\bscene\b/i,
+  /원본/i,
+  /소스/i,
+  /영상/i,
+  /비디오/i,
+];
+
+const SOURCE_ANALYSIS_EDIT_EXCLUSION_KEYWORDS = [
+  /\btimeline\b/i,
+  /\binsert\b/i,
+  /\badd\b/i,
+  /\bplace\b/i,
+  /\bapply\b/i,
+  /\bsplit\b/i,
+  /\btrim\b/i,
+  /\bcaption\b/i,
+  /\bsubtitle\b/i,
+  /\bmusic\b/i,
+  /타임라인/i,
+  /삽입/i,
+  /추가/i,
+  /적용/i,
+  /분할/i,
+  /자막/i,
+  /음악/i,
+];
+
 /**
  * Patterns that fall within the scope of the auto_caption playbook
  * (audio transcription + adding caption clips to the timeline).
@@ -202,10 +249,6 @@ export function buildOrchestrationPlaybook(
   context: AgentContext,
   toolExecutor: IToolExecutor,
 ): OrchestrationPlaybookMatch | null {
-  if (!context.sequenceId) {
-    return null;
-  }
-
   const text = buildSearchText(thought);
   const playbookContext: PlaybookContext = {
     text,
@@ -213,6 +256,15 @@ export function buildOrchestrationPlaybook(
     context,
     toolExecutor,
   };
+
+  const sourceAnalysisRead = buildSourceAnalysisReadPlaybook(playbookContext);
+  if (sourceAnalysisRead) {
+    return sourceAnalysisRead;
+  }
+
+  if (!context.sequenceId) {
+    return null;
+  }
 
   const generateAndPlace = buildGenerateAndPlacePlaybook(playbookContext);
   if (generateAndPlace) {
@@ -255,6 +307,56 @@ export function buildOrchestrationPlaybook(
   }
 
   return null;
+}
+
+function buildSourceAnalysisReadPlaybook(
+  playbookContext: PlaybookContext,
+): OrchestrationPlaybookMatch | null {
+  const { text, thought, context, toolExecutor } = playbookContext;
+
+  if (matchesAny(text, SOURCE_ANALYSIS_EDIT_EXCLUSION_KEYWORDS)) {
+    return null;
+  }
+
+  if (
+    !matchesAny(text, SOURCE_ANALYSIS_READ_KEYWORDS) ||
+    !matchesAny(text, SOURCE_MEDIA_KEYWORDS) ||
+    !hasTools(toolExecutor, ['read_source_analysis_report'])
+  ) {
+    return null;
+  }
+
+  const targetAsset = pickMentionedAsset(context, thought, 'video');
+  const referencedFile = extractMentionedMediaFile(thought);
+  if (!targetAsset && !referencedFile) {
+    return null;
+  }
+
+  const args = targetAsset ? { assetId: targetAsset.id } : { file: referencedFile };
+  const targetLabel = targetAsset?.name ?? referencedFile ?? 'source video';
+
+  return {
+    id: 'source_analysis_read',
+    confidence: 0.9,
+    plan: {
+      goal: `Read the canonical source analysis report for ${targetLabel}`,
+      steps: [
+        {
+          id: 'playbook_read_source_analysis_report',
+          tool: 'read_source_analysis_report',
+          args,
+          description:
+            'Generate or reuse the canonical Markdown source-analysis report for the target video and save the default .analysis.md file beside the asset',
+          riskLevel: 'low',
+          estimatedDuration: 1200,
+        },
+      ],
+      estimatedTotalDuration: 1200,
+      requiresApproval: false,
+      rollbackStrategy:
+        'No timeline edits are applied. Internal analysis artifacts may be refreshed for reuse.',
+    },
+  };
 }
 
 function buildInsertAndSegmentPlaybook(
@@ -1253,4 +1355,18 @@ function extractQuotedText(thought: Thought): string | null {
 
   const text = quoted[1].trim();
   return text.length > 0 ? text : null;
+}
+
+function extractMentionedMediaFile(thought: Thought): string | null {
+  const source = [thought.understanding, thought.approach, ...thought.requirements]
+    .filter((value) => value.trim().length > 0)
+    .join(' ');
+  const quoted = extractQuotedText(thought);
+  if (quoted && /\.(mp4|mov|mkv|avi|webm|m4v)$/i.test(quoted)) {
+    return quoted;
+  }
+
+  const match = source.match(/([\w./-]+\.(?:mp4|mov|mkv|avi|webm|m4v))/i);
+  const candidate = match?.[1]?.trim();
+  return candidate && candidate.length > 0 ? candidate : null;
 }

--- a/src/agents/engine/core/permissionSubject.test.ts
+++ b/src/agents/engine/core/permissionSubject.test.ts
@@ -91,11 +91,16 @@ describe('permissionSubject', () => {
       assetId: 'asset-7',
     });
     const providersSubject = buildPermissionSubject('get_analysis_providers');
+    const reportSubject = buildPermissionSubject('read_source_analysis_report', {
+      assetId: 'asset-9',
+    });
 
     expect(statusSubject.subject).toBe('asset.analysis.status.read#asset:asset-7');
     expect(statusSubject.subjectType).toBe('resource');
     expect(providersSubject.subject).toBe('external_provider.providers.read');
     expect(providersSubject.subjectType).toBe('external_provider');
+    expect(reportSubject.subject).toBe('asset.analysis.report.read#asset:asset-9');
+    expect(reportSubject.subjectType).toBe('resource');
   });
 
   it('builds a resource-aware canonical subject for meta-tool actions', () => {
@@ -135,9 +140,9 @@ describe('permissionSubject', () => {
     expect(isCanonicalPermissionPattern('timeline.clip.delete#clip:*')).toBe(true);
     expect(isExactPermissionPatternMatch('timeline.clip.delete#clip:clip-1', subject)).toBe(true);
     expect(isExactPermissionPatternMatch('timeline.clip.delete', subject)).toBe(true);
-    expect(
-      getPermissionPatternSpecificity('timeline.clip.delete#clip:clip-1'),
-    ).toBeGreaterThan(getPermissionPatternSpecificity('timeline.clip.*'));
+    expect(getPermissionPatternSpecificity('timeline.clip.delete#clip:clip-1')).toBeGreaterThan(
+      getPermissionPatternSpecificity('timeline.clip.*'),
+    );
   });
 
   it('keeps legacy tool globs working for meta-tool actions', () => {

--- a/src/agents/engine/core/permissionSubject.ts
+++ b/src/agents/engine/core/permissionSubject.ts
@@ -28,10 +28,7 @@ export interface PermissionSubject {
 
 const META_TOOL_NAMES = new Set(['query', 'edit', 'audio', 'effects', 'text']);
 
-const EXACT_SUBJECTS: Record<
-  string,
-  { subjectType: PermissionSubjectType; subject: string }
-> = {
+const EXACT_SUBJECTS: Record<string, { subjectType: PermissionSubjectType; subject: string }> = {
   analyze_asset: {
     subjectType: 'asset',
     subject: 'asset.analysis.run',
@@ -55,6 +52,10 @@ const EXACT_SUBJECTS: Record<
   get_analysis_providers: {
     subjectType: 'external_provider',
     subject: 'external_provider.providers.read',
+  },
+  read_source_analysis_report: {
+    subjectType: 'asset',
+    subject: 'asset.analysis.report.read',
   },
   list_workspace_documents: {
     subjectType: 'workspace',
@@ -130,9 +131,7 @@ function matchLegacyPermissionPattern(pattern: string, value: string): boolean {
   }
 }
 
-function splitCanonicalSubject(
-  value: string,
-): { path: string; resource: string | null } {
+function splitCanonicalSubject(value: string): { path: string; resource: string | null } {
   const separatorIndex = value.indexOf('#');
   if (separatorIndex === -1) {
     return { path: value.trim(), resource: null };
@@ -270,11 +269,11 @@ function inferDomain(toolName: string): string {
   }
 
   if (
-    toolName.includes('audio')
-    || toolName.includes('volume')
-    || toolName.includes('fade')
-    || toolName.startsWith('mute_')
-    || toolName.startsWith('normalize_')
+    toolName.includes('audio') ||
+    toolName.includes('volume') ||
+    toolName.includes('fade') ||
+    toolName.startsWith('mute_') ||
+    toolName.startsWith('normalize_')
   ) {
     return 'audio';
   }
@@ -315,11 +314,19 @@ function inferAction(toolName: string): string {
     return 'analyze';
   }
 
-  if (toolName.startsWith('delete_') || toolName.startsWith('remove_') || toolName.startsWith('cancel_')) {
+  if (
+    toolName.startsWith('delete_') ||
+    toolName.startsWith('remove_') ||
+    toolName.startsWith('cancel_')
+  ) {
     return 'delete';
   }
 
-  if (toolName.startsWith('add_') || toolName.startsWith('insert_') || toolName.startsWith('create_')) {
+  if (
+    toolName.startsWith('add_') ||
+    toolName.startsWith('insert_') ||
+    toolName.startsWith('create_')
+  ) {
     return 'create';
   }
 
@@ -495,16 +502,13 @@ export function buildPermissionSubject(
   const resourceBinding = extractResourceBinding(args);
 
   if (exact) {
-    const subject = resourceBinding
-      && exact.subjectType !== 'approval'
-      && exact.subjectType !== 'system'
-      ? `${exact.subject}#${resourceBinding}`
-      : exact.subject;
+    const subject =
+      resourceBinding && exact.subjectType !== 'approval' && exact.subjectType !== 'system'
+        ? `${exact.subject}#${resourceBinding}`
+        : exact.subject;
     return {
       subjectType:
-        resourceBinding
-        && exact.subjectType !== 'approval'
-        && exact.subjectType !== 'system'
+        resourceBinding && exact.subjectType !== 'approval' && exact.subjectType !== 'system'
           ? 'resource'
           : exact.subjectType,
       subject,
@@ -524,11 +528,12 @@ export function buildPermissionSubject(
 
   const domain = inferDomain(normalizedToolName);
   const action = inferAction(normalizedToolName);
-  const subjectBase = domain === 'tool'
-    ? `tool.${normalizedToolName}`
-    : domain.endsWith(`.${action}`)
-      ? domain
-      : `${domain}.${action}`;
+  const subjectBase =
+    domain === 'tool'
+      ? `tool.${normalizedToolName}`
+      : domain.endsWith(`.${action}`)
+        ? domain
+        : `${domain}.${action}`;
   const subject = resourceBinding ? `${subjectBase}#${resourceBinding}` : subjectBase;
 
   return {

--- a/src/agents/engine/phases/Planner.ts
+++ b/src/agents/engine/phases/Planner.ts
@@ -471,7 +471,10 @@ export class Planner {
     parts.push('5. Provide a rollback strategy in case of failure');
     parts.push(`6. Maximum ${this.config.maxSteps} steps allowed`);
     parts.push(
-      '7. When the request references source footage discovery or selecting moments, include source-aware analysis steps before edit actions (for example: catalog/unused-asset checks).',
+      '7. When the request references source footage discovery or selecting moments, include source-aware analysis steps before edit actions. Prefer read_source_analysis_report for deep inspection, then search or selects tools as needed.',
+    );
+    parts.push(
+      '7a. read_source_analysis_report and generate_source_analysis_report already persist a Markdown file beside the asset by default. Do not add a separate write step unless the user asked for a second copy or a custom output path/name.',
     );
     parts.push(
       '8. Never invent or normalize IDs. Always copy exact IDs from analysis output (no placeholders like asset_id_from_catalog or aliases like video_1).',

--- a/src/agents/engine/phases/Thinker.ts
+++ b/src/agents/engine/phases/Thinker.ts
@@ -245,6 +245,7 @@ export class Thinker {
         'Source-Aware Policy:',
         '- Do not assume timeline clips are the only available media. Imported assets may exist without timeline placement.',
         '- When the request implies searching or selecting moments from source footage, prefer using source-discovery analysis tools before asking for clarification.',
+        '- For deep source-video inspection, prefer the canonical source-analysis report reader so transcript, frame, OCR, and highlight signals are consolidated in one read step.',
         '- Use timeline-only reasoning only when the request explicitly limits scope to existing timeline clips.',
       ].join('\n'),
     );

--- a/src/agents/engine/prompts/agentPrompts.ts
+++ b/src/agents/engine/prompts/agentPrompts.ts
@@ -19,6 +19,7 @@ Use the provided tools to execute editing operations.
 - Apply effects and color correction
 - Manage audio levels and mix settings
 - Import and organize project assets
+- Inspect source footage through consolidated analysis reports before selecting moments
 - Generate captions from audio
 - Export the final project
 
@@ -28,6 +29,7 @@ Use the provided tools to execute editing operations.
 - Ask for clarification only when genuinely ambiguous
 - Prefer using tools over explaining how to do things manually
 - When multiple clips or tracks could match, use context (selection, playhead position) to resolve
+- For deep source-footage inspection, prefer the canonical source-analysis report reader before ad hoc searches
 - Report what you did after completing an action
 - If an operation fails, explain the error and suggest alternatives`;
 
@@ -62,6 +64,7 @@ You analyze timelines, assets, and project structure to provide insights.
 ## Capabilities
 - Analyze timeline structure (gaps, pacing, audio levels)
 - Inspect asset metadata and compatibility
+- Read consolidated source-analysis reports that combine transcript, frame, OCR, and highlight signals
 - Detect potential issues (aspect ratio mismatch, audio sync, etc.)
 - Generate timeline reports and summaries
 - Recommend improvements

--- a/src/agents/engine/prompts/system.test.ts
+++ b/src/agents/engine/prompts/system.test.ts
@@ -73,6 +73,7 @@ describe('assembleSystemPrompt', () => {
     expect(result).toContain('## Effects Actions');
     expect(result).toContain('## Text Actions');
     expect(result).toContain('## Common Workflows');
+    expect(result).toContain('read_source_analysis_report');
     expect(result).toContain('</tool_reference>');
   });
 
@@ -94,10 +95,7 @@ describe('assembleSystemPrompt', () => {
     const result = assembleSystemPrompt({
       role: 'editor',
       context: makeContext(),
-      knowledge: [
-        'User prefers warm tones',
-        'Always normalize audio to -6dB',
-      ],
+      knowledge: ['User prefers warm tones', 'Always normalize audio to -6dB'],
     });
 
     expect(result).toContain('<knowledge>');

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -49,7 +49,8 @@ const QUERY_ACTIONS = `## Query Actions (meta-tool: query)
 - get_analysis_cost_estimate(assetId) → cost estimate for cloud analysis
 - get_analysis_providers → available analysis backends
 - analyze_reference_video(assetId) → extract edit/style signals from a reference video
-- generate_source_analysis_report(assetId) → build a unified source-footage report (JSON + Markdown) with moments, chapters, candidate highlights, speaker turns, and visual artifacts like contact sheets
+- read_source_analysis_report(assetId|file, outputPath?) → read the canonical Markdown source-analysis report for a source video; auto-generates/refreshes analysis and saves "<asset-name>.analysis.md" beside the asset by default, or to outputPath when provided. Key outputs: data.content, data.relativePath
+- generate_source_analysis_report(assetId, outputPath?) → build/reuse the structured source-footage report (JSON + Markdown) and persist the Markdown report beside the asset by default. Key outputs: data.content, data.reportPath
 - import_external_diarization(assetId, inputPath) → import external diarization JSON and merge true speaker IDs into the cached transcript bundle
 - run_external_diarization(assetId, executable, args) → run an external diarization tool against normalized source audio and import the resulting JSON into the cached transcript bundle
 - search_source_analysis_report(assetId, query) → search report moments/chapters/highlights/speaker turns and return ranked source ranges
@@ -120,6 +121,8 @@ const TOOL_OUTPUT_CONTRACTS = buildToolOutputContractSection([
   'get_track_clips',
   'get_clips_at_time',
   'get_selected_clips',
+  'read_source_analysis_report',
+  'generate_source_analysis_report',
   'insert_clip',
   'insert_clip_from_file',
   'split_clip',
@@ -141,7 +144,9 @@ const COMMON_WORKFLOWS = `## Common Workflows
 5. Multi-step edit: issue ordered edit actions only when needed; backend-safe edit actions may be fused into one atomic backend plan
 6. Segment an inserted clip: insert_clip → split_clip using data.clipId for the first cut → later split_clip steps use the previous split's data.newClipId
 7. Track-specific clip lookup: get_track_clips(trackId) → reference clip IDs via data.clips[n].id
-8. Time-based clip lookup across tracks: get_clips_at_time(time) → reference clip IDs via data[n].id (never data[n].clipId)`;
+8. Time-based clip lookup across tracks: get_clips_at_time(time) → reference clip IDs via data[n].id (never data[n].clipId)
+9. Deep source inspection: find_workspace_file or get_asset_catalog → read_source_analysis_report (this already writes the default ".analysis.md" report beside the asset) → search_source_analysis_report / search_source_library → build_source_selects or edit actions
+10. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
 
 const CLI_REFERENCE = `## CLI (headless alternative)
 openreelio-cli <group> <command> --path <dir> [--args]

--- a/src/agents/toolOutputContracts.test.ts
+++ b/src/agents/toolOutputContracts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getToolOutputContract } from './toolOutputContracts';
+
+describe('toolOutputContracts', () => {
+  it('allows nested metadata and coverage paths for read_source_analysis_report', () => {
+    const contract = getToolOutputContract('read_source_analysis_report');
+
+    expect(contract?.validatePath?.('data.metadata.durationSec')).toBe(true);
+    expect(contract?.validatePath?.('data.coverage.annotation')).toBe(true);
+    expect(contract?.validatePath?.('data.sectionCounts.highlights')).toBe(true);
+    expect(contract?.validatePath?.('data.requestedFile')).toBe(true);
+    expect(contract?.validatePath?.('data.warnings[0]')).toBe(true);
+    expect(contract?.validatePath?.('data.errors.transcript')).toBe(true);
+    expect(contract?.validatePath?.('data.persistenceError')).toBe(true);
+  });
+
+  it('allows nested metadata and error paths for generate_source_analysis_report', () => {
+    const contract = getToolOutputContract('generate_source_analysis_report');
+
+    expect(contract?.validatePath?.('data.metadata.codec')).toBe(true);
+    expect(contract?.validatePath?.('data.coverage.visual')).toBe(true);
+    expect(contract?.validatePath?.('data.errors.visual')).toBe(true);
+  });
+});

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -97,6 +97,8 @@ function matchesSplitClipPath(path: string): boolean {
 }
 
 function matchesSourceAnalysisReportPath(path: string): boolean {
+  const matchesObjectPath = (base: string): boolean => path === base || path.startsWith(`${base}.`);
+
   return (
     path === 'data' ||
     path === 'data.content' ||
@@ -104,19 +106,22 @@ function matchesSourceAnalysisReportPath(path: string): boolean {
     path === 'data.reportPath' ||
     path === 'data.assetId' ||
     path === 'data.assetName' ||
+    path === 'data.requestedFile' ||
     path === 'data.generatedAt' ||
     path === 'data.summary' ||
     path === 'data.persisted' ||
+    path === 'data.persistenceError' ||
     path === 'data.sizeBytes' ||
     path === 'data.modifiedAtUnixSec' ||
     path === 'data.bundleSource' ||
-    path === 'data.document' ||
-    path === 'data.document.content' ||
-    path === 'data.document.relativePath' ||
-    path === 'data.document.sizeBytes' ||
-    path === 'data.document.modifiedAtUnixSec' ||
-    path === 'data.document.persisted' ||
-    path === 'data.document.persistenceError' ||
+    matchesObjectPath('data.metadata') ||
+    matchesObjectPath('data.coverage') ||
+    matchesObjectPath('data.sectionCounts') ||
+    matchesObjectPath('data.document') ||
+    path === 'data.warnings' ||
+    /^data\.warnings\[\d+\]$/.test(path) ||
+    path === 'data.errors' ||
+    /^data\.errors\.[^.]+$/.test(path) ||
     path === 'data.markdown'
   );
 }

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -96,6 +96,31 @@ function matchesSplitClipPath(path: string): boolean {
   );
 }
 
+function matchesSourceAnalysisReportPath(path: string): boolean {
+  return (
+    path === 'data' ||
+    path === 'data.content' ||
+    path === 'data.relativePath' ||
+    path === 'data.reportPath' ||
+    path === 'data.assetId' ||
+    path === 'data.assetName' ||
+    path === 'data.generatedAt' ||
+    path === 'data.summary' ||
+    path === 'data.persisted' ||
+    path === 'data.sizeBytes' ||
+    path === 'data.modifiedAtUnixSec' ||
+    path === 'data.bundleSource' ||
+    path === 'data.document' ||
+    path === 'data.document.content' ||
+    path === 'data.document.relativePath' ||
+    path === 'data.document.sizeBytes' ||
+    path === 'data.document.modifiedAtUnixSec' ||
+    path === 'data.document.persisted' ||
+    path === 'data.document.persistenceError' ||
+    path === 'data.markdown'
+  );
+}
+
 export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
   get_timeline_info: {
     summary:
@@ -136,6 +161,18 @@ export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
       'returns split result fields under data.* including data.newClipId for the newly created right-hand segment',
     examples: ['data.newClipId', 'data.sourceClipId', 'data.createdIds[0]'],
     validatePath: matchesSplitClipPath,
+  },
+  read_source_analysis_report: {
+    summary:
+      'returns the persisted Markdown report under data.content with its saved workspace path under data.relativePath/data.reportPath; nested mirror is also available at data.document.*',
+    examples: ['data.content', 'data.relativePath', 'data.document.content'],
+    validatePath: matchesSourceAnalysisReportPath,
+  },
+  generate_source_analysis_report: {
+    summary:
+      'returns structured report fields plus the persisted Markdown report under data.content/data.markdown and its saved workspace path under data.relativePath/data.reportPath',
+    examples: ['data.content', 'data.reportPath', 'data.document.relativePath'],
+    validatePath: matchesSourceAnalysisReportPath,
   },
 };
 

--- a/src/agents/tools/analysisTools.test.ts
+++ b/src/agents/tools/analysisTools.test.ts
@@ -136,11 +136,15 @@ describe('analysisTools', () => {
     });
     vi.mocked(readWorkspaceDocumentFromBackend).mockImplementation(async (relativePath) => {
       const document = workspaceDocuments.get(relativePath);
+      if (!document) {
+        throw new Error(`Workspace document not found: ${relativePath}`);
+      }
+
       return {
         relativePath,
-        content: document?.content ?? '',
-        sizeBytes: document?.content.length ?? 0,
-        modifiedAtUnixSec: document?.modifiedAtUnixSec ?? 0,
+        content: document.content,
+        sizeBytes: document.content.length,
+        modifiedAtUnixSec: document.modifiedAtUnixSec,
       };
     });
 
@@ -165,6 +169,7 @@ describe('analysisTools', () => {
   });
 
   afterEach(() => {
+    workspaceDocuments.clear();
     unregisterAnalysisTools();
   });
 
@@ -1163,6 +1168,136 @@ describe('reference style transfer analysis tools', () => {
       const data = getToolResult<Record<string, any>>(result);
       expect(data.relativePath).toBe('reports/custom-output.md');
       expect(data.reportPath).toBe('reports/custom-output.md');
+    });
+
+    it('should reject a custom outputPath that would overwrite the source asset', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'read-source-overwrite',
+            name: 'overwrite.mp4',
+            kind: 'video',
+            uri: '/media/overwrite.mp4',
+            relativePath: 'media/overwrite.mp4',
+            durationSec: 5,
+            video: {
+              width: 1280,
+              height: 720,
+              fps: { num: 30, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce({
+          assetId: 'read-source-overwrite',
+          shots: [],
+          transcript: [],
+          audioProfile: {
+            bpm: null,
+            spectralCentroidHz: 1000,
+            loudnessProfile: [-20],
+            peakDb: -6,
+            silenceRegions: [],
+            speechRegions: [],
+          },
+          segments: [],
+          frameAnalysis: [],
+          contactSheet: null,
+          metadata: {
+            durationSec: 5,
+            width: 1280,
+            height: 720,
+            fps: 30,
+            codec: 'h264',
+            hasAudio: false,
+          },
+          analyzedAt: '2026-03-07T00:00:00Z',
+          errors: {},
+        })
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+
+      const result = await globalToolRegistry.execute('read_source_analysis_report', {
+        assetId: 'read-source-overwrite',
+        outputPath: 'media/overwrite.mp4',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('outputPath cannot overwrite the source asset');
+      expect(vi.mocked(writeWorkspaceDocumentToBackend)).not.toHaveBeenCalled();
+    });
+
+    it('should keep persisted true when the report cannot be re-read after writing', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'read-source-reread-fail',
+            name: 'reread.mp4',
+            kind: 'video',
+            uri: '/media/reread.mp4',
+            relativePath: 'media/reread.mp4',
+            durationSec: 5,
+            video: {
+              width: 1280,
+              height: 720,
+              fps: { num: 30, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce({
+          assetId: 'read-source-reread-fail',
+          shots: [],
+          transcript: [],
+          audioProfile: {
+            bpm: null,
+            spectralCentroidHz: 1000,
+            loudnessProfile: [-20],
+            peakDb: -6,
+            silenceRegions: [],
+            speechRegions: [],
+          },
+          segments: [],
+          frameAnalysis: [],
+          contactSheet: null,
+          metadata: {
+            durationSec: 5,
+            width: 1280,
+            height: 720,
+            fps: 30,
+            codec: 'h264',
+            hasAudio: false,
+          },
+          analyzedAt: '2026-03-07T00:00:00Z',
+          errors: {},
+        })
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+      vi.mocked(writeWorkspaceDocumentToBackend).mockResolvedValueOnce({
+        relativePath: 'media/reread.analysis.md',
+        bytesWritten: 428,
+        created: true,
+      });
+
+      const result = await globalToolRegistry.execute('read_source_analysis_report', {
+        assetId: 'read-source-reread-fail',
+      });
+
+      const data = getToolResult<Record<string, any>>(result);
+      expect(data.persisted).toBe(true);
+      expect(typeof data.persistenceError).toBe('string');
+      expect(String(data.persistenceError).length).toBeGreaterThan(0);
+      expect(data.document.persisted).toBe(true);
+      expect(typeof data.document.persistenceError).toBe('string');
+      expect(String(data.document.persistenceError).length).toBeGreaterThan(0);
+      expect(data.relativePath).toBe('media/reread.analysis.md');
+      expect(data.sizeBytes).toBe(String(data.content).length);
     });
   });
 

--- a/src/agents/tools/analysisTools.test.ts
+++ b/src/agents/tools/analysisTools.test.ts
@@ -15,14 +15,32 @@ import {
 import { useProjectStore } from '@/stores/projectStore';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { usePlaybackStore } from '@/stores/playbackStore';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 import type { Track, Clip, Asset, Sequence } from '@/types';
 import { createMockAsset, createMockClip, createMockTrack, createMockSequence } from '@/test/mocks';
 import { invoke } from '@tauri-apps/api/core';
 import { executeAgentCommand } from './commandExecutor';
+import {
+  readWorkspaceDocumentFromBackend,
+  writeWorkspaceDocumentToBackend,
+} from '@/services/workspaceGateway';
 
 vi.mock('./commandExecutor', () => ({
   executeAgentCommand: vi.fn(),
 }));
+
+vi.mock('@/services/workspaceGateway', () => ({
+  readWorkspaceDocumentFromBackend: vi.fn(),
+  writeWorkspaceDocumentToBackend: vi.fn(),
+}));
+
+const workspaceDocuments = new Map<
+  string,
+  {
+    content: string;
+    modifiedAtUnixSec: number;
+  }
+>();
 
 // =============================================================================
 // Test Helpers
@@ -103,9 +121,28 @@ function getToolResult<T>(result: ToolExecutionResult): T {
 describe('analysisTools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    workspaceDocuments.clear();
     globalToolRegistry.clear();
     registerAnalysisTools();
     vi.mocked(executeAgentCommand).mockReset();
+    vi.mocked(writeWorkspaceDocumentToBackend).mockImplementation(async (relativePath, content) => {
+      const modifiedAtUnixSec = workspaceDocuments.size + 1;
+      workspaceDocuments.set(relativePath, { content, modifiedAtUnixSec });
+      return {
+        relativePath,
+        bytesWritten: content.length,
+        created: true,
+      };
+    });
+    vi.mocked(readWorkspaceDocumentFromBackend).mockImplementation(async (relativePath) => {
+      const document = workspaceDocuments.get(relativePath);
+      return {
+        relativePath,
+        content: document?.content ?? '',
+        sizeBytes: document?.content.length ?? 0,
+        modifiedAtUnixSec: document?.modifiedAtUnixSec ?? 0,
+      };
+    });
 
     // Reset stores
     useProjectStore.setState({
@@ -120,6 +157,10 @@ describe('analysisTools', () => {
     usePlaybackStore.setState({
       currentTime: 0,
       duration: 0,
+    });
+    useWorkspaceStore.setState({
+      fileTree: [],
+      error: null,
     });
   });
 
@@ -151,7 +192,7 @@ describe('analysisTools', () => {
 
     it('should register tools in analysis category', () => {
       const analysisTools = globalToolRegistry.listByCategory('analysis');
-      expect(analysisTools.length).toBe(27);
+      expect(analysisTools.length).toBe(28);
     });
 
     it('should return correct tool names', () => {
@@ -165,6 +206,7 @@ describe('analysisTools', () => {
       expect(names).toContain('get_workspace_files');
       expect(names).toContain('find_workspace_file');
       expect(names).toContain('get_unregistered_files');
+      expect(names).toContain('read_source_analysis_report');
       expect(names).toContain('generate_source_analysis_report');
       expect(names).toContain('search_source_analysis_report');
       expect(names).toContain('search_source_library');
@@ -173,7 +215,7 @@ describe('analysisTools', () => {
       expect(names).toContain('search_indexed_source_library');
       expect(names).toContain('import_external_diarization');
       expect(names).toContain('run_external_diarization');
-      expect(names).toHaveLength(27);
+      expect(names).toHaveLength(28);
     });
 
     it('should unregister all tools', () => {
@@ -904,6 +946,227 @@ describe('reference style transfer analysis tools', () => {
   });
 
   // ===========================================================================
+  // read_source_analysis_report
+  // ===========================================================================
+
+  describe('read_source_analysis_report', () => {
+    it('should generate, persist, and return the canonical Markdown report document', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'read-source-1',
+            name: 'readable.mp4',
+            kind: 'video',
+            uri: '/media/readable.mp4',
+            relativePath: 'media/readable.mp4',
+            durationSec: 8,
+            video: {
+              width: 1920,
+              height: 1080,
+              fps: { num: 30, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce({
+          assetId: 'read-source-1',
+          shots: [{ startSec: 0, endSec: 4, confidence: 0.9, keyframePath: 'shots/0001.jpg' }],
+          transcript: [
+            {
+              startSec: 0,
+              endSec: 2,
+              text: 'A concise transcript excerpt',
+              confidence: 0.95,
+              language: 'en',
+              speakerId: 'speaker_1',
+            },
+          ],
+          audioProfile: {
+            bpm: 120,
+            spectralCentroidHz: 1400,
+            loudnessProfile: [-18.2],
+            peakDb: -4.2,
+            silenceRegions: [],
+            speechRegions: [{ startSec: 0, endSec: 4 }],
+          },
+          segments: [
+            { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
+          ],
+          frameAnalysis: [],
+          contactSheet: null,
+          metadata: {
+            durationSec: 8,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            codec: 'h264',
+            hasAudio: true,
+          },
+          analyzedAt: '2026-03-07T00:00:00Z',
+          errors: {},
+        })
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+
+      const result = await globalToolRegistry.execute('read_source_analysis_report', {
+        assetId: 'read-source-1',
+      });
+
+      const data = getToolResult<Record<string, any>>(result);
+      expect(data.assetId).toBe('read-source-1');
+      expect(data.relativePath).toBe('media/readable.analysis.md');
+      expect(data.reportPath).toBe('media/readable.analysis.md');
+      expect(data.document.relativePath).toBe('media/readable.analysis.md');
+      expect(vi.mocked(writeWorkspaceDocumentToBackend)).toHaveBeenCalled();
+      expect(String(data.content)).toContain('# Source Analysis Report: readable.mp4');
+      expect(String(data.document.content)).toContain('# Source Analysis Report: readable.mp4');
+      expect(data.sectionCounts).toMatchObject({
+        moments: 1,
+        chapters: expect.any(Number),
+        highlights: expect.any(Number),
+        speakerTurns: 1,
+      });
+    });
+
+    it('should resolve a workspace file argument into an asset before reading', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'read-source-file',
+            name: 'library.mp4',
+            kind: 'video',
+            uri: '/media/library.mp4',
+            relativePath: 'media/library.mp4',
+            durationSec: 6,
+            video: {
+              width: 1280,
+              height: 720,
+              fps: { num: 24, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+      useWorkspaceStore.setState({
+        fileTree: [
+          {
+            name: 'library.mp4',
+            relativePath: 'media/library.mp4',
+            isDirectory: false,
+            fileSize: 1024,
+            kind: 'video',
+            assetId: 'read-source-file',
+            children: [],
+          },
+        ],
+      });
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce({
+          assetId: 'read-source-file',
+          shots: [{ startSec: 0, endSec: 6, confidence: 0.9, keyframePath: null }],
+          transcript: [],
+          audioProfile: {
+            bpm: null,
+            spectralCentroidHz: 900,
+            loudnessProfile: [-19],
+            peakDb: -5,
+            silenceRegions: [],
+          },
+          segments: [
+            { startSec: 0, endSec: 6, segmentType: 'broll', confidence: 0.85, features: {} },
+          ],
+          frameAnalysis: [],
+          contactSheet: null,
+          metadata: {
+            durationSec: 6,
+            width: 1280,
+            height: 720,
+            fps: 24,
+            codec: 'h264',
+            hasAudio: true,
+          },
+          analyzedAt: '2026-03-07T00:00:00Z',
+          errors: {},
+        })
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+
+      const result = await globalToolRegistry.execute('read_source_analysis_report', {
+        file: 'library.mp4',
+      });
+
+      const data = getToolResult<Record<string, any>>(result);
+      expect(data.assetId).toBe('read-source-file');
+      expect(data.requestedFile).toBe('media/library.mp4');
+      expect(data.relativePath).toBe('media/library.analysis.md');
+    });
+
+    it('should honor a custom outputPath when provided', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'read-source-custom',
+            name: 'custom.mp4',
+            kind: 'video',
+            uri: '/media/custom.mp4',
+            relativePath: 'media/custom.mp4',
+            durationSec: 5,
+            video: {
+              width: 1280,
+              height: 720,
+              fps: { num: 30, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce({
+          assetId: 'read-source-custom',
+          shots: [],
+          transcript: [],
+          audioProfile: {
+            bpm: null,
+            spectralCentroidHz: 1000,
+            loudnessProfile: [-20],
+            peakDb: -6,
+            silenceRegions: [],
+            speechRegions: [],
+          },
+          segments: [],
+          frameAnalysis: [],
+          contactSheet: null,
+          metadata: {
+            durationSec: 5,
+            width: 1280,
+            height: 720,
+            fps: 30,
+            codec: 'h264',
+            hasAudio: false,
+          },
+          analyzedAt: '2026-03-07T00:00:00Z',
+          errors: {},
+        })
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+
+      const result = await globalToolRegistry.execute('read_source_analysis_report', {
+        assetId: 'read-source-custom',
+        outputPath: 'reports/custom-output.md',
+      });
+
+      const data = getToolResult<Record<string, any>>(result);
+      expect(data.relativePath).toBe('reports/custom-output.md');
+      expect(data.reportPath).toBe('reports/custom-output.md');
+    });
+  });
+
+  // ===========================================================================
   // generate_source_analysis_report
   // ===========================================================================
 
@@ -916,6 +1179,7 @@ describe('reference style transfer analysis tools', () => {
             name: 'concert.mp4',
             kind: 'video',
             uri: '/media/concert.mp4',
+            relativePath: 'media/concert.mp4',
             durationSec: 12,
             video: {
               width: 1920,
@@ -1089,6 +1353,9 @@ describe('reference style transfer analysis tools', () => {
       expect(data.annotations.objectDetectionCount).toBe(1);
       expect(data.annotations.availableTypes).toContain('objects');
       expect(data.annotations.providers).toContain('google_cloud');
+      expect(data.relativePath).toBe('media/concert.analysis.md');
+      expect(data.reportPath).toBe('media/concert.analysis.md');
+      expect(String(data.content)).toContain('# Source Analysis Report: concert.mp4');
       expect(String(data.markdown)).toContain('# Source Analysis Report: concert.mp4');
       expect(String(data.markdown)).toContain('## Moments');
       expect(String(data.markdown)).toContain('## Visual Artifacts');

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -40,6 +40,11 @@ import {
 import { calculatePearsonCorrelation, getPrimaryTrackClips } from '@/utils/referenceComparison';
 import { useProjectStore } from '@/stores/projectStore';
 import { executeAgentCommand } from './commandExecutor';
+import {
+  readWorkspaceDocumentFromBackend,
+  writeWorkspaceDocumentToBackend,
+} from '@/services/workspaceGateway';
+import { resolveWorkspaceAsset } from './mediaAnalysisTools';
 
 const logger = createLogger('AnalysisTools');
 
@@ -1195,6 +1200,14 @@ function bundleSatisfiesOptions(bundle: AnalysisBundle, options: AnalysisOptions
 
 type SourceAnalysisReport = ReturnType<typeof buildSourceAnalysisReportPayload>;
 type SourceAnalysisSection = 'moments' | 'chapters' | 'highlights' | 'speakerTurns';
+type SourceAnalysisReportDocument = {
+  relativePath: string;
+  content: string;
+  sizeBytes: number;
+  modifiedAtUnixSec: number | null;
+  persisted: boolean;
+  persistenceError: string | null;
+};
 type SourceReportChunk = {
   id: string;
   sectionType: SourceAnalysisSection;
@@ -1220,6 +1233,8 @@ type IndexedSourceReportSearchResponse = {
   total: number;
   processingTimeMs: number;
 };
+
+const SOURCE_ANALYSIS_REPORT_SUFFIX = '.analysis.md';
 type RetrievalMemoryEntry = {
   assetId: string;
   sectionType: SourceAnalysisSection;
@@ -2238,6 +2253,7 @@ function buildSourceAnalysisReportPayload({
     assetName: asset?.name ?? bundle.assetId,
     assetKind: asset?.kind ?? 'video',
     assetUri: asset?.uri ?? '',
+    assetRelativePath: asset?.relativePath ?? null,
     generatedAt: new Date().toISOString(),
     analyzedAt: bundle.analyzedAt,
     bundleSource,
@@ -2554,6 +2570,125 @@ function buildSourceAnalysisMarkdown(
   }
 
   return lines.join('\n');
+}
+
+function stripFileExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, '');
+}
+
+function sanitizeReportFileStem(value: string): string {
+  const sanitized = stripFileExtension(value)
+    .trim()
+    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '');
+  return sanitized.length > 0 ? sanitized : 'source-analysis-report';
+}
+
+function buildSiblingSourceAnalysisReportRelativePath(relativePath: string): string {
+  const normalized = relativePath.replace(/\\/g, '/').trim().replace(/^\.\//, '');
+  const segments = normalized.split('/').filter(Boolean);
+  const fileName = segments.pop() ?? normalized;
+  const stem = sanitizeReportFileStem(fileName);
+  const reportFileName = `${stem}${SOURCE_ANALYSIS_REPORT_SUFFIX}`;
+  return segments.length > 0 ? `${segments.join('/')}/${reportFileName}` : reportFileName;
+}
+
+function buildDefaultSourceAnalysisReportRelativePath(report: SourceAnalysisReport): string {
+  if (typeof report.assetRelativePath === 'string' && report.assetRelativePath.trim().length > 0) {
+    return buildSiblingSourceAnalysisReportRelativePath(report.assetRelativePath);
+  }
+
+  return `analysis-reports/${sanitizeReportFileStem(report.assetName || report.assetId)}${SOURCE_ANALYSIS_REPORT_SUFFIX}`;
+}
+
+async function persistSourceAnalysisMarkdownReport(
+  report: SourceAnalysisReport,
+  requestedOutputPath?: string | null,
+): Promise<SourceAnalysisReportDocument> {
+  const relativePath =
+    typeof requestedOutputPath === 'string' && requestedOutputPath.trim().length > 0
+      ? requestedOutputPath.trim()
+      : buildDefaultSourceAnalysisReportRelativePath(report);
+  const content = buildSourceAnalysisMarkdown(report);
+
+  try {
+    await writeWorkspaceDocumentToBackend(relativePath, content, true);
+    const document = await readWorkspaceDocumentFromBackend(relativePath, {
+      failureLogLevel: 'debug',
+    });
+
+    return {
+      relativePath: document.relativePath,
+      content: document.content,
+      sizeBytes: document.sizeBytes,
+      modifiedAtUnixSec: document.modifiedAtUnixSec,
+      persisted: true,
+      persistenceError: null,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn('Failed to persist source analysis Markdown report', {
+      assetId: report.assetId,
+      relativePath,
+      error: message,
+    });
+
+    return {
+      relativePath,
+      content,
+      sizeBytes: content.length,
+      modifiedAtUnixSec: null,
+      persisted: false,
+      persistenceError: message,
+    };
+  }
+}
+
+async function prepareSourceAnalysisReportArtifacts(
+  args: Record<string, unknown>,
+): Promise<{ report: SourceAnalysisReport; document: SourceAnalysisReportDocument }> {
+  const report = await generateSourceAnalysisReportPayloadFromArgs(args);
+
+  try {
+    await indexSourceReportChunks(report);
+  } catch (error) {
+    logger.warn('source analysis report could not index report chunks', {
+      assetId: report.assetId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const requestedOutputPath =
+    typeof args.outputPath === 'string' && args.outputPath.trim().length > 0
+      ? args.outputPath.trim()
+      : null;
+  const document = await persistSourceAnalysisMarkdownReport(report, requestedOutputPath);
+  return { report, document };
+}
+
+async function resolveSourceAnalysisArgs(
+  args: Record<string, unknown>,
+): Promise<{ resolvedArgs: Record<string, unknown>; requestedFile: string | null }> {
+  const assetId = typeof args.assetId === 'string' ? args.assetId.trim() : '';
+  if (assetId.length > 0) {
+    return { resolvedArgs: args, requestedFile: null };
+  }
+
+  const file = typeof args.file === 'string' ? args.file.trim() : '';
+  if (file.length === 0) {
+    throw new Error('assetId or file is required');
+  }
+
+  const resolved = await resolveWorkspaceAsset(file);
+  return {
+    resolvedArgs: {
+      ...args,
+      assetId: resolved.assetId,
+    },
+    requestedFile: resolved.relativePath,
+  };
 }
 
 // =============================================================================
@@ -3210,17 +3345,123 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
   },
 
   // ---------------------------------------------------------------------------
+  // Read Source Analysis Report
+  // ---------------------------------------------------------------------------
+  {
+    name: 'read_source_analysis_report',
+    description:
+      'Read the canonical Markdown source-analysis report for a video asset. If needed, generate or refresh the underlying analysis first and persist the report beside the asset by default (or to outputPath when provided)',
+    category: 'analysis',
+    outputContract: getToolOutputContract('read_source_analysis_report') ?? undefined,
+    parameters: {
+      type: 'object',
+      properties: {
+        assetId: {
+          type: 'string',
+          description: 'Asset ID of the source video to inspect',
+        },
+        file: {
+          type: 'string',
+          description: 'Workspace-relative media path or filename to resolve into an asset',
+        },
+        outputPath: {
+          type: 'string',
+          description:
+            'Optional workspace-relative Markdown output path. When omitted, the report is created next to the asset as <asset-name>.analysis.md',
+        },
+        refresh: {
+          type: 'boolean',
+          description: 'Force regeneration instead of reusing a compatible cached bundle',
+        },
+        includeAnnotation: {
+          type: 'boolean',
+          description:
+            'Include stored annotation/OCR/object summaries when available (default: true)',
+        },
+        options: {
+          type: 'object',
+          description: 'Optional analysis flags used if a new bundle must be generated',
+        },
+        shots: { type: 'boolean', description: 'Include shot detection (default: true)' },
+        transcript: { type: 'boolean', description: 'Include transcript (default: true)' },
+        audio: { type: 'boolean', description: 'Include audio profiling (default: true)' },
+        segments: { type: 'boolean', description: 'Include content segmentation (default: true)' },
+        visual: { type: 'boolean', description: 'Include visual analysis (default: true)' },
+        localOnly: {
+          type: 'boolean',
+          description: 'Skip Vision API work and use local analysis where supported',
+        },
+      },
+      required: [],
+    },
+    handler: async (args) => {
+      try {
+        const { resolvedArgs, requestedFile } = await resolveSourceAnalysisArgs(
+          args as Record<string, unknown>,
+        );
+        const { report, document } = await prepareSourceAnalysisReportArtifacts(resolvedArgs);
+
+        logger.debug('read_source_analysis_report completed', {
+          assetId: report.assetId,
+          requestedFile,
+          persisted: document.persisted,
+        });
+
+        return {
+          success: true,
+          result: {
+            assetId: report.assetId,
+            assetName: report.assetName,
+            requestedFile,
+            content: document.content,
+            relativePath: document.relativePath,
+            reportPath: document.relativePath,
+            sizeBytes: document.sizeBytes,
+            modifiedAtUnixSec: document.modifiedAtUnixSec,
+            persisted: document.persisted,
+            persistenceError: document.persistenceError,
+            bundleSource: report.bundleSource,
+            generatedAt: report.generatedAt,
+            summary: report.summary,
+            metadata: report.metadata,
+            coverage: report.coverage,
+            sectionCounts: {
+              moments: report.moments.count,
+              chapters: report.chapters.count,
+              highlights: report.highlights.count,
+              speakerTurns: report.speakerTurns.count,
+            },
+            warnings: report.warnings,
+            errors: report.errors,
+            document,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error('read_source_analysis_report failed', { error: message });
+        return { success: false, error: message };
+      }
+    },
+  },
+
+  // ---------------------------------------------------------------------------
   // Generate Source Analysis Report
   // ---------------------------------------------------------------------------
   {
     name: 'generate_source_analysis_report',
     description:
-      'Build a rich source-footage analysis report for one asset by combining bundle, annotation, and asset metadata into JSON plus Markdown with moments, chapters, and candidate highlights',
+      'Build a rich source-footage analysis report for one asset by combining bundle, annotation, and asset metadata into JSON plus Markdown with moments, chapters, and candidate highlights. Also persists the Markdown report beside the asset by default.',
     category: 'analysis',
+    outputContract: getToolOutputContract('generate_source_analysis_report') ?? undefined,
     parameters: {
       type: 'object',
       properties: {
         assetId: { type: 'string', description: 'Asset ID of the source video to inspect' },
+        outputPath: {
+          type: 'string',
+          description:
+            'Optional workspace-relative Markdown output path. When omitted, the report is created next to the asset as <asset-name>.analysis.md',
+        },
         refresh: {
           type: 'boolean',
           description: 'Force regeneration instead of reusing a compatible cached bundle',
@@ -3248,18 +3489,9 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
     },
     handler: async (args) => {
       try {
-        const report = await generateSourceAnalysisReportPayloadFromArgs(
+        const { report, document } = await prepareSourceAnalysisReportArtifacts(
           args as Record<string, unknown>,
         );
-
-        try {
-          await indexSourceReportChunks(report);
-        } catch (error) {
-          logger.warn('generate_source_analysis_report could not index report chunks', {
-            assetId: report.assetId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
 
         logger.debug('generate_source_analysis_report completed', {
           assetId: report.assetId,
@@ -3272,7 +3504,15 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
           success: true,
           result: {
             ...report,
-            markdown: buildSourceAnalysisMarkdown(report),
+            content: document.content,
+            relativePath: document.relativePath,
+            markdown: document.content,
+            reportPath: document.relativePath,
+            sizeBytes: document.sizeBytes,
+            modifiedAtUnixSec: document.modifiedAtUnixSec,
+            persisted: document.persisted,
+            persistenceError: document.persistenceError,
+            document,
           },
         };
       } catch (error) {

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -2586,8 +2586,12 @@ function sanitizeReportFileStem(value: string): string {
   return sanitized.length > 0 ? sanitized : 'source-analysis-report';
 }
 
+function normalizeWorkspaceRelativePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/').trim().replace(/^\.\//, '');
+}
+
 function buildSiblingSourceAnalysisReportRelativePath(relativePath: string): string {
-  const normalized = relativePath.replace(/\\/g, '/').trim().replace(/^\.\//, '');
+  const normalized = normalizeWorkspaceRelativePath(relativePath);
   const segments = normalized.split('/').filter(Boolean);
   const fileName = segments.pop() ?? normalized;
   const stem = sanitizeReportFileStem(fileName);
@@ -2611,22 +2615,54 @@ async function persistSourceAnalysisMarkdownReport(
     typeof requestedOutputPath === 'string' && requestedOutputPath.trim().length > 0
       ? requestedOutputPath.trim()
       : buildDefaultSourceAnalysisReportRelativePath(report);
+  const assetRelativePath =
+    typeof report.assetRelativePath === 'string' && report.assetRelativePath.trim().length > 0
+      ? report.assetRelativePath
+      : null;
+
+  if (
+    assetRelativePath &&
+    normalizeWorkspaceRelativePath(relativePath).toLowerCase() ===
+      normalizeWorkspaceRelativePath(assetRelativePath).toLowerCase()
+  ) {
+    throw new Error('outputPath cannot overwrite the source asset');
+  }
+
   const content = buildSourceAnalysisMarkdown(report);
 
   try {
     await writeWorkspaceDocumentToBackend(relativePath, content, true);
-    const document = await readWorkspaceDocumentFromBackend(relativePath, {
-      failureLogLevel: 'debug',
-    });
 
-    return {
-      relativePath: document.relativePath,
-      content: document.content,
-      sizeBytes: document.sizeBytes,
-      modifiedAtUnixSec: document.modifiedAtUnixSec,
-      persisted: true,
-      persistenceError: null,
-    };
+    try {
+      const document = await readWorkspaceDocumentFromBackend(relativePath, {
+        failureLogLevel: 'debug',
+      });
+
+      return {
+        relativePath: document.relativePath,
+        content: document.content,
+        sizeBytes: document.sizeBytes,
+        modifiedAtUnixSec: document.modifiedAtUnixSec,
+        persisted: true,
+        persistenceError: null,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn('Source analysis Markdown report was written but could not be re-read', {
+        assetId: report.assetId,
+        relativePath,
+        error: message,
+      });
+
+      return {
+        relativePath,
+        content,
+        sizeBytes: content.length,
+        modifiedAtUnixSec: null,
+        persisted: true,
+        persistenceError: message,
+      };
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.warn('Failed to persist source analysis Markdown report', {

--- a/src/agents/tools/mediaAnalysisTools.ts
+++ b/src/agents/tools/mediaAnalysisTools.ts
@@ -72,7 +72,7 @@ function findAssetIdInTree(
   return undefined;
 }
 
-async function resolveWorkspaceAsset(
+export async function resolveWorkspaceAsset(
   file: string,
 ): Promise<{ assetId: string; relativePath: string }> {
   const matches = findWorkspaceFile(file);

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -213,6 +213,14 @@ const META_TOOLS: ToolDefinition[] = [
           type: 'boolean',
           description: 'Generate missing source analysis on demand when supported',
         },
+        refresh: {
+          type: 'boolean',
+          description: 'Force regeneration instead of reusing compatible cached analysis data',
+        },
+        includeAnnotation: {
+          type: 'boolean',
+          description: 'Include stored annotation/OCR/object summaries when available',
+        },
         useIndexedSearch: {
           type: 'boolean',
           description: 'Use indexed report-chunk retrieval when supported',
@@ -241,6 +249,10 @@ const META_TOOLS: ToolDefinition[] = [
         time: { type: 'number', description: 'Timeline position in seconds' },
         path: { type: 'string', description: 'File path or search pattern' },
         file: { type: 'string', description: 'Workspace-relative media file path' },
+        outputPath: {
+          type: 'string',
+          description: 'Optional workspace-relative output path for generated Markdown reports',
+        },
         kind: { type: 'string', description: 'Asset kind filter or media kind selector' },
         query: { type: 'string', description: 'Search query or filename substring' },
         provider: { type: 'string', description: 'Preferred analysis provider when supported' },

--- a/src/agents/tools/storeAccessor.ts
+++ b/src/agents/tools/storeAccessor.ts
@@ -64,6 +64,8 @@ export interface AssetSnapshot {
   name: string;
   kind: Asset['kind'];
   uri: string;
+  relativePath?: string;
+  workspaceManaged?: boolean;
   durationSec?: number;
   videoWidth?: number;
   videoHeight?: number;
@@ -148,6 +150,8 @@ function assetToSnapshot(asset: Asset, timelineClipCount: number): AssetSnapshot
     name: asset.name,
     kind: asset.kind,
     uri: asset.uri,
+    relativePath: asset.relativePath,
+    workspaceManaged: asset.workspaceManaged,
     durationSec: asset.durationSec,
     videoWidth: asset.video?.width,
     videoHeight: asset.video?.height,

--- a/src/stores/permissionStore.test.ts
+++ b/src/stores/permissionStore.test.ts
@@ -2,10 +2,7 @@
  * Permission Store Tests
  */
 
-import {
-  usePermissionStore,
-  matchPattern,
-} from './permissionStore';
+import { usePermissionStore, matchPattern } from './permissionStore';
 
 beforeEach(() => {
   usePermissionStore.getState().loadDefaults();
@@ -41,6 +38,7 @@ describe('permissionStore', () => {
     expect(store.resolvePermission('get_clip')).toBe('allow');
     expect(store.resolvePermission('list_tracks')).toBe('allow');
     expect(store.resolvePermission('find_clip')).toBe('allow');
+    expect(store.resolvePermission('read_source_analysis_report')).toBe('allow');
     expect(store.resolvePermission('analyze_video')).toBe('allow');
     expect(store.resolvePermission('search_assets')).toBe('allow');
   });
@@ -104,7 +102,9 @@ describe('permissionStore', () => {
     const store = usePermissionStore.getState();
     store.addRule('workspace.**', 'deny', 'global');
 
-    expect(usePermissionStore.getState().resolvePermission('write_workspace_document')).toBe('deny');
+    expect(usePermissionStore.getState().resolvePermission('write_workspace_document')).toBe(
+      'deny',
+    );
     expect(usePermissionStore.getState().resolvePermission('read_workspace_document')).toBe('deny');
   });
 

--- a/src/stores/permissionStore.ts
+++ b/src/stores/permissionStore.ts
@@ -76,11 +76,7 @@ export interface PermissionStoreState {
     sessionId: string,
     decisions: Array<Pick<PermissionDecision, 'id' | 'subject' | 'action' | 'createdAt'>>,
   ) => void;
-  addRule: (
-    pattern: string,
-    permission: ToolPermission,
-    scope: 'global' | 'session',
-  ) => void;
+  addRule: (pattern: string, permission: ToolPermission, scope: 'global' | 'session') => void;
   removeRule: (id: string) => void;
   allowAlways: (toolName: string, args?: Record<string, unknown>) => void;
   resetSessionRules: () => void;
@@ -110,6 +106,7 @@ const BALANCED_RULES: Omit<PermissionRule, 'id'>[] = [
   { pattern: 'get_*', permission: 'allow', scope: 'global' },
   { pattern: 'list_*', permission: 'allow', scope: 'global' },
   { pattern: 'find_*', permission: 'allow', scope: 'global' },
+  { pattern: 'read_*', permission: 'allow', scope: 'global' },
   { pattern: 'analyze_*', permission: 'allow', scope: 'global' },
   { pattern: 'search_*', permission: 'allow', scope: 'global' },
   { pattern: 'inspect_*', permission: 'allow', scope: 'global' },
@@ -120,6 +117,7 @@ const RESTRICTIVE_RULES: Omit<PermissionRule, 'id'>[] = [
   { pattern: '*', permission: 'ask', scope: 'global' },
   { pattern: 'get_*', permission: 'allow', scope: 'global' },
   { pattern: 'list_*', permission: 'allow', scope: 'global' },
+  { pattern: 'read_*', permission: 'allow', scope: 'global' },
 ];
 
 const PERMISSIVE_RULES: Omit<PermissionRule, 'id'>[] = [
@@ -189,10 +187,7 @@ function toResolution(
     permission: match?.rule.permission ?? 'ask',
     matchedRuleId: match?.rule.id ?? null,
     matchedPattern: match?.rule.pattern ?? null,
-    matchedScope:
-      match && match.rule.scope !== 'builtin'
-        ? match.rule.scope
-        : null,
+    matchedScope: match && match.rule.scope !== 'builtin' ? match.rule.scope : null,
     source,
   };
 }
@@ -221,7 +216,8 @@ function chooseBetterMatch(
     return candidate.insertionRank > current.insertionRank ? candidate : current;
   }
 
-  return PERMISSION_PRIORITY[candidate.rule.permission] >= PERMISSION_PRIORITY[current.rule.permission]
+  return PERMISSION_PRIORITY[candidate.rule.permission] >=
+    PERMISSION_PRIORITY[current.rule.permission]
     ? candidate
     : current;
 }
@@ -326,10 +322,7 @@ export const usePermissionStore = create<PermissionStoreState>()(
       sessionRules: [],
       hydratedSessionId: null,
 
-      resolvePermission: (
-        toolName: string,
-        args: Record<string, unknown> = {},
-      ): ToolPermission => {
+      resolvePermission: (toolName: string, args: Record<string, unknown> = {}): ToolPermission => {
         return get().resolvePermissionDetails(toolName, args).permission;
       },
 
@@ -364,11 +357,7 @@ export const usePermissionStore = create<PermissionStoreState>()(
         });
       },
 
-      addRule: (
-        pattern: string,
-        permission: ToolPermission,
-        scope: 'global' | 'session',
-      ) => {
+      addRule: (pattern: string, permission: ToolPermission, scope: 'global' | 'session') => {
         const rule: PermissionRule = {
           id: crypto.randomUUID(),
           pattern,


### PR DESCRIPTION
### **User description**
## Description

Add a canonical source-analysis report reading workflow that persists `.analysis.md` beside source assets by default, harden backend metadata resolution for workspace-managed analysis targets, and route deep source inspection through the canonical report reader before edit actions.

## Related Issue

Closes #608

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- add `read_source_analysis_report`, persist canonical Markdown reports beside source assets by default, and expose stable report path/content contracts for agent tooling
- backfill and probe missing workspace asset metadata so analysis can run reliably for workspace-managed media and propagate `ffprobe` into the analysis pipeline
- teach permissions, playbooks, planner guidance, and prompt/tool references to prefer canonical source-analysis report reads for deep source inspection

## Screenshots / Videos

N/A

## Testing

Ran targeted Vitest coverage for analysis tools, permission subjects/stores, orchestration playbooks, and system prompt assembly, plus `cargo test -p openreelio --lib`. Pre-commit hooks also ran `npx tsx scripts/sync-version.ts --check`, `tsc --noEmit`, and `eslint . --ext .js,.jsx,.ts,.tsx --fix`.

### Test Environment

- OS: Microsoft Windows 11 Pro
- Node.js version: v22.19.0
- Rust version: rustc 1.92.0 (ded5c06cf 2025-12-08)

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

This change set is a follow-up to `#576`. The lint step passed but still reports 16 pre-existing warnings in unrelated files such as `AgentArtifactReviewPanel.tsx`, `effectCategoryData.tsx`, `ErrorOverlay.tsx`, `TimelineOperationsContext.tsx`, `useKeyboardScope.tsx`, and `useTranscriptEditing.ts`.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Adds `read_source_analysis_report` tool for consolidated deep source inspection.

- Persists Markdown analysis reports beside source assets by default.

- Hardens backend metadata resolution for workspace-managed media files.

- Updates agent playbooks and prompts to prefer canonical report reading.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Agent Thought"] -- "inspect source" --> B["Orchestration Playbook"]
  B -- "trigger" --> C["read_source_analysis_report"]
  C -- "resolve" --> D["Workspace Asset Metadata"]
  D -- "generate/read" --> E[".analysis.md Report"]
  E -- "return" --> F["Consolidated Insights"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>orchestrationPlaybooks.ts</strong><dd><code>Add source analysis read playbook and keyword matching</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-1ee42f69433d7f5b0ae2ed0d4266e876c367fb882e94916bc493082e13145990">+120/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>analysisTools.ts</strong><dd><code>Implement read_source_analysis_report and report persistence logic</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-717609a79d522c08834e29f962677b6c063796dd112f1c4bf93d697292f48a4a">+252/-12</a></td>

</tr>

<tr>
  <td><strong>analysis.rs</strong><dd><code>Probe missing asset metadata during analysis command execution</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-27ee8d77b931eb5265b4548b8b912173ea914870e28c0a6e0ecba9a971e37f5f">+169/-26</a></td>

</tr>

<tr>
  <td><strong>toolOutputContracts.ts</strong><dd><code>Define output contracts for new analysis report tools</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-2fe279e63827a652ff07a52579998fb029ad15e9604be67586e5659c39ddc75f">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Propagate ffprobe path to analysis job runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-ee1ec68a6c16498846fbdeed6ee57a511828e681c5493aee1cd5b746fbfe8312">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mediaAnalysisTools.ts</strong><dd><code>Export workspace asset resolution helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-566b923e084c1f2544f668ed36d9fcf3983f7b85a639ee4500fc27f919418e9d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.ts</strong><dd><code>Expose report parameters in meta-tool definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-842f7132c091ca5476d87b73a280cb7192ba997487dfea06a0bd4e097e1a19b7">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storeAccessor.ts</strong><dd><code>Include workspace management flags in asset snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-03ec3c4960e952497a36b3cc1aee0c0e43a8861c8d68d08598db959b14420d63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>service.rs</strong><dd><code>Backfill and refresh workspace asset metadata using ffprobe</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-2191768c9a1c055309a22d33e0bd16a1d858a2aad33f19857ee6698f481d62f6">+102/-45</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>permissionSubject.ts</strong><dd><code>Define permission subjects for source analysis reports</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-6c9e740e8475349cb8abd4b19f6826ef03e278906e8fd9e98ff331e7666eb595">+32/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>permissionStore.ts</strong><dd><code>Allow read-only analysis report tools in balanced rules</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-e090f113e358f85942064c56d996e9d0d6b15bed01e2ac1a0fb9894127f591cf">+8/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>Planner.ts</strong><dd><code>Update planning guidelines to prefer canonical report reading</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-1e5ea3140bf5195731831d1f841eab96267fb69ecd723c29629de81b92fca9e6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolReference.ts</strong><dd><code>Update tool references and common workflows for agents</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Thinker.ts</strong><dd><code>Update thinker policy for deep source inspection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-7f12369d7b758f64f123f12df982012da3927808cf541e8ffe178b50c2044732">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agentPrompts.ts</strong><dd><code>Update agent behavior guidelines for source inspection</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-2615ba60043ade4efae32193316508b690dcb3aa86452dfe388abacdb9c9fc5c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>analysisTools.test.ts</strong><dd><code>Add unit tests for report reading and persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-ebc3842977d35600a53a65876d8082c469318e39e66177c38b0353647045f040">+269/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>orchestrationPlaybooks.test.ts</strong><dd><code>Test source analysis read playbook selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-67d3eacb874ecec818bd0ce91121099f09ec003b88b4d925c6c196977bc37ece">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>permissionSubject.test.ts</strong><dd><code>Test permission subject building for analysis reports</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-fe8eadd97dd1548ff045b7d76e44c4045d89bdbb1b23cac4ce328eb42f7207ba">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>system.test.ts</strong><dd><code>Verify system prompt includes new analysis tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-11c45d80fdf51061bfeed2f31b9d64db0babd1ec4ae6a6fd4421900ae3f5bcea">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>permissionStore.test.ts</strong><dd><code>Test default permissions for analysis report reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-40b371a70f0cab370f3865070b504761f768164efc87b9a64fb5d56d4beca814">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>worker.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/609/files#diff-698f85a82a42a143fbeb1e262f70ca49bd20962595288210b54b7e84602ad6b3">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read and generate consolidated source-analysis reports (Markdown) with workspace persistence and optional output paths
  * Explicit support for selecting ffmpeg/ffprobe binaries

* **Improvements**
  * Asset metadata detection/refresh now more robust (fills missing duration, size, audio/video info)
  * Agents and prompts now prefer canonical source-analysis report reads for deep inspection
  * Tool output contracts and permissions updated to support source-analysis report workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->