### PR TITLE
Stabilize advanced clip timing and compound preview workflows

### DIFF
--- a/src-tauri/src/core/commands/clip.rs
+++ b/src-tauri/src/core/commands/clip.rs
@@ -2755,8 +2755,7 @@ impl Command for TrimClipCommand {
 
         if original.freeze_frame || original.has_time_remap() {
             return Err(CoreError::ValidationError(
-                "TrimClip does not yet support freeze-frame or time-remapped clips"
-                    .to_string(),
+                "TrimClip does not yet support freeze-frame or time-remapped clips".to_string(),
             ));
         }
 
@@ -7501,8 +7500,9 @@ mod tests {
 
         let clip_id = state.sequences[&seq_id].tracks[0].clips[0].id.clone();
 
-        // Set speed to 2.0
-        state.sequences.get_mut(&seq_id).unwrap().tracks[0].clips[0].speed = 2.0;
+        // Set speed to 2.0 and update the clip's explicit timeline duration.
+        let mut speed_cmd = SetClipSpeedCommand::new(&seq_id, &track_id, &clip_id, 2.0, false);
+        speed_cmd.execute(&mut state).unwrap();
 
         // Timeline duration should be 10 sec (20 source sec / 2.0 speed)
         let clip = &state.sequences[&seq_id].tracks[0].clips[0];
@@ -7531,6 +7531,7 @@ mod tests {
         let clip = &state.sequences[&seq_id].tracks[0].clips[0];
         assert_eq!(clip.range.source_in_sec, 0.0);
         assert_eq!(clip.range.source_out_sec, 20.0);
+        assert_eq!(clip.place.duration_sec, 10.0);
         assert_eq!(clip.speed, 2.0);
     }
 

--- a/src-tauri/src/core/commands/clip.rs
+++ b/src-tauri/src/core/commands/clip.rs
@@ -2753,6 +2753,13 @@ impl Command for TrimClipCommand {
 
         let original = sequence.tracks[track_idx].clips[clip_idx].clone();
 
+        if original.freeze_frame || original.has_time_remap() {
+            return Err(CoreError::ValidationError(
+                "TrimClip does not yet support freeze-frame or time-remapped clips"
+                    .to_string(),
+            ));
+        }
+
         // Store old values for undo BEFORE modification
         self.old_source_in = Some(original.range.source_in_sec);
         self.old_source_out = Some(original.range.source_out_sec);
@@ -7235,6 +7242,66 @@ mod tests {
         let clip = &state.sequences[&seq_id].tracks[0].clips[0];
         assert_eq!(clip.range.source_in_sec, 2.0);
         assert_eq!(clip.range.source_out_sec, 8.0);
+    }
+
+    #[test]
+    fn test_trim_clip_rejects_freeze_frame() {
+        let mut state = create_test_state();
+        let seq_id = state.active_sequence_id.clone().unwrap();
+        let track_id = state.sequences[&seq_id].tracks[0].id.clone();
+        let asset_id = state.assets.keys().next().unwrap().clone();
+
+        let mut insert_cmd =
+            InsertClipCommand::new(&seq_id, &track_id, &asset_id, 0.0).with_source_range(0.0, 10.0);
+        insert_cmd.execute(&mut state).unwrap();
+
+        let clip = &mut state.sequences.get_mut(&seq_id).unwrap().tracks[0].clips[0];
+        clip.freeze_frame = true;
+        clip.range.source_out_sec = 0.04;
+        clip.place.duration_sec = 2.0;
+        let clip_id = clip.id.clone();
+
+        let mut trim_cmd = TrimClipCommand::new_simple(&seq_id, &clip_id).with_source_out(0.08);
+        assert!(matches!(
+            trim_cmd.execute(&mut state),
+            Err(CoreError::ValidationError(message))
+                if message.contains("freeze-frame")
+        ));
+    }
+
+    #[test]
+    fn test_trim_clip_rejects_time_remapped_clip() {
+        let mut state = create_test_state();
+        let seq_id = state.active_sequence_id.clone().unwrap();
+        let track_id = state.sequences[&seq_id].tracks[0].id.clone();
+        let asset_id = state.assets.keys().next().unwrap().clone();
+
+        let mut insert_cmd =
+            InsertClipCommand::new(&seq_id, &track_id, &asset_id, 0.0).with_source_range(0.0, 10.0);
+        insert_cmd.execute(&mut state).unwrap();
+
+        let clip = &mut state.sequences.get_mut(&seq_id).unwrap().tracks[0].clips[0];
+        clip.time_remap = Some(TimeRemapCurve::new(vec![
+            TimeRemapKeyframe {
+                timeline_time: 0.0,
+                source_time: 0.0,
+                interpolation: KeyframeInterpolation::Linear,
+            },
+            TimeRemapKeyframe {
+                timeline_time: 4.0,
+                source_time: 10.0,
+                interpolation: KeyframeInterpolation::Linear,
+            },
+        ]));
+        clip.place.duration_sec = 4.0;
+        let clip_id = clip.id.clone();
+
+        let mut trim_cmd = TrimClipCommand::new_simple(&seq_id, &clip_id).with_source_out(8.0);
+        assert!(matches!(
+            trim_cmd.execute(&mut state),
+            Err(CoreError::ValidationError(message))
+                if message.contains("time-remapped")
+        ));
     }
 
     #[test]

--- a/src-tauri/src/core/timeline/models.rs
+++ b/src-tauri/src/core/timeline/models.rs
@@ -1263,6 +1263,9 @@ impl Clip {
     /// When a valid time remap curve is active, the timeline duration comes from
     /// the curve. Otherwise falls back to `source_duration / speed`.
     pub fn duration(&self) -> TimeSec {
+        if self.place.duration_sec.is_finite() && self.place.duration_sec > 0.0 {
+            return self.place.duration_sec;
+        }
         if let Some(ref remap) = self.time_remap {
             if remap.is_valid() {
                 return remap.timeline_duration();
@@ -1293,7 +1296,10 @@ impl Clip {
     /// When a valid time remap curve is active, evaluates the curve to find the
     /// source time. Otherwise uses the constant speed mapping.
     pub fn timeline_to_source(&self, timeline_sec: TimeSec) -> TimeSec {
-        let offset = timeline_sec - self.place.timeline_in_sec;
+        let offset = (timeline_sec - self.place.timeline_in_sec).clamp(0.0, self.duration());
+        if self.freeze_frame {
+            return self.range.source_in_sec;
+        }
         if let Some(ref remap) = self.time_remap {
             if remap.is_valid() {
                 return remap.evaluate(offset);
@@ -1503,6 +1509,14 @@ mod tests {
     }
 
     #[test]
+    fn test_clip_duration_prefers_explicit_place_duration() {
+        let mut clip = Clip::with_range("asset_123", 1.0, 2.0);
+        clip.place.duration_sec = 4.0;
+
+        assert_eq!(clip.duration(), 4.0);
+    }
+
+    #[test]
     fn test_clip_place_overlap() {
         let place1 = ClipPlace::new(0.0, 10.0);
         let place2 = ClipPlace::new(5.0, 10.0);
@@ -1554,6 +1568,19 @@ mod tests {
         assert_eq!(clip.timeline_to_source(5.0), 20.0);
         assert_eq!(clip.timeline_to_source(10.0), 15.0);
         assert_eq!(clip.timeline_to_source(15.0), 10.0);
+    }
+
+    #[test]
+    fn test_timeline_to_source_with_freeze_frame() {
+        let mut clip = Clip::new("asset_123")
+            .with_source_range(10.0, 10.04)
+            .place_at(5.0);
+        clip.freeze_frame = true;
+        clip.place.duration_sec = 3.0;
+
+        assert_eq!(clip.timeline_to_source(5.0), 10.0);
+        assert_eq!(clip.timeline_to_source(6.5), 10.0);
+        assert_eq!(clip.timeline_to_source(8.0), 10.0);
     }
 
     #[test]

--- a/src-tauri/src/core/timeline/models.rs
+++ b/src-tauri/src/core/timeline/models.rs
@@ -1503,7 +1503,7 @@ mod tests {
     fn test_clip_speed() {
         let mut clip = Clip::with_range("asset_123", 0.0, 10.0);
         clip.speed = 2.0;
-        clip.place.duration_sec = clip.duration();
+        clip.place.duration_sec = 0.0;
 
         assert_eq!(clip.duration(), 5.0); // 10 seconds at 2x speed
     }
@@ -2008,6 +2008,7 @@ mod tests {
                 interpolation: KeyframeInterpolation::Linear,
             },
         ]));
+        clip.place.duration_sec = 0.0;
         assert!((clip.duration() - 5.0).abs() < 1e-6);
     }
 

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -38,6 +38,7 @@ import {
   findWorkspaceFile,
 } from './storeAccessor';
 import { calculatePearsonCorrelation, getPrimaryTrackClips } from '@/utils/referenceComparison';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 import { useProjectStore } from '@/stores/projectStore';
 import { executeAgentCommand } from './commandExecutor';
 import {
@@ -5201,7 +5202,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
                 ? Math.max(
                     0,
                     ...existingTrack.clips.map(
-                      (clip) => clip.place.timelineInSec + clip.place.durationSec,
+                      (clip) => getClipTimelineEndSec(clip),
                     ),
                   )
                 : 0;
@@ -5277,7 +5278,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
                   ? Math.max(
                       0,
                       ...targetTrack.clips.map(
-                        (clip) => clip.place.timelineInSec + clip.place.durationSec,
+                        (clip) => getClipTimelineEndSec(clip),
                       ),
                     )
                   : 0;

--- a/src/agents/tools/editingTools.ts
+++ b/src/agents/tools/editingTools.ts
@@ -14,6 +14,7 @@ import { executeAgentCommand } from './commandExecutor';
 import { useProjectStore } from '@/stores/projectStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { probeMedia } from '@/utils/ffmpeg';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 import { applyProjectState, refreshProjectState } from '@/utils/stateRefreshHelper';
 import {
   buildRippleEditPlan,
@@ -113,7 +114,7 @@ function buildTimelineIntervalSplitOperations(
 
     for (const clip of track.clips) {
       const clipStart = clip.place.timelineInSec;
-      const clipEnd = clipStart + clip.place.durationSec;
+      const clipEnd = getClipTimelineEndSec(clip);
       const boundaries = buildIntervalBoundaries(
         clipStart,
         clipEnd,
@@ -170,7 +171,7 @@ function estimateTimelineIntervalSplitOperations(
 
     for (const clip of track.clips) {
       const clipStart = clip.place.timelineInSec;
-      const clipEnd = clipStart + clip.place.durationSec;
+      const clipEnd = getClipTimelineEndSec(clip);
       const effectiveStart = Math.max(clipStart, startTime);
       const effectiveEnd = Math.min(clipEnd, endTime);
 
@@ -279,7 +280,7 @@ function trackHasOverlap(track: Track, timelineIn: number, durationSec: number):
   const end = timelineIn + durationSec;
   return track.clips.some((clip) => {
     const clipStart = clip.place.timelineInSec;
-    const clipEnd = clip.place.timelineInSec + clip.place.durationSec;
+    const clipEnd = getClipTimelineEndSec(clip);
     return timelineIn < clipEnd && end > clipStart;
   });
 }

--- a/src/agents/tools/storeAccessor.ts
+++ b/src/agents/tools/storeAccessor.ts
@@ -14,6 +14,7 @@ import { useTimelineStore } from '@/stores/timelineStore';
 import { usePlaybackStore } from '@/stores/playbackStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import type { Asset, AssetKind, Clip, FileTreeEntry, Track, Sequence } from '@/types';
+import { getClipTimelineDurationSec, getClipTimelineEndSec, isClipActiveAtTime } from '@/utils/clipTiming';
 
 // =============================================================================
 // Snapshot Types
@@ -99,7 +100,7 @@ function clipToSnapshot(clip: Clip, trackId: string): ClipSnapshot {
     assetId: clip.assetId,
     trackId,
     timelineIn: clip.place.timelineInSec,
-    duration: clip.place.durationSec,
+    duration: getClipTimelineDurationSec(clip),
     sourceIn: clip.range.sourceInSec,
     sourceOut: clip.range.sourceOutSec,
     speed: clip.speed,
@@ -332,9 +333,7 @@ export function getClipsAtTime(time: number): ClipSnapshot[] {
   const result: ClipSnapshot[] = [];
   for (const track of activeSequence.tracks) {
     for (const clip of track.clips) {
-      const clipStart = clip.place.timelineInSec;
-      const clipEnd = clipStart + clip.place.durationSec;
-      if (time >= clipStart && time < clipEnd) {
+      if (isClipActiveAtTime(clip, time)) {
         result.push(clipToSnapshot(clip, track.id));
       }
     }
@@ -383,7 +382,7 @@ export function findGaps(
     const sorted = [...track.clips].sort((a, b) => a.place.timelineInSec - b.place.timelineInSec);
 
     if (sorted.length === 0) continue;
-    let maxEndTime = sorted[0].place.timelineInSec + sorted[0].place.durationSec;
+    let maxEndTime = getClipTimelineEndSec(sorted[0]);
 
     for (let i = 1; i < sorted.length; i++) {
       const nextStart = sorted[i].place.timelineInSec;
@@ -399,7 +398,7 @@ export function findGaps(
       }
       maxEndTime = Math.max(
         maxEndTime,
-        sorted[i].place.timelineInSec + sorted[i].place.durationSec,
+        getClipTimelineEndSec(sorted[i]),
       );
     }
   }
@@ -440,9 +439,9 @@ export function findOverlaps(trackId?: string): Array<{
     for (let i = 0; i < sorted.length; i++) {
       for (let j = i + 1; j < sorted.length; j++) {
         const aStart = sorted[i].place.timelineInSec;
-        const aEnd = aStart + sorted[i].place.durationSec;
+        const aEnd = getClipTimelineEndSec(sorted[i]);
         const bStart = sorted[j].place.timelineInSec;
-        const bEnd = bStart + sorted[j].place.durationSec;
+        const bEnd = getClipTimelineEndSec(sorted[j]);
 
         const overlapStart = Math.max(aStart, bStart);
         const overlapEnd = Math.min(aEnd, bEnd);

--- a/src/components/features/editor/EditorView.tsx
+++ b/src/components/features/editor/EditorView.tsx
@@ -37,6 +37,7 @@ import { useDockableAIPanel } from './hooks/useDockableAIPanel';
 import { dbToLinear, linearToDb } from '@/utils/audioMeter';
 import { resolveAutoDuckTargets } from '@/utils/audioDucking';
 import { extractTextDataFromClipWithMap } from '@/utils/textRenderer';
+import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
 import { commands } from '@/bindings';
 import { createLogger } from '@/services/logger';
 import { startPlayheadBackendSync } from '@/services/playheadBackendSync';
@@ -681,6 +682,7 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
         place: {
           trackId: track.id,
           timelineInSec: clip.place.timelineInSec,
+          durationSec: clip.place.durationSec,
         },
         effects: clip.effects
           .map((effectId) => effects.get(effectId))
@@ -688,6 +690,7 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
         blendMode: clip.blendMode,
         speed: clip.speed,
         reverse: clip.reverse,
+        freezeFrame: clip.freezeFrame,
         hasTimeRemap: hasActiveTimeRemap(clip),
       };
     }
@@ -768,15 +771,11 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
       if (track.kind === 'caption') {
         const clip = track.clips.find((c) => c.id === clipId);
         if (clip) {
-          // Calculate duration adjusting for speed
-          const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-          const duration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-
           return {
             id: clip.id,
             text: clip.label || '', // Using label as text storage for now
             startSec: clip.place.timelineInSec,
-            endSec: clip.place.timelineInSec + duration,
+            endSec: getClipTimelineEndSec(clip),
             style: clip.captionStyle,
             position: clip.captionPosition,
           };
@@ -807,14 +806,11 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
         return undefined;
       }
 
-      const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-      const duration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-
       return {
         id: clip.id,
         textData,
         timelineInSec: clip.place.timelineInSec,
-        durationSec: duration,
+        durationSec: getClipTimelineDurationSec(clip),
       };
     }
 

--- a/src/components/features/editor/EditorView.tsx
+++ b/src/components/features/editor/EditorView.tsx
@@ -131,6 +131,7 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
   const { selectedAssetId, assets, effects, executeCommand } = useProjectStore();
   const currentTime = usePlaybackStore((state) => state.currentTime);
   const { selectedClipIds, linkedSelectionEnabled } = useTimelineStore();
+  const sanitizeSelection = useTimelineStore((state) => state.sanitizeSelection);
   const aiPanelZoneId = useWorkspaceLayoutStore(
     (state) => findPanelZone(state.layout, 'ai-assistant') ?? 'right',
   );
@@ -162,6 +163,12 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
   // Mixer visibility state (toggled from timeline header)
   const [showMixer, setShowMixer] = useState(false);
   const handleToggleMixer = useCallback(() => setShowMixer((prev) => !prev), []);
+
+  useEffect(() => {
+    const validClipIds = sequence?.tracks.flatMap((track) => track.clips.map((clip) => clip.id)) ?? [];
+    const validTrackIds = sequence?.tracks.map((track) => track.id) ?? [];
+    sanitizeSelection(validClipIds, validTrackIds);
+  }, [sanitizeSelection, sequence]);
 
   // AI Sidebar state
   const {

--- a/src/components/features/inspector/Inspector.tsx
+++ b/src/components/features/inspector/Inspector.tsx
@@ -45,6 +45,7 @@ export interface SelectedClip {
   place: {
     trackId: string;
     timelineInSec: number;
+    durationSec?: number;
   };
   /** Effects applied to this clip */
   effects?: Effect[];
@@ -54,6 +55,8 @@ export interface SelectedClip {
   speed?: number;
   /** Whether clip plays in reverse */
   reverse?: boolean;
+  /** Whether clip is a freeze frame */
+  freezeFrame?: boolean;
   /** Whether clip has time remap active */
   hasTimeRemap?: boolean;
 }
@@ -155,7 +158,14 @@ export function Inspector({
 
   const clipDuration = useMemo(() => {
     if (!selectedClip) return null;
-    return selectedClip.range.sourceOutSec - selectedClip.range.sourceInSec;
+    const explicitDuration = selectedClip.place.durationSec ?? 0;
+    if (Number.isFinite(explicitDuration) && explicitDuration > 0) {
+      return explicitDuration;
+    }
+
+    const safeSpeed =
+      typeof selectedClip.speed === 'number' && selectedClip.speed > 0 ? selectedClip.speed : 1;
+    return (selectedClip.range.sourceOutSec - selectedClip.range.sourceInSec) / safeSpeed;
   }, [selectedClip]);
 
   const selectedEffect = useMemo(() => {

--- a/src/components/features/text/AddTextDialog.test.tsx
+++ b/src/components/features/text/AddTextDialog.test.tsx
@@ -412,6 +412,47 @@ describe('AddTextDialog', () => {
       expect(onAdd).not.toHaveBeenCalled();
       expect(screen.getByText(/already has a clip at this time/i)).toBeInTheDocument();
     });
+
+    it('should detect overlap against freeze-frame clips using explicit timeline duration', async () => {
+      const user = userEvent.setup();
+      const onAdd = vi.fn().mockResolvedValue(undefined);
+      const tracksWithFreezeConflict: Track[] = [
+        {
+          ...mockTracks[0],
+          clips: [
+            {
+              id: 'clip-freeze',
+              assetId: 'asset-freeze',
+              range: { sourceInSec: 5, sourceOutSec: 5 },
+              place: { timelineInSec: 4, durationSec: 4 },
+              transform: {
+                position: { x: 0.5, y: 0.5 },
+                scale: { x: 1, y: 1 },
+                rotationDeg: 0,
+                anchor: { x: 0.5, y: 0.5 },
+              },
+              opacity: 1,
+              speed: 1,
+              freezeFrame: true,
+              effects: [],
+              audio: {
+                volumeDb: 0,
+                pan: 0,
+                muted: false,
+              },
+            },
+          ],
+        },
+        ...mockTracks.slice(1),
+      ];
+
+      render(<AddTextDialog {...defaultProps} onAdd={onAdd} tracks={tracksWithFreezeConflict} currentTime={6} />);
+
+      await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+      expect(onAdd).not.toHaveBeenCalled();
+      expect(screen.getByText(/already has a clip at this time/i)).toBeInTheDocument();
+    });
   });
 
   // ===========================================================================

--- a/src/components/features/text/AddTextDialog.tsx
+++ b/src/components/features/text/AddTextDialog.tsx
@@ -11,6 +11,7 @@ import { X, Type } from 'lucide-react';
 import type { Track, TextClipData, TrackKind } from '@/types';
 import { TextPresetPicker } from './TextPresetPicker';
 import { getPresetById, presetToTextClipData, type TextPreset } from '@/data/textPresets';
+import { getClipTimelineDurationSec as resolveClipTimelineDurationSec } from '@/utils/clipTiming';
 
 /** Payload for adding a text clip */
 export interface AddTextPayload {
@@ -60,16 +61,7 @@ const DEFAULT_TEXT_STYLE: TextClipData['style'] = {
 const TEXT_SUPPORTED_TRACK_KINDS: TrackKind[] = ['video', 'overlay'];
 
 function getClipTimelineDurationSec(clip: Track['clips'][number]): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  const sourceDuration = clip.range.sourceOutSec - clip.range.sourceInSec;
-
-  if (Number.isFinite(sourceDuration) && sourceDuration > 0) {
-    return sourceDuration / safeSpeed;
-  }
-
-  return Number.isFinite(clip.place.durationSec) && clip.place.durationSec > 0
-    ? clip.place.durationSec
-    : 0;
+  return resolveClipTimelineDurationSec(clip);
 }
 
 function trackHasOverlap(track: Track, timelineIn: number, durationSec: number): boolean {

--- a/src/components/layout/DockableEditorLayout.tsx
+++ b/src/components/layout/DockableEditorLayout.tsx
@@ -179,6 +179,9 @@ export function DockableEditorLayout({
   const leftZoneWidth = leftHasPanels ? leftWidth : MIN_ZONE_SIZES.sidebarWidth;
   const rightZoneWidth = rightHasPanels ? rightWidth : MIN_ZONE_SIZES.sidebarWidth;
   const bottomZoneHeight = bottomHasPanels ? bottomHeight : MIN_ZONE_SIZES.bottomHeight;
+  const centerTopActivePanelId = filteredCenterTop.includes(zones['center-top'].activePanelId!)
+    ? zones['center-top'].activePanelId
+    : (filteredCenterTop[0] ?? null);
 
   return (
     <div
@@ -225,11 +228,7 @@ export function DockableEditorLayout({
             <DockZone
               zoneId="center-top"
               panelIds={filteredCenterTop}
-              activePanelId={
-                filteredCenterTop.includes(zones['center-top'].activePanelId!)
-                  ? zones['center-top'].activePanelId
-                  : (filteredCenterTop[0] ?? null)
-              }
+              activePanelId={centerTopActivePanelId}
               collapsed={zones['center-top'].collapsed}
               onTabClick={makeTabClickHandler('center-top')}
               onToggleCollapse={() => toggleZoneCollapse('center-top')}

--- a/src/components/preview/TimelinePreviewPlayer.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.tsx
@@ -77,6 +77,8 @@ interface ActiveClipInfo {
   asset: Asset | undefined;
 }
 
+type DrawableVisual = HTMLImageElement | HTMLCanvasElement;
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -84,6 +86,7 @@ interface ActiveClipInfo {
 const DEFAULT_ASPECT_RATIO = 16 / 9;
 const DEFAULT_WIDTH = 640;
 const DEFAULT_HEIGHT = 360;
+const MAX_COMPOUND_RENDER_DEPTH = 6;
 
 /** Map BlendMode to Canvas globalCompositeOperation.
  * Canvas 2D only supports a subset of blend modes natively.
@@ -169,6 +172,45 @@ function applyClipTransformToTextData(textData: TextClipData, transform: Transfo
   };
 }
 
+function drawVisualWithClipTransform(
+  ctx: CanvasRenderingContext2D,
+  visual: DrawableVisual,
+  clip: Clip,
+  blendMode: BlendMode,
+  canvasWidth: number,
+  canvasHeight: number,
+): void {
+  const transform = clip.transform;
+  const sourceWidth = Math.max(1, visual.width);
+  const sourceHeight = Math.max(1, visual.height);
+
+  ctx.save();
+  ctx.globalAlpha = clip.opacity;
+  ctx.globalCompositeOperation = BLEND_MODE_MAP[blendMode] || 'source-over';
+
+  const baseScaleX = canvasWidth / sourceWidth;
+  const baseScaleY = canvasHeight / sourceHeight;
+  const baseScale = Math.min(baseScaleX, baseScaleY);
+
+  const scaledWidth = sourceWidth * baseScale * transform.scale.x;
+  const scaledHeight = sourceHeight * baseScale * transform.scale.y;
+
+  const centerX = transform.position.x * canvasWidth;
+  const centerY = transform.position.y * canvasHeight;
+
+  const anchorOffsetX = transform.anchor.x * scaledWidth;
+  const anchorOffsetY = transform.anchor.y * scaledHeight;
+
+  ctx.translate(centerX, centerY);
+
+  if (transform.rotationDeg !== 0) {
+    ctx.rotate((transform.rotationDeg * Math.PI) / 180);
+  }
+
+  ctx.drawImage(visual, -anchorOffsetX, -anchorOffsetY, scaledWidth, scaledHeight);
+  ctx.restore();
+}
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -220,10 +262,6 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
     return activeSequenceId ? sequences.get(activeSequenceId) : undefined;
   }, [activeSequenceId, sequences]);
 
-  const tracks: Track[] = useMemo(() => {
-    return activeSequence?.tracks ?? [];
-  }, [activeSequence]);
-
   const textClipDataById = useSequenceTextClipData(activeSequence ?? null);
 
   // Note: Sequence format canvas dimensions are available via activeSequence?.format.canvas
@@ -238,10 +276,14 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
    * sorted by layer order (higher track index = further back, rendered first).
    */
   const getActiveClipsAtTime = useCallback(
-    (time: number): ActiveClipInfo[] => {
+    (sequence: Sequence | undefined, time: number): ActiveClipInfo[] => {
+      if (!sequence) {
+        return [];
+      }
+
       const activeClips: ActiveClipInfo[] = [];
 
-      tracks.forEach((track, trackIndex) => {
+      sequence.tracks.forEach((track, trackIndex) => {
         // Skip non-renderable tracks (audio), hidden tracks, and muted tracks.
         // Video, overlay, and caption tracks can render visuals in canvas mode.
         const isRenderableTrack =
@@ -285,20 +327,24 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 
       return activeClips;
     },
-    [tracks, assets],
+    [assets],
   );
 
   // Get active clip info for the legacy single-asset frame extractor
   // (used for prefetching on the topmost visible clip)
   const getClipAtTime = useCallback(
     (time: number): { clip: Clip; sourceTime: number } | null => {
-      const activeClips = getActiveClipsAtTime(time);
+      if (!activeSequence) {
+        return null;
+      }
+
+      const activeClips = getActiveClipsAtTime(activeSequence, time);
       if (activeClips.length === 0) return null;
       // Return the topmost clip (last in sorted array)
       const topClip = activeClips[activeClips.length - 1];
       return { clip: topClip.clip, sourceTime: topClip.sourceTime };
     },
-    [getActiveClipsAtTime],
+    [activeSequence, getActiveClipsAtTime],
   );
 
   // Get active clip info for frame extraction (legacy hook compatibility)
@@ -377,10 +423,212 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         return;
       }
 
-      const activeClips = getActiveClipsAtTime(time);
+      const renderSequenceToCanvas = async (
+        targetCtx: CanvasRenderingContext2D,
+        sequence: Sequence,
+        timelineTime: number,
+        requestTime: number,
+        visitedSequenceIds: Set<string>,
+        depth: number,
+      ): Promise<boolean> => {
+        if (depth > MAX_COMPOUND_RENDER_DEPTH) {
+          console.warn('[TimelinePreviewPlayer] Skipped nested compound render beyond depth limit', {
+            sequenceId: sequence.id,
+            depth,
+          });
+          return true;
+        }
+
+        const activeClips = getActiveClipsAtTime(sequence, timelineTime);
+        if (activeClips.length === 0) {
+          return true;
+        }
+
+        const mediaClips = activeClips.filter(({ clip, track, asset }) => {
+          if (clip.compoundSequenceId) {
+            return false;
+          }
+
+          return !isCaptionLikeClip(track, clip, asset) && !isTextClip(clip.assetId);
+        });
+
+        const frameResults = await Promise.all(
+          mediaClips.map(async (clipInfo) => {
+            if (!clipInfo.asset) {
+              return { clipInfo, imgUrl: null as string | null };
+            }
+
+            if (clipInfo.asset.kind === 'image') {
+              return {
+                clipInfo,
+                imgUrl: convertFileSrc(clipInfo.asset.uri),
+              };
+            }
+
+            const frameUrl = await extractFrameForAsset(
+              clipInfo.asset.id,
+              clipInfo.asset.uri,
+              clipInfo.sourceTime,
+            );
+
+            return { clipInfo, imgUrl: frameUrl };
+          }),
+        );
+
+        if (requestTime !== lastRenderTimeRef.current) {
+          return false;
+        }
+
+        const loadedFrames = await Promise.all(
+          frameResults.map(async ({ clipInfo, imgUrl }) => {
+            if (!imgUrl) {
+              return { clipInfo, img: null as HTMLImageElement | null };
+            }
+
+            return new Promise<{ clipInfo: ActiveClipInfo; img: HTMLImageElement | null }>(
+              (resolve) => {
+                const img = new Image();
+                img.crossOrigin = 'anonymous';
+                img.onload = () => resolve({ clipInfo, img });
+                img.onerror = () => resolve({ clipInfo, img: null });
+                img.src = imgUrl;
+              },
+            );
+          }),
+        );
+
+        if (requestTime !== lastRenderTimeRef.current) {
+          return false;
+        }
+
+        const mediaFrameByClipId = new Map<string, HTMLImageElement>();
+        for (const { clipInfo, img } of loadedFrames) {
+          if (img) {
+            mediaFrameByClipId.set(clipInfo.clip.id, img);
+          }
+        }
+
+        for (const clipInfo of activeClips) {
+          const { clip, track, asset } = clipInfo;
+          const blendMode = getEffectiveBlendMode(clip.blendMode, track.blendMode);
+
+          if (clip.compoundSequenceId) {
+            if (visitedSequenceIds.has(clip.compoundSequenceId)) {
+              console.warn('[TimelinePreviewPlayer] Skipped cyclic compound clip render', {
+                clipId: clip.id,
+                compoundSequenceId: clip.compoundSequenceId,
+              });
+              continue;
+            }
+
+            const nestedSequence = sequences.get(clip.compoundSequenceId);
+            if (!nestedSequence) {
+              continue;
+            }
+
+            const nestedCanvas = targetCtx.canvas.ownerDocument.createElement('canvas');
+            nestedCanvas.width = targetCtx.canvas.width;
+            nestedCanvas.height = targetCtx.canvas.height;
+
+            const nestedCtx = nestedCanvas.getContext('2d');
+            if (!nestedCtx) {
+              continue;
+            }
+
+            const nestedTime = getClipSourceTimeAtTimelineTime(clip, timelineTime);
+            const completed = await renderSequenceToCanvas(
+              nestedCtx,
+              nestedSequence,
+              nestedTime,
+              requestTime,
+              new Set([...visitedSequenceIds, clip.compoundSequenceId]),
+              depth + 1,
+            );
+
+            if (!completed) {
+              return false;
+            }
+
+            drawVisualWithClipTransform(
+              targetCtx,
+              nestedCanvas,
+              clip,
+              blendMode,
+              targetCtx.canvas.width,
+              targetCtx.canvas.height,
+            );
+            continue;
+          }
+
+          if (isCaptionLikeClip(track, clip, asset)) {
+            const text = clip.label?.trim();
+            if (!text) {
+              continue;
+            }
+
+            targetCtx.save();
+            targetCtx.globalCompositeOperation = BLEND_MODE_MAP[blendMode] || 'source-over';
+            renderCaptionClipToCanvas(
+              targetCtx,
+              clip,
+              track.kind,
+              text,
+              targetCtx.canvas.width,
+              targetCtx.canvas.height,
+            );
+            targetCtx.restore();
+            continue;
+          }
+
+          if (isTextClip(clip.assetId)) {
+            const textData = extractTextDataFromClipWithMap(clip, textClipDataById);
+            if (!textData) {
+              continue;
+            }
+
+            const transformedTextData = applyClipTransformToTextData(textData, clip.transform);
+
+            targetCtx.save();
+            targetCtx.globalCompositeOperation = BLEND_MODE_MAP[blendMode] || 'source-over';
+            renderTextToCanvas(
+              targetCtx,
+              transformedTextData,
+              targetCtx.canvas.width,
+              targetCtx.canvas.height,
+              clip.opacity,
+            );
+            targetCtx.restore();
+            continue;
+          }
+
+          const img = mediaFrameByClipId.get(clip.id);
+          if (!img) {
+            continue;
+          }
+
+          drawVisualWithClipTransform(
+            targetCtx,
+            img,
+            clip,
+            blendMode,
+            targetCtx.canvas.width,
+            targetCtx.canvas.height,
+          );
+        }
+
+        return true;
+      };
+
+      const activeClips = getActiveClipsAtTime(activeSequence, time);
 
       if (activeClips.length === 0) {
         // No clips at this time - clear canvas and show black
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        return;
+      }
+
+      if (!activeSequence) {
         ctx.fillStyle = '#000000';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         return;
@@ -394,145 +642,20 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         setIsMultiFrameLoading(true);
       }
 
-      // Only media clips require frame extraction.
-      const mediaClips = activeClips.filter(
-        (clipInfo) =>
-          !isCaptionLikeClip(clipInfo.track, clipInfo.clip, clipInfo.asset) &&
-          !isTextClip(clipInfo.clip.assetId),
-      );
-
-      // Load all frames in parallel (only for media clips)
-      const framePromises = mediaClips.map(async (clipInfo) => {
-        if (!clipInfo.asset) return { clipInfo, img: null };
-
-        // For images, use the asset URI directly
-        if (clipInfo.asset.kind === 'image') {
-          return {
-            clipInfo,
-            imgUrl: convertFileSrc(clipInfo.asset.uri),
-          };
-        }
-
-        // For videos, extract the frame
-        const frameUrl = await extractFrameForAsset(
-          clipInfo.asset.id,
-          clipInfo.asset.uri,
-          clipInfo.sourceTime,
-        );
-
-        return { clipInfo, imgUrl: frameUrl };
-      });
-
-      const frameResults = await Promise.all(framePromises);
-
-      // Check if this is still the latest request (race condition prevention)
-      if (time !== lastRenderTimeRef.current) {
-        // Don't clear loading state here - a newer request is in progress
-        // and will manage its own loading state
-        return;
-      }
-
-      // Load all images
-      const loadedFrames = await Promise.all(
-        frameResults.map(async (result) => {
-          // Type guard: check if imgUrl exists and is a string
-          const imgUrl = 'imgUrl' in result ? result.imgUrl : null;
-          if (!imgUrl || typeof imgUrl !== 'string') {
-            return { clipInfo: result.clipInfo, img: null };
-          }
-
-          return new Promise<{ clipInfo: ActiveClipInfo; img: HTMLImageElement | null }>(
-            (resolve) => {
-              const img = new Image();
-              img.crossOrigin = 'anonymous';
-              img.onload = () => resolve({ clipInfo: result.clipInfo, img });
-              img.onerror = () => resolve({ clipInfo: result.clipInfo, img: null });
-              img.src = imgUrl;
-            },
-          );
-        }),
-      );
-
-      // Check again for race condition after async image loading
-      if (time !== lastRenderTimeRef.current) {
-        // Don't clear loading state here - a newer request is in progress
-        // and will manage its own loading state
-        return;
-      }
-
-      const mediaFrameByClipId = new Map<string, HTMLImageElement>();
-      for (const { clipInfo, img } of loadedFrames) {
-        if (img) {
-          mediaFrameByClipId.set(clipInfo.clip.id, img);
-        }
-      }
-
       // Clear canvas before compositing
       ctx.fillStyle = '#000000';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
+      const completed = await renderSequenceToCanvas(
+        ctx,
+        activeSequence,
+        time,
+        time,
+        new Set([activeSequence.id]),
+        0,
+      );
 
-      // Render each clip in z-order (back to front) regardless of clip type.
-      for (const clipInfo of activeClips) {
-        const { clip, track, asset } = clipInfo;
-        const blendMode = getEffectiveBlendMode(clip.blendMode, track.blendMode);
-
-        if (isCaptionLikeClip(track, clip, asset)) {
-          const text = clip.label?.trim();
-          if (!text) {
-            continue;
-          }
-
-          renderCaptionClipToCanvas(ctx, clip, track.kind, text, canvas.width, canvas.height);
-          continue;
-        }
-
-        if (isTextClip(clip.assetId)) {
-          const textData = extractTextDataFromClipWithMap(clip, textClipDataById);
-          if (!textData) {
-            continue;
-          }
-
-          const transformedTextData = applyClipTransformToTextData(textData, clip.transform);
-
-          ctx.save();
-          ctx.globalCompositeOperation = BLEND_MODE_MAP[blendMode] || 'source-over';
-          renderTextToCanvas(ctx, transformedTextData, canvas.width, canvas.height, clip.opacity);
-          ctx.restore();
-          continue;
-        }
-
-        const img = mediaFrameByClipId.get(clip.id);
-        if (!img) {
-          continue;
-        }
-
-        const transform = clip.transform;
-
-        ctx.save();
-        ctx.globalAlpha = clip.opacity;
-        ctx.globalCompositeOperation = BLEND_MODE_MAP[blendMode] || 'source-over';
-
-        const baseScaleX = canvas.width / img.width;
-        const baseScaleY = canvas.height / img.height;
-        const baseScale = Math.min(baseScaleX, baseScaleY);
-
-        const scaledWidth = img.width * baseScale * transform.scale.x;
-        const scaledHeight = img.height * baseScale * transform.scale.y;
-
-        const centerX = transform.position.x * canvas.width;
-        const centerY = transform.position.y * canvas.height;
-
-        const anchorOffsetX = transform.anchor.x * scaledWidth;
-        const anchorOffsetY = transform.anchor.y * scaledHeight;
-
-        ctx.translate(centerX, centerY);
-
-        if (transform.rotationDeg !== 0) {
-          ctx.rotate((transform.rotationDeg * Math.PI) / 180);
-        }
-
-        ctx.drawImage(img, -anchorOffsetX, -anchorOffsetY, scaledWidth, scaledHeight);
-        ctx.restore();
+      if (!completed) {
+        return;
       }
 
       // Clear multi-frame loading state (only if mounted and was loading)
@@ -544,7 +667,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 
       onFrameRender?.(time);
     },
-    [getActiveClipsAtTime, extractFrameForAsset, onFrameRender, textClipDataById],
+    [activeSequence, getActiveClipsAtTime, extractFrameForAsset, onFrameRender, sequences, textClipDataById],
   );
 
   // Playback loop integration

--- a/src/components/timeline/AudioRubberBand.test.tsx
+++ b/src/components/timeline/AudioRubberBand.test.tsx
@@ -291,10 +291,11 @@ describe('AudioRubberBand', () => {
       expect(container.querySelector('[data-testid="audio-rubber-band"]')).not.toBeInTheDocument();
     });
 
-    it('should not render when clip has zero source duration', () => {
+    it('should not render when clip resolves to zero timeline duration', () => {
       const actions = createMockActions();
       const zeroDurationClip: Clip = {
         ...mockClip,
+        place: { timelineInSec: 0, durationSec: 0 },
         range: { sourceInSec: 5, sourceOutSec: 5 },
       };
 
@@ -310,6 +311,7 @@ describe('AudioRubberBand', () => {
       const fastClip: Clip = {
         ...mockClip,
         speed: 2,
+        place: { timelineInSec: 0, durationSec: 0 },
         audio: {
           volumeDb: 0,
           pan: 0,
@@ -323,7 +325,6 @@ describe('AudioRubberBand', () => {
 
       render(<AudioRubberBand clip={fastClip} width={500} actions={actions} />);
 
-      // Clip duration = (10-0)/2 = 5s; has 2 keyframes and width >= 40 => should render
       expect(screen.getByTestId('audio-rubber-band')).toBeInTheDocument();
     });
   });

--- a/src/components/timeline/Clip.tsx
+++ b/src/components/timeline/Clip.tsx
@@ -12,6 +12,7 @@ import { useEditorToolStore } from '@/stores/editorToolStore';
 import { useClipDrag, type DragPreviewPosition, type ClipDragData } from '@/hooks/useClipDrag';
 import { useWaveformPeaks } from '@/hooks/useWaveformPeaks';
 import type { Clip as ClipType, SnapPoint, Asset, TrackKind } from '@/types';
+import { getClipTimelineDurationSec } from '@/utils/clipTiming';
 import { isTextClip, hasActiveTimeRemap } from '@/types';
 import { AudioClipWaveform } from './AudioClipWaveform';
 import { WaveformPeaksDisplay } from './WaveformPeaksDisplay';
@@ -179,8 +180,7 @@ export function Clip({
       };
     }
 
-    const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-    const duration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+    const duration = getClipTimelineDurationSec(clip);
     return {
       duration,
       left: clip.place.timelineInSec * zoom,

--- a/src/components/timeline/Clip.tsx
+++ b/src/components/timeline/Clip.tsx
@@ -12,8 +12,8 @@ import { useEditorToolStore } from '@/stores/editorToolStore';
 import { useClipDrag, type DragPreviewPosition, type ClipDragData } from '@/hooks/useClipDrag';
 import { useWaveformPeaks } from '@/hooks/useWaveformPeaks';
 import type { Clip as ClipType, SnapPoint, Asset, TrackKind } from '@/types';
-import { getClipTimelineDurationSec } from '@/utils/clipTiming';
 import { isTextClip, hasActiveTimeRemap } from '@/types';
+import { getClipTimelineDurationSec, supportsSourceBoundaryTrimming } from '@/utils/clipTiming';
 import { AudioClipWaveform } from './AudioClipWaveform';
 import { WaveformPeaksDisplay } from './WaveformPeaksDisplay';
 import { LazyThumbnailStrip } from './LazyThumbnailStrip';
@@ -145,6 +145,7 @@ export function Clip({
   const isRazorToolActive = activeTool === 'razor';
 
   const { isDragging, previewPosition, activeSnapPoint, handleMouseDown } = useClipDrag({
+    clip,
     clipId: clip.id,
     initialTimelineIn: clip.place.timelineInSec,
     initialSourceIn: clip.range.sourceInSec,
@@ -271,7 +272,7 @@ export function Clip({
 
   // Handle mouse down on left trim handle
   const handleLeftTrimMouseDown = (e: MouseEvent) => {
-    if (isRazorToolActive) {
+    if (isRazorToolActive || trimHandlesDisabled) {
       return;
     }
 
@@ -281,7 +282,7 @@ export function Clip({
 
   // Handle mouse down on right trim handle
   const handleRightTrimMouseDown = (e: MouseEvent) => {
-    if (isRazorToolActive) {
+    if (isRazorToolActive || trimHandlesDisabled) {
       return;
     }
 
@@ -293,6 +294,7 @@ export function Clip({
   const hasSpeedChange = clip.speed !== 1;
   const isReversed = clip.reverse === true;
   const hasTimeRemap = hasActiveTimeRemap(clip);
+  const trimHandlesDisabled = disabled || !supportsSourceBoundaryTrimming(clip);
 
   // Determine if this is a text clip or adjustment layer
   const isText = isTextClip(clip.assetId);
@@ -560,19 +562,21 @@ export function Clip({
       <div
         data-testid="resize-handle-left"
         className={`
-          absolute left-0 top-0 w-2 h-full cursor-ew-resize
+          absolute left-0 top-0 w-2 h-full ${trimHandlesDisabled ? 'cursor-not-allowed' : 'cursor-ew-resize'}
           ${selected ? 'bg-primary-400 bg-opacity-50' : 'bg-white bg-opacity-0 hover:bg-opacity-20'}
         `}
         style={{ cursor: isRazorToolActive ? 'inherit' : undefined }}
+        title={trimHandlesDisabled ? 'Trim is unavailable for freeze-frame and time-remapped clips' : undefined}
         onMouseDown={handleLeftTrimMouseDown}
       />
       <div
         data-testid="resize-handle-right"
         className={`
-          absolute right-0 top-0 w-2 h-full cursor-ew-resize
+          absolute right-0 top-0 w-2 h-full ${trimHandlesDisabled ? 'cursor-not-allowed' : 'cursor-ew-resize'}
           ${selected ? 'bg-primary-400 bg-opacity-50' : 'bg-white bg-opacity-0 hover:bg-opacity-20'}
         `}
         style={{ cursor: isRazorToolActive ? 'inherit' : undefined }}
+        title={trimHandlesDisabled ? 'Trim is unavailable for freeze-frame and time-remapped clips' : undefined}
         onMouseDown={handleRightTrimMouseDown}
       />
     </div>

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -385,11 +385,7 @@ export function Timeline({
     if (!sequence) return DEFAULT_TIMELINE_DURATION;
 
     const clipEndTimes = sequence.tracks.flatMap((track) =>
-      track.clips.map(
-        (clip) =>
-          clip.place.timelineInSec +
-          (clip.range.sourceOutSec - clip.range.sourceInSec) / (clip.speed > 0 ? clip.speed : 1),
-      ),
+      track.clips.map((clip) => clip.place.timelineInSec + getClipTimelineDuration(clip)),
     );
 
     if (clipEndTimes.length === 0) {
@@ -1686,9 +1682,7 @@ export function Timeline({
       const caption: Caption = {
         id: clip.id,
         startSec: clip.place.timelineInSec,
-        endSec:
-          clip.place.timelineInSec +
-          (clip.range.sourceOutSec - clip.range.sourceInSec) / (clip.speed > 0 ? clip.speed : 1),
+        endSec: clip.place.timelineInSec + getClipTimelineDuration(clip),
         text: clip.label || '',
         speaker: undefined,
       };

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -580,69 +580,72 @@ export function Timeline({
     },
   });
 
+  const applyAdvancedTrimChange = useCallback(
+    (change: {
+      clipId: string;
+      sourceIn?: number;
+      sourceOut?: number;
+      timelineIn?: number;
+    } | null) => {
+      if (
+        !sequence ||
+        !onClipTrim ||
+        !change ||
+        (typeof change.sourceIn !== 'number' &&
+          typeof change.sourceOut !== 'number' &&
+          typeof change.timelineIn !== 'number')
+      ) {
+        return;
+      }
+
+      for (const track of sequence.tracks) {
+        if (!track.clips.some((clip) => clip.id === change.clipId)) {
+          continue;
+        }
+
+        onClipTrim({
+          sequenceId: sequence.id,
+          trackId: track.id,
+          clipId: change.clipId,
+          newSourceIn: change.sourceIn,
+          newSourceOut: change.sourceOut,
+          newTimelineIn: change.timelineIn,
+        });
+        break;
+      }
+    },
+    [sequence, onClipTrim],
+  );
+
   const { isSlideToolActive } = useSlideEdit({
     onSlideEnd: (result) => {
-      if (!sequence || !onClipMove || !onClipTrim) return;
-      // Apply changes to previous clip (find correct track)
-      if (result.previousClipChange) {
-        for (const track of sequence.tracks) {
-          if (track.clips.some((c) => c.id === result.previousClipChange!.clipId)) {
-            onClipTrim({
-              sequenceId: sequence.id,
-              trackId: track.id,
-              clipId: result.previousClipChange.clipId,
-              newSourceOut: result.previousClipChange.sourceOut,
-            });
-            break;
-          }
+      if (!sequence || !onClipMove) return;
+
+      for (const track of sequence.tracks) {
+        if (!track.clips.some((clip) => clip.id === result.clipId)) {
+          continue;
         }
+
+        onClipMove({
+          sequenceId: sequence.id,
+          trackId: track.id,
+          clipId: result.clipId,
+          newTimelineIn: result.newTimelineIn,
+        });
+        break;
       }
-      // Apply changes to next clip (find correct track)
-      if (result.nextClipChange) {
-        for (const track of sequence.tracks) {
-          if (track.clips.some((c) => c.id === result.nextClipChange!.clipId)) {
-            onClipTrim({
-              sequenceId: sequence.id,
-              trackId: track.id,
-              clipId: result.nextClipChange.clipId,
-              newSourceIn: result.nextClipChange.sourceIn,
-            });
-            break;
-          }
-        }
-      }
+
+      applyAdvancedTrimChange(result.previousClipChange);
+      applyAdvancedTrimChange(result.nextClipChange);
     },
   });
 
   const { isRollToolActive } = useRollEdit({
     onRollEnd: (result) => {
-      if (!sequence || !onClipTrim) return;
-      // Apply roll changes to both clips
-      for (const track of sequence.tracks) {
-        if (
-          track.clips.some(
-            (c) =>
-              c.id === result.outgoingClipChange.clipId ||
-              c.id === result.incomingClipChange.clipId,
-          )
-        ) {
-          // Update outgoing clip
-          onClipTrim({
-            sequenceId: sequence.id,
-            trackId: track.id,
-            clipId: result.outgoingClipChange.clipId,
-            newSourceOut: result.outgoingClipChange.sourceOut,
-          });
-          // Update incoming clip
-          onClipTrim({
-            sequenceId: sequence.id,
-            trackId: track.id,
-            clipId: result.incomingClipChange.clipId,
-            newSourceIn: result.incomingClipChange.sourceIn,
-          });
-          break;
-        }
-      }
+      if (!sequence) return;
+
+      applyAdvancedTrimChange(result.outgoingClipChange);
+      applyAdvancedTrimChange(result.incomingClipChange);
     },
   });
 

--- a/src/components/timeline/TimelineTrackRows.tsx
+++ b/src/components/timeline/TimelineTrackRows.tsx
@@ -6,6 +6,7 @@ import type {
   Track as TrackType,
 } from '@/types';
 import { getTrackSwapTargets, isProtectedBaseTrack } from '@/utils/trackReorder';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 import { CaptionTrack } from './CaptionTrack';
 import { Track } from './Track';
 
@@ -13,9 +14,7 @@ function adaptTrackToCaptionTrack(track: TrackType): CaptionTrackType {
   const captions: Caption[] = track.clips.map((clip) => ({
     id: clip.id,
     startSec: clip.place.timelineInSec,
-    endSec:
-      clip.place.timelineInSec +
-      (clip.range.sourceOutSec - clip.range.sourceInSec) / (clip.speed > 0 ? clip.speed : 1),
+    endSec: getClipTimelineEndSec(clip),
     text: clip.label || '',
     speaker: undefined,
     styleOverride: clip.captionStyle,

--- a/src/components/timeline/Track.tsx
+++ b/src/components/timeline/Track.tsx
@@ -48,6 +48,7 @@ import type { DropValidity } from '@/utils/dropValidity';
 import { TRACK_HEIGHT } from './constants';
 import { getTrackHeaderControls } from './trackHeaderControls';
 import { PasteAttributesDialog, RemoveAttributesDialog } from '@/components/features/effects';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -630,7 +631,7 @@ export function Track({
       const sortedClips = [...clips].sort((a, b) => a.place.timelineInSec - b.place.timelineInSec);
 
       for (let i = 0; i < sortedClips.length - 1; i++) {
-        const currentEnd = sortedClips[i].place.timelineInSec + sortedClips[i].place.durationSec;
+        const currentEnd = getClipTimelineEndSec(sortedClips[i]);
         const nextStart = sortedClips[i + 1].place.timelineInSec;
 
         if (nextStart > currentEnd && timeSec >= currentEnd && timeSec < nextStart) {

--- a/src/components/timeline/TransitionZone.tsx
+++ b/src/components/timeline/TransitionZone.tsx
@@ -12,6 +12,7 @@ import { memo, useCallback, useMemo, type KeyboardEvent, type MouseEvent } from 
 import { Layers, X, Plus } from 'lucide-react';
 import type { Clip, Effect, EffectId } from '@/types';
 import { EFFECT_TYPE_LABELS } from '@/types';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Security Helpers
@@ -110,7 +111,7 @@ const TRANSITION_WIDTH_MAX = 10000; // Max visual width for transition indicator
  * Check if two clips are adjacent (touching or overlapping within tolerance)
  */
 function areClipsAdjacent(clipA: Clip, clipB: Clip, tolerance: number): boolean {
-  const clipAEnd = clipA.place.timelineInSec + clipA.place.durationSec;
+  const clipAEnd = getClipTimelineEndSec(clipA);
   const clipBStart = clipB.place.timelineInSec;
   const gap = clipBStart - clipAEnd;
 
@@ -122,7 +123,7 @@ function areClipsAdjacent(clipA: Clip, clipB: Clip, tolerance: number): boolean 
  * Get junction point between two clips in seconds
  */
 function getJunctionPoint(clipA: Clip, clipB: Clip): number {
-  const clipAEnd = clipA.place.timelineInSec + clipA.place.durationSec;
+  const clipAEnd = getClipTimelineEndSec(clipA);
   const clipBStart = clipB.place.timelineInSec;
   // Return the midpoint if overlapping, otherwise clipA end
   return clipAEnd <= clipBStart ? clipAEnd : (clipAEnd + clipBStart) / 2;

--- a/src/hooks/__tests__/useTranscriptEditing.test.ts
+++ b/src/hooks/__tests__/useTranscriptEditing.test.ts
@@ -12,6 +12,7 @@ import { usePlaybackStore } from '@/stores/playbackStore';
 import { useProjectStore } from '@/stores/projectStore';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { refreshProjectState } from '@/utils/stateRefreshHelper';
+import type { Clip } from '@/types';
 
 vi.mock('@/utils/stateRefreshHelper', () => ({
   refreshProjectState: vi.fn().mockResolvedValue({
@@ -39,7 +40,7 @@ function createMockWords(count: number): TranscriptWord[] {
 }
 
 // Helper: set up a selected clip in stores
-function setupClipSelection(assetId = 'asset_1'): void {
+function setupClipSelection(assetId = 'asset_1', clipOverrides: Partial<Clip> = {}): void {
   const clipId = 'clip_1';
   const trackId = 'track_1';
   const seqId = 'seq_1';
@@ -58,18 +59,19 @@ function setupClipSelection(assetId = 'asset_1'): void {
               id: trackId,
               kind: 'video',
               clips: [
-                {
-                  id: clipId,
-                  assetId,
-                  range: { sourceInSec: 0.0, sourceOutSec: 10.0 },
-                  place: { timelineInSec: 0.0, durationSec: 10.0 },
-                  speed: 1.0,
-                  effects: [],
-                  audio: {},
-                  transform: {},
-                  opacity: 1.0,
-                  blendMode: 'Normal',
-                },
+                      {
+                        id: clipId,
+                        assetId,
+                        range: { sourceInSec: 0.0, sourceOutSec: 10.0 },
+                        place: { timelineInSec: 0.0, durationSec: 10.0 },
+                        speed: 1.0,
+                        effects: [],
+                        audio: {},
+                        transform: {},
+                        opacity: 1.0,
+                        blendMode: 'Normal',
+                        ...clipOverrides,
+                      },
               ],
               name: 'Video 1',
               muted: false,
@@ -310,6 +312,28 @@ describe('useTranscriptEditing', () => {
       });
 
       expect(usePlaybackStore.getState().currentTime).toBe(3.0);
+    });
+
+    it('should map transcript seeks through reverse clips', async () => {
+      const mockWords = createMockWords(5);
+      mockInvoke.mockResolvedValueOnce(mockWords);
+      setupClipSelection('asset_1', {
+        reverse: true,
+        range: { sourceInSec: 0, sourceOutSec: 10 },
+        place: { timelineInSec: 0, durationSec: 10 },
+      });
+
+      const { result } = renderHook(() => useTranscriptEditing());
+
+      await waitFor(() => {
+        expect(result.current.words).toHaveLength(5);
+      });
+
+      act(() => {
+        result.current.seekToWord(3);
+      });
+
+      expect(usePlaybackStore.getState().currentTime).toBe(7);
     });
   });
 

--- a/src/hooks/useAdvancedEditModes.test.ts
+++ b/src/hooks/useAdvancedEditModes.test.ts
@@ -312,7 +312,7 @@ describe('useSlideEdit', () => {
       const prevClip: AdjacentClip = {
         clip: createTestClip({
           id: 'prev',
-          range: { sourceInSec: 0, sourceOutSec: 5 },
+          range: { sourceInSec: 2, sourceOutSec: 7 },
         }),
         side: 'before',
         sourceDuration: 10,
@@ -321,7 +321,7 @@ describe('useSlideEdit', () => {
       const nextClip: AdjacentClip = {
         clip: createTestClip({
           id: 'next',
-          range: { sourceInSec: 0, sourceOutSec: 5 },
+          range: { sourceInSec: 2, sourceOutSec: 7 },
         }),
         side: 'after',
         sourceDuration: 10,
@@ -615,10 +615,12 @@ describe('useRollEdit', () => {
       const editPoint = {
         outgoingClip: createTestClip({
           id: 'outgoing',
+          place: { timelineInSec: 0, durationSec: 5 },
           range: { sourceInSec: 0, sourceOutSec: 5 },
         }),
         incomingClip: createTestClip({
           id: 'incoming',
+          place: { timelineInSec: 5, durationSec: 5 },
           range: { sourceInSec: 0, sourceOutSec: 5 },
         }),
         trackId: 'track-1',

--- a/src/hooks/useAudioPlayback.ts
+++ b/src/hooks/useAudioPlayback.ts
@@ -31,6 +31,7 @@ import {
   resolveMasterOutputGain,
   resolveTrackPlaybackRouting,
 } from '@/utils/audioRouting';
+import { getClipSourceTimeAtTimelineTime, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 const logger = createLogger('AudioPlayback');
 
@@ -722,8 +723,7 @@ export function useAudioPlayback({
 
           // Calculate clip timing
           const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-          const clipDuration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-          const clipEnd = clip.place.timelineInSec + clipDuration;
+          const clipEnd = getClipTimelineEndSec(clip);
 
           // Skip clips that have ended
           if (currentTime >= clipEnd) continue;
@@ -774,8 +774,7 @@ export function useAudioPlayback({
           connectSourceToDestination(source, gainNode, pannerNode, trackChain.inputGain);
 
           // Calculate start timing
-          const timeIntoClip = Math.max(0, currentTime - clip.place.timelineInSec);
-          const sourceOffset = clip.range.sourceInSec + timeIntoClip * safeSpeed;
+          const sourceOffset = getClipSourceTimeAtTimelineTime(clip, currentTime);
           const startDelay = Math.max(0, clip.place.timelineInSec - currentTime);
 
           // Calculate duration to stop at clip's source out point
@@ -853,10 +852,7 @@ export function useAudioPlayback({
         if (ctx && scheduledSourcesRef.current.size > 0) {
           // Find the first active clip to calculate audio timeline position
           const firstActiveClip = audioClips.find((c) => {
-            const syncSpeed = c.clip.speed > 0 ? c.clip.speed : 1;
-            const clipEnd =
-              c.clip.place.timelineInSec +
-              (c.clip.range.sourceOutSec - c.clip.range.sourceInSec) / syncSpeed;
+            const clipEnd = getClipTimelineEndSec(c.clip);
             return currentTime >= c.clip.place.timelineInSec && currentTime < clipEnd;
           });
 

--- a/src/hooks/useAudioPlaybackWithEffects.ts
+++ b/src/hooks/useAudioPlaybackWithEffects.ts
@@ -19,6 +19,7 @@ import type { Sequence, Asset, Clip, Effect } from '@/types';
 import { createLogger } from '@/services/logger';
 import { collectPlaybackAudioClips } from '@/utils/audioPlayback';
 import { clampClipPan, clampClipVolumeDb, getClipFadeFactor } from '@/utils/clipAudio';
+import { getClipSourceTimeAtTimelineTime, getClipTimelineEndSec } from '@/utils/clipTiming';
 import { normalizeFileUriToPath } from '@/utils/uri';
 import {
   createAudioEffectNode,
@@ -448,8 +449,7 @@ export function useAudioPlaybackWithEffects({
           if (trackMuted) continue;
 
           const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-          const clipDuration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-          const clipEnd = clip.place.timelineInSec + clipDuration;
+          const clipEnd = getClipTimelineEndSec(clip);
 
           if (currentTime >= clipEnd) continue;
           if (clip.place.timelineInSec > currentTime + SCHEDULE_AHEAD_TIME) continue;
@@ -499,8 +499,7 @@ export function useAudioPlaybackWithEffects({
             pannerNode.connect(masterGainRef.current);
           }
 
-          const timeIntoClip = Math.max(0, currentTime - clip.place.timelineInSec);
-          const sourceOffset = clip.range.sourceInSec + timeIntoClip * safeSpeed;
+          const sourceOffset = getClipSourceTimeAtTimelineTime(clip, currentTime);
           const startDelay = Math.max(0, clip.place.timelineInSec - currentTime);
           const remainingSourceDuration = clip.range.sourceOutSec - sourceOffset;
           const audioDuration = Math.max(0, remainingSourceDuration);

--- a/src/hooks/useAudioScrubbing.ts
+++ b/src/hooks/useAudioScrubbing.ts
@@ -30,6 +30,7 @@ import {
   decodeAssetAudioBuffer,
 } from '@/utils/audioPreview';
 import type { Sequence, Asset } from '@/types';
+import { getClipSourceTimeAtTimelineTime, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Constants
@@ -197,15 +198,13 @@ export function useAudioScrubbing({
         if (!trackRouting.isAudible) continue;
 
         const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-        const clipDuration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-        const clipEnd = clip.place.timelineInSec + clipDuration;
+        const clipEnd = getClipTimelineEndSec(clip);
 
         // Skip clips that don't overlap with the scrub position
         if (time < clip.place.timelineInSec || time >= clipEnd) continue;
 
         // Calculate the source offset corresponding to timeline time
-        const timeIntoClip = time - clip.place.timelineInSec;
-        const sourceOffset = clip.range.sourceInSec + timeIntoClip * safeSpeed;
+        const sourceOffset = getClipSourceTimeAtTimelineTime(clip, time);
 
         const buffer = await loadBuffer(asset);
         // Bail if a newer request has superseded this one

--- a/src/hooks/useClipDrag.test.ts
+++ b/src/hooks/useClipDrag.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useClipDrag, type UseClipDragOptions } from './useClipDrag';
+import type { Clip } from '@/types';
 
 // =============================================================================
 // Test Setup
@@ -28,6 +29,24 @@ const createMouseEvent = (
 };
 
 describe('useClipDrag', () => {
+  const createClip = (overrides: Partial<Clip> = {}): Clip =>
+    ({
+      id: 'clip-1',
+      assetId: 'asset-1',
+      range: { sourceInSec: 0, sourceOutSec: 10 },
+      place: { timelineInSec: 5, durationSec: 10 },
+      transform: {
+        position: { x: 0, y: 0 },
+        scale: { x: 1, y: 1 },
+        rotationDeg: 0,
+      },
+      opacity: 1,
+      speed: 1,
+      effects: [],
+      audio: { volumeDb: 0, muted: false, pan: 0 },
+      ...overrides,
+    }) as Clip;
+
   const defaultOptions: UseClipDragOptions = {
     clipId: 'clip-1',
     initialTimelineIn: 5,
@@ -347,6 +366,45 @@ describe('useClipDrag', () => {
       // sourceIn should be clamped to 0 (can extend to source start)
       expect(result.current.previewPosition?.sourceIn).toBeGreaterThanOrEqual(0);
     });
+
+    it('updates sourceOut when trimming the left edge of a reverse clip', () => {
+      const reverseClip = createClip({
+        range: { sourceInSec: 2, sourceOutSec: 8 },
+        place: { timelineInSec: 5, durationSec: 6 },
+        reverse: true,
+      });
+
+      const { result } = renderHook(() =>
+        useClipDrag({
+          ...defaultOptions,
+          clip: reverseClip,
+          initialTimelineIn: reverseClip.place.timelineInSec,
+          initialSourceIn: reverseClip.range.sourceInSec,
+          initialSourceOut: reverseClip.range.sourceOutSec,
+          maxSourceDuration: 10,
+        }),
+      );
+
+      act(() => {
+        const event = createMouseEvent('mousedown', 100);
+        result.current.handleMouseDown(event as unknown as React.MouseEvent, 'trim-left');
+      });
+
+      act(() => {
+        const event = createMouseEvent('mousemove', 110);
+        document.dispatchEvent(event);
+      });
+
+      act(() => {
+        const event = createMouseEvent('mousemove', 200);
+        document.dispatchEvent(event);
+      });
+
+      expect(result.current.previewPosition?.timelineIn).toBeCloseTo(6, 5);
+      expect(result.current.previewPosition?.sourceOut).toBeCloseTo(7, 5);
+      expect(result.current.previewPosition?.sourceIn).toBe(2);
+      expect(result.current.previewPosition?.duration).toBeCloseTo(5, 5);
+    });
   });
 
   // ===========================================================================
@@ -421,6 +479,45 @@ describe('useClipDrag', () => {
       });
 
       expect(result.current.previewPosition?.duration).toBeGreaterThanOrEqual(1);
+    });
+
+    it('updates sourceIn when trimming the right edge of a reverse clip', () => {
+      const reverseClip = createClip({
+        range: { sourceInSec: 2, sourceOutSec: 8 },
+        place: { timelineInSec: 5, durationSec: 6 },
+        reverse: true,
+      });
+
+      const { result } = renderHook(() =>
+        useClipDrag({
+          ...defaultOptions,
+          clip: reverseClip,
+          initialTimelineIn: reverseClip.place.timelineInSec,
+          initialSourceIn: reverseClip.range.sourceInSec,
+          initialSourceOut: reverseClip.range.sourceOutSec,
+          maxSourceDuration: 10,
+        }),
+      );
+
+      act(() => {
+        const event = createMouseEvent('mousedown', 500);
+        result.current.handleMouseDown(event as unknown as React.MouseEvent, 'trim-right');
+      });
+
+      act(() => {
+        const event = createMouseEvent('mousemove', 490);
+        document.dispatchEvent(event);
+      });
+
+      act(() => {
+        const event = createMouseEvent('mousemove', 300);
+        document.dispatchEvent(event);
+      });
+
+      expect(result.current.previewPosition?.timelineIn).toBe(5);
+      expect(result.current.previewPosition?.sourceIn).toBeCloseTo(4, 5);
+      expect(result.current.previewPosition?.sourceOut).toBe(8);
+      expect(result.current.previewPosition?.duration).toBeCloseTo(4, 5);
     });
   });
 

--- a/src/hooks/useClipDrag.ts
+++ b/src/hooks/useClipDrag.ts
@@ -22,6 +22,15 @@ import {
 import { snapToGrid, clampTime, MIN_CLIP_DURATION } from '@/utils/timeline';
 import { snapToNearestPoint, type SnapPoint } from '@/utils/gridSnapping';
 import { createLogger } from '@/services/logger';
+import type { Clip } from '@/types';
+import {
+  buildLeftTrimChange,
+  buildRightTrimChange,
+  getClipLeftTrimDeltaBoundsSec,
+  getClipRightTrimDeltaBoundsSec,
+  getClipTimelineDurationSec,
+  supportsSourceBoundaryTrimming,
+} from '@/utils/clipTiming';
 
 const logger = createLogger('useClipDrag');
 
@@ -70,6 +79,8 @@ export interface DragPreviewPosition {
  * Hook options
  */
 export interface UseClipDragOptions {
+  /** Full clip data when timing-aware trim behavior is required */
+  clip?: Clip;
   /** Clip identifier */
   clipId: string;
   /** Initial timeline position in seconds */
@@ -217,10 +228,14 @@ export function useClipDrag(options: UseClipDragOptions): UseClipDragReturn {
       const clipGridInterval = opts.gridInterval ?? 0;
       const clipMinDuration = opts.minDuration ?? MIN_CLIP_DURATION;
       const clipMaxSourceDuration = opts.maxSourceDuration;
+      const clipDuration = opts.clip
+        ? getClipTimelineDurationSec(opts.clip)
+        : calculateDuration(origSourceIn, origSourceOut, clipSpeed);
 
       let newTimelineIn = origTimelineIn;
       let newSourceIn = origSourceIn;
       let newSourceOut = origSourceOut;
+      let previewDuration = clipDuration;
 
       if (type === 'move') {
         // Move: adjust timeline position only
@@ -229,54 +244,123 @@ export function useClipDrag(options: UseClipDragOptions): UseClipDragReturn {
           newTimelineIn = snapToGrid(newTimelineIn, clipGridInterval);
         }
       } else if (type === 'trim-left') {
+        if (opts.clip && !supportsSourceBoundaryTrimming(opts.clip)) {
+          return {
+            timelineIn: origTimelineIn,
+            sourceIn: origSourceIn,
+            sourceOut: origSourceOut,
+            duration: clipDuration,
+          };
+        }
+
         // Trim left: adjust both sourceIn and timelineIn
         const rawDelta = deltaTime;
 
-        // Calculate max trim (can't go past source start or leave less than minDuration)
-        const maxTrimLeft = -origSourceIn; // Can extend to source start
-        const maxTrimRight = (origSourceOut - origSourceIn) / clipSpeed - clipMinDuration;
-        const clampedDelta = clampTime(rawDelta, maxTrimLeft, maxTrimRight);
+        const sourceDurationSec = clipMaxSourceDuration ?? Number.POSITIVE_INFINITY;
+        const { minDeltaSec, maxDeltaSec } = opts.clip
+          ? getClipLeftTrimDeltaBoundsSec(opts.clip, sourceDurationSec, clipMinDuration)
+          : {
+              minDeltaSec: -origSourceIn,
+              maxDeltaSec: calculateDuration(origSourceIn, origSourceOut, clipSpeed) - clipMinDuration,
+            };
+        const clampedDelta = clampTime(rawDelta, minDeltaSec, maxDeltaSec);
 
-        newSourceIn = origSourceIn + clampedDelta * clipSpeed;
         newTimelineIn = origTimelineIn + clampedDelta;
 
-        // Ensure sourceIn doesn't go negative
-        if (newSourceIn < 0) {
-          newSourceIn = 0;
-          newTimelineIn = origTimelineIn - origSourceIn / clipSpeed;
+        if (opts.clip) {
+          const trimChange = buildLeftTrimChange(opts.clip, newTimelineIn);
+          newSourceIn = trimChange?.sourceIn ?? origSourceIn;
+          newSourceOut = trimChange?.sourceOut ?? origSourceOut;
+        } else {
+          newSourceIn = origSourceIn + clampedDelta * clipSpeed;
+
+          // Ensure sourceIn doesn't go negative
+          if (newSourceIn < 0) {
+            newSourceIn = 0;
+            newTimelineIn = origTimelineIn - origSourceIn / clipSpeed;
+          }
         }
 
         if (clipGridInterval > 0) {
           newTimelineIn = snapToGrid(newTimelineIn, clipGridInterval);
-          // Recalculate sourceIn based on snapped timelineIn
-          const timelineDelta = newTimelineIn - origTimelineIn;
-          newSourceIn = origSourceIn + timelineDelta * clipSpeed;
+
+          if (opts.clip) {
+            const trimChange = buildLeftTrimChange(opts.clip, newTimelineIn);
+            newSourceIn = trimChange?.sourceIn ?? origSourceIn;
+            newSourceOut = trimChange?.sourceOut ?? origSourceOut;
+          } else {
+            // Recalculate sourceIn based on snapped timelineIn
+            const timelineDelta = newTimelineIn - origTimelineIn;
+            newSourceIn = origSourceIn + timelineDelta * clipSpeed;
+          }
         }
+
+        previewDuration = Math.max(0, origTimelineIn + clipDuration - newTimelineIn);
       } else if (type === 'trim-right') {
+        if (opts.clip && !supportsSourceBoundaryTrimming(opts.clip)) {
+          return {
+            timelineIn: origTimelineIn,
+            sourceIn: origSourceIn,
+            sourceOut: origSourceOut,
+            duration: clipDuration,
+          };
+        }
+
         // Trim right: adjust sourceOut only
-        const rawDelta = deltaTime * clipSpeed;
+        const sourceDurationSec = clipMaxSourceDuration ?? Number.POSITIVE_INFINITY;
+        const { minDeltaSec, maxDeltaSec } = opts.clip
+          ? getClipRightTrimDeltaBoundsSec(opts.clip, sourceDurationSec, clipMinDuration)
+          : {
+              minDeltaSec:
+                -(calculateDuration(origSourceIn, origSourceOut, clipSpeed) - clipMinDuration),
+              maxDeltaSec:
+                ((clipMaxSourceDuration ?? Number.POSITIVE_INFINITY) - origSourceOut) / clipSpeed,
+            };
+        const clampedDelta = clampTime(deltaTime, minDeltaSec, maxDeltaSec);
+        let newTimelineOut = origTimelineIn + clipDuration + clampedDelta;
 
-        // Calculate bounds
-        const minSourceOut = origSourceIn + clipMinDuration * clipSpeed;
-        const maxSourceOut = clipMaxSourceDuration ?? Number.POSITIVE_INFINITY;
-
-        newSourceOut = clampTime(origSourceOut + rawDelta, minSourceOut, maxSourceOut);
+        if (opts.clip) {
+          const trimChange = buildRightTrimChange(opts.clip, newTimelineOut);
+          newSourceIn = trimChange?.sourceIn ?? origSourceIn;
+          newSourceOut = trimChange?.sourceOut ?? origSourceOut;
+        } else {
+          const rawDelta = clampedDelta * clipSpeed;
+          const minSourceOut = origSourceIn + clipMinDuration * clipSpeed;
+          const maxSourceOut = clipMaxSourceDuration ?? Number.POSITIVE_INFINITY;
+          newSourceOut = clampTime(origSourceOut + rawDelta, minSourceOut, maxSourceOut);
+        }
 
         if (clipGridInterval > 0) {
-          const duration = calculateDuration(origSourceIn, newSourceOut, clipSpeed);
+          const duration = opts.clip
+            ? Math.max(clipMinDuration, newTimelineOut - origTimelineIn)
+            : calculateDuration(origSourceIn, newSourceOut, clipSpeed);
           const snappedDuration = snapToGrid(duration, clipGridInterval);
-          newSourceOut = origSourceIn + snappedDuration * clipSpeed;
+          newTimelineOut = origTimelineIn + snappedDuration;
 
-          // Re-clamp after snapping
-          newSourceOut = clampTime(newSourceOut, minSourceOut, maxSourceOut);
+          if (opts.clip) {
+            const trimChange = buildRightTrimChange(opts.clip, newTimelineOut);
+            newSourceIn = trimChange?.sourceIn ?? origSourceIn;
+            newSourceOut = trimChange?.sourceOut ?? origSourceOut;
+          } else {
+            const minSourceOut = origSourceIn + clipMinDuration * clipSpeed;
+            const maxSourceOut = clipMaxSourceDuration ?? Number.POSITIVE_INFINITY;
+            newSourceOut = origSourceIn + snappedDuration * clipSpeed;
+
+            // Re-clamp after snapping
+            newSourceOut = clampTime(newSourceOut, minSourceOut, maxSourceOut);
+          }
         }
+
+        previewDuration = Math.max(0, newTimelineOut - origTimelineIn);
+      } else {
+        previewDuration = clipDuration;
       }
 
       return {
         timelineIn: newTimelineIn,
         sourceIn: newSourceIn,
         sourceOut: newSourceOut,
-        duration: calculateDuration(newSourceIn, newSourceOut, clipSpeed),
+        duration: opts.clip ? previewDuration : calculateDuration(newSourceIn, newSourceOut, clipSpeed),
       };
     },
     [calculateDuration],

--- a/src/hooks/useClipboard.test.ts
+++ b/src/hooks/useClipboard.test.ts
@@ -162,6 +162,31 @@ describe('useClipboard', () => {
       expect(onCopy).toHaveBeenCalled();
     });
 
+    it('should preserve explicit timeline duration when copying freeze-frame clips', () => {
+      const clip = createTestClip({
+        id: 'clip-freeze',
+        range: { sourceInSec: 5, sourceOutSec: 5 },
+        place: { timelineInSec: 4, durationSec: 3 },
+        freezeFrame: true,
+      });
+      const track = createTestTrack([clip]);
+      const sequence = createTestSequence([track]);
+
+      const { result } = renderHook(() =>
+        useClipboard({
+          sequence,
+          selectedClipIds: ['clip-freeze'],
+        })
+      );
+
+      act(() => {
+        result.current.copy();
+      });
+
+      const clipboardItem = useEditorToolStore.getState().clipboard?.[0];
+      expect(clipboardItem?.clipData.durationSec).toBe(3);
+    });
+
     it('should copy multiple clips', () => {
       const clip1 = createTestClip({ id: 'clip-1' });
       const clip2 = createTestClip({ id: 'clip-2', place: { timelineInSec: 5, durationSec: 5 } });
@@ -405,8 +430,8 @@ describe('useClipboard', () => {
         result.current.duplicate();
       });
 
-      // clip-2 ends at 5 + 4 = 9
-      expect(onDuplicate).toHaveBeenCalledWith(['clip-1', 'clip-2'], 9);
+      // clip-2 ends at 5 + explicit duration 5 = 10
+      expect(onDuplicate).toHaveBeenCalledWith(['clip-1', 'clip-2'], 10);
     });
 
     it('should fail when no clips selected', () => {

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -12,6 +12,7 @@ import { useEditorToolStore, type ClipboardItem } from '@/stores/editorToolStore
 import { usePlaybackStore } from '@/stores/playbackStore';
 import type { Sequence, Clip, Track, TextClipData } from '@/types';
 import { MAX_CLIPBOARD_ITEMS } from '@/constants/editing';
+import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -91,8 +92,7 @@ function findClipInSequence(
  * Calculate clip duration
  */
 function getClipDuration(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+  return getClipTimelineDurationSec(clip);
 }
 
 /**
@@ -126,7 +126,7 @@ function clipToClipboardItem(clip: Clip, track: Track, textData?: TextClipData):
           ? {
               text: clip.label || '',
               startSec: clip.place.timelineInSec,
-              endSec: clip.place.timelineInSec + durationSec,
+              endSec: getClipTimelineEndSec(clip),
               style: clip.captionStyle,
               position: clip.captionPosition,
             }

--- a/src/hooks/useEnhancedKeyboardShortcuts.ts
+++ b/src/hooks/useEnhancedKeyboardShortcuts.ts
@@ -16,6 +16,7 @@ import { PLAYBACK } from '@/constants/preview';
 import type { Sequence, Clip, Track } from '@/types';
 import { isTextClip } from '@/types';
 import { extractTextDataFromClip } from '@/utils/textRenderer';
+import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -121,8 +122,7 @@ function findClipInSequence(
 }
 
 function getClipDuration(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+  return getClipTimelineDurationSec(clip);
 }
 
 // =============================================================================
@@ -236,7 +236,7 @@ export function useEnhancedKeyboardShortcuts(options: UseEnhancedKeyboardShortcu
                 ? {
                     text: clip.label || '',
                     startSec: clip.place.timelineInSec,
-                    endSec: clip.place.timelineInSec + getClipDuration(clip),
+                    endSec: getClipTimelineEndSec(clip),
                     style: clip.captionStyle,
                     position: clip.captionPosition,
                   }

--- a/src/hooks/usePreviewMode.ts
+++ b/src/hooks/usePreviewMode.ts
@@ -170,6 +170,10 @@ function getCanvasFallbackReason({ clip, track, asset }: ActiveClipInfo): string
     return 'Overlay/caption compositing requires canvas mode';
   }
 
+  if (clip.compoundSequenceId) {
+    return 'Compound clips require canvas compositing';
+  }
+
   if (!asset) {
     return 'Active clip asset is unavailable - using frame extraction';
   }

--- a/src/hooks/usePreviewSource.ts
+++ b/src/hooks/usePreviewSource.ts
@@ -11,6 +11,7 @@ import { useProjectStore } from '@/stores';
 import { usePlaybackStore } from '@/stores/playbackStore';
 import type { Sequence, Clip } from '@/types';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { getClipSourceTimeAtTimelineTime, isClipActiveAtTime } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -47,13 +48,7 @@ function findClipAtTime(sequence: Sequence, time: number): Clip | null {
     if (track.muted || !track.visible) continue;
 
     for (const clip of track.clips) {
-      const clipStart = clip.place.timelineInSec;
-      const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-      const clipDuration =
-        (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-      const clipEnd = clipStart + clipDuration;
-
-      if (time >= clipStart && time < clipEnd) {
+      if (isClipActiveAtTime(clip, time)) {
         return clip;
       }
     }
@@ -65,11 +60,7 @@ function findClipAtTime(sequence: Sequence, time: number): Clip | null {
  * Calculate the source time for a clip at a given timeline position
  */
 function getSourceTimeForClip(clip: Clip, timelineTime: number): number {
-  const clipStart = clip.place.timelineInSec;
-  const timeInClip = timelineTime - clipStart;
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  const sourceTime = clip.range.sourceInSec + timeInClip * safeSpeed;
-  return sourceTime;
+  return getClipSourceTimeAtTimelineTime(clip, timelineTime);
 }
 
 // =============================================================================

--- a/src/hooks/useRazorTool.test.ts
+++ b/src/hooks/useRazorTool.test.ts
@@ -131,4 +131,48 @@ describe('useRazorTool', () => {
 
     expect(result.current.getCursorStyle()).toContain('url(');
   });
+
+  it('should find freeze-frame clips using their explicit timeline duration', () => {
+    useEditorToolStore.setState({ activeTool: 'razor' });
+    const onSplit = vi.fn();
+    const freezeSequence: Sequence = {
+      ...mockSequence,
+      tracks: [
+        {
+          ...mockSequence.tracks[0],
+          clips: [
+            {
+              ...mockSequence.tracks[0].clips[0],
+              id: 'clip_freeze',
+              range: { sourceInSec: 5, sourceOutSec: 5 },
+              place: { timelineInSec: 10, durationSec: 4 },
+              freezeFrame: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      useRazorTool({
+        sequence: freezeSequence,
+        zoom: 100,
+        scrollX: 0,
+        trackHeaderWidth: 192,
+        trackHeight: 48,
+        onSplit,
+      }),
+    );
+
+    const handled = result.current.handleTimelineClick(1392, 40, mockRect);
+
+    expect(handled).toBe(true);
+    expect(onSplit).toHaveBeenCalledWith({
+      sequenceId: 'seq_001',
+      trackId: 'track_001',
+      clipId: 'clip_freeze',
+      splitTime: 12,
+      ignoreLinkedSelection: false,
+    });
+  });
 });

--- a/src/hooks/useRazorTool.ts
+++ b/src/hooks/useRazorTool.ts
@@ -11,6 +11,7 @@ import { useCallback, useEffect } from 'react';
 import { RAZOR_CURSOR, useEditorToolStore, type EditorTool } from '@/stores/editorToolStore';
 import { RAZOR_EDGE_THRESHOLD_SEC } from '@/constants/editing';
 import type { Sequence, Clip } from '@/types';
+import { getClipTimelineDurationSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -142,8 +143,7 @@ export function useRazorTool(options: UseRazorToolOptions): UseRazorToolReturn {
    * Get clip duration
    */
   const getClipDuration = useCallback((clip: Clip): number => {
-    const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-    return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+    return getClipTimelineDurationSec(clip);
   }, []);
 
   /**

--- a/src/hooks/useReferenceComparison.ts
+++ b/src/hooks/useReferenceComparison.ts
@@ -16,6 +16,7 @@ import {
   getPrimaryTrackClips,
   type OutputStructureSegment,
 } from '@/utils/referenceComparison';
+import { getClipTimelineDurationSec } from '@/utils/clipTiming';
 
 export interface UseReferenceComparisonReturn {
   /** Loaded ESD document */
@@ -165,7 +166,7 @@ export function useReferenceComparison(esdId?: string): UseReferenceComparisonRe
         track.clips.map((clip) => ({
           trackId: track.id,
           timelineInSec: clip.place.timelineInSec,
-          durationSec: clip.place.durationSec,
+          durationSec: getClipTimelineDurationSec(clip),
         })),
       ),
     );

--- a/src/hooks/useRippleEdit.ts
+++ b/src/hooks/useRippleEdit.ts
@@ -12,6 +12,7 @@ import { useCallback } from 'react';
 import { useEditorToolStore } from '@/stores/editorToolStore';
 import type { Sequence, Clip, Track } from '@/types';
 import { MIN_CLIP_GAP_SEC } from '@/constants/editing';
+import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -76,15 +77,14 @@ export interface UseRippleEditReturn {
  * Calculate clip duration accounting for speed
  */
 function getClipDuration(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+  return getClipTimelineDurationSec(clip);
 }
 
 /**
  * Get the end time of a clip
  */
 function getClipEndTime(clip: Clip): number {
-  return clip.place.timelineInSec + getClipDuration(clip);
+  return getClipTimelineEndSec(clip);
 }
 
 /**

--- a/src/hooks/useRollEdit.ts
+++ b/src/hooks/useRollEdit.ts
@@ -12,6 +12,14 @@ import { useCallback, useRef, useState } from 'react';
 import { useEditorToolStore } from '@/stores/editorToolStore';
 import type { Clip } from '@/types';
 import { MIN_CLIP_DURATION_SEC } from '@/constants/editing';
+import {
+  buildLeftTrimChange,
+  buildRightTrimChange,
+  getClipLeftTrimDeltaBoundsSec,
+  getClipRightTrimDeltaBoundsSec,
+  getClipTimelineEndSec,
+  type ClipTrimChange,
+} from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -47,21 +55,13 @@ export interface RollEditResult {
   /** New edit time */
   newEditTime: number;
   /** Changes to outgoing clip */
-  outgoingClipChange: {
-    clipId: string;
-    sourceOut: number;
-    timelineOut: number;
-  };
+  outgoingClipChange: ClipTrimChange;
   /** Changes to incoming clip */
-  incomingClipChange: {
-    clipId: string;
-    sourceIn: number;
-    timelineIn: number;
-  };
+  incomingClipChange: ClipTrimChange;
   /** Whether the roll was constrained */
   constrained: boolean;
   /** Constraint reason if constrained */
-  constraintReason?: 'outgoing-min' | 'incoming-min' | 'outgoing-source' | 'incoming-source';
+  constraintReason?: 'outgoing-min' | 'incoming-min' | 'outgoing-source' | 'incoming-source' | 'unsupported';
 }
 
 export interface UseRollEditOptions {
@@ -100,17 +100,8 @@ export interface UseRollEditReturn {
   calculateRollConstraints: (editPoint: EditPoint) => { minOffset: number; maxOffset: number };
 }
 
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-function getClipDuration(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-}
-
 function getClipEndTime(clip: Clip): number {
-  return clip.place.timelineInSec + getClipDuration(clip);
+  return getClipTimelineEndSec(clip);
 }
 
 // =============================================================================
@@ -213,28 +204,19 @@ export function useRollEdit(options: UseRollEditOptions = {}): UseRollEditReturn
    */
   const calculateRollConstraints = useCallback(
     (editPoint: EditPoint): { minOffset: number; maxOffset: number } => {
-      const { outgoingClip, incomingClip, outgoingSourceDuration } = editPoint;
+      const outgoingBounds = getClipRightTrimDeltaBoundsSec(
+        editPoint.outgoingClip,
+        editPoint.outgoingSourceDuration,
+        MIN_CLIP_DURATION_SEC,
+      );
+      const incomingBounds = getClipLeftTrimDeltaBoundsSec(
+        editPoint.incomingClip,
+        editPoint.incomingSourceDuration,
+        MIN_CLIP_DURATION_SEC,
+      );
 
-      // Minimum offset (rolling left, shortening outgoing)
-      const outgoingDuration = getClipDuration(outgoingClip);
-      const minByOutgoingDuration = -(outgoingDuration - MIN_CLIP_DURATION_SEC);
-
-      // Maximum offset (rolling right, extending outgoing)
-      const incomingDuration = getClipDuration(incomingClip);
-      const maxByIncomingDuration = incomingDuration - MIN_CLIP_DURATION_SEC;
-
-      // Can't roll right past source availability of outgoing
-      const outgoingSourceRemaining = outgoingSourceDuration - outgoingClip.range.sourceOutSec;
-      const safeOutgoingSpeed = outgoingClip.speed > 0 ? outgoingClip.speed : 1;
-      const maxByOutgoingSource = outgoingSourceRemaining / safeOutgoingSpeed;
-
-      // Can't roll left past source availability of incoming
-      const incomingSourceRemaining = incomingClip.range.sourceInSec;
-      const safeIncomingSpeed = incomingClip.speed > 0 ? incomingClip.speed : 1;
-      const minByIncomingSource = -(incomingSourceRemaining / safeIncomingSpeed);
-
-      const minOffset = Math.max(minByOutgoingDuration, minByIncomingSource);
-      const maxOffset = Math.min(maxByIncomingDuration, maxByOutgoingSource);
+      const minOffset = Math.max(outgoingBounds.minDeltaSec, incomingBounds.minDeltaSec);
+      const maxOffset = Math.min(outgoingBounds.maxDeltaSec, incomingBounds.maxDeltaSec);
 
       return { minOffset, maxOffset };
     },
@@ -273,30 +255,27 @@ export function useRollEdit(options: UseRollEditOptions = {}): UseRollEditReturn
 
       let constraintReason: RollEditResult['constraintReason'];
       if (constrained) {
-        if (offset < minOffset) {
-          constraintReason = offset < -(getClipDuration(editPoint.outgoingClip) - MIN_CLIP_DURATION_SEC)
-            ? 'outgoing-min'
-            : 'incoming-source';
+        if (
+          buildRightTrimChange(editPoint.outgoingClip, getClipEndTime(editPoint.outgoingClip)) === null ||
+          buildLeftTrimChange(editPoint.incomingClip, editPoint.incomingClip.place.timelineInSec) === null
+        ) {
+          constraintReason = 'unsupported';
+        } else if (offset < minOffset) {
+          constraintReason = 'incoming-source';
         } else {
-          constraintReason = offset > (getClipDuration(editPoint.incomingClip) - MIN_CLIP_DURATION_SEC)
-            ? 'incoming-min'
-            : 'outgoing-source';
+          constraintReason = 'outgoing-source';
         }
       }
 
       const newEditTime = editPoint.editTime + constrainedOffset;
 
       // Calculate changes to clips
-      const outgoingClipChange = {
+      const outgoingClipChange = buildRightTrimChange(editPoint.outgoingClip, newEditTime) ?? {
         clipId: editPoint.outgoingClip.id,
-        sourceOut: editPoint.outgoingClip.range.sourceOutSec + (constrainedOffset * editPoint.outgoingClip.speed),
-        timelineOut: newEditTime,
       };
 
-      const incomingClipChange = {
+      const incomingClipChange = buildLeftTrimChange(editPoint.incomingClip, newEditTime) ?? {
         clipId: editPoint.incomingClip.id,
-        sourceIn: editPoint.incomingClip.range.sourceInSec + (constrainedOffset * editPoint.incomingClip.speed),
-        timelineIn: newEditTime,
       };
 
       return {

--- a/src/hooks/useSelectionBox.ts
+++ b/src/hooks/useSelectionBox.ts
@@ -7,6 +7,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import type { Track } from '@/types';
+import { getClipTimelineDurationSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -130,9 +131,7 @@ export function useSelectionBox({
         track.clips.forEach((clip) => {
           // Calculate clip position in pixels
           const clipLeft = clip.place.timelineInSec * currentZoom - currentScrollX + trackHeaderWidth;
-          const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-          const clipDuration =
-            (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+          const clipDuration = getClipTimelineDurationSec(clip);
           const clipWidth = clipDuration * currentZoom;
           const clipRight = clipLeft + clipWidth;
 

--- a/src/hooks/useSlideEdit.ts
+++ b/src/hooks/useSlideEdit.ts
@@ -12,6 +12,14 @@ import { useCallback, useState } from 'react';
 import { useEditorToolStore } from '@/stores/editorToolStore';
 import type { Clip, Track } from '@/types';
 import { MIN_CLIP_DURATION_SEC } from '@/constants/editing';
+import {
+  buildLeftTrimChange,
+  buildRightTrimChange,
+  getClipLeftTrimDeltaBoundsSec,
+  getClipRightTrimDeltaBoundsSec,
+  getClipTimelineEndSec,
+  type ClipTrimChange,
+} from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -39,22 +47,18 @@ export interface SlideEditState {
 }
 
 export interface SlideEditResult {
+  /** Clip being slid */
+  clipId: string;
   /** New timeline position for the sliding clip */
   newTimelineIn: number;
   /** Changes to apply to previous clip (if any) */
-  previousClipChange: {
-    clipId: string;
-    sourceOut: number;
-  } | null;
+  previousClipChange: ClipTrimChange | null;
   /** Changes to apply to next clip (if any) */
-  nextClipChange: {
-    clipId: string;
-    sourceIn: number;
-  } | null;
+  nextClipChange: ClipTrimChange | null;
   /** Whether the slide was constrained */
   constrained: boolean;
   /** Constraint reason if constrained */
-  constraintReason?: 'no-previous' | 'no-next' | 'min-duration' | 'source-limit';
+  constraintReason?: 'no-previous' | 'no-next' | 'min-duration' | 'source-limit' | 'unsupported';
 }
 
 export interface UseSlideEditOptions {
@@ -92,15 +96,6 @@ export interface UseSlideEditReturn {
     previousClip: AdjacentClip | null,
     nextClip: AdjacentClip | null
   ) => { minOffset: number; maxOffset: number };
-}
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-function getClipDuration(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
 }
 
 // =============================================================================
@@ -165,22 +160,24 @@ export function useSlideEdit(options: UseSlideEditOptions = {}): UseSlideEditRet
 
       // Constraint from previous clip
       if (previousClip) {
-        const prevDuration = getClipDuration(previousClip.clip);
-        // Can't slide left more than would reduce previous clip below min duration
-        minOffset = Math.max(minOffset, -(prevDuration - MIN_CLIP_DURATION_SEC));
-
-        // Source headroom constraint (for future enhancement)
-        // const prevSourceRemaining = previousClip.sourceDuration - previousClip.clip.range.sourceOutSec;
+        const previousBounds = getClipRightTrimDeltaBoundsSec(
+          previousClip.clip,
+          previousClip.sourceDuration,
+          MIN_CLIP_DURATION_SEC,
+        );
+        minOffset = Math.max(minOffset, previousBounds.minDeltaSec);
+        maxOffset = Math.min(maxOffset, previousBounds.maxDeltaSec);
       }
 
       // Constraint from next clip
       if (nextClip) {
-        const nextDuration = getClipDuration(nextClip.clip);
-        // Can't slide right more than would reduce next clip below min duration
-        maxOffset = Math.min(maxOffset, nextDuration - MIN_CLIP_DURATION_SEC);
-
-        // Source headroom constraint (for future enhancement)
-        // const nextSourceIn = nextClip.clip.range.sourceInSec;
+        const nextBounds = getClipLeftTrimDeltaBoundsSec(
+          nextClip.clip,
+          nextClip.sourceDuration,
+          MIN_CLIP_DURATION_SEC,
+        );
+        minOffset = Math.max(minOffset, nextBounds.minDeltaSec);
+        maxOffset = Math.min(maxOffset, nextBounds.maxDeltaSec);
       }
 
       // If no adjacent clips, constrain heavily
@@ -228,6 +225,7 @@ export function useSlideEdit(options: UseSlideEditOptions = {}): UseSlideEditRet
    */
   const calculateSlideResult = useCallback(
     (
+      clipId: string,
       originalTimelineIn: number,
       offset: number,
       previousClip: AdjacentClip | null,
@@ -243,32 +241,36 @@ export function useSlideEdit(options: UseSlideEditOptions = {}): UseSlideEditRet
       if (constrained) {
         if (!previousClip && offset < 0) constraintReason = 'no-previous';
         else if (!nextClip && offset > 0) constraintReason = 'no-next';
-        else constraintReason = 'min-duration';
+        else if (
+          (previousClip &&
+            buildRightTrimChange(previousClip.clip, getClipTimelineEndSec(previousClip.clip))) ===
+            null ||
+          (nextClip && buildLeftTrimChange(nextClip.clip, nextClip.clip.place.timelineInSec) === null)
+        ) {
+          constraintReason = 'unsupported';
+        } else {
+          constraintReason = 'min-duration';
+        }
       }
 
       const newTimelineIn = originalTimelineIn + constrainedOffset;
 
       // Calculate changes to adjacent clips
-      let previousClipChange: SlideEditResult['previousClipChange'] = null;
-      let nextClipChange: SlideEditResult['nextClipChange'] = null;
+      const previousClipChange =
+        previousClip && constrainedOffset !== 0
+          ? buildRightTrimChange(
+              previousClip.clip,
+              getClipTimelineEndSec(previousClip.clip) + constrainedOffset,
+            )
+          : null;
 
-      if (previousClip && constrainedOffset !== 0) {
-        // Extend or shorten previous clip's out point
-        previousClipChange = {
-          clipId: previousClip.clip.id,
-          sourceOut: previousClip.clip.range.sourceOutSec + constrainedOffset,
-        };
-      }
-
-      if (nextClip && constrainedOffset !== 0) {
-        // Extend or shorten next clip's in point
-        nextClipChange = {
-          clipId: nextClip.clip.id,
-          sourceIn: nextClip.clip.range.sourceInSec + constrainedOffset,
-        };
-      }
+      const nextClipChange =
+        nextClip && constrainedOffset !== 0
+          ? buildLeftTrimChange(nextClip.clip, nextClip.clip.place.timelineInSec + constrainedOffset)
+          : null;
 
       return {
+        clipId,
         newTimelineIn,
         previousClipChange,
         nextClipChange,
@@ -291,6 +293,7 @@ export function useSlideEdit(options: UseSlideEditOptions = {}): UseSlideEditRet
       const newOffset = slideState.slideOffset + deltaSeconds;
 
       const result = calculateSlideResult(
+        slideState.clipId,
         slideState.originalTimelineIn,
         newOffset,
         slideState.previousClip,
@@ -320,6 +323,7 @@ export function useSlideEdit(options: UseSlideEditOptions = {}): UseSlideEditRet
     }
 
     const result = calculateSlideResult(
+      slideState.clipId,
       slideState.originalTimelineIn,
       slideState.slideOffset,
       slideState.previousClip,

--- a/src/hooks/useTimelineClipOperations.test.ts
+++ b/src/hooks/useTimelineClipOperations.test.ts
@@ -629,6 +629,58 @@ describe('useTimelineClipOperations', () => {
         }),
       );
     });
+
+    it('should trim reverse clips by updating sourceOut and timelineIn', () => {
+      const onClipTrim = vi.fn();
+      const reverseSequence: Sequence = {
+        ...mockSequence,
+        tracks: [
+          {
+            ...mockSequence.tracks[0],
+            clips: [{ ...mockClip, reverse: true, range: { sourceInSec: 2, sourceOutSec: 8 } }],
+          },
+          mockSequence.tracks[1],
+        ],
+      };
+
+      const { result } = renderHook(() =>
+        useTimelineClipOperations({
+          sequence: reverseSequence,
+          zoom: 100,
+          onClipMove: undefined,
+          onClipTrim,
+        }),
+      );
+
+      const dragData: ClipDragData = {
+        clipId: 'clip_001',
+        type: 'trim-left',
+        startX: 500,
+        startY: 0,
+        originalTimelineIn: 5,
+        originalSourceIn: 2,
+        originalSourceOut: 8,
+      };
+
+      const finalPosition: DragPreviewPosition = {
+        timelineIn: 7,
+        sourceIn: 2,
+        sourceOut: 6,
+        duration: 4,
+      };
+
+      act(() => {
+        result.current.handleClipDragEnd('track_001', dragData, finalPosition);
+      });
+
+      expect(onClipTrim).toHaveBeenCalledWith({
+        sequenceId: 'seq_001',
+        trackId: 'track_001',
+        clipId: 'clip_001',
+        newSourceOut: 6,
+        newTimelineIn: 7,
+      } satisfies ClipTrimData);
+    });
   });
 
   describe('handleClipDragEnd for trim-right', () => {
@@ -669,6 +721,57 @@ describe('useTimelineClipOperations', () => {
         trackId: 'track_001',
         clipId: 'clip_001',
         newSourceOut: 8,
+      } satisfies ClipTrimData);
+    });
+
+    it('should trim reverse clips by updating sourceIn', () => {
+      const onClipTrim = vi.fn();
+      const reverseSequence: Sequence = {
+        ...mockSequence,
+        tracks: [
+          {
+            ...mockSequence.tracks[0],
+            clips: [{ ...mockClip, reverse: true, range: { sourceInSec: 2, sourceOutSec: 8 } }],
+          },
+          mockSequence.tracks[1],
+        ],
+      };
+
+      const { result } = renderHook(() =>
+        useTimelineClipOperations({
+          sequence: reverseSequence,
+          zoom: 100,
+          onClipMove: undefined,
+          onClipTrim,
+        }),
+      );
+
+      const dragData: ClipDragData = {
+        clipId: 'clip_001',
+        type: 'trim-right',
+        startX: 500,
+        startY: 0,
+        originalTimelineIn: 5,
+        originalSourceIn: 2,
+        originalSourceOut: 8,
+      };
+
+      const finalPosition: DragPreviewPosition = {
+        timelineIn: 5,
+        sourceIn: 4,
+        sourceOut: 8,
+        duration: 4,
+      };
+
+      act(() => {
+        result.current.handleClipDragEnd('track_001', dragData, finalPosition);
+      });
+
+      expect(onClipTrim).toHaveBeenCalledWith({
+        sequenceId: 'seq_001',
+        trackId: 'track_001',
+        clipId: 'clip_001',
+        newSourceIn: 4,
       } satisfies ClipTrimData);
     });
   });

--- a/src/hooks/useTimelineClipOperations.ts
+++ b/src/hooks/useTimelineClipOperations.ts
@@ -11,6 +11,10 @@ import type { ClipMoveData, ClipTrimData } from '@/components/timeline/types';
 import type { ClipDragData, DragPreviewPosition } from '@/components/timeline/Clip';
 import type { DragPreviewState } from '@/components/timeline/DragPreviewLayer';
 import { useToastStore } from '@/hooks/useToast';
+import {
+  getClipTimelineDurationSec,
+  supportsSourceBoundaryTrimming,
+} from '@/utils/clipTiming';
 
 // =============================================================================
 // Helper Functions
@@ -216,9 +220,7 @@ export function useTimelineClipOperations({
         const clipInfo = findClip(data.clipId);
 
         if (clipInfo && trackIndex >= 0) {
-          const clipDuration =
-            (data.originalSourceOut - data.originalSourceIn) /
-            (clipInfo.clip.speed > 0 ? clipInfo.clip.speed : 1);
+          const clipDuration = getClipTimelineDurationSec(clipInfo.clip);
 
           setDragPreview({
             clipId: data.clipId,
@@ -363,14 +365,27 @@ export function useTimelineClipOperations({
 
         onClipMove(moveData);
       } else if ((data.type === 'trim-left' || data.type === 'trim-right') && onClipTrim) {
+        const clipInfo = sequence.tracks
+          .flatMap((track) => track.clips)
+          .find((clip) => clip.id === data.clipId);
+        if (!clipInfo || !supportsSourceBoundaryTrimming(clipInfo)) {
+          setDragPreview(null);
+          return;
+        }
+
         if (data.type === 'trim-left') {
           const trimData: ClipTrimData = {
             sequenceId: sequence.id,
             trackId,
             clipId: data.clipId,
-            newSourceIn: safeSourceIn,
             newTimelineIn: safeTimelineIn,
           };
+
+          if (clipInfo.reverse) {
+            trimData.newSourceOut = safeSourceOut;
+          } else {
+            trimData.newSourceIn = safeSourceIn;
+          }
 
           if (data.ignoreLinkedSelection) {
             trimData.ignoreLinkedSelection = true;
@@ -382,8 +397,13 @@ export function useTimelineClipOperations({
             sequenceId: sequence.id,
             trackId,
             clipId: data.clipId,
-            newSourceOut: safeSourceOut,
           };
+
+          if (clipInfo.reverse) {
+            trimData.newSourceIn = safeSourceIn;
+          } else {
+            trimData.newSourceOut = safeSourceOut;
+          }
 
           if (data.ignoreLinkedSelection) {
             trimData.ignoreLinkedSelection = true;

--- a/src/hooks/useTimelineCoordinates.ts
+++ b/src/hooks/useTimelineCoordinates.ts
@@ -20,6 +20,7 @@ import {
 } from '@/utils/gridSnapping';
 import { getGridIntervalForZoom } from '@/utils/timeline';
 import type { Sequence, SnapPoint } from '@/types';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -112,10 +113,7 @@ export function useTimelineCoordinates({
     const points: SnapPoint[] = [];
     for (const track of sequence.tracks) {
       for (const clip of track.clips) {
-        const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-        const endTime =
-          clip.place.timelineInSec +
-          (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+        const endTime = getClipTimelineEndSec(clip);
         points.push(...createClipSnapPoints(clip.id, clip.place.timelineInSec, endTime));
       }
     }

--- a/src/hooks/useTranscriptEditing.ts
+++ b/src/hooks/useTranscriptEditing.ts
@@ -12,6 +12,7 @@ import { usePlaybackStore } from '@/stores/playbackStore';
 import { useProjectStore } from '@/stores/projectStore';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { applyProjectState, refreshProjectState } from '@/utils/stateRefreshHelper';
+import { getClipSourceTimeAtTimelineTime, getClipTimelineTimeAtSourceTime } from '@/utils/clipTiming';
 
 const logger = createLogger('useTranscriptEditing');
 
@@ -104,6 +105,7 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
           sourceOutSec: clip.range.sourceOutSec,
           speed: clip.speed,
           timelineInSec: clip.place.timelineInSec,
+          clip,
         };
       }
     }
@@ -173,8 +175,7 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
     if (visibleWords.length === 0 || !clipInfo) return -1;
 
     // Convert timeline time to source time
-    const sourceTime =
-      clipInfo.sourceInSec + (currentTime - clipInfo.timelineInSec) * clipInfo.speed;
+    const sourceTime = getClipSourceTimeAtTimelineTime(clipInfo.clip, currentTime);
 
     for (let i = 0; i < visibleWords.length; i++) {
       if (sourceTime >= visibleWords[i].startSec && sourceTime < visibleWords[i].endSec) {
@@ -190,8 +191,7 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
       if (wordIndex < 0 || wordIndex >= visibleWords.length || !clipInfo) return;
       const word = visibleWords[wordIndex];
       // Convert source time to timeline time
-      const timelineTime =
-        clipInfo.timelineInSec + (word.startSec - clipInfo.sourceInSec) / clipInfo.speed;
+      const timelineTime = getClipTimelineTimeAtSourceTime(clipInfo.clip, word.startSec);
       seek(timelineTime, 'transcript-word');
     },
     [visibleWords, clipInfo, seek],
@@ -254,8 +254,7 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
       if (!startWord || !endWord || !targetWord) return;
 
       // Convert target word's source time to timeline position
-      const targetTimelineSec =
-        clipInfo.timelineInSec + (targetWord.startSec - clipInfo.sourceInSec) / clipInfo.speed;
+      const targetTimelineSec = getClipTimelineTimeAtSourceTime(clipInfo.clip, targetWord.startSec);
 
       mutationInFlightRef.current = true;
       setError(null);

--- a/src/hooks/useTransitionZones.ts
+++ b/src/hooks/useTransitionZones.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import type { Clip } from '@/types';
+import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -49,12 +50,12 @@ function safeNumber(value: unknown, fallback: number): number {
  * Validates that a clip has valid numeric place data.
  */
 function hasValidPlaceData(clip: Clip): boolean {
-  const { timelineInSec, durationSec } = clip?.place ?? {};
+  const timelineInSec = clip?.place?.timelineInSec;
+  const durationSec = getClipTimelineDurationSec(clip);
   return (
     typeof timelineInSec === 'number' &&
     Number.isFinite(timelineInSec) &&
     timelineInSec >= 0 &&
-    typeof durationSec === 'number' &&
     Number.isFinite(durationSec) &&
     durationSec > 0
   );
@@ -78,9 +79,7 @@ function sortClipsByPosition(clips: Clip[]): Clip[] {
  * Get the end time of a clip on the timeline with validation.
  */
 function getClipEndTime(clip: Clip): number {
-  const start = safeNumber(clip.place.timelineInSec, 0);
-  const duration = safeNumber(clip.place.durationSec, 0);
-  return start + duration;
+  return getClipTimelineEndSec(clip);
 }
 
 /**

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -11,6 +11,12 @@ import { useEffect, useCallback, useRef } from 'react';
 import { usePlaybackStore } from '@/stores/playbackStore';
 import { SYNC_THRESHOLDS } from '@/constants/precision';
 import type { Clip, Asset } from '@/types';
+import {
+  getClipSourceTimeAtTimelineTime,
+  getClipTimelineDurationSec,
+  getClipTimelineTimeAtSourceTime,
+  isClipActiveAtTime,
+} from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -82,9 +88,7 @@ export function useVideoSync({
    * Calculate the source time for a clip given a timeline time
    */
   const calculateSourceTime = useCallback((clip: Clip, timelineTime: number): number => {
-    const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-    const offsetInClip = timelineTime - clip.place.timelineInSec;
-    return clip.range.sourceInSec + (offsetInClip * safeSpeed);
+    return getClipSourceTimeAtTimelineTime(clip, timelineTime);
   }, []);
 
   /**
@@ -260,25 +264,19 @@ export function useVideoSync({
  * Calculate timeline time from a video's current time
  */
 export function calculateTimelineTime(clip: Clip, sourceTime: number): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  const offsetInSource = sourceTime - clip.range.sourceInSec;
-  return clip.place.timelineInSec + (offsetInSource / safeSpeed);
+  return getClipTimelineTimeAtSourceTime(clip, sourceTime);
 }
 
 /**
  * Check if a timeline time falls within a clip's range
  */
 export function isTimeInClip(clip: Clip, timelineTime: number): boolean {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  const clipDuration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-  const clipEnd = clip.place.timelineInSec + clipDuration;
-  return timelineTime >= clip.place.timelineInSec && timelineTime < clipEnd;
+  return isClipActiveAtTime(clip, timelineTime);
 }
 
 /**
  * Get the duration of a clip on the timeline
  */
 export function getClipTimelineDuration(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+  return getClipTimelineDurationSec(clip);
 }

--- a/src/hooks/useVideoSync.utils.test.ts
+++ b/src/hooks/useVideoSync.utils.test.ts
@@ -21,12 +21,20 @@ function makeClip(overrides: Partial<{
   sourceIn: number;
   sourceOut: number;
   timelineIn: number;
+  placeDuration: number;
+  reverse: boolean;
+  freezeFrame: boolean;
+  timeRemap: Clip['timeRemap'];
 }>): Clip {
   const {
     speed = 1,
     sourceIn = 0,
     sourceOut = 10,
     timelineIn = 0,
+    placeDuration,
+    reverse = false,
+    freezeFrame = false,
+    timeRemap = null,
   } = overrides;
 
   return {
@@ -40,7 +48,11 @@ function makeClip(overrides: Partial<{
     },
     place: {
       timelineInSec: timelineIn,
+      durationSec: placeDuration,
     },
+    reverse,
+    freezeFrame,
+    timeRemap,
   } as unknown as Clip;
 }
 
@@ -87,6 +99,45 @@ describe('calculateTimelineTime', () => {
   it('should return timelineIn when sourceTime equals sourceIn', () => {
     const clip = makeClip({ timelineIn: 20, sourceIn: 5, sourceOut: 15, speed: 1 });
     expect(calculateTimelineTime(clip, 5)).toBe(20);
+  });
+
+  it('should invert reverse playback using sourceOut as the timeline origin', () => {
+    const clip = makeClip({
+      timelineIn: 10,
+      sourceIn: 2,
+      sourceOut: 12,
+      reverse: true,
+      placeDuration: 10,
+    });
+
+    expect(calculateTimelineTime(clip, 9)).toBe(13);
+  });
+
+  it('should anchor freeze-frame clips at the timeline start', () => {
+    const clip = makeClip({
+      timelineIn: 7,
+      sourceIn: 5,
+      sourceOut: 5,
+      freezeFrame: true,
+      placeDuration: 4,
+    });
+
+    expect(calculateTimelineTime(clip, 5)).toBe(7);
+  });
+
+  it('should invert linear time-remap curves back to timeline time', () => {
+    const clip = makeClip({
+      timelineIn: 3,
+      placeDuration: 4,
+      timeRemap: {
+        keyframes: [
+          { timelineTime: 0, sourceTime: 2, interpolation: 'linear' },
+          { timelineTime: 4, sourceTime: 10, interpolation: 'linear' },
+        ],
+      },
+    });
+
+    expect(calculateTimelineTime(clip, 6)).toBeCloseTo(5, 6);
   });
 });
 
@@ -135,6 +186,19 @@ describe('isTimeInClip', () => {
     expect(isTimeInClip(clip, 5)).toBe(true);
     expect(isTimeInClip(clip, 10)).toBe(false);
   });
+
+  it('should use explicit place duration for freeze-frame clips', () => {
+    const clip = makeClip({
+      timelineIn: 1,
+      sourceIn: 5,
+      sourceOut: 5,
+      freezeFrame: true,
+      placeDuration: 3,
+    });
+
+    expect(isTimeInClip(clip, 3.999)).toBe(true);
+    expect(isTimeInClip(clip, 4)).toBe(false);
+  });
 });
 
 // =============================================================================
@@ -175,5 +239,29 @@ describe('getClipTimelineDuration', () => {
   it('should return 0 when sourceIn equals sourceOut', () => {
     const clip = makeClip({ sourceIn: 5, sourceOut: 5, speed: 1 });
     expect(getClipTimelineDuration(clip)).toBe(0);
+  });
+
+  it('should prefer explicit place duration for freeze-frame clips', () => {
+    const clip = makeClip({
+      sourceIn: 5,
+      sourceOut: 5,
+      freezeFrame: true,
+      placeDuration: 3.5,
+    });
+
+    expect(getClipTimelineDuration(clip)).toBe(3.5);
+  });
+
+  it('should derive duration from time-remap keyframes when place duration is absent', () => {
+    const clip = makeClip({
+      timeRemap: {
+        keyframes: [
+          { timelineTime: 0, sourceTime: 0, interpolation: 'linear' },
+          { timelineTime: 6, sourceTime: 8, interpolation: 'linear' },
+        ],
+      },
+    });
+
+    expect(getClipTimelineDuration(clip)).toBe(6);
   });
 });

--- a/src/hooks/useVirtualizedClips.test.ts
+++ b/src/hooks/useVirtualizedClips.test.ts
@@ -173,6 +173,21 @@ describe('useVirtualizedClips', () => {
 
       expect(result.current.visibleClips[0].durationSec).toBe(10);
     });
+
+    it('should prefer explicit timeline duration for freeze-frame style clips', () => {
+      const clips = [
+        createMockClip('freeze', 2, 5, 5, 1),
+      ];
+      clips[0].freezeFrame = true;
+      clips[0].place.durationSec = 4;
+
+      const { result } = renderHook(() =>
+        useVirtualizedClips(clips, defaultConfig)
+      );
+
+      expect(result.current.visibleClips[0].durationSec).toBe(4);
+      expect(result.current.visibleClips[0].widthPx).toBe(400);
+    });
   });
 
   // ===========================================================================

--- a/src/hooks/useVirtualizedClips.ts
+++ b/src/hooks/useVirtualizedClips.ts
@@ -11,6 +11,7 @@
 
 import { useMemo } from 'react';
 import type { Clip, TimeSec } from '@/types';
+import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -62,8 +63,7 @@ const MIN_CLIP_WIDTH_PX = 4;
  * Calculate clip position and dimensions in pixels
  */
 function computeClipMetrics(clip: Clip, zoom: number): VirtualizedClip {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  const durationSec = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+  const durationSec = getClipTimelineDurationSec(clip);
   const leftPx = clip.place.timelineInSec * zoom;
   const widthPx = Math.max(durationSec * zoom, MIN_CLIP_WIDTH_PX);
 
@@ -183,9 +183,7 @@ export function calculateTimelineExtent(clips: Clip[]): {
 
   for (const clip of clips) {
     const startTime = clip.place.timelineInSec;
-    const speed = clip.speed > 0 ? clip.speed : 1;
-    const duration = (clip.range.sourceOutSec - clip.range.sourceInSec) / speed;
-    const endTime = startTime + duration;
+    const endTime = getClipTimelineEndSec(clip);
 
     minTimeSec = Math.min(minTimeSec, startTime);
     maxTimeSec = Math.max(maxTimeSec, endTime);

--- a/src/services/SnapPointManager.test.ts
+++ b/src/services/SnapPointManager.test.ts
@@ -137,6 +137,18 @@ describe('SnapPointManager', () => {
       const stats = manager.getStats();
       expect(stats.clipCount).toBe(3);
     });
+
+    it('should honor explicit clip duration when generating snap points', () => {
+      const clip = createMockClip('clip-freeze', 5, 0);
+      clip.range = { sourceInSec: 4, sourceOutSec: 4 };
+      clip.place = { timelineInSec: 5, durationSec: 4 } as Clip['place'];
+      clip.freezeFrame = true;
+
+      manager.updateClip(clip);
+
+      const snapPoints = manager.getSnapPoints();
+      expect(snapPoints).toContainEqual(expect.objectContaining({ time: 9, type: 'clip-end' }));
+    });
   });
 
   describe('Playhead', () => {

--- a/src/services/SnapPointManager.ts
+++ b/src/services/SnapPointManager.ts
@@ -16,6 +16,7 @@
 import type { SnapPoint, Clip, Sequence } from '@/types';
 import { createLogger } from '@/services/logger';
 import { calculateSnapThreshold } from '@/constants/precision';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 
 const logger = createLogger('SnapPointManager');
 
@@ -158,8 +159,7 @@ export class SnapPointManager {
   updateClip(clip: Clip): void {
     const clipId = clip.id;
     const inTime = clip.place.timelineInSec;
-    const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-    const outTime = inTime + (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+    const outTime = getClipTimelineEndSec(clip);
 
     const snapPoints: ManagedSnapPoint[] = [
       {
@@ -209,8 +209,7 @@ export class SnapPointManager {
     for (const track of sequence.tracks) {
       for (const clip of track.clips) {
         const inTime = clip.place.timelineInSec;
-        const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-        const outTime = inTime + (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+        const outTime = getClipTimelineEndSec(clip);
 
         const snapPoints: ManagedSnapPoint[] = [
           {

--- a/src/stores/timelineStore.test.ts
+++ b/src/stores/timelineStore.test.ts
@@ -128,6 +128,31 @@ describe('timelineStore', () => {
       });
     });
 
+    describe('sanitizeSelection', () => {
+      it('should remove clip and track ids that are no longer present', () => {
+        useTimelineStore.setState({
+          selectedClipIds: ['clip_001', 'clip_stale'],
+          selectedTrackIds: ['track_001', 'track_stale'],
+        });
+
+        const { sanitizeSelection } = useTimelineStore.getState();
+        sanitizeSelection(['clip_001', 'clip_002'], ['track_001']);
+
+        const state = useTimelineStore.getState();
+        expect(state.selectedClipIds).toEqual(['clip_001']);
+        expect(state.selectedTrackIds).toEqual(['track_001']);
+      });
+
+      it('should clear track selection when no valid track ids are provided', () => {
+        useTimelineStore.setState({ selectedTrackIds: ['track_001'] });
+
+        const { sanitizeSelection } = useTimelineStore.getState();
+        sanitizeSelection(['clip_001']);
+
+        expect(useTimelineStore.getState().selectedTrackIds).toEqual([]);
+      });
+    });
+
     describe('deselectClip', () => {
       it('should remove clip from selection', () => {
         useTimelineStore.setState({ selectedClipIds: ['clip_001', 'clip_002'] });

--- a/src/stores/timelineStore.ts
+++ b/src/stores/timelineStore.ts
@@ -41,6 +41,7 @@ interface TimelineState {
   // Actions - Selection
   selectClip: (clipId: string, addToSelection?: boolean) => void;
   selectClips: (clipIds: string[]) => void;
+  sanitizeSelection: (validClipIds: string[], validTrackIds?: string[]) => void;
   deselectClip: (clipId: string) => void;
   clearClipSelection: () => void;
   selectTrack: (trackId: string) => void;
@@ -117,6 +118,18 @@ export const useTimelineStore = create<TimelineState>()(
     selectClips: (clipIds: string[]) => {
       set((state) => {
         state.selectedClipIds = [...clipIds];
+      });
+    },
+
+    sanitizeSelection: (validClipIds, validTrackIds = []) => {
+      set((state) => {
+        const validClipIdSet = new Set(validClipIds);
+        const validTrackIdSet = new Set(validTrackIds);
+
+        state.selectedClipIds = state.selectedClipIds.filter((clipId) => validClipIdSet.has(clipId));
+        state.selectedTrackIds = state.selectedTrackIds.filter((trackId) =>
+          validTrackIdSet.has(trackId),
+        );
       });
     },
 

--- a/src/stores/workspaceLayoutStore.test.ts
+++ b/src/stores/workspaceLayoutStore.test.ts
@@ -33,6 +33,7 @@ describe('WorkspaceLayoutStore', () => {
     it('should initialize with monitors in center-top zone', () => {
       const { layout } = useWorkspaceLayoutStore.getState();
       expect(layout.zones['center-top'].panelIds).toEqual(['source-monitor', 'program-monitor']);
+      expect(layout.zones['center-top'].activePanelId).toBe('source-monitor');
     });
 
     it('should initialize with timeline in center-bottom zone', () => {
@@ -344,6 +345,7 @@ describe('WorkspaceLayoutStore', () => {
         const { layout, activePresetId } = useWorkspaceLayoutStore.getState();
         expect(activePresetId).toBe('editing');
         expect(layout.zones.left.panelIds).toEqual(['explorer']);
+        expect(layout.zones['center-top'].activePanelId).toBe('source-monitor');
         expect(layout.sizes.centerSplitRatio).toBe(0.4);
       });
 

--- a/src/utils/clipAudio.test.ts
+++ b/src/utils/clipAudio.test.ts
@@ -60,13 +60,25 @@ describe('clipAudio utils', () => {
   });
 
   describe('getClipTimelineDurationSec', () => {
-    it('returns speed-adjusted clip duration', () => {
+    it('returns explicit timeline duration when present', () => {
       const clip = createClip({ speed: 2, range: { sourceInSec: 0, sourceOutSec: 8 } });
+      expect(getClipTimelineDurationSec(clip)).toBe(10);
+    });
+
+    it('returns speed-adjusted clip duration when explicit duration is unavailable', () => {
+      const clip = createClip({
+        speed: 2,
+        range: { sourceInSec: 0, sourceOutSec: 8 },
+        place: { timelineInSec: 0, durationSec: 0 },
+      });
       expect(getClipTimelineDurationSec(clip)).toBe(4);
     });
 
-    it('returns 0 for invalid clip duration', () => {
-      const clip = createClip({ range: { sourceInSec: 10, sourceOutSec: 0 } });
+    it('returns 0 for invalid clip duration when explicit duration is unavailable', () => {
+      const clip = createClip({
+        range: { sourceInSec: 10, sourceOutSec: 0 },
+        place: { timelineInSec: 0, durationSec: 0 },
+      });
       expect(getClipTimelineDurationSec(clip)).toBe(0);
     });
   });

--- a/src/utils/clipAudio.ts
+++ b/src/utils/clipAudio.ts
@@ -1,4 +1,5 @@
 import type { Clip } from '@/types';
+import { getClipTimelineDurationSec as resolveClipTimelineDurationSec } from '@/utils/clipTiming';
 
 export const CLIP_AUDIO_MIN_VOLUME_DB = -60;
 export const CLIP_AUDIO_MAX_VOLUME_DB = 6;
@@ -15,14 +16,7 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 export function getClipTimelineDurationSec(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  const rawDuration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-
-  if (!Number.isFinite(rawDuration) || rawDuration <= 0) {
-    return 0;
-  }
-
-  return rawDuration;
+  return resolveClipTimelineDurationSec(clip);
 }
 
 export function clampClipVolumeDb(volumeDb: number): number {

--- a/src/utils/clipLinking.test.ts
+++ b/src/utils/clipLinking.test.ts
@@ -216,6 +216,100 @@ describe('clipLinking utilities', () => {
     ]);
   });
 
+  it('maps linked left trims through reverse companions using timeline edge movement', () => {
+    const sequence = createSequence([
+      createTrack({
+        id: 'video-track',
+        kind: 'video',
+        clips: [
+          createClip({
+            id: 'video-clip',
+            assetId: 'asset-1',
+            range: { sourceInSec: 2, sourceOutSec: 8 },
+            place: { timelineInSec: 10, durationSec: 6 },
+          }),
+        ],
+      }),
+      createTrack({
+        id: 'audio-track',
+        kind: 'audio',
+        clips: [
+          createClip({
+            id: 'audio-clip',
+            assetId: 'asset-1',
+            range: { sourceInSec: 2, sourceOutSec: 8 },
+            place: { timelineInSec: 10, durationSec: 6 },
+            reverse: true,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(
+      buildLinkedTrimTargets(sequence, {
+        sequenceId: 'seq-1',
+        trackId: 'video-track',
+        clipId: 'video-clip',
+        newSourceIn: 3,
+        newTimelineIn: 11,
+      }),
+    ).toEqual([
+      {
+        sequenceId: 'seq-1',
+        trackId: 'audio-track',
+        clipId: 'audio-clip',
+        newSourceOut: 7,
+        newTimelineIn: 11,
+      },
+    ]);
+  });
+
+  it('maps linked right trims through reverse companions using timeline edge movement', () => {
+    const sequence = createSequence([
+      createTrack({
+        id: 'video-track',
+        kind: 'video',
+        clips: [
+          createClip({
+            id: 'video-clip',
+            assetId: 'asset-1',
+            range: { sourceInSec: 2, sourceOutSec: 8 },
+            place: { timelineInSec: 10, durationSec: 6 },
+          }),
+        ],
+      }),
+      createTrack({
+        id: 'audio-track',
+        kind: 'audio',
+        clips: [
+          createClip({
+            id: 'audio-clip',
+            assetId: 'asset-1',
+            range: { sourceInSec: 2, sourceOutSec: 8 },
+            place: { timelineInSec: 10, durationSec: 6 },
+            reverse: true,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(
+      buildLinkedTrimTargets(sequence, {
+        sequenceId: 'seq-1',
+        trackId: 'video-track',
+        clipId: 'video-clip',
+        newSourceOut: 7,
+      }),
+    ).toEqual([
+      {
+        sequenceId: 'seq-1',
+        trackId: 'audio-track',
+        clipId: 'audio-clip',
+        newSourceIn: 3,
+      },
+    ]);
+  });
+
   it('returns linked split targets that contain split time', () => {
     const sequence = createSequence([
       createTrack({

--- a/src/utils/clipLinking.ts
+++ b/src/utils/clipLinking.ts
@@ -1,5 +1,12 @@
 import type { Clip, Sequence, Track, TrackKind } from '@/types';
 import type { ClipTrimData } from '@/components/timeline/types';
+import {
+  buildLeftTrimChange,
+  buildRightTrimChange,
+  getClipTimelineEndSec,
+  isClipActiveAtTime,
+  supportsSourceBoundaryTrimming,
+} from '@/utils/clipTiming';
 
 const LINK_KEY_PRECISION = 6;
 
@@ -55,12 +62,7 @@ function isVisualTrackKind(trackKind: TrackKind): boolean {
 }
 
 function clipContainsTime(clip: Clip, time: number): boolean {
-  const safeSpeed = getSafeSpeed(clip);
-  const duration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-  const clipStart = clip.place.timelineInSec;
-  const clipEnd = clipStart + duration;
-
-  return time > clipStart && time < clipEnd;
+  return isClipActiveAtTime(clip, time) && time > clip.place.timelineInSec && time < getClipTimelineEndSec(clip);
 }
 
 export function findClipReference(sequence: Sequence, clipId: string): ClipReference | null {
@@ -224,6 +226,11 @@ export function buildLinkedTrimTargets(sequence: Sequence, trimData: ClipTrimDat
 
   const sourceClip = sourceRef.clip;
 
+  const isLeftTrim = typeof trimData.newTimelineIn === 'number';
+  const timelineInDelta =
+    typeof trimData.newTimelineIn === 'number'
+      ? trimData.newTimelineIn - sourceClip.place.timelineInSec
+      : undefined;
   const sourceInDelta =
     typeof trimData.newSourceIn === 'number'
       ? trimData.newSourceIn - sourceClip.range.sourceInSec
@@ -232,15 +239,21 @@ export function buildLinkedTrimTargets(sequence: Sequence, trimData: ClipTrimDat
     typeof trimData.newSourceOut === 'number'
       ? trimData.newSourceOut - sourceClip.range.sourceOutSec
       : undefined;
-  const timelineInDelta =
-    typeof trimData.newTimelineIn === 'number'
-      ? trimData.newTimelineIn - sourceClip.place.timelineInSec
-      : undefined;
+
+  const rightTrimTimelineDelta =
+    !isLeftTrim && typeof sourceOutDelta === 'number'
+      ? sourceOutDelta / getSafeSpeed(sourceClip)
+      : !isLeftTrim && typeof sourceInDelta === 'number'
+        ? -sourceInDelta / getSafeSpeed(sourceClip)
+        : undefined;
 
   const targets: ClipTrimData[] = [];
   for (const companionId of companionIds) {
     const companionRef = findClipReference(sequence, companionId);
     if (!companionRef) {
+      continue;
+    }
+    if (!supportsSourceBoundaryTrimming(companionRef.clip)) {
       continue;
     }
 
@@ -250,16 +263,29 @@ export function buildLinkedTrimTargets(sequence: Sequence, trimData: ClipTrimDat
       clipId: companionRef.clip.id,
     };
 
-    if (typeof sourceInDelta === 'number') {
-      companionTrim.newSourceIn = companionRef.clip.range.sourceInSec + sourceInDelta;
-    }
+    if (isLeftTrim && typeof timelineInDelta === 'number') {
+      const linkedLeftTrim = buildLeftTrimChange(
+        companionRef.clip,
+        companionRef.clip.place.timelineInSec + timelineInDelta,
+      );
+      if (!linkedLeftTrim) {
+        continue;
+      }
 
-    if (typeof sourceOutDelta === 'number') {
-      companionTrim.newSourceOut = companionRef.clip.range.sourceOutSec + sourceOutDelta;
-    }
+      companionTrim.newTimelineIn = linkedLeftTrim.timelineIn;
+      companionTrim.newSourceIn = linkedLeftTrim.sourceIn;
+      companionTrim.newSourceOut = linkedLeftTrim.sourceOut;
+    } else if (!isLeftTrim && typeof rightTrimTimelineDelta === 'number') {
+      const linkedRightTrim = buildRightTrimChange(
+        companionRef.clip,
+        getClipTimelineEndSec(companionRef.clip) + rightTrimTimelineDelta,
+      );
+      if (!linkedRightTrim) {
+        continue;
+      }
 
-    if (typeof timelineInDelta === 'number') {
-      companionTrim.newTimelineIn = companionRef.clip.place.timelineInSec + timelineInDelta;
+      companionTrim.newSourceIn = linkedRightTrim.sourceIn;
+      companionTrim.newSourceOut = linkedRightTrim.sourceOut;
     }
 
     targets.push(companionTrim);

--- a/src/utils/clipTiming.test.ts
+++ b/src/utils/clipTiming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isClipActiveAtTime } from './clipTiming';
+import { getClipTimelineDurationSec, isClipActiveAtTime } from './clipTiming';
 import type { Clip } from '@/types';
 
 function createClip(overrides: Partial<Clip> = {}): Clip {
@@ -39,6 +39,49 @@ describe('isClipActiveAtTime', () => {
   it('should return false when the clip is disabled even if the time overlaps', () => {
     const clip = createClip({ enabled: false });
 
+    expect(isClipActiveAtTime(clip, 5)).toBe(false);
+  });
+});
+
+describe('getClipTimelineDurationSec', () => {
+  it('should prefer explicit timeline duration to match backend clip duration rules', () => {
+    const clip = createClip({
+      speed: 2,
+      range: {
+        sourceInSec: 0,
+        sourceOutSec: 8,
+      },
+      place: {
+        timelineInSec: 0,
+        durationSec: 10,
+      },
+    });
+
+    expect(getClipTimelineDurationSec(clip)).toBe(10);
+  });
+
+  it('should fall back to speed-adjusted source duration when explicit duration is invalid', () => {
+    const clip = createClip({
+      speed: 2,
+      range: {
+        sourceInSec: 0,
+        sourceOutSec: 8,
+      },
+      place: {
+        timelineInSec: 0,
+        durationSec: 0,
+      },
+    });
+
+    expect(getClipTimelineDurationSec(clip)).toBe(4);
+  });
+
+  it('should derive duration safely when malformed clips are missing place data', () => {
+    const clip = createClip({
+      place: undefined as unknown as Clip['place'],
+    });
+
+    expect(getClipTimelineDurationSec(clip)).toBe(10);
     expect(isClipActiveAtTime(clip, 5)).toBe(false);
   });
 });

--- a/src/utils/clipTiming.ts
+++ b/src/utils/clipTiming.ts
@@ -181,7 +181,7 @@ function invertTimeRemapCurve(
 }
 
 export function getClipTimelineDurationSec(clip: Clip): number {
-  const placeDuration = clip.place.durationSec;
+  const placeDuration = clip.place?.durationSec;
   if (Number.isFinite(placeDuration) && placeDuration > 0) {
     return placeDuration;
   }
@@ -202,8 +202,13 @@ export function getClipTimelineDurationSec(clip: Clip): number {
   return 0;
 }
 
+function getClipTimelineInSec(clip: Clip): number | null {
+  const timelineInSec = clip.place?.timelineInSec;
+  return Number.isFinite(timelineInSec) ? timelineInSec : null;
+}
+
 export function getClipTimelineEndSec(clip: Clip): number {
-  return clip.place.timelineInSec + getClipTimelineDurationSec(clip);
+  return (getClipTimelineInSec(clip) ?? 0) + getClipTimelineDurationSec(clip);
 }
 
 export function isClipActiveAtTime(clip: Clip, timelineTimeSec: number, epsilonSec = 0): boolean {
@@ -215,7 +220,12 @@ export function isClipActiveAtTime(clip: Clip, timelineTimeSec: number, epsilonS
     return false;
   }
 
-  const clipStart = clip.place.timelineInSec - epsilonSec;
+  const clipTimelineInSec = getClipTimelineInSec(clip);
+  if (clipTimelineInSec == null) {
+    return false;
+  }
+
+  const clipStart = clipTimelineInSec - epsilonSec;
   const clipEnd = getClipTimelineEndSec(clip) + epsilonSec;
   if (clipEnd - clipStart <= MIN_DURATION_EPSILON_SEC) {
     return false;
@@ -226,7 +236,8 @@ export function isClipActiveAtTime(clip: Clip, timelineTimeSec: number, epsilonS
 
 export function getClipSourceTimeAtTimelineTime(clip: Clip, timelineTimeSec: number): number {
   const durationSec = getClipTimelineDurationSec(clip);
-  const offsetInTimeline = clamp(timelineTimeSec - clip.place.timelineInSec, 0, durationSec);
+  const clipTimelineInSec = getClipTimelineInSec(clip) ?? 0;
+  const offsetInTimeline = clamp(timelineTimeSec - clipTimelineInSec, 0, durationSec);
 
   if (clip.freezeFrame) {
     return clip.range.sourceInSec;
@@ -245,18 +256,20 @@ export function getClipSourceTimeAtTimelineTime(clip: Clip, timelineTimeSec: num
 }
 
 export function getClipTimelineTimeAtSourceTime(clip: Clip, sourceTimeSec: number): number {
+  const clipTimelineInSec = getClipTimelineInSec(clip) ?? 0;
+
   if (clip.freezeFrame) {
-    return clip.place.timelineInSec;
+    return clipTimelineInSec;
   }
 
   const durationSec = getClipTimelineDurationSec(clip);
   if (durationSec <= 0) {
-    return clip.place.timelineInSec;
+    return clipTimelineInSec;
   }
 
   if (hasActiveTimeRemap(clip) && clip.timeRemap) {
     const timelineOffset = invertTimeRemapCurve(clip.timeRemap, sourceTimeSec, durationSec);
-    return clip.place.timelineInSec + clamp(timelineOffset, 0, durationSec);
+    return clipTimelineInSec + clamp(timelineOffset, 0, durationSec);
   }
 
   const clampedSourceTime = clamp(sourceTimeSec, clip.range.sourceInSec, clip.range.sourceOutSec);
@@ -265,7 +278,7 @@ export function getClipTimelineTimeAtSourceTime(clip: Clip, sourceTimeSec: numbe
     ? clip.range.sourceOutSec - clampedSourceTime
     : clampedSourceTime - clip.range.sourceInSec;
 
-  return clip.place.timelineInSec + clamp(offsetInSource / safeSpeed, 0, durationSec);
+  return clipTimelineInSec + clamp(offsetInSource / safeSpeed, 0, durationSec);
 }
 
 export interface ClipTrimChange {

--- a/src/utils/clipTiming.ts
+++ b/src/utils/clipTiming.ts
@@ -1,6 +1,16 @@
-import type { Clip } from '@/types';
+import { hasActiveTimeRemap, type Clip, type TimeRemapCurve } from '@/types';
 
 const MIN_DURATION_EPSILON_SEC = 1e-6;
+const BEZIER_SOLVER_ITERATIONS = 8;
+const TIME_REMAP_INVERSION_ITERATIONS = 24;
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  return Math.max(min, Math.min(max, value));
+}
 
 export function getSafeClipSpeed(clip: Clip): number {
   return clip.speed > 0 ? clip.speed : 1;
@@ -15,16 +25,178 @@ export function getClipRangeDurationSec(clip: Clip): number {
   return Math.max(0, rangeDuration);
 }
 
+export function getTimeRemapTimelineDurationSec(curve: TimeRemapCurve | null | undefined): number {
+  if (!curve || curve.keyframes.length < 2) {
+    return 0;
+  }
+
+  const firstTimelineTime = curve.keyframes[0]?.timelineTime;
+  const lastTimelineTime = curve.keyframes[curve.keyframes.length - 1]?.timelineTime;
+  if (!Number.isFinite(firstTimelineTime) || !Number.isFinite(lastTimelineTime)) {
+    return 0;
+  }
+
+  return Math.max(0, lastTimelineTime - firstTimelineTime);
+}
+
+function cubicBezierT(cp1x: number, cp2x: number, targetX: number): number {
+  let t = clamp(targetX, 0, 1);
+
+  for (let iteration = 0; iteration < BEZIER_SOLVER_ITERATIONS; iteration += 1) {
+    const t2 = t * t;
+    const t3 = t2 * t;
+    const mt = 1 - t;
+    const mt2 = mt * mt;
+
+    const x = 3 * mt2 * t * cp1x + 3 * mt * t2 * cp2x + t3;
+    const dx = 3 * mt2 * cp1x + 6 * mt * t * (cp2x - cp1x) + 3 * t2 * (1 - cp2x);
+
+    if (Math.abs(dx) < 1e-12) {
+      break;
+    }
+
+    t = clamp(t - (x - targetX) / dx, 0, 1);
+  }
+
+  return t;
+}
+
+function cubicBezierY(cp1y: number, cp2y: number, t: number): number {
+  const mt = 1 - t;
+  const mt2 = mt * mt;
+  const t2 = t * t;
+  return 3 * mt2 * t * cp1y + 3 * mt * t2 * cp2y + t * t2;
+}
+
+export function evaluateTimeRemapCurve(
+  curve: TimeRemapCurve | null | undefined,
+  timelineOffsetSec: number,
+): number {
+  if (!curve || curve.keyframes.length === 0) {
+    return Number.isFinite(timelineOffsetSec) ? timelineOffsetSec : 0;
+  }
+
+  const safeTimelineOffset = Number.isFinite(timelineOffsetSec) ? timelineOffsetSec : 0;
+  const firstKeyframe = curve.keyframes[0];
+  if (safeTimelineOffset <= firstKeyframe.timelineTime) {
+    return firstKeyframe.sourceTime;
+  }
+
+  const lastKeyframe = curve.keyframes[curve.keyframes.length - 1];
+  if (safeTimelineOffset >= lastKeyframe.timelineTime) {
+    return lastKeyframe.sourceTime;
+  }
+
+  for (let index = 0; index < curve.keyframes.length - 1; index += 1) {
+    const start = curve.keyframes[index];
+    const end = curve.keyframes[index + 1];
+    if (safeTimelineOffset < start.timelineTime || safeTimelineOffset >= end.timelineTime) {
+      continue;
+    }
+
+    const segmentDuration = end.timelineTime - start.timelineTime;
+    if (!Number.isFinite(segmentDuration) || segmentDuration <= 0) {
+      return start.sourceTime;
+    }
+
+    const t = clamp((safeTimelineOffset - start.timelineTime) / segmentDuration, 0, 1);
+    const interpolation = start.interpolation;
+    if (interpolation === 'hold') {
+      return start.sourceTime;
+    }
+
+    if (typeof interpolation === 'object' && interpolation && 'bezier' in interpolation) {
+      const { cp1x, cp1y, cp2x, cp2y } = interpolation.bezier;
+      const bezierT = cubicBezierT(cp1x, cp2x, t);
+      const y = cubicBezierY(cp1y, cp2y, bezierT);
+      return start.sourceTime + y * (end.sourceTime - start.sourceTime);
+    }
+
+    return start.sourceTime + t * (end.sourceTime - start.sourceTime);
+  }
+
+  return lastKeyframe.sourceTime;
+}
+
+function invertTimeRemapCurve(
+  curve: TimeRemapCurve,
+  sourceTimeSec: number,
+  durationSec: number,
+): number {
+  if (curve.keyframes.length === 0) {
+    return 0;
+  }
+
+  const safeSourceTime = Number.isFinite(sourceTimeSec)
+    ? sourceTimeSec
+    : curve.keyframes[0].sourceTime;
+  const firstKeyframe = curve.keyframes[0];
+  const lastKeyframe = curve.keyframes[curve.keyframes.length - 1];
+  if (safeSourceTime <= firstKeyframe.sourceTime) {
+    return 0;
+  }
+  if (safeSourceTime >= lastKeyframe.sourceTime) {
+    return durationSec;
+  }
+
+  for (let index = 0; index < curve.keyframes.length - 1; index += 1) {
+    const start = curve.keyframes[index];
+    const end = curve.keyframes[index + 1];
+    const segmentMin = Math.min(start.sourceTime, end.sourceTime);
+    const segmentMax = Math.max(start.sourceTime, end.sourceTime);
+    if (safeSourceTime < segmentMin || safeSourceTime > segmentMax) {
+      continue;
+    }
+
+    if (start.interpolation === 'hold') {
+      return clamp(start.timelineTime, 0, durationSec);
+    }
+
+    let low = clamp(start.timelineTime, 0, durationSec);
+    let high = clamp(end.timelineTime, 0, durationSec);
+    const ascending = end.sourceTime >= start.sourceTime;
+
+    for (let iteration = 0; iteration < TIME_REMAP_INVERSION_ITERATIONS; iteration += 1) {
+      const mid = (low + high) / 2;
+      const midSourceTime = evaluateTimeRemapCurve(curve, mid);
+
+      if (Math.abs(midSourceTime - safeSourceTime) <= MIN_DURATION_EPSILON_SEC) {
+        return mid;
+      }
+
+      if (
+        (ascending && midSourceTime < safeSourceTime) ||
+        (!ascending && midSourceTime > safeSourceTime)
+      ) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+
+    return (low + high) / 2;
+  }
+
+  return clamp(durationSec, 0, durationSec);
+}
+
 export function getClipTimelineDurationSec(clip: Clip): number {
+  const placeDuration = clip.place.durationSec;
+  if (Number.isFinite(placeDuration) && placeDuration > 0) {
+    return placeDuration;
+  }
+
+  if (hasActiveTimeRemap(clip)) {
+    const remapDuration = getTimeRemapTimelineDurationSec(clip.timeRemap);
+    if (Number.isFinite(remapDuration) && remapDuration > 0) {
+      return remapDuration;
+    }
+  }
+
   const safeSpeed = getSafeClipSpeed(clip);
   const rangeDerivedDuration = getClipRangeDurationSec(clip) / safeSpeed;
   if (Number.isFinite(rangeDerivedDuration) && rangeDerivedDuration > 0) {
     return rangeDerivedDuration;
-  }
-
-  const placeDuration = clip.place.durationSec;
-  if (Number.isFinite(placeDuration) && placeDuration > 0) {
-    return placeDuration;
   }
 
   return 0;
@@ -53,9 +225,146 @@ export function isClipActiveAtTime(clip: Clip, timelineTimeSec: number, epsilonS
 }
 
 export function getClipSourceTimeAtTimelineTime(clip: Clip, timelineTimeSec: number): number {
-  const offsetInTimeline = timelineTimeSec - clip.place.timelineInSec;
+  const durationSec = getClipTimelineDurationSec(clip);
+  const offsetInTimeline = clamp(timelineTimeSec - clip.place.timelineInSec, 0, durationSec);
+
+  if (clip.freezeFrame) {
+    return clip.range.sourceInSec;
+  }
+
+  if (hasActiveTimeRemap(clip)) {
+    return evaluateTimeRemapCurve(clip.timeRemap, offsetInTimeline);
+  }
+
   const safeSpeed = getSafeClipSpeed(clip);
-  const sourceTime = clip.range.sourceInSec + offsetInTimeline * safeSpeed;
+  const sourceTime = clip.reverse
+    ? clip.range.sourceOutSec - offsetInTimeline * safeSpeed
+    : clip.range.sourceInSec + offsetInTimeline * safeSpeed;
 
   return Math.max(clip.range.sourceInSec, Math.min(sourceTime, clip.range.sourceOutSec));
+}
+
+export function getClipTimelineTimeAtSourceTime(clip: Clip, sourceTimeSec: number): number {
+  if (clip.freezeFrame) {
+    return clip.place.timelineInSec;
+  }
+
+  const durationSec = getClipTimelineDurationSec(clip);
+  if (durationSec <= 0) {
+    return clip.place.timelineInSec;
+  }
+
+  if (hasActiveTimeRemap(clip) && clip.timeRemap) {
+    const timelineOffset = invertTimeRemapCurve(clip.timeRemap, sourceTimeSec, durationSec);
+    return clip.place.timelineInSec + clamp(timelineOffset, 0, durationSec);
+  }
+
+  const clampedSourceTime = clamp(sourceTimeSec, clip.range.sourceInSec, clip.range.sourceOutSec);
+  const safeSpeed = getSafeClipSpeed(clip);
+  const offsetInSource = clip.reverse
+    ? clip.range.sourceOutSec - clampedSourceTime
+    : clampedSourceTime - clip.range.sourceInSec;
+
+  return clip.place.timelineInSec + clamp(offsetInSource / safeSpeed, 0, durationSec);
+}
+
+export interface ClipTrimChange {
+  clipId: string;
+  timelineIn?: number;
+  sourceIn?: number;
+  sourceOut?: number;
+}
+
+export function supportsSourceBoundaryTrimming(clip: Clip): boolean {
+  return !clip.freezeFrame && !hasActiveTimeRemap(clip);
+}
+
+export function getClipLeftTrimDeltaBoundsSec(
+  clip: Clip,
+  sourceDurationSec: number,
+  minDurationSec: number,
+): { minDeltaSec: number; maxDeltaSec: number } {
+  const durationSec = getClipTimelineDurationSec(clip);
+  const maxDeltaSec = Math.max(0, durationSec - Math.max(0, minDurationSec));
+
+  if (!supportsSourceBoundaryTrimming(clip)) {
+    return { minDeltaSec: 0, maxDeltaSec: 0 };
+  }
+
+  const safeSpeed = getSafeClipSpeed(clip);
+  const availableExtensionSec = clip.reverse
+    ? Math.max(0, sourceDurationSec - clip.range.sourceOutSec)
+    : Math.max(0, clip.range.sourceInSec);
+
+  return {
+    minDeltaSec: -(availableExtensionSec / safeSpeed),
+    maxDeltaSec,
+  };
+}
+
+export function getClipRightTrimDeltaBoundsSec(
+  clip: Clip,
+  sourceDurationSec: number,
+  minDurationSec: number,
+): { minDeltaSec: number; maxDeltaSec: number } {
+  const durationSec = getClipTimelineDurationSec(clip);
+  const minDeltaSec = -Math.max(0, durationSec - Math.max(0, minDurationSec));
+
+  if (!supportsSourceBoundaryTrimming(clip)) {
+    return { minDeltaSec: 0, maxDeltaSec: 0 };
+  }
+
+  const safeSpeed = getSafeClipSpeed(clip);
+  const availableExtensionSec = clip.reverse
+    ? Math.max(0, clip.range.sourceInSec)
+    : Math.max(0, sourceDurationSec - clip.range.sourceOutSec);
+
+  return {
+    minDeltaSec,
+    maxDeltaSec: availableExtensionSec / safeSpeed,
+  };
+}
+
+export function buildLeftTrimChange(clip: Clip, newTimelineInSec: number): ClipTrimChange | null {
+  if (!Number.isFinite(newTimelineInSec) || !supportsSourceBoundaryTrimming(clip)) {
+    return null;
+  }
+
+  const safeSpeed = getSafeClipSpeed(clip);
+  const deltaSec = newTimelineInSec - clip.place.timelineInSec;
+
+  if (clip.reverse) {
+    return {
+      clipId: clip.id,
+      timelineIn: newTimelineInSec,
+      sourceOut: clip.range.sourceOutSec - deltaSec * safeSpeed,
+    };
+  }
+
+  return {
+    clipId: clip.id,
+    timelineIn: newTimelineInSec,
+    sourceIn: clip.range.sourceInSec + deltaSec * safeSpeed,
+  };
+}
+
+export function buildRightTrimChange(clip: Clip, newTimelineOutSec: number): ClipTrimChange | null {
+  if (!Number.isFinite(newTimelineOutSec) || !supportsSourceBoundaryTrimming(clip)) {
+    return null;
+  }
+
+  const safeSpeed = getSafeClipSpeed(clip);
+  const deltaSec = newTimelineOutSec - getClipTimelineEndSec(clip);
+
+  if (clip.reverse) {
+    return {
+      clipId: clip.id,
+      sourceIn: clip.range.sourceInSec - deltaSec * safeSpeed,
+    };
+  }
+
+  return {
+    clipId: clip.id,
+    sourceOut: clip.range.sourceOutSec + deltaSec * safeSpeed,
+  };
 }

--- a/src/utils/dropValidity.test.ts
+++ b/src/utils/dropValidity.test.ts
@@ -197,6 +197,16 @@ describe('checkClipOverlap', () => {
     const result = checkClipOverlap(clips, 10, 20);
     expect(result).toBeNull();
   });
+
+  it('should use explicit clip duration for freeze-frame overlap checks', () => {
+    const freezeClip = createTestClip('freeze', 10, 5, 5, {
+      freezeFrame: true,
+      place: { timelineInSec: 10, durationSec: 4 },
+    });
+
+    const result = checkClipOverlap([freezeClip], 13, 15);
+    expect(result?.id).toBe('freeze');
+  });
 });
 
 // =============================================================================

--- a/src/utils/dropValidity.ts
+++ b/src/utils/dropValidity.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Track, Clip, Asset, AssetKind, TrackKind } from '@/types';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 
 // =============================================================================
 // Types
@@ -117,9 +118,7 @@ export function checkClipOverlap(
     if (excludeClipId && clip.id === excludeClipId) continue;
 
     const clipStart = clip.place.timelineInSec;
-    const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-    const clipDuration = (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
-    const clipEnd = clipStart + clipDuration;
+    const clipEnd = getClipTimelineEndSec(clip);
 
     // Check for overlap
     if (startTime < clipEnd && endTime > clipStart) {

--- a/src/utils/playheadRazor.test.ts
+++ b/src/utils/playheadRazor.test.ts
@@ -97,4 +97,27 @@ describe('getPlayheadRazorSplitTarget', () => {
 
     expect(getPlayheadRazorSplitTarget(sequence, 0, 4)).toBeNull();
   });
+
+  it('uses explicit clip timeline duration for freeze-frame clips', () => {
+    const sequence = createSequence([
+      createTrack({
+        id: 'track_v1',
+        kind: 'video',
+        clips: [
+          createClip({
+            id: 'clip_freeze',
+            range: { sourceInSec: 5, sourceOutSec: 5 },
+            place: { timelineInSec: 10, durationSec: 4 },
+            freezeFrame: true,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(getPlayheadRazorSplitTarget(sequence, 0, 12)).toEqual({
+      trackId: 'track_v1',
+      clipId: 'clip_freeze',
+      splitTime: 12,
+    });
+  });
 });

--- a/src/utils/playheadRazor.ts
+++ b/src/utils/playheadRazor.ts
@@ -1,5 +1,6 @@
 import { RAZOR_EDGE_THRESHOLD_SEC } from '@/constants/editing';
 import type { Clip, Sequence } from '@/types';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
 
 export interface PlayheadRazorSplitTarget {
   trackId: string;
@@ -8,8 +9,7 @@ export interface PlayheadRazorSplitTarget {
 }
 
 function getClipEndTime(clip: Clip): number {
-  const safeSpeed = clip.speed > 0 ? clip.speed : 1;
-  return clip.place.timelineInSec + (clip.range.sourceOutSec - clip.range.sourceInSec) / safeSpeed;
+  return getClipTimelineEndSec(clip);
 }
 
 export function getPlayheadRazorSplitTarget(


### PR DESCRIPTION
### **User description**
## Description

This PR centralizes advanced clip timing calculations for freeze-frame, reverse, and time-remapped clips, propagates those calculations through playback/editor/AI workflows, fixes reverse trim handling and unsupported trim guards, adds compound clip canvas preview rendering, and includes the related regression coverage and small UI stability fixes that were required to make those flows consistent.

## Related Issue

Closes #629
Closes #630

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Centralized computed clip timing and source-time mapping in TypeScript and Rust so freeze-frame, reverse, and time-remapped clips use one timing model across timeline, playback, transcript, and AI tooling flows.
- Fixed reverse trim, roll, slide, linked trim, overlap, snap, clipboard, razor, and selection behaviors, and added backend guards so unsupported freeze-frame and time-remapped trims fail safely.
- Added recursive compound clip rendering for canvas preview, improved preview fallback handling, and stabilized related UI state such as stale timeline selection cleanup and center monitor active-tab fallback.

## Screenshots / Videos

N/A

## Testing

### Test Environment

- OS: Linux (WSL2 on Windows 11 host)
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Validation commands run for this branch:
- `node --import tsx ./scripts/sync-version.ts --check`
- `npm test -- --run src/hooks/useVideoSync.utils.test.ts src/hooks/__tests__/useTranscriptEditing.test.ts`
- `npm test -- --run src/components/features/text/AddTextDialog.test.tsx src/hooks/useClipboard.test.ts src/hooks/useRazorTool.test.ts src/hooks/useVirtualizedClips.test.ts src/services/SnapPointManager.test.ts src/utils/dropValidity.test.ts src/utils/playheadRazor.test.ts`
- `npm test -- --run src/hooks/useClipDrag.test.ts src/hooks/useTimelineClipOperations.test.ts src/hooks/useAdvancedEditModes.test.ts src/utils/clipLinking.test.ts`
- `npm test -- --run src/stores/timelineStore.test.ts`
- `npm test -- --run src/stores/workspaceLayoutStore.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml trim_clip_rejects`

Note: the local Husky pre-commit hook failed in WSL when `npx tsx scripts/sync-version.ts --check` attempted to create its IPC pipe (`ENOTSUP`). The same version-sync check passed when run directly with `node --import tsx`.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Centralizes clip timing logic for advanced playback.

- Implements recursive compound clip rendering in canvas.

- Fixes reverse trim and time-remap interaction bugs.

- Sanitizes stale UI state and layout transitions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["clipTiming.ts"] -- "Centralized Logic" --> B["Timeline & Playback"]
  B -- "Recursive Render" --> C["Compound Clip Preview"]
  A -- "Boundary Guards" --> D["Trim & Edit Tools"]
  E["Sequence Change"] -- "Sanitize" --> F["Selection State"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>clipTiming.ts</strong><dd><code>Centralize timing and trim logic for advanced clips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-296457bbb256e8c1d39be00e6da258c743ac5157a43a71d709653e40bb982af8">+332/-10</a></td>

</tr>

<tr>
  <td><strong>TimelinePreviewPlayer.tsx</strong><dd><code>Add recursive compound clip rendering to canvas preview</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-4d288d619dc53b5be764a00b666c542c6daa5d478e6fd1e7e1a6d6e4c9cf90c0">+259/-136</a></td>

</tr>

<tr>
  <td><strong>Timeline.tsx</strong><dd><code>Update timeline duration and trim application logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-aa6135079648e8794f963c931644d6f4084fadee28e27a737af5a23e7d6a089d">+59/-62</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Clip.tsx</strong><dd><code>Disable trim handles for unsupported clip types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-66869f8820472d680685f27af6ddfa7391261776247561439b98c4914ae1c93c">+10/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storeAccessor.ts</strong><dd><code>Expose accurate clip snapshots to AI agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-03ec3c4960e952497a36b3cc1aee0c0e43a8861c8d68d08598db959b14420d63">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>useClipDrag.ts</strong><dd><code>Update trim behavior to support reverse and freeze-frame</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-c51ac0077bb58bb91382160c3bd0373bc674a34283874fd2a0914c28cd4a71ca">+107/-23</a></td>

</tr>

<tr>
  <td><strong>useSlideEdit.ts</strong><dd><code>Refactor slide edits to use centralized trim boundaries</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-3f1bf17fa9031205b19c548e8e03b9851b06c3913a0e58529f5b3c853f3f25cb">+53/-49</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useRollEdit.ts</strong><dd><code>Refactor roll edits with advanced timing support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-8c2e295b0d6cfdccd677b8c1e9993646584f676ec3dfe077a9d8f2b1f1e5567b">+34/-55</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useTranscriptEditing.ts</strong><dd><code>Map transcript seeks through advanced clip timing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-de912b25ad0d8f1b3b71d38b2d1d53e7f71b989c96eb5a29c95868697e87ea7e">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EditorView.tsx</strong><dd><code>Sanitize selection state on sequence changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-382f457b2b2ae7d56d3a83f74c92b764a355a1f23c23ae7bb103d3ad306a63da">+12/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clipLinking.ts</strong><dd><code>Propagate linked trims through reverse clip companions</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-6a44e21e1860da1b4b05edf0dbe34f087f75703d0cb9b26df862d758fce770ac">+44/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useVideoSync.ts</strong><dd><code>Sync video playback using centralized timing model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-04316ab030ec5fd1d395f37eba848b6523457d99e62ffebbd95440d483cd45dd">+10/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DockableEditorLayout.tsx</strong><dd><code>Stabilize active tab fallback in center monitor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-1d2026f6ad29f7ed1f464eb483e0ac1796a0357998178cb6b56a66fc595d3776">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAudioPlayback.ts</strong><dd><code>Align audio scheduling with computed clip timing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cf">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>clipTiming.test.ts</strong><dd><code>Add unit tests for centralized timing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-ae4a687e28102c4136c11294a96f27f1634cb3227d0c4800d74b5cc70ecdd95a">+44/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useClipDrag.test.ts</strong><dd><code>Test reverse clip trimming and boundary clamping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-c45c6a9e95a71895bb9c70f16724ea6fe0c133372fc5cc6b51058b9a649ec463">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useVideoSync.utils.test.ts</strong><dd><code>Verify source-to-timeline mapping for complex clips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-88c79cc246ec026f1b819ac15e2488f1e37d26b4203da4c92dab91393b0f8165">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useTranscriptEditing.test.ts</strong><dd><code>Test transcript seeking on reversed media</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-e798f5f2509b8c9c2ec2084f9e3a6fe1d222e3d114d7b9a3763c323cfc231d68">+37/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useClipboard.test.ts</strong><dd><code>Verify freeze-frame duration persistence in clipboard</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-85d373d1831a3c7dfb612db3aa8483db479cdc7a21d68f9daa6375e903ab1102">+27/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AddTextDialog.test.tsx</strong><dd><code>Test overlap detection against freeze-frame clips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-96d7a501877b17c13ab517d444ad619600974dc9521e379eb46d89aa12408571">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>40 files</summary><table>
<tr>
  <td><strong>clip.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-2b6c9e796cc9a63d9e704761fef21629435147a53fdf5249a85cf03e4e9cf6d0">+70/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-a0a985993666555ca078f63169c5db73b3f76b54ab9f35f719b881ecb932df59">+30/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysisTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-717609a79d522c08834e29f962677b6c063796dd112f1c4bf93d697292f48a4a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>editingTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-feff783abcf967fed37830f7fe4794b447012a538bea6a9d96f778cd37b01c7d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Inspector.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-d4baf848d3d3c346a280c4049f8adf0ff0b20052bb6cf927f6f7163a92614947">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AddTextDialog.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-cc909bc9ed04d1a5672b789d36221675dc8a034cf5aaedd8e4f6e28a7c8ee6af">+2/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AudioRubberBand.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-5f908d1e83840212013fa2d3fa6960623aba9e0685729d106f56d5a05e89b900">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimelineTrackRows.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-b07db08bfb83c1a9b7724a1d33b60611ea00d75a7f792c0c0a9d50e2ab312b2d">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Track.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-3c7bff0b7b1877671f6af986cc033b1256b8b850bbfd1d55ac2b34d5be04b4d0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TransitionZone.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-5dbf444756fc4eb0dd8a78a2ec76b86b66ac41471c4c6a170b52cefe48648262">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAdvancedEditModes.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-f8167857c084b7e42cea4901043bc4b666ec963c93e133f60f0849a12f325115">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAudioPlaybackWithEffects.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-9fcddb2a993579e15e97cfedee0fb1a8735a3b1f983936bf93a9711913f88802">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAudioScrubbing.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-2e49c51ca8463093187e43265a50c1b7fa0c8b06267fa42656aadf2ec9c4f391">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useClipboard.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-b3beb336248eb6ca237ab81907f9b8d5bd5e3f0d9b597aac1b7d5d3c0aac8f56">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useEnhancedKeyboardShortcuts.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-1df383746f7f1daa5ae889a34e70b1ebcd02656e75367bb7776599c7f48f1cf7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>usePreviewMode.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-69d58c4cdc6e3faccda1a977b18588371f4f4b76108de1bde4180d6df2c9c596">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>usePreviewSource.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-194df0f0ea0f25de475fd52fb59a9521c8b9781fda3186d5b4c0b96ad5ed52e0">+3/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRazorTool.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-a09130ff0c6c111467f26a7fa1255e8fdb4be57fe0536be34b0f83650ec3a2d4">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRazorTool.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-d72db41717c8ed4f1227df69326ab406f9aadfb773dcae5e8221e7b8a48360e7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useReferenceComparison.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-81e8f82bef4e5be9a747887c76d443e19a634994f8c6b30432f895fb66959a9f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRippleEdit.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-2d885c8ef670be13987adcac797814b9e41c4d805092610b7bea22f87810c9d8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useSelectionBox.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-c0bbee7bda435b92278f07d682aa899fc7af20cbb1ecd69364b6481ae7b35edd">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useTimelineClipOperations.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-81c81b2e2492fcfb601427c9fbcb678e3d8aa9b26fc0c215779517ddeeaa57c1">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useTimelineClipOperations.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-3c0f8748d0fee4ad6bb79f0c3ed1a66766d1d7f6d80a9d13a47146ebbf91ab7c">+25/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useTimelineCoordinates.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-6794c80c4bc305d8821b84cc6dc267f61bc60e131d0b1f73d3b4d6f6b3378f0b">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useTransitionZones.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-8444e195cd1b0ea5a468097f547162de301dc9fd4e6315dcb640519df4be73bf">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useVirtualizedClips.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-b2ae5cd2a4ec03a26a1be18cd0edebf96478a08514ee09d9ab4bc4114d987a8d">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useVirtualizedClips.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-2cf0b88b46995fb3c863e69cfb0916b479d9852a92fbbd45461b7fa187aa5f3e">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnapPointManager.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-8b0e95676c5c496b22ca04e71c93eec89a4e7f5920ad620be8c2a73674b3656b">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SnapPointManager.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-7ec2c64ef3703bb40dbd4ab0faca9d0f8027fa9e8bbff2e347dd54d3f7549e92">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>timelineStore.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-714017970f2cdd0ed858a504ddc9323237070406860afffc0dbaeec4a8247aac">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>timelineStore.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-800f9fe3c9d99b3d7e14a8f27d7fb031ad3eb762199825a0d50282bfa13e6762">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceLayoutStore.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-c1d0d7dd985c79782311335e52f9aa870e2715231250d28f8f85a29de425c216">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clipAudio.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-0d81ce8cd72e2403d9b3918e4a5338b2b3d0824506351412d0963189ef36bac1">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clipAudio.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-750729cbe56ce0ace638991d41aa281a052dd7a4e7855658444d7d429bde9c70">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clipLinking.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-29a6340e9fafabdb2edab10ebcddddcf8368ab1a1ffdd9e181d903d23c8e99cc">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dropValidity.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-9fb9f9c5e48a5c0a3f1e1f9c0b50a76ff7eff33828ffacc09172fa414fda355a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dropValidity.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-5d8aea9dc1e855f07de9cab8e92d549c76e0830b1b99a072c679abeb52d9376c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playheadRazor.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-1f4c13e33b0cdcdb1d227e1c283dd7d58f16df656f7c92dc68cda0bbb93b1476">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playheadRazor.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/631/files#diff-7135390677c3701e2936cf52e87129faba27eb81a57d68fe825625cddb4faebd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for freeze-frame clips with customizable timeline duration.
  * Introduced compound sequence clips for nesting sequences within clips.
  * Enhanced reverse playback and time-remap curve evaluation.

* **Improvements**
  * Trimming controls now properly disabled for freeze-frame and time-remapped clips.
  * Centralized clip timing calculations for improved accuracy and consistency across the timeline.

* **Bug Fixes**
  * Fixed overlap detection and gap calculations to respect explicit clip durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->