### PR TITLE
Fix timeline responsive scroll bounds

### DIFF
--- a/src/components/timeline/CaptionTrack.tsx
+++ b/src/components/timeline/CaptionTrack.tsx
@@ -203,7 +203,7 @@ export function CaptionTrack({
         data-track-row="true"
         data-track-id={track.id}
         data-track-kind="caption"
-        className="flex border-b border-editor-border"
+        className="flex min-w-0 border-b border-editor-border"
       >
         {/* Track Header */}
         <div
@@ -276,7 +276,7 @@ export function CaptionTrack({
         <div
           ref={contentRef}
           data-testid="caption-track-content"
-          className={`flex-1 bg-editor-bg relative overflow-hidden ${
+          className={`min-w-0 flex-1 bg-editor-bg relative overflow-hidden ${
             !track.visible ? 'opacity-50' : ''
           }`}
           style={{ height: TRACK_HEIGHT }}

--- a/src/components/timeline/Clip.test.tsx
+++ b/src/components/timeline/Clip.test.tsx
@@ -225,7 +225,7 @@ describe('Clip', () => {
       expect(screen.queryByTestId('video-audio-source-tag')).not.toBeInTheDocument();
     });
 
-    it('should allow label overflow for audio-style clips', () => {
+    it('should keep audio-style labels contained within the clip bounds', () => {
       render(
         <Clip
           clip={{ ...mockClip, label: undefined }}
@@ -241,7 +241,10 @@ describe('Clip', () => {
         />,
       );
 
-      expect(screen.getByTestId('clip-clip_001')).toHaveClass('overflow-visible');
+      expect(screen.getByTestId('clip-clip_001')).toHaveClass('overflow-hidden');
+      expect(screen.getByText('Very long audio source label that must remain visible')).toHaveClass(
+        'text-ellipsis',
+      );
     });
   });
 

--- a/src/components/timeline/Clip.tsx
+++ b/src/components/timeline/Clip.tsx
@@ -337,7 +337,6 @@ export function Clip({
   const showVideoAudioSourceTag =
     !isText && Boolean(waveformConfig?.isVideoSource) && !thumbnailConfig?.enabled;
   const showAudioLabelBackdrop = !isText && !thumbnailConfig?.enabled;
-  const allowLabelOverflow = showAudioLabelBackdrop;
   const showAudioEditorControls = !isText && trackKind === 'audio';
   const showAudioAutomationEditor = (clip.audio?.volumeKeyframes?.length ?? 0) >= 1;
 
@@ -351,8 +350,7 @@ export function Clip({
     <div
       data-testid={`clip-${clip.id}`}
       className={`
-        absolute h-full rounded-sm cursor-pointer transition-shadow select-none
-        ${allowLabelOverflow ? 'overflow-visible' : 'overflow-hidden'}
+        absolute h-full overflow-hidden rounded-sm cursor-pointer transition-shadow select-none
         ${selected ? 'ring-2 ring-primary-400 z-10' : clip.groupId ? 'ring-1 ring-emerald-400/70' : ''}
         ${disabled ? 'cursor-not-allowed' : 'hover:brightness-110'}
         ${isDragging ? 'z-20' : ''}
@@ -444,12 +442,12 @@ export function Clip({
 
       {/* Clip content */}
       <div
-        className={`h-full p-1 pointer-events-none relative z-10 ${allowLabelOverflow ? 'overflow-visible' : 'overflow-hidden'}`}
+        className="h-full p-1 pointer-events-none relative z-10 overflow-hidden"
       >
         {/* Label */}
         {displayLabel && (
           <span
-            className={`text-xs text-white block max-w-full drop-shadow-sm ${showAudioLabelBackdrop ? 'inline-block rounded bg-black/55 px-1.5 py-0.5 whitespace-nowrap' : 'truncate'}`}
+            className={`text-xs text-white block max-w-full drop-shadow-sm ${showAudioLabelBackdrop ? 'inline-block overflow-hidden text-ellipsis whitespace-nowrap rounded bg-black/55 px-1.5 py-0.5 align-top' : 'truncate'}`}
           >
             {displayLabel}
           </span>

--- a/src/components/timeline/EnhancedTimelineToolbar.tsx
+++ b/src/components/timeline/EnhancedTimelineToolbar.tsx
@@ -313,12 +313,12 @@ function EnhancedTimelineToolbarComponent({
   return (
     <div
       data-testid="enhanced-timeline-toolbar"
-      className="flex items-center justify-between gap-2 px-2 py-1 bg-editor-sidebar border-b border-editor-border"
+      className="flex min-h-[38px] min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-editor-border bg-editor-sidebar px-2 py-1 lg:justify-between"
       tabIndex={0}
       onKeyDown={handleKeyDown}
     >
       {/* Left Section: Tools and Editing Actions */}
-      <div className="flex items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1">
         {/* Tool Selection */}
         <div className="flex items-center gap-0.5 bg-editor-panel/50 rounded p-0.5">
           <ToolButton tool="select" activeTool={activeTool} onClick={handleToolChange} />
@@ -455,7 +455,7 @@ function EnhancedTimelineToolbarComponent({
       </div>
 
       {/* Center Section: Playback Controls and Timecode */}
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         {/* Playback Controls */}
         <div className="flex items-center gap-0.5">
           <button
@@ -517,7 +517,7 @@ function EnhancedTimelineToolbarComponent({
       </div>
 
       {/* Right Section: View Controls */}
-      <div className="flex items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1">
         {/* Mode Toggles */}
         <button
           data-testid="snap-toggle-button"

--- a/src/components/timeline/TimeRuler.test.tsx
+++ b/src/components/timeline/TimeRuler.test.tsx
@@ -161,10 +161,21 @@ describe('TimeRuler', () => {
       const mockCtx = createMockContext();
       HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(mockCtx);
 
-      render(<TimeRuler duration={60} zoom={100} scrollX={0} viewportWidth={800} />);
+      const { container } = render(
+        <TimeRuler duration={60} zoom={100} scrollX={0} viewportWidth={800} />,
+      );
 
       // Canvas should be sized based on viewport + buffer
       expect(mockCtx.scale).toHaveBeenCalled();
+      expect(container.querySelector('canvas')).toHaveStyle({ width: '1000px' });
+    });
+
+    it('should cover wide responsive timeline viewports', () => {
+      const { container } = render(
+        <TimeRuler duration={60} zoom={100} scrollX={0} viewportWidth={1400} />,
+      );
+
+      expect(container.querySelector('canvas')).toHaveStyle({ width: '1600px' });
     });
 
     it('should handle scroll offset', () => {

--- a/src/components/timeline/Timeline.test.tsx
+++ b/src/components/timeline/Timeline.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act, createEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act, createEvent, waitFor } from '@testing-library/react';
 import { Timeline } from './Timeline';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { usePlaybackStore } from '@/stores/playbackStore';
@@ -173,6 +173,17 @@ describe('Timeline', () => {
     it('should render time ruler', () => {
       render(<Timeline sequence={mockSequence} />);
       expect(screen.getByTestId('time-ruler')).toBeInTheDocument();
+    });
+
+    it('should size the ruler canvas to the measured timeline viewport', async () => {
+      const { container } = render(<Timeline sequence={mockSequence} />);
+
+      await waitFor(() => {
+        const canvas = container.querySelector('[data-testid="time-ruler"] canvas') as
+          | HTMLCanvasElement
+          | null;
+        expect(canvas?.style.width).toBe('808px');
+      });
     });
 
     it('should render all tracks', () => {
@@ -710,6 +721,36 @@ describe('Timeline', () => {
 
       expect(usePlaybackStore.getState().currentTime).toBe(0);
       expect(document.body.style.cursor).toBe('');
+    });
+
+    it('should clamp empty-area pan to the content width without header overscroll', async () => {
+      useTimelineStore.setState({ scrollX: 350, scrollY: 0 });
+      render(<Timeline sequence={mockSequence} />);
+
+      const tracksArea = screen.getByTestId('timeline-tracks-area');
+
+      await act(async () => {
+        fireEvent.pointerDown(tracksArea, { clientX: 400, clientY: 120, button: 0, pointerId: 5 });
+      });
+
+      await act(async () => {
+        fireEvent.pointerMove(tracksArea, { clientX: 100, clientY: 120, pointerId: 5 });
+      });
+
+      expect(useTimelineStore.getState().scrollX).toBe(392);
+
+      await act(async () => {
+        fireEvent.pointerUp(tracksArea, { clientX: 100, clientY: 120, button: 0, pointerId: 5 });
+      });
+    });
+
+    it('should clamp stale horizontal scroll after viewport measurement changes', async () => {
+      useTimelineStore.setState({ scrollX: 999, scrollY: 0 });
+      render(<Timeline sequence={mockSequence} />);
+
+      await waitFor(() => {
+        expect(useTimelineStore.getState().scrollX).toBe(392);
+      });
     });
 
     it('should treat mostly vertical empty-area movement as click seek, not horizontal pan', async () => {

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -516,11 +516,23 @@ export function Timeline({
   // ===========================================================================
   // Timeline Panning (Hand Tool / Middle Mouse)
   // ===========================================================================
-  const maxScrollX = Math.max(0, duration * zoom - viewportWidth + TRACK_HEADER_WIDTH);
+  const maxScrollX = Math.max(0, duration * zoom - viewportWidth);
   const maxScrollY = Math.max(0, (sequence?.tracks.length ?? 0) * TRACK_HEIGHT - viewportHeight);
   const isHandToolActive = activeTool === 'hand';
 
   const { segments: cacheSegments } = useRenderCache();
+
+  useEffect(() => {
+    if (scrollX > maxScrollX) {
+      setScrollX(maxScrollX);
+    }
+  }, [maxScrollX, scrollX, setScrollX]);
+
+  useEffect(() => {
+    if (scrollY > maxScrollY) {
+      setScrollY(maxScrollY);
+    }
+  }, [maxScrollY, scrollY, setScrollY]);
 
   const { isPanning, handleMouseDown: handlePanMouseDown } = useTimelinePan({
     scrollX,
@@ -1966,6 +1978,7 @@ export function Timeline({
             duration={duration}
             zoom={zoom}
             scrollX={scrollX}
+            viewportWidth={viewportWidth}
             onSeek={handleSeek}
             onWheel={handleWheel}
           />

--- a/src/components/timeline/TimelineRenderLayers.tsx
+++ b/src/components/timeline/TimelineRenderLayers.tsx
@@ -62,6 +62,7 @@ export interface TimelineHeaderLayerProps {
   duration: number;
   zoom: number;
   scrollX: number;
+  viewportWidth: number;
   onSeek: (time: number) => void;
   onWheel: WheelEventHandler<HTMLDivElement>;
 }
@@ -71,6 +72,7 @@ export function TimelineHeaderLayer({
   duration,
   zoom,
   scrollX,
+  viewportWidth,
   onSeek,
   onWheel,
 }: TimelineHeaderLayerProps): JSX.Element {
@@ -87,7 +89,13 @@ export function TimelineHeaderLayer({
             data-testid="timeline-ruler-scroll-layer"
             style={{ transform: `translateX(-${scrollX}px)` }}
           >
-            <TimeRuler duration={duration} zoom={zoom} scrollX={scrollX} onSeek={onSeek} />
+            <TimeRuler
+              duration={duration}
+              zoom={zoom}
+              scrollX={scrollX}
+              viewportWidth={viewportWidth}
+              onSeek={onSeek}
+            />
           </div>
         </div>
       </div>

--- a/src/components/timeline/Track.tsx
+++ b/src/components/timeline/Track.tsx
@@ -702,7 +702,7 @@ export function Track({
         data-track-row="true"
         data-track-id={track.id}
         data-track-kind={track.kind}
-        className="flex border-b border-editor-border"
+        className="flex min-w-0 border-b border-editor-border"
       >
         {/* Track Header */}
         <div
@@ -793,7 +793,7 @@ export function Track({
           data-drop-target={isDropTarget}
           data-drop-valid={dropValidity?.isValid}
           className={`
-            flex-1 bg-editor-bg relative overflow-hidden transition-colors duration-100
+            min-w-0 flex-1 bg-editor-bg relative overflow-hidden transition-colors duration-100
             ${!track.visible ? 'opacity-50' : ''}
             ${isDropTarget && dropValidity?.isValid ? 'bg-blue-500/10 ring-1 ring-blue-500/50 ring-inset' : ''}
             ${isDropTarget && dropValidity && !dropValidity.isValid ? 'bg-red-500/10 ring-1 ring-red-500/50 ring-inset' : ''}


### PR DESCRIPTION
### **User description**
## Description

Fixes responsive timeline overflow and scroll-bound issues. The timeline now clamps stale scroll positions against measured viewport bounds, sizes the ruler from the actual viewport width, and keeps narrow timeline rows, toolbar controls, and audio-style clip labels contained.

## Related Issue

Closes #639
Closes #640

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Clamp timeline horizontal and vertical scroll values after viewport bounds change, and remove header-width overscroll from the horizontal max scroll calculation.
- Pass the measured timeline viewport width into the ruler layer so the ruler canvas covers responsive layouts.
- Contain narrow timeline row, toolbar, and clip label overflow with `min-w-0`, horizontal toolbar scrolling, and ellipsis-constrained audio labels.

## Screenshots / Videos

Not applicable.

## Testing

Validated locally with type checking, focused timeline tests, and the repository pre-commit checks for both commits.

### Test Environment

- OS: Linux WSL2
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Commands run:

- `npm run type-check`
- `TMPDIR=/tmp TMP=/tmp TEMP=/tmp npm run test:run -- src/components/timeline/Timeline.test.tsx src/components/timeline/TimeRuler.test.tsx src/components/timeline/Clip.test.tsx`

Pre-commit also ran `version:check`, `type-check`, and `lint` for each commit. Lint completed with 0 errors and the existing 19 warnings.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Clamps timeline scroll positions to measured bounds.

- Fixes ruler sizing using actual viewport width.

- Prevents layout overflow in narrow viewports.

- Constrains audio clip labels with ellipsis truncation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph UI_Fixes["UI & Layout"]
    A["Toolbar"] -- "Horizontal Scroll" --> B["Narrow Viewports"]
    C["Clip Labels"] -- "Ellipsis Truncation" --> D["Overflow Prevention"]
  end
  subgraph Logic_Fixes["Scroll & Ruler"]
    E["Timeline Store"] -- "Clamp Scroll" --> F["Viewport Bounds"]
    G["TimeRuler"] -- "Dynamic Width" --> H["Responsive Canvas"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>Timeline.tsx</strong><dd><code>Clamp scroll positions and update max scroll logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-aa6135079648e8794f963c931644d6f4084fadee28e27a737af5a23e7d6a089d">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimelineRenderLayers.tsx</strong><dd><code>Pass viewport width to timeline header layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-17e8ef8978a82d9bd831f7fb09f40e823afb4734dbb8bf447db8e9fe17f132aa">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Track.tsx</strong><dd><code>Prevent track row overflow with min-width zero</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-3c7bff0b7b1877671f6af986cc033b1256b8b850bbfd1d55ac2b34d5be04b4d0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CaptionTrack.tsx</strong><dd><code>Apply min-width constraints to caption tracks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-32f8cb050f03fb24c93b5aa5e06833154976013a8f980b35f6f751bd247e64f3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Clip.tsx</strong><dd><code>Contain clip labels and enforce overflow hidden</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-66869f8820472d680685f27af6ddfa7391261776247561439b98c4914ae1c93c">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EnhancedTimelineToolbar.tsx</strong><dd><code>Enable horizontal scrolling for toolbar controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-9e1af788c02ffa27c1e8ad687dd438c02027eda1c083e86c9fc45de72c3aa35d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>Timeline.test.tsx</strong><dd><code>Add tests for scroll clamping and ruler sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-fc2a8dfbed110e1d3ce4f3339bbefdbc16b74244f5fe9b00a3e56152bcafa802">+42/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Clip.test.tsx</strong><dd><code>Update clip tests for label containment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-cc1c406d945a17f26679fd6ab90394f513723d7552ab5ea4b43318a4f17653c4">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimeRuler.test.tsx</strong><dd><code>Add tests for responsive ruler viewport coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/641/files#diff-ae1ce6e3eedc733bafc280fec0b53db051d9ded29a606d91000a6c64677b9468">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text truncation and overflow handling in timeline captions and clips for improved readability in constrained layouts.
  * Timeline toolbar now supports horizontal scrolling for better content navigation when space is limited.
  * Improved scroll boundary enforcement to prevent unintended overscroll during timeline panning.

* **Tests**
  * Expanded coverage for viewport measurements, canvas sizing, and scroll clamping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->