### PR TITLE
feat(export): add structured exports and inline artifact review

### DIFF
--- a/src-tauri/src/bin/export_bindings.rs
+++ b/src-tauri/src/bin/export_bindings.rs
@@ -28,10 +28,54 @@ fn normalize_bindings(path: &std::path::Path) {
             "if(e instanceof Error) throw e;\n    else return { status: \"error\", error: e  as any };\n",
             "return { status: \"error\", error: e  as any };\n",
         );
+    let normalized = normalize_unstable_type_line_spacing(&normalized);
 
     if normalized != contents {
         let _ = fs::write(path, normalized);
     }
+}
+
+fn normalize_unstable_type_line_spacing(input: &str) -> String {
+    let mut in_batch_render_item = false;
+    let mut normalized = input
+        .lines()
+        .map(|line| {
+            // Keep the generated output stable for newly documented union and DTO lines without
+            // rewriting the legacy trailing-space style across the entire bindings file.
+            if line.starts_with("export type BatchRenderItemDto =") {
+                in_batch_render_item = true;
+            }
+
+            let normalized_line = if in_batch_render_item && line == "outPoint: number | null; " {
+                "outPoint: number | null;"
+            } else {
+                line
+            };
+
+            if in_batch_render_item && line.starts_with("settings?: VideoExportRequest") {
+                in_batch_render_item = false;
+            }
+
+            match line {
+                "export type ContainerFormat = " => "export type ContainerFormat =",
+                "\"mp4\" | " => "\"mp4\" |",
+                "\"mov\" | " => "\"mov\" |",
+                "export type ExportQualityTier = " => "export type ExportQualityTier =",
+                "\"draft\" | " => "\"draft\" |",
+                "\"standard\" | " => "\"standard\" |",
+                "\"high\" | " => "\"high\" |",
+                "\"master\" | " => "\"master\" |",
+                _ => normalized_line,
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if input.ends_with('\n') {
+        normalized.push('\n');
+    }
+
+    normalized
 }
 
 fn main() {

--- a/src-tauri/src/core/jobs/payloads.rs
+++ b/src-tauri/src/core/jobs/payloads.rs
@@ -8,7 +8,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::{fs::validate_path_id_component, AssetId, ClipId, SequenceId, TimeSec, TrackId};
+use crate::core::{
+    fs::validate_path_id_component, render::VideoExportRequest, AssetId, ClipId, SequenceId,
+    TimeSec, TrackId,
+};
 
 const MAX_JOB_PAYLOAD_BYTES: usize = 256 * 1024; // 256KiB
 
@@ -280,6 +283,7 @@ pub struct FinalRenderJobPayload {
     pub sequence_id: SequenceId,
     pub output_path: String,
     pub preset: Option<String>,
+    pub settings: Option<VideoExportRequest>,
 }
 
 impl FinalRenderJobPayload {
@@ -496,6 +500,42 @@ mod tests {
             ValidatedJobPayload::Transcription(p) => {
                 assert_eq!(p.model, "tiny");
                 assert!(p.translate);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn accepts_structured_final_render_settings() {
+        let payload = serde_json::json!({
+            "sequenceId": "seq_001",
+            "outputPath": "/tmp/out.mp4",
+            "preset": "mp4-high",
+            "settings": {
+                "container": "mp4",
+                "videoCodec": "h264",
+                "audioCodec": "aac",
+                "qualityTier": "high",
+                "width": 1920,
+                "height": 1080,
+                "fps": 30.0,
+                "videoBitrate": "15M",
+                "audioBitrate": "320k",
+                "crf": 18,
+                "twoPass": false
+            }
+        });
+
+        let parsed = ValidatedJobPayload::parse(&JobType::FinalRender, payload).unwrap();
+
+        match parsed {
+            ValidatedJobPayload::FinalRender(p) => {
+                let settings = p.settings.expect("structured settings should parse");
+                assert_eq!(
+                    settings.quality_tier,
+                    crate::core::render::ExportQualityTier::High
+                );
+                assert_eq!(settings.width, Some(1920));
             }
             _ => panic!("wrong variant"),
         }

--- a/src-tauri/src/core/jobs/worker.rs
+++ b/src-tauri/src/core/jobs/worker.rs
@@ -101,6 +101,17 @@ where
     }
 }
 
+fn parse_optional_video_export_request(
+    payload: &serde_json::Value,
+) -> Result<Option<crate::core::render::VideoExportRequest>, String> {
+    match payload.get("settings") {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|e| format!("Invalid export settings payload: {e}")),
+    }
+}
+
 // =============================================================================
 // Job Handle
 // =============================================================================
@@ -1436,6 +1447,7 @@ impl JobProcessor {
     /// * `sequenceId` (required) - ID of the sequence to render
     /// * `outputPath` (required) - Destination path
     /// * `preset` (optional) - Export preset name (default: "youtube_1080p")
+    /// * `settings` (optional) - Structured video export settings
     ///
     /// # Events
     ///
@@ -1514,20 +1526,23 @@ impl JobProcessor {
             let validated_output_path =
                 validate_scoped_output_path(output_path_str, "outputPath", &root_refs)?;
 
-            // 3. Configure Export Settings
-            let export_preset = match preset_name.to_lowercase().as_str() {
-                "youtube_1080p" | "youtube1080p" => ExportPreset::Youtube1080p,
-                "youtube_4k" | "youtube4k" => ExportPreset::Youtube4k,
-                "youtube_shorts" | "youtubeshorts" => ExportPreset::YoutubeShorts,
-                "twitter" => ExportPreset::Twitter,
-                "instagram" => ExportPreset::Instagram,
-                "webm" | "webm_vp9" => ExportPreset::WebmVp9,
-                "prores" => ExportPreset::ProRes,
-                _ => ExportPreset::Youtube1080p,
-            };
+            // 3. Configure export settings.
+            let structured_settings = parse_optional_video_export_request(&job.payload)?;
 
-            let settings =
-                ExportSettings::from_preset(export_preset, validated_output_path.clone());
+            let settings = match structured_settings.as_ref() {
+                Some(request) => ExportSettings::from_video_request(
+                    request,
+                    validated_output_path.clone(),
+                    None,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+                None => {
+                    let export_preset =
+                        ExportPreset::from_legacy_id(preset_name).map_err(|e| e.to_string())?;
+                    ExportSettings::from_preset(export_preset, validated_output_path.clone())
+                }
+            };
 
             // 4. Validate export feasibility
             let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
@@ -2240,6 +2255,43 @@ mod tests {
         assert_eq!(sequence_id, Some("seq_002"));
         assert_eq!(start_time, None); // Optional, not provided
         assert_eq!(end_time, None); // Optional, not provided
+    }
+
+    #[test]
+    fn parses_optional_video_export_request_null_as_absent() {
+        let payload = serde_json::json!({
+            "settings": null
+        });
+
+        let parsed = parse_optional_video_export_request(&payload).unwrap();
+
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parses_optional_video_export_request_object() {
+        let payload = serde_json::json!({
+            "settings": {
+                "container": "mp4",
+                "videoCodec": "h264",
+                "audioCodec": "aac",
+                "qualityTier": "high",
+                "width": 1920,
+                "height": 1080,
+                "fps": 30.0,
+                "videoBitrate": "15M",
+                "audioBitrate": "320k",
+                "crf": 18,
+                "twoPass": false
+            }
+        });
+
+        let parsed = parse_optional_video_export_request(&payload)
+            .unwrap()
+            .expect("settings should parse");
+
+        assert_eq!(parsed.video_codec, crate::core::render::VideoCodec::H264);
+        assert_eq!(parsed.width, Some(1920));
     }
 
     #[test]

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -9,6 +9,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use specta::Type;
 use tokio::sync::mpsc::Sender;
 
 use crate::core::{
@@ -238,6 +239,10 @@ fn sequence_has_exportable_audio(
 pub enum ExportPreset {
     /// YouTube 1080p (H.264, AAC)
     Youtube1080p,
+    /// Draft MP4 (H.264, AAC, 720p)
+    Mp4Draft,
+    /// High quality MP4 (H.264, AAC, 1080p)
+    Mp4High,
     /// YouTube 4K (H.264, AAC)
     Youtube4k,
     /// YouTube Shorts (Vertical 1080x1920)
@@ -254,22 +259,51 @@ pub enum ExportPreset {
     Custom,
 }
 
+impl ExportPreset {
+    /// Parse a legacy preset identifier.
+    pub fn from_legacy_id(preset: &str) -> Result<Self, ExportError> {
+        let normalized = preset.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+
+        match normalized.as_str() {
+            "youtube_1080p" | "youtube1080p" | "youtube_1080" | "mp4_h264_1080p" => {
+                Ok(Self::Youtube1080p)
+            }
+            "mp4_draft" | "mp4_h264_720p" | "mp4_h264_draft" => Ok(Self::Mp4Draft),
+            "mp4_high" | "mp4_h264_high" | "mp4_h264_1080p_high" => Ok(Self::Mp4High),
+            "youtube_4k" | "youtube4k" | "youtube_2160p" | "mp4_h264_4k" | "mp4_h264_2160p" => {
+                Ok(Self::Youtube4k)
+            }
+            "youtube_shorts" | "youtubeshorts" | "shorts_reels" => Ok(Self::YoutubeShorts),
+            "twitter" => Ok(Self::Twitter),
+            "instagram" => Ok(Self::Instagram),
+            "webm" | "webm_vp9" | "webm_vp9_1080p" | "webm_vp9_720p" => Ok(Self::WebmVp9),
+            "prores" | "prores_422" => Ok(Self::ProRes),
+            other => Err(ExportError::InvalidSettings(format!(
+                "Unknown export preset: {other}"
+            ))),
+        }
+    }
+}
+
 /// Video codec selection
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum VideoCodec {
     H264,
     H265,
+    #[serde(rename = "vp9")]
     Vp9,
+    #[serde(rename = "prores")]
     ProRes,
     Copy,
 }
 
 /// Audio codec selection
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum AudioCodec {
     Aac,
+    #[serde(rename = "mp3")]
     Mp3,
     Opus,
     Pcm,
@@ -277,7 +311,7 @@ pub enum AudioCodec {
 }
 
 /// HDR (High Dynamic Range) mode for export
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum HdrMode {
     /// SDR (Standard Dynamic Range) - default
@@ -289,6 +323,65 @@ pub enum HdrMode {
     /// HLG (Hybrid Log-Gamma) HDR format
     /// Compatible with both HDR and SDR displays
     Hlg,
+}
+
+/// Output media container.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ContainerFormat {
+    /// MPEG-4 container, typically H.264/H.265 + AAC.
+    #[default]
+    #[serde(rename = "mp4")]
+    Mp4,
+    /// QuickTime container for ProRes/H.264/H.265 delivery and masters.
+    Mov,
+    /// WebM container for VP9/Opus delivery.
+    Webm,
+}
+
+impl ContainerFormat {
+    pub fn extension(&self) -> &'static str {
+        match self {
+            Self::Mp4 => "mp4",
+            Self::Mov => "mov",
+            Self::Webm => "webm",
+        }
+    }
+}
+
+/// User-facing quality tier that maps to concrete encoder settings.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportQualityTier {
+    /// Fast, lower-bitrate review export.
+    Draft,
+    /// Balanced default delivery.
+    #[default]
+    Standard,
+    /// Higher-quality web delivery.
+    High,
+    /// Editing/mastering-oriented output.
+    Master,
+    /// Caller supplied explicit bitrate/CRF settings.
+    Custom,
+}
+
+/// Structured video export request used by UI and agent-driven export paths.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoExportRequest {
+    pub container: ContainerFormat,
+    pub video_codec: VideoCodec,
+    pub audio_codec: AudioCodec,
+    pub quality_tier: ExportQualityTier,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub fps: Option<f64>,
+    pub video_bitrate: Option<String>,
+    pub audio_bitrate: Option<String>,
+    pub crf: Option<u8>,
+    #[serde(default)]
+    pub two_pass: bool,
 }
 
 /// Export settings
@@ -419,6 +512,50 @@ impl ExportSettings {
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
             },
+            ExportPreset::Mp4Draft => Self {
+                preset: ExportPreset::Mp4Draft,
+                output_path,
+                video_codec: VideoCodec::H264,
+                audio_codec: AudioCodec::Aac,
+                width: Some(1280),
+                height: Some(720),
+                video_bitrate: Some("3M".to_string()),
+                audio_bitrate: Some("128k".to_string()),
+                fps: Some(30.0),
+                crf: Some(28),
+                two_pass: false,
+                start_time: None,
+                end_time: None,
+                hdr_mode: HdrMode::Sdr,
+                max_cll: None,
+                max_fall: None,
+                bit_depth: None,
+                tonemap_mode: None,
+                hardware_accel: super::hardware::HardwareAccelMode::default(),
+                resolved_encoder_name: None,
+            },
+            ExportPreset::Mp4High => Self {
+                preset: ExportPreset::Mp4High,
+                output_path,
+                video_codec: VideoCodec::H264,
+                audio_codec: AudioCodec::Aac,
+                width: Some(1920),
+                height: Some(1080),
+                video_bitrate: Some("15M".to_string()),
+                audio_bitrate: Some("320k".to_string()),
+                fps: Some(30.0),
+                crf: Some(18),
+                two_pass: false,
+                start_time: None,
+                end_time: None,
+                hdr_mode: HdrMode::Sdr,
+                max_cll: None,
+                max_fall: None,
+                bit_depth: None,
+                tonemap_mode: None,
+                hardware_accel: super::hardware::HardwareAccelMode::default(),
+                resolved_encoder_name: None,
+            },
             ExportPreset::Youtube4k => Self {
                 preset: ExportPreset::Youtube4k,
                 output_path,
@@ -430,7 +567,7 @@ impl ExportSettings {
                 audio_bitrate: Some("320k".to_string()),
                 fps: Some(30.0),
                 crf: Some(18),
-                two_pass: true,
+                two_pass: false,
                 start_time: None,
                 end_time: None,
                 hdr_mode: HdrMode::Sdr,
@@ -534,11 +671,11 @@ impl ExportSettings {
                 output_path,
                 video_codec: VideoCodec::ProRes,
                 audio_codec: AudioCodec::Pcm,
-                width: Some(1920),
-                height: Some(1080),
+                width: None,
+                height: None,
                 video_bitrate: None,
                 audio_bitrate: None,
-                fps: Some(30.0),
+                fps: None,
                 crf: None,
                 two_pass: false,
                 start_time: None,
@@ -556,6 +693,64 @@ impl ExportSettings {
                 output_path,
                 ..Default::default()
             },
+        }
+    }
+
+    /// Create settings from a structured video export request.
+    pub fn from_video_request(
+        request: &VideoExportRequest,
+        output_path: PathBuf,
+        start_time: Option<f64>,
+        end_time: Option<f64>,
+    ) -> Result<Self, ExportError> {
+        validate_video_export_request(request, &output_path)?;
+
+        Ok(Self {
+            preset: ExportPreset::Custom,
+            output_path,
+            video_codec: request.video_codec.clone(),
+            audio_codec: request.audio_codec.clone(),
+            width: request.width,
+            height: request.height,
+            video_bitrate: request.video_bitrate.clone(),
+            audio_bitrate: request.audio_bitrate.clone(),
+            fps: request.fps,
+            crf: request.crf,
+            two_pass: request.two_pass,
+            start_time,
+            end_time,
+            hdr_mode: HdrMode::Sdr,
+            max_cll: None,
+            max_fall: None,
+            bit_depth: None,
+            tonemap_mode: None,
+            hardware_accel: super::hardware::HardwareAccelMode::default(),
+            resolved_encoder_name: None,
+        })
+    }
+
+    /// Create a structured request from a legacy preset.
+    pub fn request_from_preset(preset: ExportPreset) -> VideoExportRequest {
+        let settings = Self::from_preset(
+            preset.clone(),
+            PathBuf::from(format!(
+                "output.{}",
+                preset_default_container(&preset).extension()
+            )),
+        );
+
+        VideoExportRequest {
+            container: preset_default_container(&preset),
+            video_codec: settings.video_codec,
+            audio_codec: settings.audio_codec,
+            quality_tier: preset_default_quality_tier(&preset),
+            width: settings.width,
+            height: settings.height,
+            fps: settings.fps,
+            video_bitrate: settings.video_bitrate,
+            audio_bitrate: settings.audio_bitrate,
+            crf: settings.crf,
+            two_pass: settings.two_pass,
         }
     }
 
@@ -768,6 +963,247 @@ impl ExportSettings {
     }
 }
 
+fn preset_default_container(preset: &ExportPreset) -> ContainerFormat {
+    match preset {
+        ExportPreset::WebmVp9 => ContainerFormat::Webm,
+        ExportPreset::ProRes => ContainerFormat::Mov,
+        ExportPreset::Youtube1080p
+        | ExportPreset::Mp4Draft
+        | ExportPreset::Mp4High
+        | ExportPreset::Youtube4k
+        | ExportPreset::YoutubeShorts
+        | ExportPreset::Twitter
+        | ExportPreset::Instagram
+        | ExportPreset::Custom => ContainerFormat::Mp4,
+    }
+}
+
+fn preset_default_quality_tier(preset: &ExportPreset) -> ExportQualityTier {
+    match preset {
+        ExportPreset::Mp4Draft | ExportPreset::Twitter => ExportQualityTier::Draft,
+        ExportPreset::Mp4High | ExportPreset::Youtube4k | ExportPreset::WebmVp9 => {
+            ExportQualityTier::High
+        }
+        ExportPreset::ProRes => ExportQualityTier::Master,
+        ExportPreset::Youtube1080p | ExportPreset::YoutubeShorts | ExportPreset::Instagram => {
+            ExportQualityTier::Standard
+        }
+        ExportPreset::Custom => ExportQualityTier::Custom,
+    }
+}
+
+fn output_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.trim_start_matches('.').to_ascii_lowercase())
+}
+
+fn bitrate_is_valid(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() {
+        return false;
+    }
+
+    let split_at = value
+        .find(|ch: char| !ch.is_ascii_digit() && ch != '.')
+        .unwrap_or(value.len());
+    let (number, suffix) = value.split_at(split_at);
+
+    if number.is_empty() || number == "." {
+        return false;
+    }
+
+    let Ok(parsed) = number.parse::<f64>() else {
+        return false;
+    };
+
+    parsed.is_finite()
+        && parsed > 0.0
+        && matches!(
+            suffix.to_ascii_lowercase().as_str(),
+            "" | "k" | "m" | "g" | "kbps" | "mbps"
+        )
+}
+
+fn crf_range_for_codec(codec: &VideoCodec) -> Option<std::ops::RangeInclusive<u8>> {
+    match codec {
+        VideoCodec::H264 | VideoCodec::H265 => Some(0..=51),
+        VideoCodec::Vp9 => Some(0..=63),
+        VideoCodec::ProRes | VideoCodec::Copy => None,
+    }
+}
+
+fn container_supports_video_codec(container: &ContainerFormat, codec: &VideoCodec) -> bool {
+    matches!(
+        (container, codec),
+        (ContainerFormat::Mp4, VideoCodec::H264 | VideoCodec::H265)
+            | (
+                ContainerFormat::Mov,
+                VideoCodec::H264 | VideoCodec::H265 | VideoCodec::ProRes
+            )
+            | (ContainerFormat::Webm, VideoCodec::Vp9)
+    )
+}
+
+fn container_supports_audio_codec(container: &ContainerFormat, codec: &AudioCodec) -> bool {
+    matches!(
+        (container, codec),
+        (ContainerFormat::Mp4, AudioCodec::Aac | AudioCodec::Mp3)
+            | (
+                ContainerFormat::Mov,
+                AudioCodec::Aac | AudioCodec::Mp3 | AudioCodec::Pcm
+            )
+            | (ContainerFormat::Webm, AudioCodec::Opus)
+    )
+}
+
+fn container_supports_extension(container: &ContainerFormat, extension: &str) -> bool {
+    matches!(
+        (container, extension),
+        (ContainerFormat::Mp4, "mp4" | "m4v")
+            | (ContainerFormat::Mov, "mov")
+            | (ContainerFormat::Webm, "webm")
+    )
+}
+
+/// Validate a structured video export request before render setup.
+pub fn validate_video_export_request(
+    request: &VideoExportRequest,
+    output_path: &Path,
+) -> Result<(), ExportError> {
+    let expected_ext = request.container.extension();
+    let actual_ext = output_extension(output_path).ok_or_else(|| {
+        ExportError::InvalidSettings("Output path must include a file extension".to_string())
+    })?;
+    if !container_supports_extension(&request.container, &actual_ext) {
+        return Err(ExportError::InvalidSettings(format!(
+            "Output extension '.{}' does not match selected container '{}'",
+            actual_ext, expected_ext
+        )));
+    }
+
+    if !container_supports_video_codec(&request.container, &request.video_codec) {
+        return Err(ExportError::InvalidSettings(format!(
+            "Container {:?} does not support video codec {:?}",
+            request.container, request.video_codec
+        )));
+    }
+
+    if !container_supports_audio_codec(&request.container, &request.audio_codec) {
+        return Err(ExportError::InvalidSettings(format!(
+            "Container {:?} does not support audio codec {:?}",
+            request.container, request.audio_codec
+        )));
+    }
+
+    match (request.width, request.height) {
+        (Some(width), Some(height)) if width > 0 && height > 0 => {}
+        (None, None) => {}
+        _ => {
+            return Err(ExportError::InvalidSettings(
+                "Export resolution must provide both width and height, or neither".to_string(),
+            ));
+        }
+    }
+
+    if let Some(fps) = request.fps {
+        if !fps.is_finite() || fps <= 0.0 || fps > 240.0 {
+            return Err(ExportError::InvalidSettings(
+                "Frame rate must be greater than 0 and no more than 240 fps".to_string(),
+            ));
+        }
+    }
+
+    if let Some(ref bitrate) = request.video_bitrate {
+        if !bitrate_is_valid(bitrate) {
+            return Err(ExportError::InvalidSettings(format!(
+                "Invalid video bitrate: {bitrate}"
+            )));
+        }
+    }
+
+    if let Some(ref bitrate) = request.audio_bitrate {
+        if !bitrate_is_valid(bitrate) {
+            return Err(ExportError::InvalidSettings(format!(
+                "Invalid audio bitrate: {bitrate}"
+            )));
+        }
+    }
+
+    if let Some(crf) = request.crf {
+        let Some(range) = crf_range_for_codec(&request.video_codec) else {
+            return Err(ExportError::InvalidSettings(format!(
+                "Codec {:?} does not support CRF/CQ quality control",
+                request.video_codec
+            )));
+        };
+        if !range.contains(&crf) {
+            return Err(ExportError::InvalidSettings(format!(
+                "CRF/CQ value {} is outside the supported range for {:?}",
+                crf, request.video_codec
+            )));
+        }
+    }
+
+    if request.two_pass {
+        return Err(ExportError::InvalidSettings(
+            "Two-pass export is not exposed until pass-one/pass-two execution is implemented"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn container_from_output_path(path: &Path) -> Result<ContainerFormat, ExportError> {
+    match output_extension(path).as_deref() {
+        Some("mp4") | Some("m4v") => Ok(ContainerFormat::Mp4),
+        Some("mov") => Ok(ContainerFormat::Mov),
+        Some("webm") => Ok(ContainerFormat::Webm),
+        Some(ext) => Err(ExportError::InvalidSettings(format!(
+            "Unsupported video output extension: .{ext}"
+        ))),
+        None => Err(ExportError::InvalidSettings(
+            "Output path must include a file extension".to_string(),
+        )),
+    }
+}
+
+fn validate_export_settings_options(settings: &ExportSettings) -> Vec<String> {
+    let mut errors = Vec::new();
+    let container = match container_from_output_path(&settings.output_path) {
+        Ok(container) => container,
+        Err(error) => {
+            errors.push(error.to_string());
+            return errors;
+        }
+    };
+
+    let request = VideoExportRequest {
+        container,
+        video_codec: settings.video_codec.clone(),
+        audio_codec: settings.audio_codec.clone(),
+        quality_tier: ExportQualityTier::Custom,
+        width: settings.width,
+        height: settings.height,
+        fps: settings.fps,
+        video_bitrate: settings.video_bitrate.clone(),
+        audio_bitrate: settings.audio_bitrate.clone(),
+        crf: settings.crf,
+        two_pass: settings.two_pass,
+    };
+
+    if let Err(error) = validate_video_export_request(&request, &settings.output_path) {
+        errors.push(error.to_string());
+    }
+
+    if let Some(error) = settings.validate_hdr_settings() {
+        errors.push(error);
+    }
+
+    errors
+}
+
 /// Export progress update
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -819,6 +1255,9 @@ pub struct BatchRenderItem {
     pub in_point: Option<f64>,
     /// Optional Out point in seconds for range export
     pub out_point: Option<f64>,
+    /// Optional structured export settings. When omitted, `preset` is used.
+    #[serde(default)]
+    pub settings: Option<VideoExportRequest>,
 }
 
 /// Status of an individual render job within a batch
@@ -2399,7 +2838,10 @@ impl ExportEngine {
 
         // Quality settings (CRF for software, CQ/QP for hardware encoders)
         if let Some(crf) = settings.crf {
-            if matches!(settings.video_codec, VideoCodec::H264 | VideoCodec::H265) {
+            if matches!(
+                settings.video_codec,
+                VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9
+            ) {
                 args.extend(super::hardware::resolve_quality_args(&video_codec, crf));
             }
         }
@@ -2872,7 +3314,10 @@ impl ExportEngine {
 
         // Quality args (CRF for software, CQ/QP for hardware encoders)
         if let Some(crf) = settings.crf {
-            if matches!(settings.video_codec, VideoCodec::H264 | VideoCodec::H265) {
+            if matches!(
+                settings.video_codec,
+                VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9
+            ) {
                 args.extend(super::hardware::resolve_quality_args(&video_encoder, crf));
             }
         }
@@ -3884,9 +4329,13 @@ pub fn validate_export_settings(
     sequence: &Sequence,
     assets: &std::collections::HashMap<String, Asset>,
     effects: &std::collections::HashMap<String, Effect>,
-    _settings: &ExportSettings,
+    settings: &ExportSettings,
 ) -> ExportValidation {
     let mut validation = ExportValidation::valid();
+
+    for error in validate_export_settings_options(settings) {
+        validation.add_error(error);
+    }
 
     // Check for empty sequence after applying clip-enabled state.
     let total_clips: usize = sequence
@@ -4388,7 +4837,10 @@ pub fn build_complex_filter_args_with_audio_info(
 
     // Quality args (CRF for software, CQ/QP for hardware encoders)
     if let Some(crf) = settings.crf {
-        if matches!(settings.video_codec, VideoCodec::H264 | VideoCodec::H265) {
+        if matches!(
+            settings.video_codec,
+            VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9
+        ) {
             args.extend(super::hardware::resolve_quality_args(&video_encoder, crf));
         }
     }
@@ -5184,6 +5636,28 @@ mod tests {
     }
 
     #[test]
+    fn test_export_preset_mp4_draft() {
+        let settings =
+            ExportSettings::from_preset(ExportPreset::Mp4Draft, PathBuf::from("draft.mp4"));
+
+        assert_eq!(settings.width, Some(1280));
+        assert_eq!(settings.height, Some(720));
+        assert_eq!(settings.video_bitrate, Some("3M".to_string()));
+        assert_eq!(settings.crf, Some(28));
+    }
+
+    #[test]
+    fn test_export_preset_mp4_high() {
+        let settings =
+            ExportSettings::from_preset(ExportPreset::Mp4High, PathBuf::from("high.mp4"));
+
+        assert_eq!(settings.width, Some(1920));
+        assert_eq!(settings.height, Some(1080));
+        assert_eq!(settings.video_bitrate, Some("15M".to_string()));
+        assert_eq!(settings.crf, Some(18));
+    }
+
+    #[test]
     fn test_export_preset_youtube_shorts() {
         let settings =
             ExportSettings::from_preset(ExportPreset::YoutubeShorts, PathBuf::from("shorts.mp4"));
@@ -5200,6 +5674,141 @@ mod tests {
 
         assert_eq!(settings.video_codec, VideoCodec::Vp9);
         assert_eq!(settings.audio_codec, AudioCodec::Opus);
+    }
+
+    #[test]
+    fn test_export_preset_prores_master_preserves_sequence_format() {
+        let settings =
+            ExportSettings::from_preset(ExportPreset::ProRes, PathBuf::from("master.mov"));
+
+        assert_eq!(settings.video_codec, VideoCodec::ProRes);
+        assert_eq!(settings.audio_codec, AudioCodec::Pcm);
+        assert_eq!(settings.width, None);
+        assert_eq!(settings.height, None);
+        assert_eq!(settings.fps, None);
+    }
+
+    /// Feature: Structured video export requests
+    /// Scenario: should convert legacy YouTube preset to an explicit request
+    #[test]
+    fn video_export_request_should_convert_legacy_youtube_preset() {
+        let preset = ExportPreset::from_legacy_id("youtube_1080p").unwrap();
+        let request = ExportSettings::request_from_preset(preset);
+
+        assert_eq!(request.container, ContainerFormat::Mp4);
+        assert_eq!(request.video_codec, VideoCodec::H264);
+        assert_eq!(request.audio_codec, AudioCodec::Aac);
+        assert_eq!(request.quality_tier, ExportQualityTier::Standard);
+        assert_eq!(request.width, Some(1920));
+        assert_eq!(request.height, Some(1080));
+    }
+
+    /// Feature: Structured video export requests
+    /// Scenario: should accept project-wide hyphenated preset aliases
+    #[test]
+    fn video_export_request_should_accept_project_preset_aliases() {
+        let aliases = [
+            ("youtube-1080p", ExportPreset::Youtube1080p),
+            ("mp4-h264-1080p", ExportPreset::Youtube1080p),
+            ("mp4-draft", ExportPreset::Mp4Draft),
+            ("mp4-high", ExportPreset::Mp4High),
+            ("webm-vp9-720p", ExportPreset::WebmVp9),
+        ];
+
+        for (alias, expected) in aliases {
+            let actual = ExportPreset::from_legacy_id(alias).unwrap();
+            assert_eq!(actual, expected, "alias {alias} should map correctly");
+        }
+    }
+
+    /// Feature: Structured video export requests
+    /// Scenario: should reject unknown legacy presets instead of silently defaulting
+    #[test]
+    fn video_export_request_should_reject_unknown_legacy_preset() {
+        let error = ExportPreset::from_legacy_id("unknown_delivery").unwrap_err();
+
+        assert!(
+            error.to_string().contains("Unknown export preset"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Feature: Structured video export validation
+    /// Scenario: should reject incompatible container and codec combinations
+    #[test]
+    fn video_export_request_should_reject_container_codec_mismatch() {
+        let request = VideoExportRequest {
+            container: ContainerFormat::Webm,
+            video_codec: VideoCodec::ProRes,
+            audio_codec: AudioCodec::Opus,
+            quality_tier: ExportQualityTier::Master,
+            width: Some(1920),
+            height: Some(1080),
+            fps: Some(30.0),
+            video_bitrate: None,
+            audio_bitrate: None,
+            crf: None,
+            two_pass: false,
+        };
+
+        let error =
+            validate_video_export_request(&request, Path::new("/tmp/master.webm")).unwrap_err();
+
+        assert!(
+            error.to_string().contains("does not support video codec"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Feature: Structured video export validation
+    /// Scenario: should reject output extension mismatches before rendering
+    #[test]
+    fn video_export_request_should_reject_extension_mismatch() {
+        let request = ExportSettings::request_from_preset(ExportPreset::ProRes);
+
+        let error =
+            validate_video_export_request(&request, Path::new("/tmp/master.mp4")).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match selected container"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Feature: Structured video export validation
+    /// Scenario: should accept alternate file extensions for the same container
+    #[test]
+    fn video_export_request_should_accept_mp4_container_m4v_extension() {
+        let request = ExportSettings::request_from_preset(ExportPreset::Youtube1080p);
+
+        validate_video_export_request(&request, Path::new("/tmp/delivery.m4v"))
+            .expect("m4v is an MPEG-4 container extension");
+    }
+
+    /// Feature: WebM VP9 quality export
+    /// Scenario: should include VP9 CRF quality args in generated FFmpeg args
+    #[test]
+    fn webm_vp9_export_should_include_crf_quality_args() {
+        use crate::core::ffmpeg::{FFmpegInfo, FFmpegRunner};
+
+        let engine = ExportEngine::new(FFmpegRunner::new(FFmpegInfo {
+            ffmpeg_path: PathBuf::from("/usr/bin/ffmpeg"),
+            ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
+            version: "test".to_string(),
+            is_bundled: false,
+        }));
+        let settings =
+            ExportSettings::from_preset(ExportPreset::WebmVp9, PathBuf::from("output.webm"));
+
+        let args = engine.build_simple_export_args(Path::new("/tmp/input.webm"), &settings);
+
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "-crf" && pair[1] == "31"),
+            "expected VP9 CRF args, got: {args:?}"
+        );
     }
 
     #[test]
@@ -7340,6 +7949,8 @@ mod tests {
 
         let presets = vec![
             ExportPreset::Youtube1080p,
+            ExportPreset::Mp4Draft,
+            ExportPreset::Mp4High,
             ExportPreset::Youtube4k,
             ExportPreset::YoutubeShorts,
             ExportPreset::Twitter,
@@ -7986,6 +8597,7 @@ mod tests {
             output_path: "/tmp/output.mp4".to_string(),
             in_point: Some(1.5),
             out_point: Some(10.0),
+            settings: None,
         };
 
         let json = serde_json::to_string(&item).unwrap();
@@ -8009,6 +8621,7 @@ mod tests {
             output_path: "/export/final.mov".to_string(),
             in_point: None,
             out_point: None,
+            settings: None,
         };
 
         let json = serde_json::to_string(&item).unwrap();

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2243,9 +2243,17 @@ fn output_video_fps(sequence: &Sequence, settings: &ExportSettings) -> f64 {
 }
 
 fn output_video_pixel_format(settings: &ExportSettings) -> &'static str {
+    let use_10_bit = settings.is_hdr() || settings.bit_depth.unwrap_or(8) >= 10;
+
     match settings.video_codec {
         VideoCodec::ProRes => "yuv422p10le",
-        VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9 | VideoCodec::Copy => "yuv420p",
+        VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9 | VideoCodec::Copy => {
+            if use_10_bit {
+                "yuv420p10le"
+            } else {
+                "yuv420p"
+            }
+        }
     }
 }
 
@@ -4818,7 +4826,8 @@ pub fn build_complex_filter_args_with_audio_info(
                     stream_label: format!("[{}]", normalized_video_label),
                     start_sec: clip.place.timeline_in_sec,
                     end_sec: clip.place.timeline_out_sec(),
-                    transition_filter: None,
+                    transition_filter: find_transition_effect(clip, effects)
+                        .map(|effect| effect.to_filter_body()),
                 });
                 timeline_end_sec = timeline_end_sec.max(clip.place.timeline_out_sec());
 
@@ -4914,7 +4923,8 @@ pub fn build_complex_filter_args_with_audio_info(
                         stream_label: format!("[{}]", normalized_video_label),
                         start_sec: clip.place.timeline_in_sec,
                         end_sec: clip.place.timeline_out_sec(),
-                        transition_filter: None,
+                        transition_filter: find_transition_effect(clip, effects)
+                            .map(|effect| effect.to_filter_body()),
                     });
                 }
 
@@ -8119,6 +8129,31 @@ mod tests {
         let settings = ExportSettings::default();
         let args = settings.hdr_args();
         assert!(args.is_empty(), "SDR mode should return empty args");
+    }
+
+    #[test]
+    fn test_output_video_pixel_format_preserves_10_bit_requests() {
+        let sdr = ExportSettings::default();
+        assert_eq!(output_video_pixel_format(&sdr), "yuv420p");
+
+        let hdr_h265 = ExportSettings {
+            hdr_mode: HdrMode::Hdr10,
+            video_codec: VideoCodec::H265,
+            ..Default::default()
+        };
+        assert_eq!(output_video_pixel_format(&hdr_h265), "yuv420p10le");
+
+        let explicit_10_bit = ExportSettings {
+            bit_depth: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(output_video_pixel_format(&explicit_10_bit), "yuv420p10le");
+
+        let prores = ExportSettings {
+            video_codec: VideoCodec::ProRes,
+            ..Default::default()
+        };
+        assert_eq!(output_video_pixel_format(&prores), "yuv422p10le");
     }
 
     #[test]

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2204,6 +2204,213 @@ fn apply_audio_mix_settings(
     current_label
 }
 
+const TIMELINE_EPSILON_SEC: f64 = 0.001;
+
+#[derive(Clone, Debug)]
+struct VideoTimelineSegment {
+    stream_label: String,
+    start_sec: f64,
+    end_sec: f64,
+    transition_filter: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct VideoConcatPart {
+    stream_label: String,
+    transition_filter: Option<String>,
+}
+
+fn output_video_dimensions(sequence: &Sequence, settings: &ExportSettings) -> (u32, u32) {
+    let width = settings
+        .width
+        .unwrap_or(sequence.format.canvas.width)
+        .max(1);
+    let height = settings
+        .height
+        .unwrap_or(sequence.format.canvas.height)
+        .max(1);
+    (width, height)
+}
+
+fn output_video_fps(sequence: &Sequence, settings: &ExportSettings) -> f64 {
+    let fps = settings.fps.unwrap_or_else(|| sequence.format.fps.as_f64());
+
+    if fps.is_finite() && fps > 0.0 {
+        fps
+    } else {
+        30.0
+    }
+}
+
+fn output_video_pixel_format(settings: &ExportSettings) -> &'static str {
+    match settings.video_codec {
+        VideoCodec::ProRes => "yuv422p10le",
+        VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9 | VideoCodec::Copy => "yuv420p",
+    }
+}
+
+fn append_video_stream_normalization(
+    filter_complex: &mut String,
+    input_label: &str,
+    output_label: &str,
+    width: u32,
+    height: u32,
+    fps: f64,
+    pixel_format: &str,
+) {
+    filter_complex.push_str(&format!(
+        "[{}]scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps={},format={}[{}];",
+        input_label,
+        width,
+        height,
+        width,
+        height,
+        format_speed_number(fps),
+        pixel_format,
+        output_label
+    ));
+}
+
+fn append_black_video_gap(
+    filter_complex: &mut String,
+    output_label: &str,
+    duration_sec: f64,
+    width: u32,
+    height: u32,
+    fps: f64,
+    pixel_format: &str,
+) {
+    filter_complex.push_str(&format!(
+        "color=c=black:s={}x{}:r={}:d={},format={}[{}];",
+        width,
+        height,
+        format_speed_number(fps),
+        format_speed_number(duration_sec),
+        pixel_format,
+        output_label
+    ));
+}
+
+fn append_timeline_video_output(
+    filter_complex: &mut String,
+    segments: &[VideoTimelineSegment],
+    timeline_end_sec: f64,
+    width: u32,
+    height: u32,
+    fps: f64,
+    pixel_format: &str,
+) -> Result<(), ExportError> {
+    let mut sorted_segments: Vec<&VideoTimelineSegment> = segments
+        .iter()
+        .filter(|segment| segment.end_sec > segment.start_sec + TIMELINE_EPSILON_SEC)
+        .collect();
+
+    if sorted_segments.is_empty() {
+        return Err(ExportError::InvalidSettings(
+            "Sequence has no visual clips to export".to_string(),
+        ));
+    }
+
+    sorted_segments.sort_by(|a, b| {
+        a.start_sec
+            .partial_cmp(&b.start_sec)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut parts: Vec<VideoConcatPart> = Vec::new();
+    let mut cursor = 0.0_f64;
+    let mut gap_index = 0_usize;
+
+    for segment in sorted_segments {
+        let start = segment.start_sec.max(0.0);
+        let end = segment.end_sec.max(start);
+
+        if start > cursor + TIMELINE_EPSILON_SEC {
+            if let Some(previous) = parts.last_mut() {
+                previous.transition_filter = None;
+            }
+
+            let gap_label = format!("vgap{}", gap_index);
+            append_black_video_gap(
+                filter_complex,
+                &gap_label,
+                start - cursor,
+                width,
+                height,
+                fps,
+                pixel_format,
+            );
+            parts.push(VideoConcatPart {
+                stream_label: format!("[{}]", gap_label),
+                transition_filter: None,
+            });
+            gap_index += 1;
+            cursor = start;
+        }
+
+        parts.push(VideoConcatPart {
+            stream_label: segment.stream_label.clone(),
+            transition_filter: segment.transition_filter.clone(),
+        });
+        cursor = cursor.max(end);
+    }
+
+    if timeline_end_sec.is_finite() && timeline_end_sec > cursor + TIMELINE_EPSILON_SEC {
+        if let Some(previous) = parts.last_mut() {
+            previous.transition_filter = None;
+        }
+
+        let gap_label = format!("vgap{}", gap_index);
+        append_black_video_gap(
+            filter_complex,
+            &gap_label,
+            timeline_end_sec - cursor,
+            width,
+            height,
+            fps,
+            pixel_format,
+        );
+        parts.push(VideoConcatPart {
+            stream_label: format!("[{}]", gap_label),
+            transition_filter: None,
+        });
+    }
+
+    if parts.len() == 1 {
+        filter_complex.push_str(&format!("{}null[outv]", parts[0].stream_label));
+        return Ok(());
+    }
+
+    let mut current_stream = parts[0].stream_label.clone();
+    for i in 0..parts.len() - 1 {
+        let next_stream = &parts[i + 1].stream_label;
+        let output_label = if i == parts.len() - 2 {
+            "[outv]".to_string()
+        } else {
+            format!("[vseq{}]", i)
+        };
+
+        if let Some(ref transition_filter) = parts[i].transition_filter {
+            filter_complex.push_str(&format!(
+                "{}{}{}{}",
+                current_stream, next_stream, transition_filter, output_label
+            ));
+        } else {
+            filter_complex.push_str(&format!(
+                "{}{}concat=n=2:v=1:a=0{}",
+                current_stream, next_stream, output_label
+            ));
+        }
+
+        if i < parts.len() - 2 {
+            filter_complex.push(';');
+            current_stream = output_label;
+        }
+    }
+
+    Ok(())
+}
+
 fn append_master_audio_output(
     filter_complex: &mut String,
     audio_streams: &[String],
@@ -2943,9 +3150,9 @@ impl ExportEngine {
         let mut args = Vec::new();
         let mut input_index = 0;
         let mut filter_complex = String::new();
-        let mut video_streams = Vec::new();
+        let mut video_segments = Vec::new();
         let mut audio_streams = Vec::new();
-        let mut video_transitions: Vec<Option<&Effect>> = Vec::new();
+        let mut timeline_end_sec = 0.0_f64;
         let audio_companion_keys = collect_audio_companion_keys(sequence, assets, audio_info);
 
         // Collect enabled clips sorted by timeline position.
@@ -2957,9 +3164,9 @@ impl ExportEngine {
 
         let caption_filters = collect_caption_drawtext_filters(&all_clips);
 
-        // Get output dimensions from settings or use defaults
-        let output_width = settings.width.unwrap_or(1920);
-        let output_height = settings.height.unwrap_or(1080);
+        let (output_width, output_height) = output_video_dimensions(sequence, settings);
+        let output_fps = output_video_fps(sequence, settings);
+        let output_pixel_format = output_video_pixel_format(settings);
 
         // Collect adjustment layer effects for post-processing.
         // These are applied to the composited output after the main concat,
@@ -3004,6 +3211,7 @@ impl ExportEngine {
                     args.extend(input_args);
 
                     let video_out_label = format!("v{}", input_index);
+                    let normalized_video_label = format!("vnorm{}", input_index);
 
                     // Apply drawtext filter directly to color source
                     let text_filter = format!(
@@ -3013,8 +3221,24 @@ impl ExportEngine {
                     filter_complex.push_str(&text_filter);
                     filter_complex.push(';');
 
-                    video_streams.push(format!("[{}]", video_out_label));
-                    video_transitions.push(find_transition_effect(clip, effects));
+                    append_video_stream_normalization(
+                        &mut filter_complex,
+                        &video_out_label,
+                        &normalized_video_label,
+                        output_width,
+                        output_height,
+                        output_fps,
+                        output_pixel_format,
+                    );
+
+                    video_segments.push(VideoTimelineSegment {
+                        stream_label: format!("[{}]", normalized_video_label),
+                        start_sec: clip.place.timeline_in_sec,
+                        end_sec: clip.place.timeline_out_sec(),
+                        transition_filter: find_transition_effect(clip, effects)
+                            .map(|effect| effect.to_filter_body()),
+                    });
+                    timeline_end_sec = timeline_end_sec.max(clip.place.timeline_out_sec());
 
                     // Text clips have no audio
                     input_index += 1;
@@ -3050,6 +3274,7 @@ impl ExportEngine {
             if !contributes_visual_output && !clip_has_audio {
                 continue;
             }
+            timeline_end_sec = timeline_end_sec.max(clip.place.timeline_out_sec());
 
             // Add input (using validated path)
             args.push("-i".to_string());
@@ -3074,6 +3299,7 @@ impl ExportEngine {
                         // Video processing: trim → [reverse] → [speed] → effects → [tonemap] → output
                         let trim_label = format!("trim{}", input_index);
                         let video_out_label = format!("v{}", input_index);
+                        let normalized_video_label = format!("vnorm{}", input_index);
 
                         let effects_out_label = if tonemap_filter.is_some() {
                             format!("vfx{}", input_index)
@@ -3108,8 +3334,23 @@ impl ExportEngine {
                             ));
                         }
 
-                        video_streams.push(format!("[{}]", video_out_label));
-                        video_transitions.push(find_transition_effect(clip, effects));
+                        append_video_stream_normalization(
+                            &mut filter_complex,
+                            &video_out_label,
+                            &normalized_video_label,
+                            output_width,
+                            output_height,
+                            output_fps,
+                            output_pixel_format,
+                        );
+
+                        video_segments.push(VideoTimelineSegment {
+                            stream_label: format!("[{}]", normalized_video_label),
+                            start_sec: clip.place.timeline_in_sec,
+                            end_sec: clip.place.timeline_out_sec(),
+                            transition_filter: find_transition_effect(clip, effects)
+                                .map(|effect| effect.to_filter_body()),
+                        });
                     }
 
                     // Audio processing: ONLY if this asset has audio
@@ -3192,7 +3433,7 @@ impl ExportEngine {
             input_index += 1;
         }
 
-        if video_streams.is_empty() {
+        if video_segments.is_empty() {
             return Err(ExportError::InvalidSettings(
                 "Sequence has no visual clips to export".to_string(),
             ));
@@ -3204,46 +3445,15 @@ impl ExportEngine {
         }
         filter_complex.push(';');
 
-        // Concat video streams with optional xfade transitions
-        if video_streams.len() == 1 {
-            // Single clip - just use the processed stream
-            filter_complex.push_str(&format!("{}null[outv]", video_streams[0]));
-        } else {
-            // Multiple clips - check for transitions and apply xfade where needed
-            let mut current_stream = video_streams[0].clone();
-
-            for i in 0..video_streams.len() - 1 {
-                let next_stream = &video_streams[i + 1];
-                let output_label = if i == video_streams.len() - 2 {
-                    "[outv]".to_string()
-                } else {
-                    format!("[xfade{}]", i)
-                };
-
-                // Check if current clip has a transition effect (applies to transition INTO next clip)
-                if let Some(transition_effect) = video_transitions.get(i).and_then(|t| *t) {
-                    // Build xfade filter using the transition effect parameters
-                    let xfade_filter = transition_effect.to_filter_body();
-
-                    // Apply xfade: [current][next]xfade=...[output]
-                    filter_complex.push_str(&format!(
-                        "{}{}{}{}",
-                        current_stream, next_stream, xfade_filter, output_label
-                    ));
-                } else {
-                    // No transition - use concat for these two clips
-                    filter_complex.push_str(&format!(
-                        "{}{}concat=n=2:v=1:a=0{}",
-                        current_stream, next_stream, output_label
-                    ));
-                }
-
-                if i < video_streams.len() - 2 {
-                    filter_complex.push(';');
-                    current_stream = output_label;
-                }
-            }
-        }
+        append_timeline_video_output(
+            &mut filter_complex,
+            &video_segments,
+            timeline_end_sec,
+            output_width,
+            output_height,
+            output_fps,
+            output_pixel_format,
+        )?;
 
         // Apply adjustment layer effects as post-processing on the composited output.
         // Each adjustment layer's effects are time-scoped to the layer's clip range
@@ -4448,15 +4658,6 @@ pub fn validate_export_settings(
         }
     }
 
-    // Check for timeline gaps (warning, not error)
-    let gaps = detect_timeline_gaps(sequence);
-    if !gaps.is_empty() {
-        validation.add_warning(format!(
-            "Timeline has {} gap(s). Final render does not preserve gaps yet; insert filler clips before export.",
-            gaps.len()
-        ));
-    }
-
     if has_layered_visual_overlap(sequence) {
         validation.add_error(
             "Final render export does not support simultaneous layered video clips yet".to_string(),
@@ -4499,8 +4700,9 @@ pub fn build_complex_filter_args_with_audio_info(
     let mut args = Vec::new();
     let mut input_index = 0;
     let mut filter_complex = String::new();
-    let mut video_streams = Vec::new();
+    let mut video_segments = Vec::new();
     let mut audio_streams = Vec::new();
+    let mut timeline_end_sec = 0.0_f64;
     let audio_companion_keys = collect_audio_companion_keys(sequence, assets, audio_info);
 
     // Collect enabled clips sorted by timeline position.
@@ -4551,9 +4753,9 @@ pub fn build_complex_filter_args_with_audio_info(
         graph
     }
 
-    // Get output dimensions from settings or use defaults
-    let output_width = settings.width.unwrap_or(1920);
-    let output_height = settings.height.unwrap_or(1080);
+    let (output_width, output_height) = output_video_dimensions(sequence, settings);
+    let output_fps = output_video_fps(sequence, settings);
+    let output_pixel_format = output_video_pixel_format(settings);
 
     // Collect adjustment layer effects for post-processing, time-scoped to clip range
     let mut adjustment_layer_effects: Vec<(FilterGraph, f64, f64)> = Vec::new();
@@ -4592,6 +4794,7 @@ pub fn build_complex_filter_args_with_audio_info(
                 args.extend(input_args);
 
                 let video_out_label = format!("v{}", input_index);
+                let normalized_video_label = format!("vnorm{}", input_index);
 
                 // Apply drawtext filter directly to color source
                 let text_filter = format!(
@@ -4601,7 +4804,23 @@ pub fn build_complex_filter_args_with_audio_info(
                 filter_complex.push_str(&text_filter);
                 filter_complex.push(';');
 
-                video_streams.push(format!("[{}]", video_out_label));
+                append_video_stream_normalization(
+                    &mut filter_complex,
+                    &video_out_label,
+                    &normalized_video_label,
+                    output_width,
+                    output_height,
+                    output_fps,
+                    output_pixel_format,
+                );
+
+                video_segments.push(VideoTimelineSegment {
+                    stream_label: format!("[{}]", normalized_video_label),
+                    start_sec: clip.place.timeline_in_sec,
+                    end_sec: clip.place.timeline_out_sec(),
+                    transition_filter: None,
+                });
+                timeline_end_sec = timeline_end_sec.max(clip.place.timeline_out_sec());
 
                 // Text clips have no audio
                 input_index += 1;
@@ -4633,6 +4852,7 @@ pub fn build_complex_filter_args_with_audio_info(
         if !contributes_visual_output && !clip_has_audio {
             continue;
         }
+        timeline_end_sec = timeline_end_sec.max(clip.place.timeline_out_sec());
 
         // Validate asset URI before passing to FFmpeg
         let validated_path = validate_local_input_path(&asset.uri, "Asset file")
@@ -4654,6 +4874,7 @@ pub fn build_complex_filter_args_with_audio_info(
                 if track.visible {
                     let trim_label = format!("trim{}", input_index);
                     let video_out_label = format!("v{}", input_index);
+                    let normalized_video_label = format!("vnorm{}", input_index);
                     let effects_out_label = if tonemap_filter.is_some() {
                         format!("vfx{}", input_index)
                     } else {
@@ -4679,7 +4900,22 @@ pub fn build_complex_filter_args_with_audio_info(
                         ));
                     }
 
-                    video_streams.push(format!("[{}]", video_out_label));
+                    append_video_stream_normalization(
+                        &mut filter_complex,
+                        &video_out_label,
+                        &normalized_video_label,
+                        output_width,
+                        output_height,
+                        output_fps,
+                        output_pixel_format,
+                    );
+
+                    video_segments.push(VideoTimelineSegment {
+                        stream_label: format!("[{}]", normalized_video_label),
+                        start_sec: clip.place.timeline_in_sec,
+                        end_sec: clip.place.timeline_out_sec(),
+                        transition_filter: None,
+                    });
                 }
 
                 if clip_has_audio && !clip.freeze_frame && !clip.audio.muted {
@@ -4757,7 +4993,7 @@ pub fn build_complex_filter_args_with_audio_info(
         input_index += 1;
     }
 
-    if video_streams.is_empty() {
+    if video_segments.is_empty() {
         return Err(ExportError::InvalidSettings(
             "Sequence has no visual clips to export".to_string(),
         ));
@@ -4769,13 +5005,15 @@ pub fn build_complex_filter_args_with_audio_info(
     }
     filter_complex.push(';');
 
-    // Concat video streams
-    if video_streams.len() == 1 {
-        filter_complex.push_str(&format!("{}null[outv]", video_streams[0]));
-    } else {
-        filter_complex.push_str(&video_streams.join(""));
-        filter_complex.push_str(&format!("concat=n={}:v=1:a=0[outv]", video_streams.len()));
-    }
+    append_timeline_video_output(
+        &mut filter_complex,
+        &video_segments,
+        timeline_end_sec,
+        output_width,
+        output_height,
+        output_fps,
+        output_pixel_format,
+    )?;
 
     // Apply adjustment layer effects as post-processing, time-scoped via enable clause
     let mut adj_video_label = "outv".to_string();
@@ -6753,8 +6991,137 @@ mod tests {
             "Expected delayed audio placement for downstream clip. Got: {filter_complex}"
         );
         assert!(
+            filter_complex.contains("color=c=black:s=1920x1080:r=30:d=3"),
+            "Expected black video filler to preserve the timeline gap. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("[vgap0]"),
+            "Expected video gap segment to participate in the video concat chain. Got: {filter_complex}"
+        );
+        assert!(
             filter_complex.contains("amix=inputs=2"),
             "Expected audio timeline mix instead of concat. Got: {filter_complex}"
+        );
+    }
+
+    #[test]
+    fn test_build_filter_extends_video_for_trailing_audio_only_timeline() {
+        use crate::core::assets::{AudioInfo, VideoInfo};
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut video_track = Track::new_video("Video 1");
+        video_track.add_clip(
+            Clip::new("video_asset")
+                .with_source_range(0.0, 5.0)
+                .place_at(0.0),
+        );
+        sequence.add_track(video_track);
+
+        let mut audio_track = Track::new_audio("Audio 1");
+        audio_track.add_clip(
+            Clip::new("audio_asset")
+                .with_source_range(0.0, 4.0)
+                .place_at(8.0),
+        );
+        sequence.add_track(audio_track);
+
+        let video_path = create_temp_media_file("trailing_audio_video.mp4");
+        let mut video_asset = Asset::new_video(
+            "trailing_audio_video.mp4",
+            &video_path,
+            VideoInfo::default(),
+        )
+        .with_duration(5.0)
+        .with_file_size(5_000_000);
+        video_asset.id = "video_asset".to_string();
+
+        let audio_path = create_temp_media_file("trailing_audio.wav");
+        let mut audio_asset =
+            Asset::new_audio("trailing_audio.wav", &audio_path, AudioInfo::default())
+                .with_duration(4.0)
+                .with_file_size(1_000_000);
+        audio_asset.id = "audio_asset".to_string();
+
+        let mut assets = HashMap::new();
+        assets.insert(video_asset.id.clone(), video_asset);
+        assets.insert(audio_asset.id.clone(), audio_asset);
+
+        let args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ExportSettings::default(),
+        )
+        .expect("trailing audio-only timeline should build");
+
+        let filter_complex = args
+            .windows(2)
+            .find_map(|window| (window[0] == "-filter_complex").then_some(window[1].as_str()))
+            .unwrap();
+
+        assert!(
+            filter_complex.contains("adelay=delays=8000:all=1"),
+            "Expected trailing audio clip to keep its timeline position. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("color=c=black:s=1920x1080:r=30:d=7"),
+            "Expected black video extension from the last visual clip to the audio timeline end. Got: {filter_complex}"
+        );
+    }
+
+    #[test]
+    fn test_validation_does_not_warn_for_supported_timeline_gaps() {
+        use crate::core::assets::{AudioInfo, VideoInfo};
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("Video 1");
+        track.add_clip(
+            Clip::new("asset1")
+                .with_source_range(0.0, 5.0)
+                .place_at(0.0),
+        );
+        track.add_clip(
+            Clip::new("asset2")
+                .with_source_range(0.0, 5.0)
+                .place_at(8.0),
+        );
+        sequence.add_track(track);
+
+        let path1 = create_temp_media_file("gap_validation_1.mp4");
+        let mut asset1 = Asset::new_video("gap_validation_1.mp4", &path1, VideoInfo::default())
+            .with_duration(5.0)
+            .with_file_size(5_000_000);
+        asset1.id = "asset1".to_string();
+        asset1.audio = Some(AudioInfo::default());
+
+        let path2 = create_temp_media_file("gap_validation_2.mp4");
+        let mut asset2 = Asset::new_video("gap_validation_2.mp4", &path2, VideoInfo::default())
+            .with_duration(5.0)
+            .with_file_size(5_000_000);
+        asset2.id = "asset2".to_string();
+        asset2.audio = Some(AudioInfo::default());
+
+        let mut assets = HashMap::new();
+        assets.insert(asset1.id.clone(), asset1);
+        assets.insert(asset2.id.clone(), asset2);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+
+        assert!(
+            !validation
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("does not preserve gaps")),
+            "Timeline gaps are now represented by video filler segments. Got warnings: {:?}",
+            validation.warnings
         );
     }
 

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -125,6 +125,32 @@ fn build_export_settings(
     }
 }
 
+fn validate_batch_item_range(
+    index: usize,
+    in_point: Option<f64>,
+    out_point: Option<f64>,
+) -> Result<(), String> {
+    if let Some(in_pt) = in_point {
+        if in_pt < 0.0 {
+            return Err(format!(
+                "Batch item {}: In point must be non-negative",
+                index
+            ));
+        }
+    }
+
+    if let (Some(in_pt), Some(out_pt)) = (in_point, out_point) {
+        if in_pt >= out_pt {
+            return Err(format!(
+                "Batch item {}: In point must be before Out point",
+                index
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Cached FFmpeg hardware probe results (decoders + encoders).
 ///
 /// FFmpeg encoder/decoder availability does not change within a session,
@@ -644,6 +670,8 @@ pub async fn batch_render(
             &root_refs,
         )?;
 
+        validate_batch_item_range(i, item.in_point, item.out_point)?;
+
         let settings = build_export_settings(
             validated_path,
             &item.preset,
@@ -651,16 +679,6 @@ pub async fn batch_render(
             item.in_point,
             item.out_point,
         )?;
-
-        // Validate range if provided
-        if let (Some(in_pt), Some(out_pt)) = (item.in_point, item.out_point) {
-            if in_pt >= out_pt {
-                return Err(format!(
-                    "Batch item {}: In point must be before Out point",
-                    i
-                ));
-            }
-        }
 
         let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
         if !validation.is_valid {
@@ -2569,4 +2587,36 @@ pub async fn track_point(
         points_count,
         average_confidence,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_batch_item_range;
+
+    #[test]
+    fn validate_batch_item_range_rejects_negative_in_point() {
+        assert_eq!(
+            validate_batch_item_range(2, Some(-0.1), Some(1.0)).unwrap_err(),
+            "Batch item 2: In point must be non-negative"
+        );
+    }
+
+    #[test]
+    fn validate_batch_item_range_rejects_in_point_at_or_after_out_point() {
+        assert_eq!(
+            validate_batch_item_range(1, Some(5.0), Some(5.0)).unwrap_err(),
+            "Batch item 1: In point must be before Out point"
+        );
+        assert_eq!(
+            validate_batch_item_range(1, Some(6.0), Some(5.0)).unwrap_err(),
+            "Batch item 1: In point must be before Out point"
+        );
+    }
+
+    #[test]
+    fn validate_batch_item_range_accepts_open_or_forward_ranges() {
+        assert!(validate_batch_item_range(0, None, None).is_ok());
+        assert!(validate_batch_item_range(0, Some(0.0), None).is_ok());
+        assert!(validate_batch_item_range(0, Some(0.0), Some(1.0)).is_ok());
+    }
 }

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -10,7 +10,7 @@ use crate::core::{
     fs::{default_export_allowed_roots, validate_local_input_path, validate_scoped_output_path},
     render::{
         cancel_render_job, register_render_job, unregister_render_job, AudioExportFormat,
-        ExportError, ExportPreset, ImageFormat,
+        ExportError, ExportPreset, ImageFormat, VideoExportRequest,
     },
     CoreError,
 };
@@ -44,6 +44,10 @@ pub struct BatchRenderItemDto {
     pub in_point: Option<f64>,
     /// Optional Out point in seconds for range export
     pub out_point: Option<f64>,
+    /// Optional structured export settings. If omitted, `preset` is used for
+    /// legacy compatibility.
+    #[serde(default)]
+    pub settings: Option<VideoExportRequest>,
 }
 
 /// Result returned when a batch render is started.
@@ -91,21 +95,32 @@ pub struct FrameExportResultDto {
 // =============================================================================
 
 /// Parse a preset string into an ExportPreset enum.
-fn parse_export_preset(preset: &str) -> ExportPreset {
-    match preset.to_lowercase().as_str() {
-        "youtube_1080p" | "youtube1080p" => ExportPreset::Youtube1080p,
-        "youtube_4k" | "youtube4k" => ExportPreset::Youtube4k,
-        "youtube_shorts" | "youtubeshorts" => ExportPreset::YoutubeShorts,
-        "twitter" => ExportPreset::Twitter,
-        "instagram" => ExportPreset::Instagram,
-        "webm" | "webm_vp9" => ExportPreset::WebmVp9,
-        "prores" => ExportPreset::ProRes,
-        other => {
-            tracing::warn!(
-                "Unknown export preset '{}', defaulting to youtube_1080p",
-                other
-            );
-            ExportPreset::Youtube1080p
+fn parse_export_preset(preset: &str) -> Result<ExportPreset, String> {
+    ExportPreset::from_legacy_id(preset).map_err(|e| e.to_string())
+}
+
+fn build_export_settings(
+    output_path: std::path::PathBuf,
+    preset: &str,
+    request: Option<&VideoExportRequest>,
+    start_time: Option<f64>,
+    end_time: Option<f64>,
+) -> Result<crate::core::render::ExportSettings, String> {
+    match request {
+        Some(request) => crate::core::render::ExportSettings::from_video_request(
+            request,
+            output_path,
+            start_time,
+            end_time,
+        )
+        .map_err(|e| e.to_string()),
+        None => {
+            let export_preset = parse_export_preset(preset)?;
+            let mut settings =
+                crate::core::render::ExportSettings::from_preset(export_preset, output_path);
+            settings.start_time = start_time;
+            settings.end_time = end_time;
+            Ok(settings)
         }
     }
 }
@@ -201,13 +216,12 @@ pub async fn start_render(
     sequence_id: String,
     output_path: String,
     preset: String,
+    settings: Option<VideoExportRequest>,
     state: State<'_, AppState>,
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
 ) -> Result<RenderStartResult, String> {
-    use crate::core::render::{
-        validate_export_settings, ExportEngine, ExportProgress, ExportSettings,
-    };
+    use crate::core::render::{validate_export_settings, ExportEngine, ExportProgress};
     use tauri::Emitter;
 
     // Get sequence/assets/effects + project path from project state
@@ -263,11 +277,14 @@ pub async fn start_render(
         "FFmpeg not initialized. Please install FFmpeg and restart the application.".to_string()
     })?;
 
-    // Parse preset
-    let export_preset = parse_export_preset(&preset);
-
     // Create export settings using validated path
-    let mut settings = ExportSettings::from_preset(export_preset, validated_output_path.clone());
+    let mut settings = build_export_settings(
+        validated_output_path.clone(),
+        &preset,
+        settings.as_ref(),
+        None,
+        None,
+    )?;
 
     resolve_export_hardware_preferences(&app_handle, &ffmpeg.info().ffmpeg_path, &mut settings)
         .await?;
@@ -394,15 +411,14 @@ pub async fn render_range(
     sequence_id: String,
     output_path: String,
     preset: String,
+    settings: Option<VideoExportRequest>,
     in_point: f64,
     out_point: f64,
     state: State<'_, AppState>,
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
 ) -> Result<RenderStartResult, String> {
-    use crate::core::render::{
-        validate_export_settings, ExportEngine, ExportProgress, ExportSettings,
-    };
+    use crate::core::render::{validate_export_settings, ExportEngine, ExportProgress};
     use tauri::Emitter;
 
     // Validate range
@@ -456,10 +472,13 @@ pub async fn render_range(
     })?;
 
     // Build settings with range
-    let export_preset = parse_export_preset(&preset);
-    let mut settings = ExportSettings::from_preset(export_preset, validated_output_path);
-    settings.start_time = Some(in_point);
-    settings.end_time = Some(out_point);
+    let mut settings = build_export_settings(
+        validated_output_path,
+        &preset,
+        settings.as_ref(),
+        Some(in_point),
+        Some(out_point),
+    )?;
 
     resolve_export_hardware_preferences(&app_handle, &ffmpeg.info().ffmpeg_path, &mut settings)
         .await?;
@@ -625,10 +644,13 @@ pub async fn batch_render(
             &root_refs,
         )?;
 
-        let export_preset = parse_export_preset(&item.preset);
-        let mut settings = ExportSettings::from_preset(export_preset, validated_path);
-        settings.start_time = item.in_point;
-        settings.end_time = item.out_point;
+        let settings = build_export_settings(
+            validated_path,
+            &item.preset,
+            item.settings.as_ref(),
+            item.in_point,
+            item.out_point,
+        )?;
 
         // Validate range if provided
         if let (Some(in_pt), Some(out_pt)) = (item.in_point, item.out_point) {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -457,9 +457,9 @@ async getJobStats() : Promise<Result<JsonValue, string>> {
  * This command validates the export settings before starting the render,
  * and reports real-time progress via Tauri events.
  */
-async startRender(sequenceId: string, outputPath: string, preset: string) : Promise<Result<RenderStartResult, string>> {
+async startRender(sequenceId: string, outputPath: string, preset: string, settings: VideoExportRequest | null) : Promise<Result<RenderStartResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("start_render", { sequenceId, outputPath, preset }) };
+    return { status: "ok", data: await TAURI_INVOKE("start_render", { sequenceId, outputPath, preset, settings }) };
 } catch (e) {
     return { status: "error", error: e  as any };
 }
@@ -470,9 +470,9 @@ async startRender(sequenceId: string, outputPath: string, preset: string) : Prom
  * Uses `in_point` and `out_point` (in seconds) to restrict the export
  * to a portion of the timeline. Reports progress via Tauri events.
  */
-async renderRange(sequenceId: string, outputPath: string, preset: string, inPoint: number, outPoint: number) : Promise<Result<RenderStartResult, string>> {
+async renderRange(sequenceId: string, outputPath: string, preset: string, settings: VideoExportRequest | null, inPoint: number, outPoint: number) : Promise<Result<RenderStartResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("render_range", { sequenceId, outputPath, preset, inPoint, outPoint }) };
+    return { status: "ok", data: await TAURI_INVOKE("render_range", { sequenceId, outputPath, preset, settings, inPoint, outPoint }) };
 } catch (e) {
     return { status: "error", error: e  as any };
 }
@@ -2982,6 +2982,10 @@ duration: number | null;
  */
 tags: string[] }
 /**
+ * Audio codec selection
+ */
+export type AudioCodec = "aac" | "mp3" | "opus" | "pcm" | "copy"
+/**
  * Parameters for audio ducking.
  */
 export type AudioDuckingParams = { 
@@ -3189,7 +3193,12 @@ inPoint: number | null;
 /**
  * Optional Out point in seconds for range export
  */
-outPoint: number | null }
+outPoint: number | null;
+/**
+ * Optional structured export settings. If omitted, `preset` is used for
+ * legacy compatibility.
+ */
+settings?: VideoExportRequest | null }
 /**
  * Result returned when a batch render is started.
  */
@@ -3669,6 +3678,22 @@ columns: number;
  */
 rows: number }
 /**
+ * Output media container.
+ */
+export type ContainerFormat =
+/**
+ * MPEG-4 container, typically H.264/H.265 + AAC.
+ */
+"mp4" |
+/**
+ * QuickTime container for ProRes/H.264/H.265 delivery and masters.
+ */
+"mov" |
+/**
+ * WebM container for VP9/Opus delivery.
+ */
+"webm"
+/**
  * A classified time segment of video content
  */
 export type ContentSegment = { 
@@ -4019,6 +4044,30 @@ tempoClassification: TempoClassification }
  * Response for estimate_generation_cost
  */
 export type EstimateGenerationCostResponse = { estimatedCents: number; quality: string; durationSec: number }
+/**
+ * User-facing quality tier that maps to concrete encoder settings.
+ */
+export type ExportQualityTier =
+/**
+ * Fast, lower-bitrate review export.
+ */
+"draft" |
+/**
+ * Balanced default delivery.
+ */
+"standard" |
+/**
+ * Higher-quality web delivery.
+ */
+"high" |
+/**
+ * Editing/mastering-oriented output.
+ */
+"master" |
+/**
+ * Caller supplied explicit bitrate/CRF settings.
+ */
+"custom"
 export type ExportSettingsDto = { defaultFormat: string; defaultVideoCodec: string; defaultAudioCodec: string; defaultExportLocation: string | null; openFolderAfterExport: boolean }
 export type ExternalDiarizationRunSummary = { assetId: string; inputAudioPath: string; outputJsonPath: string; transcriptSegmentCount: number; speakerCount: number; speakerTurnCount: number }
 /**
@@ -6956,6 +7005,14 @@ issues: string[];
  * Non-critical warnings
  */
 warnings: string[] }
+/**
+ * Video codec selection
+ */
+export type VideoCodec = "h264" | "h265" | "vp9" | "prores" | "copy"
+/**
+ * Structured video export request used by UI and agent-driven export paths.
+ */
+export type VideoExportRequest = { container: ContainerFormat; videoCodec: VideoCodec; audioCodec: AudioCodec; qualityTier: ExportQualityTier; width: number | null; height: number | null; fps: number | null; videoBitrate: string | null; audioBitrate: string | null; crf: number | null; twoPass?: boolean }
 /**
  * Video-specific metadata
  */

--- a/src/components/features/agent/AgentArtifactReviewPanel.test.tsx
+++ b/src/components/features/agent/AgentArtifactReviewPanel.test.tsx
@@ -101,6 +101,23 @@ describe('AgentArtifactReviewPanel', () => {
     expect(screen.getByText('Select an artifact to review')).toBeInTheDocument();
   });
 
+  it('renders an empty state without an active conversation', () => {
+    act(() => {
+      useConversationStore.setState((state) => ({
+        ...state,
+        activeProjectId: null,
+        activeConversation: null,
+        activeSessionId: null,
+        sessions: [],
+      }));
+    });
+
+    render(<AgentArtifactReviewPanel />);
+
+    expect(screen.getByTestId('agent-artifact-review-panel-empty')).toBeInTheDocument();
+    expect(screen.getByText('No artifact selected')).toBeInTheDocument();
+  });
+
   it('renders review detail for the selected artifact in the active conversation', () => {
     act(() => {
       useAgentArtifactReviewStore.getState().setSelection({

--- a/src/components/features/agent/AgentArtifactReviewPanel.tsx
+++ b/src/components/features/agent/AgentArtifactReviewPanel.tsx
@@ -4,6 +4,7 @@ import { useAgentArtifactReviewStore } from '@/stores/agentArtifactReviewStore';
 import { useAgentDelegationStore } from '@/stores/agentDelegationStore';
 import { useAgentSessionStore } from '@/stores/agentSessionStore';
 import { getAgentDisplayName } from '@/agents/engine/core/agentCatalog';
+import type { ConversationMessage } from '@/agents/engine/core/conversation';
 import { writeWorkspaceDocumentToBackend } from '@/services/workspaceGateway';
 import {
   buildAgentArtifactSessionSummary,
@@ -36,6 +37,13 @@ interface ReviewSourceNavItem {
   statusLabel?: string | null;
   defaultFocus: AgentArtifactFocus | null;
 }
+
+interface AgentArtifactReviewPanelProps {
+  className?: string;
+  layout?: 'default' | 'compact';
+}
+
+const EMPTY_MESSAGES: readonly ConversationMessage[] = [];
 
 function formatDelegationMergeStatus(status: string): string {
   switch (status) {
@@ -85,7 +93,10 @@ function formatDelegationRecommendation(recommendation: DelegationRecommendation
   }
 }
 
-export function AgentArtifactReviewPanel({ className = '' }: { className?: string }) {
+export function AgentArtifactReviewPanel({
+  className = '',
+  layout = 'default',
+}: AgentArtifactReviewPanelProps) {
   const [isApplyingReviewDecision, setIsApplyingReviewDecision] = useState(false);
   const [isLaunchingVerifier, setIsLaunchingVerifier] = useState(false);
   const [verifierLaunchError, setVerifierLaunchError] = useState<string | null>(null);
@@ -94,7 +105,9 @@ export function AgentArtifactReviewPanel({ className = '' }: { className?: strin
   );
   const activeProjectId = useConversationStore((state) => state.activeProjectId);
   const activeSessions = useConversationStore((state) => state.sessions);
-  const messages = useConversationStore((state) => state.activeConversation?.messages ?? []);
+  const messages = useConversationStore(
+    (state) => state.activeConversation?.messages ?? EMPTY_MESSAGES,
+  );
   const loadSessions = useConversationStore((state) => state.loadSessions);
   const switchSession = useConversationStore((state) => state.switchSession);
   const addSystemMessageToSession = useConversationStore(
@@ -189,7 +202,7 @@ export function AgentArtifactReviewPanel({ className = '' }: { className?: strin
     selection.sourceLabel,
   ]);
 
-  const reviewMessages = reviewSession?.messages ?? [];
+  const reviewMessages = reviewSession?.messages ?? EMPTY_MESSAGES;
   const sessionSummary = useMemo(
     () => buildAgentArtifactSessionSummary(reviewMessages),
     [reviewMessages],
@@ -801,12 +814,25 @@ export function AgentArtifactReviewPanel({ className = '' }: { className?: strin
     );
   }
 
+  const headerClassName =
+    layout === 'compact'
+      ? 'max-h-[38%] shrink-0 overflow-y-auto border-b border-editor-border px-3 py-2.5'
+      : 'max-h-[42%] shrink-0 overflow-y-auto border-b border-editor-border px-4 py-3';
+  const contentClassName =
+    layout === 'compact'
+      ? 'flex min-h-0 flex-1 flex-col'
+      : 'grid min-h-0 flex-1 [grid-template-columns:minmax(0,_min(12rem,_38%))_minmax(0,_1fr)]';
+  const sourceListClassName =
+    layout === 'compact'
+      ? 'max-h-44 shrink-0 overflow-auto border-b border-editor-border p-3'
+      : 'overflow-auto border-r border-editor-border p-3';
+
   return (
     <div
       className={`flex h-full flex-col bg-editor-bg ${className}`}
       data-testid="agent-artifact-review-panel"
     >
-      <div className="max-h-[42%] shrink-0 overflow-y-auto border-b border-editor-border px-4 py-3">
+      <div className={headerClassName}>
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-editor-text-muted">
             Agent Review
@@ -1092,8 +1118,8 @@ export function AgentArtifactReviewPanel({ className = '' }: { className?: strin
         )}
       </div>
 
-      <div className="grid min-h-0 flex-1 [grid-template-columns:minmax(0,_min(12rem,_38%))_minmax(0,_1fr)]">
-        <div className="overflow-auto border-r border-editor-border p-3">
+      <div className={contentClassName}>
+        <div className={sourceListClassName}>
           <div className="space-y-3">
             {relatedSources.length > 0 && (
               <section>

--- a/src/components/features/agent/AgentRuntimeChatShell.test.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.test.tsx
@@ -690,7 +690,7 @@ describe('AgentRuntimeChatShell', () => {
     });
   });
 
-  it('opens the external agent review panel when an artifact is selected', async () => {
+  it('keeps artifact review inline when an artifact is selected', async () => {
     const user = userEvent.setup();
 
     act(() => {
@@ -748,9 +748,10 @@ describe('AgentRuntimeChatShell', () => {
     await user.click(screen.getByTestId('artifact-tool-delete_clip'));
 
     const layout = useWorkspaceLayoutStore.getState().layout;
-    expect(layout.zones.bottom.panelIds).toContain('agent-review');
-    expect(layout.zones.bottom.activePanelId).toBe('agent-review');
-    expect(layout.zones.bottom.collapsed).toBe(false);
+    expect(layout.zones.bottom.panelIds).not.toContain('agent-review');
+    expect(layout.zones.bottom.activePanelId).toBe('history');
+    expect(layout.zones.bottom.collapsed).toBe(true);
+    expect(screen.getByTestId('agent-artifact-detail-panel')).toHaveTextContent('delete_clip');
     expect(useAgentArtifactReviewStore.getState().selection.focus).toEqual({
       kind: 'tool',
       value: 'delete_clip',

--- a/src/components/features/agent/AgentRuntimeChatShell.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.tsx
@@ -20,7 +20,6 @@ import { useConversationStore } from '@/stores/conversationStore';
 import { useMessageQueueStore } from '@/stores/messageQueueStore';
 import { useProjectStore } from '@/stores';
 import { useAgentArtifactReviewStore } from '@/stores/agentArtifactReviewStore';
-import { revealWorkspacePanel, type DockZoneId, type PanelId } from '@/stores/workspaceLayoutStore';
 import { ChatMessageList, type ChatMessageListProps } from './ChatMessageList';
 import { ChatInputArea } from './ChatInputArea';
 import { AgentArtifactFocusBanner } from './AgentArtifactFocusBanner';
@@ -31,8 +30,6 @@ import type { AgentRuntimePermissionRequest, AgentRuntimeSummary } from './Agent
 import { isSameArtifactFocus, type AgentArtifactFocus } from './agentArtifactFocus';
 
 const EMPTY_MESSAGES: readonly never[] = [];
-const AGENT_REVIEW_PANEL_ID: PanelId = 'agent-review';
-const DEFAULT_AGENT_REVIEW_ZONE: DockZoneId = 'bottom';
 
 export interface AgentRuntimeChatHandle {
   abort: () => void;
@@ -296,10 +293,6 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
       };
     }, [clearQueue, clearQueueOnUnmount, onUnmount]);
 
-    const openAgentReviewPanel = useCallback(() => {
-      revealWorkspacePanel(AGENT_REVIEW_PANEL_ID, DEFAULT_AGENT_REVIEW_ZONE);
-    }, []);
-
     const handleArtifactFocus = useCallback(
       (focus: AgentArtifactFocus) => {
         if (isSameArtifactFocus(artifactFocus, focus)) {
@@ -312,14 +305,12 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
           projectId: activeProjectId,
           conversationId: activeConversationId,
         });
-        openAgentReviewPanel();
       },
       [
         activeConversationId,
         activeProjectId,
         artifactFocus,
         clearArtifactSelection,
-        openAgentReviewPanel,
         setArtifactSelection,
       ],
     );

--- a/src/components/features/agent/AgenticSidebarContent.test.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.test.tsx
@@ -871,11 +871,17 @@ describe('AgenticSidebarContent', () => {
         focus: { kind: 'file', value: 'src/foo.ts' },
       }),
     );
-    expect(useWorkspaceLayoutStore.getState().layout.zones.bottom.panelIds).toContain(
+    expect(screen.getByTestId('agent-review-inline-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('agentic-chat')).not.toBeInTheDocument();
+    expect(useWorkspaceLayoutStore.getState().layout.zones.bottom.panelIds).not.toContain(
       'agent-review',
     );
-    expect(useWorkspaceLayoutStore.getState().layout.zones.bottom.activePanelId).toBe(
-      'agent-review',
-    );
+    expect(useWorkspaceLayoutStore.getState().layout.zones.bottom.activePanelId).toBe('history');
+
+    await user.click(screen.getByTestId('agent-review-inline-close-btn'));
+
+    expect(screen.queryByTestId('agent-review-inline-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agentic-chat')).toBeInTheDocument();
+    expect(useAgentArtifactReviewStore.getState().selection.conversationId).toBeNull();
   });
 });

--- a/src/components/features/agent/AgenticSidebarContent.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.tsx
@@ -6,7 +6,9 @@
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
 import { AgenticChat } from './AgenticChat';
+import { AgentArtifactReviewPanel } from './AgentArtifactReviewPanel';
 import type { AgentRuntimeChatHandle } from './AgentRuntimeChatShell';
 import { AgenticSidebarWorkspace } from './AgenticSidebarWorkspace';
 import { DEFAULT_AGENT_PROFILE_ID, type AgentRunResult } from '@/agents/engine';
@@ -32,7 +34,6 @@ import { useAgentArtifactReviewStore } from '@/stores/agentArtifactReviewStore';
 import { useAgentSessionStore } from '@/stores/agentSessionStore';
 import { useAgentDelegationStore } from '@/stores/agentDelegationStore';
 import { useMessageQueueStore } from '@/stores/messageQueueStore';
-import { revealWorkspacePanel, type DockZoneId, type PanelId } from '@/stores/workspaceLayoutStore';
 import { createLogger } from '@/services/logger';
 import {
   buildCancelledDelegationPayload,
@@ -57,8 +58,6 @@ import { useAgentSessionTransition } from './useAgentSessionTransition';
 const logger = createLogger('AgenticSidebarContent');
 const EMPTY_DELEGATIONS: readonly DelegationRecord[] = [];
 const EMPTY_MESSAGES: readonly ConversationMessage[] = [];
-const AGENT_REVIEW_PANEL_ID: PanelId = 'agent-review';
-const DEFAULT_AGENT_REVIEW_ZONE: DockZoneId = 'bottom';
 
 export interface AgenticSidebarContentProps {
   /** Whether the component is visible */
@@ -82,6 +81,7 @@ export function AgenticSidebarContent({
   className = '',
 }: AgenticSidebarContentProps) {
   const [showSessionList, setShowSessionList] = useState(false);
+  const [showArtifactReviewPanel, setShowArtifactReviewPanel] = useState(false);
   const [projectPromptContext, setProjectPromptContext] = useState<ProjectPromptContext>({
     knowledge: [],
   });
@@ -136,6 +136,7 @@ export function AgenticSidebarContent({
   );
   const getLastUserInput = useConversationStore((state) => state.getLastUserInput);
   const clearQueuedMessages = useMessageQueueStore((state) => state.clear);
+  const artifactReviewSelection = useAgentArtifactReviewStore((state) => state.selection);
   const setArtifactReviewSelection = useAgentArtifactReviewStore((state) => state.setSelection);
   const clearArtifactReviewSelection = useAgentArtifactReviewStore((state) => state.clearSelection);
   const agentSnapshotsById = useAgentSessionStore((state) => state.snapshotsById);
@@ -184,13 +185,10 @@ export function AgenticSidebarContent({
     }
 
     abortCurrentSession();
+    setShowArtifactReviewPanel(false);
     clearArtifactReviewSelection();
     resetSessionTransition({ bumpChatSurfaceKey: true });
   }, [abortCurrentSession, clearArtifactReviewSelection, currentProjectId, resetSessionTransition]);
-
-  const openAgentReviewPanel = useCallback(() => {
-    revealWorkspacePanel(AGENT_REVIEW_PANEL_ID, DEFAULT_AGENT_REVIEW_ZONE);
-  }, []);
 
   const openDelegationReview = useCallback(
     (input: OpenDelegationReviewInput) => {
@@ -207,10 +205,40 @@ export function AgenticSidebarContent({
         sourceLabel: input.title,
         sourceAgentProfileId: input.agentProfileId,
       });
-      openAgentReviewPanel();
+      setShowArtifactReviewPanel(true);
     },
-    [currentProjectId, openAgentReviewPanel, setArtifactReviewSelection],
+    [currentProjectId, setArtifactReviewSelection],
   );
+
+  const closeArtifactReviewPanel = useCallback(() => {
+    setShowArtifactReviewPanel(false);
+    clearArtifactReviewSelection();
+  }, [clearArtifactReviewSelection]);
+
+  const shouldShowArtifactReviewPanel = Boolean(
+    showArtifactReviewPanel &&
+    currentProjectId &&
+    artifactReviewSelection.projectId === currentProjectId &&
+    artifactReviewSelection.conversationId,
+  );
+
+  useEffect(() => {
+    if (!showArtifactReviewPanel) {
+      return;
+    }
+
+    if (
+      !artifactReviewSelection.conversationId ||
+      (currentProjectId && artifactReviewSelection.projectId !== currentProjectId)
+    ) {
+      setShowArtifactReviewPanel(false);
+    }
+  }, [
+    artifactReviewSelection.conversationId,
+    artifactReviewSelection.projectId,
+    currentProjectId,
+    showArtifactReviewPanel,
+  ]);
 
   useEffect(() => {
     if (!activeSessionId) {
@@ -610,25 +638,54 @@ export function AgenticSidebarContent({
       }
       sessionTransitionLabel={sessionTransitionLabel}
     >
-      <AgenticChat
-        key={`agent-workspace-${chatSurfaceKey}`}
-        ref={chatHandleRef}
-        llmClient={llmClient}
-        toolExecutor={toolExecutor}
-        config={chatPromptConfig}
-        onSubmit={handleSubmit}
-        onComplete={handleComplete}
-        onAbort={handleAbort}
-        onError={handleError}
-        placeholder={promptPlaceholder}
-        disabled={isSessionTransitionPending}
-        currentAgentName={activeAgentDefinition?.name ?? 'Editor'}
-        currentAgentDescription={activeAgentDefinition?.description}
-        isExperimentalSession={activeAgentDefinition?.mode === 'subagent'}
-        specialistDefinitions={specialistDefinitions}
-        onStartSession={handleTrayStartSession}
-        className="flex-1"
-      />
+      {shouldShowArtifactReviewPanel ? (
+        <section
+          className="flex min-h-0 flex-1 flex-col overflow-hidden bg-surface-base"
+          data-testid="agent-review-inline-panel"
+        >
+          <div className="flex shrink-0 items-center justify-between border-b border-border-subtle px-3 py-2">
+            <div className="min-w-0">
+              <p className="truncate text-xs font-medium text-text-primary">Agent Review</p>
+              {artifactReviewSelection.sourceLabel && (
+                <p className="mt-0.5 truncate text-[11px] text-text-secondary">
+                  {artifactReviewSelection.sourceLabel}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={closeArtifactReviewPanel}
+              className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface-active hover:text-text-primary"
+              aria-label="Close agent review"
+              title="Close agent review"
+              data-testid="agent-review-inline-close-btn"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <AgentArtifactReviewPanel className="min-h-0 flex-1" layout="compact" />
+        </section>
+      ) : (
+        <AgenticChat
+          key={`agent-workspace-${chatSurfaceKey}`}
+          ref={chatHandleRef}
+          llmClient={llmClient}
+          toolExecutor={toolExecutor}
+          config={chatPromptConfig}
+          onSubmit={handleSubmit}
+          onComplete={handleComplete}
+          onAbort={handleAbort}
+          onError={handleError}
+          placeholder={promptPlaceholder}
+          disabled={isSessionTransitionPending}
+          currentAgentName={activeAgentDefinition?.name ?? 'Editor'}
+          currentAgentDescription={activeAgentDefinition?.description}
+          isExperimentalSession={activeAgentDefinition?.mode === 'subagent'}
+          specialistDefinitions={specialistDefinitions}
+          onStartSession={handleTrayStartSession}
+          className="flex-1"
+        />
+      )}
     </AgenticSidebarWorkspace>
   );
 }

--- a/src/components/features/editor/EditorPanels.tsx
+++ b/src/components/features/editor/EditorPanels.tsx
@@ -279,9 +279,11 @@ export function createEditorPanelContent({
     ),
 
     'agent-review': (
-      <Suspense fallback={BOTTOM_PANEL_LOADING_FALLBACK}>
-        <AgentArtifactReviewPanelLazy />
-      </Suspense>
+      <AIErrorBoundary onError={(error) => logger.error('Agent review panel error', { error })}>
+        <Suspense fallback={BOTTOM_PANEL_LOADING_FALLBACK}>
+          <AgentArtifactReviewPanelLazy />
+        </Suspense>
+      </AIErrorBoundary>
     ),
 
     history: (

--- a/src/components/features/export/ExportDialog.test.tsx
+++ b/src/components/features/export/ExportDialog.test.tsx
@@ -28,6 +28,7 @@ describe('ExportDialog', () => {
   const setExportKind = vi.fn();
   const setSelectedPreset = vi.fn();
   const setSelectedAudioFormat = vi.fn();
+  const setSelectedTimelineFormat = vi.fn();
   const handleBrowse = vi.fn();
   const handleExport = vi.fn();
   const handleRetry = vi.fn();
@@ -58,6 +59,8 @@ describe('ExportDialog', () => {
       setSelectedPreset,
       selectedAudioFormat: 'wav',
       setSelectedAudioFormat,
+      selectedTimelineFormat: 'fcpxml',
+      setSelectedTimelineFormat,
       outputPath: 'D:/exports/out.mp4',
       status: { type: 'idle' },
       isExporting: false,
@@ -164,5 +167,25 @@ describe('ExportDialog', () => {
     await waitFor(() => {
       expect(resetQueue).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('does not block timeline export when a stale video range is invalid', () => {
+    exportDialogState = {
+      ...exportDialogState,
+      exportKind: 'timeline',
+      outputPath: 'D:/exports/timeline.fcpxml',
+    };
+    renderQueueState = {
+      ...renderQueueState,
+      useRange: true,
+      inPoint: 8,
+      outPoint: 4,
+    };
+
+    render(
+      <ExportDialog isOpen onClose={vi.fn()} sequenceId="sequence-1" sequenceName="Sequence" />,
+    );
+
+    expect(screen.getByRole('button', { name: /export timeline/i })).not.toBeDisabled();
   });
 });

--- a/src/components/features/export/ExportDialog.tsx
+++ b/src/components/features/export/ExportDialog.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useRef, useCallback, useState, useEffect } from 'react';
-import { X, Download, ListPlus, Cpu, Zap, Music } from 'lucide-react';
+import { X, Download, ListPlus, Cpu, Zap, Music, FileCode } from 'lucide-react';
 import { useExportDialog } from '@/hooks/useExportDialog';
 import { useRenderQueue } from '@/hooks/useRenderQueue';
 import {
@@ -13,7 +13,7 @@ import {
   RangeControls,
   RenderQueuePanel,
 } from './ExportHelpers';
-import { AUDIO_EXPORT_FORMATS, EXPORT_PRESETS } from './constants';
+import { AUDIO_EXPORT_FORMATS, EXPORT_PRESETS, TIMELINE_EXPORT_FORMATS } from './constants';
 import type { ExportDialogProps } from './types';
 import { commands } from '@/bindings';
 
@@ -41,6 +41,8 @@ export function ExportDialog({
     setSelectedPreset,
     selectedAudioFormat,
     setSelectedAudioFormat,
+    selectedTimelineFormat,
+    setSelectedTimelineFormat,
     outputPath,
     status,
     isExporting,
@@ -115,10 +117,17 @@ export function ExportDialog({
   const isBusy = isExporting || renderQueue.isBatchRendering;
   const hasPendingItems = renderQueue.queue.some((item) => item.status === 'pending');
   const isRangeValid =
+    exportKind === 'timeline' ||
     !renderQueue.useRange ||
     (renderQueue.inPoint >= 0 && renderQueue.inPoint < renderQueue.outPoint);
-  const exportTitle = exportKind === 'audio' ? 'Export Audio' : 'Export Video';
-  const ExportTitleIcon = exportKind === 'audio' ? Music : Download;
+  const exportTitle =
+    exportKind === 'audio'
+      ? 'Export Audio'
+      : exportKind === 'timeline'
+        ? 'Export Editable Timeline'
+        : 'Export Video';
+  const ExportTitleIcon =
+    exportKind === 'audio' ? Music : exportKind === 'timeline' ? FileCode : Download;
 
   return (
     <div
@@ -154,7 +163,7 @@ export function ExportDialog({
         <div className="space-y-4 px-6 py-4">
           {showSettings && !renderQueue.isBatchRendering ? (
             <>
-              <div className="grid grid-cols-2 gap-2 rounded-lg bg-editor-bg p-1">
+              <div className="grid grid-cols-3 gap-2 rounded-lg bg-editor-bg p-1">
                 <button
                   type="button"
                   onClick={() => setExportKind('video')}
@@ -179,6 +188,18 @@ export function ExportDialog({
                 >
                   Audio
                 </button>
+                <button
+                  type="button"
+                  onClick={() => setExportKind('timeline')}
+                  disabled={isBusy}
+                  className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    exportKind === 'timeline'
+                      ? 'bg-primary-600 text-white'
+                      : 'text-editor-text-muted hover:bg-editor-panel'
+                  }`}
+                >
+                  Timeline
+                </button>
               </div>
 
               <div className="flex items-center justify-between gap-3 rounded-lg bg-editor-bg p-3">
@@ -188,6 +209,11 @@ export function ExportDialog({
                   {exportKind === 'audio' && (
                     <p className="mt-1 text-xs text-editor-text-muted">
                       Mix down enabled audio tracks to a single master file.
+                    </p>
+                  )}
+                  {exportKind === 'timeline' && (
+                    <p className="mt-1 text-xs text-editor-text-muted">
+                      Export an editable timeline interchange file.
                     </p>
                   )}
                 </div>
@@ -202,8 +228,17 @@ export function ExportDialog({
                   </div>
                 ) : (
                   <div className="flex items-center gap-1.5 text-xs text-editor-text-muted">
-                    <Music className="h-3.5 w-3.5" />
-                    <span>Audio-only mixdown</span>
+                    {exportKind === 'audio' ? (
+                      <>
+                        <Music className="h-3.5 w-3.5" />
+                        <span>Audio-only mixdown</span>
+                      </>
+                    ) : (
+                      <>
+                        <FileCode className="h-3.5 w-3.5" />
+                        <span>Editable export</span>
+                      </>
+                    )}
                   </div>
                 )}
               </div>
@@ -225,7 +260,7 @@ export function ExportDialog({
                     ))}
                   </div>
                 </div>
-              ) : (
+              ) : exportKind === 'audio' ? (
                 <div>
                   <label className="mb-2 block text-sm font-medium text-editor-text">
                     Audio Format
@@ -242,17 +277,36 @@ export function ExportDialog({
                     ))}
                   </div>
                 </div>
+              ) : (
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-editor-text">
+                    Timeline Format
+                  </label>
+                  <div className="grid max-h-48 grid-cols-2 gap-2 overflow-y-auto">
+                    {TIMELINE_EXPORT_FORMATS.map((format) => (
+                      <PresetOption
+                        key={format.id}
+                        preset={format}
+                        isSelected={selectedTimelineFormat === format.id}
+                        onSelect={() => setSelectedTimelineFormat(format.id)}
+                        disabled={isBusy}
+                      />
+                    ))}
+                  </div>
+                </div>
               )}
 
-              <RangeControls
-                useRange={renderQueue.useRange}
-                onUseRangeChange={renderQueue.setUseRange}
-                inPoint={renderQueue.inPoint}
-                onInPointChange={renderQueue.setInPoint}
-                outPoint={renderQueue.outPoint}
-                onOutPointChange={renderQueue.setOutPoint}
-                disabled={isBusy}
-              />
+              {exportKind !== 'timeline' && (
+                <RangeControls
+                  useRange={renderQueue.useRange}
+                  onUseRangeChange={renderQueue.setUseRange}
+                  inPoint={renderQueue.inPoint}
+                  onInPointChange={renderQueue.setInPoint}
+                  outPoint={renderQueue.outPoint}
+                  onOutPointChange={renderQueue.setOutPoint}
+                  disabled={isBusy}
+                />
+              )}
 
               <OutputLocationField
                 outputPath={outputPath}
@@ -328,7 +382,11 @@ export function ExportDialog({
                 className="flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Download className="h-4 w-4" />
-                {exportKind === 'audio' ? 'Export Audio' : 'Export'}
+                {exportKind === 'audio'
+                  ? 'Export Audio'
+                  : exportKind === 'timeline'
+                    ? 'Export Timeline'
+                    : 'Export'}
               </button>
             </div>
           </div>

--- a/src/components/features/export/constants.test.ts
+++ b/src/components/features/export/constants.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getExportPreset, getPresetExtension } from './constants';
+
+describe('export constants', () => {
+  it('derives preset extensions from the preset container', () => {
+    expect(getPresetExtension('webm_vp9')).toBe('webm');
+    expect(getPresetExtension('prores')).toBe('mov');
+  });
+
+  it('throws when an unknown preset is requested', () => {
+    expect(() => getExportPreset('missing-preset')).toThrow('Unknown export preset: missing-preset');
+    expect(() => getPresetExtension('missing-preset')).toThrow(
+      'Unknown export preset: missing-preset',
+    );
+  });
+});

--- a/src/components/features/export/constants.ts
+++ b/src/components/features/export/constants.ts
@@ -4,7 +4,14 @@
  * Centralized constants for export dialog component.
  */
 
-import type { AudioExportFormat, AudioFormatOption, ExportPreset } from './types';
+import type {
+  AudioExportFormat,
+  AudioFormatOption,
+  ExportPreset,
+  TimelineExportFormat,
+  TimelineFormatOption,
+} from './types';
+import type { VideoExportRequest } from '@/bindings';
 
 // =============================================================================
 // Export Presets
@@ -14,45 +21,174 @@ import type { AudioExportFormat, AudioFormatOption, ExportPreset } from './types
 export const EXPORT_PRESETS: ExportPreset[] = [
   {
     id: 'youtube_1080p',
-    name: 'YouTube 1080p',
-    description: 'H.264, 1920x1080, 8Mbps',
+    name: 'MP4 Standard',
+    description: 'H.264, 1080p, balanced delivery',
     icon: 'monitor',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'standard',
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      videoBitrate: '8M',
+      audioBitrate: '192k',
+      crf: 23,
+      twoPass: false,
+    },
+  },
+  {
+    id: 'mp4_draft',
+    name: 'MP4 Draft',
+    description: 'H.264, 720p, small review file',
+    icon: 'monitor',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'draft',
+      width: 1280,
+      height: 720,
+      fps: 30,
+      videoBitrate: '3M',
+      audioBitrate: '128k',
+      crf: 28,
+      twoPass: false,
+    },
+  },
+  {
+    id: 'mp4_high',
+    name: 'MP4 High',
+    description: 'H.264, 1080p, higher quality',
+    icon: 'monitor',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'high',
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      videoBitrate: '15M',
+      audioBitrate: '320k',
+      crf: 18,
+      twoPass: false,
+    },
   },
   {
     id: 'youtube_4k',
-    name: 'YouTube 4K',
-    description: 'H.264, 3840x2160, 35Mbps',
+    name: 'MP4 4K High',
+    description: 'H.264, 2160p, high bitrate',
     icon: 'monitor',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'high',
+      width: 3840,
+      height: 2160,
+      fps: 30,
+      videoBitrate: '35M',
+      audioBitrate: '320k',
+      crf: 18,
+      twoPass: false,
+    },
   },
   {
     id: 'youtube_shorts',
     name: 'Shorts/Reels',
-    description: 'Vertical 1080x1920',
+    description: 'H.264, vertical 1080x1920',
     icon: 'smartphone',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'standard',
+      width: 1080,
+      height: 1920,
+      fps: 30,
+      videoBitrate: '8M',
+      audioBitrate: '192k',
+      crf: 23,
+      twoPass: false,
+    },
   },
   {
     id: 'twitter',
     name: 'Twitter/X',
     description: 'H.264, 1280x720, 5Mbps',
     icon: 'globe',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'draft',
+      width: 1280,
+      height: 720,
+      fps: 30,
+      videoBitrate: '5M',
+      audioBitrate: '128k',
+      crf: 24,
+      twoPass: false,
+    },
   },
   {
     id: 'instagram',
     name: 'Instagram',
-    description: 'Square 1080x1080',
+    description: 'H.264, square 1080x1080',
     icon: 'smartphone',
+    settings: {
+      container: 'mp4',
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      qualityTier: 'standard',
+      width: 1080,
+      height: 1080,
+      fps: 30,
+      videoBitrate: '6M',
+      audioBitrate: '128k',
+      crf: 23,
+      twoPass: false,
+    },
   },
   {
     id: 'webm_vp9',
     name: 'WebM VP9',
     description: 'VP9/Opus, High quality',
     icon: 'globe',
+    settings: {
+      container: 'webm',
+      videoCodec: 'vp9',
+      audioCodec: 'opus',
+      qualityTier: 'high',
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      videoBitrate: '6M',
+      audioBitrate: '128k',
+      crf: 31,
+      twoPass: false,
+    },
   },
   {
     id: 'prores',
-    name: 'ProRes',
-    description: 'Apple ProRes 422',
+    name: 'MOV Master',
+    description: 'ProRes 422, PCM audio',
     icon: 'film',
+    settings: {
+      container: 'mov',
+      videoCodec: 'prores',
+      audioCodec: 'pcm',
+      qualityTier: 'master',
+      width: null,
+      height: null,
+      fps: null,
+      videoBitrate: null,
+      audioBitrate: null,
+      crf: null,
+      twoPass: false,
+    },
   },
 ];
 
@@ -90,13 +226,31 @@ export const AUDIO_EXPORT_FORMATS: AudioFormatOption[] = [
   },
 ];
 
+/** Editable timeline export formats */
+export const TIMELINE_EXPORT_FORMATS: TimelineFormatOption[] = [
+  {
+    id: 'fcpxml',
+    name: 'FCPXML',
+    description: 'Editable timeline for FCP/Resolve',
+    icon: 'film',
+  },
+  {
+    id: 'edl',
+    name: 'EDL',
+    description: 'CMX 3600 edit decision list',
+    icon: 'film',
+  },
+];
+
 // =============================================================================
 // Preset ID to File Extension Mapping
 // =============================================================================
 
 /** Map of preset IDs to file extensions */
 export const PRESET_EXTENSIONS: Record<string, string> = {
+  mp4_draft: 'mp4',
   youtube_1080p: 'mp4',
+  mp4_high: 'mp4',
   youtube_4k: 'mp4',
   youtube_shorts: 'mp4',
   twitter: 'mp4',
@@ -114,6 +268,12 @@ export const AUDIO_FORMAT_EXTENSIONS: Record<AudioExportFormat, string> = {
   ogg: 'ogg',
 };
 
+/** Map of editable timeline formats to file extensions */
+export const TIMELINE_FORMAT_EXTENSIONS: Record<TimelineExportFormat, string> = {
+  edl: 'edl',
+  fcpxml: 'fcpxml',
+};
+
 /**
  * Get file extension for a preset ID.
  * @param presetId - The preset ID
@@ -128,7 +288,30 @@ export function getAudioFormatExtension(format: AudioExportFormat): string {
   return AUDIO_FORMAT_EXTENSIONS[format] || 'wav';
 }
 
+/** Get file extension for an editable timeline format. */
+export function getTimelineFormatExtension(format: TimelineExportFormat): string {
+  return TIMELINE_FORMAT_EXTENSIONS[format] || 'fcpxml';
+}
+
 /** Look up the metadata for an audio export format. */
 export function getAudioFormatOption(format: AudioExportFormat): AudioFormatOption {
   return AUDIO_EXPORT_FORMATS.find((option) => option.id === format) ?? AUDIO_EXPORT_FORMATS[0];
+}
+
+/** Look up the metadata for a video export preset. */
+export function getExportPreset(presetId: string): ExportPreset {
+  return EXPORT_PRESETS.find((option) => option.id === presetId) ?? EXPORT_PRESETS[0];
+}
+
+/** Return a fresh request object for the selected video export preset. */
+export function getVideoExportRequest(presetId: string): VideoExportRequest {
+  const preset = getExportPreset(presetId);
+  return { ...preset.settings };
+}
+
+/** Look up the metadata for an editable timeline export format. */
+export function getTimelineFormatOption(format: TimelineExportFormat): TimelineFormatOption {
+  return (
+    TIMELINE_EXPORT_FORMATS.find((option) => option.id === format) ?? TIMELINE_EXPORT_FORMATS[0]
+  );
 }

--- a/src/components/features/export/constants.ts
+++ b/src/components/features/export/constants.ts
@@ -242,23 +242,6 @@ export const TIMELINE_EXPORT_FORMATS: TimelineFormatOption[] = [
   },
 ];
 
-// =============================================================================
-// Preset ID to File Extension Mapping
-// =============================================================================
-
-/** Map of preset IDs to file extensions */
-export const PRESET_EXTENSIONS: Record<string, string> = {
-  mp4_draft: 'mp4',
-  youtube_1080p: 'mp4',
-  mp4_high: 'mp4',
-  youtube_4k: 'mp4',
-  youtube_shorts: 'mp4',
-  twitter: 'mp4',
-  instagram: 'mp4',
-  webm_vp9: 'webm',
-  prores: 'mov',
-};
-
 /** Map of audio formats to file extensions */
 export const AUDIO_FORMAT_EXTENSIONS: Record<AudioExportFormat, string> = {
   wav: 'wav',
@@ -277,10 +260,11 @@ export const TIMELINE_FORMAT_EXTENSIONS: Record<TimelineExportFormat, string> = 
 /**
  * Get file extension for a preset ID.
  * @param presetId - The preset ID
- * @returns The file extension (default: 'mp4')
+ * @returns The file extension for the preset container
+ * @throws Error when the preset ID is unknown
  */
 export function getPresetExtension(presetId: string): string {
-  return PRESET_EXTENSIONS[presetId] || 'mp4';
+  return getExportPreset(presetId).settings.container;
 }
 
 /** Get file extension for an audio export format. */
@@ -300,7 +284,11 @@ export function getAudioFormatOption(format: AudioExportFormat): AudioFormatOpti
 
 /** Look up the metadata for a video export preset. */
 export function getExportPreset(presetId: string): ExportPreset {
-  return EXPORT_PRESETS.find((option) => option.id === presetId) ?? EXPORT_PRESETS[0];
+  const preset = EXPORT_PRESETS.find((option) => option.id === presetId);
+  if (!preset) {
+    throw new Error(`Unknown export preset: ${presetId}`);
+  }
+  return preset;
 }
 
 /** Return a fresh request object for the selected video export preset. */

--- a/src/components/features/export/index.ts
+++ b/src/components/features/export/index.ts
@@ -10,4 +10,4 @@ export { PresetOption, ProgressDisplay } from './ExportHelpers';
 export type { PresetOptionProps, ProgressDisplayProps } from './ExportHelpers';
 
 // Constants
-export { EXPORT_PRESETS, PRESET_EXTENSIONS, getPresetExtension } from './constants';
+export { EXPORT_PRESETS, getPresetExtension } from './constants';

--- a/src/components/features/export/types.ts
+++ b/src/components/features/export/types.ts
@@ -4,12 +4,14 @@
  * Type definitions for the ExportDialog component and related sub-components.
  */
 
+import type { VideoExportRequest } from '@/bindings';
+
 // =============================================================================
 // Export Preset Types
 // =============================================================================
 
 /** Export workflow kind */
-export type ExportKind = 'video' | 'audio';
+export type ExportKind = 'video' | 'audio' | 'timeline';
 
 /** Export option icon options */
 export type ExportOptionIcon = 'monitor' | 'smartphone' | 'film' | 'globe' | 'audio';
@@ -27,15 +29,27 @@ export interface SelectableExportOption {
 }
 
 /** Export preset configuration */
-export type ExportPreset = SelectableExportOption;
+export interface ExportPreset extends SelectableExportOption {
+  /** Explicit video export request sent to the backend */
+  settings: VideoExportRequest;
+}
 
 /** Audio export format IDs */
 export type AudioExportFormat = 'wav' | 'mp3' | 'm4a' | 'flac' | 'ogg';
+
+/** Editable timeline export format IDs */
+export type TimelineExportFormat = 'edl' | 'fcpxml';
 
 /** Audio export option configuration */
 export interface AudioFormatOption extends SelectableExportOption {
   /** Audio format identifier */
   id: AudioExportFormat;
+}
+
+/** Editable timeline export option configuration */
+export interface TimelineFormatOption extends SelectableExportOption {
+  /** Timeline interchange format identifier */
+  id: TimelineExportFormat;
 }
 
 // =============================================================================
@@ -154,6 +168,8 @@ export interface RenderQueueItem {
   jobId: string;
   /** Export preset ID */
   presetId: string;
+  /** Explicit video export request for this queue item */
+  settings: VideoExportRequest;
   /** Display name of the preset */
   presetName: string;
   /** Output file path */

--- a/src/hooks/useExportDialog.test.ts
+++ b/src/hooks/useExportDialog.test.ts
@@ -227,6 +227,44 @@ describe('useExportDialog', () => {
     expect(invoke).not.toHaveBeenCalledWith('start_render', expect.anything());
   });
 
+  it('should route editable timeline exports to EDL and update the extension', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      format: 'edl',
+      outputPath: '/tmp/sequence.edl',
+      eventCount: 2,
+      trackCount: 1,
+      durationSec: 10,
+    });
+
+    const { result } = renderHook(() =>
+      useExportDialog({
+        isOpen: true,
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+        initialExportKind: 'timeline',
+      }),
+    );
+
+    act(() => {
+      result.current.setOutputPath('/tmp/sequence.fcpxml');
+      result.current.setSelectedTimelineFormat('edl');
+    });
+
+    await waitFor(() => {
+      expect(result.current.outputPath).toBe('/tmp/sequence.edl');
+    });
+
+    await act(async () => {
+      await result.current.handleExport();
+    });
+
+    expect(invoke).toHaveBeenCalledWith('export_edl', {
+      sequenceId: 'sequence-1',
+      outputPath: '/tmp/sequence.edl',
+    });
+    expect(invoke).not.toHaveBeenCalledWith('start_render', expect.anything());
+  });
+
   it('should ignore invalid render ranges when exporting editable timelines', async () => {
     vi.mocked(invoke).mockResolvedValue({
       format: 'fcpxml',

--- a/src/hooks/useExportDialog.test.ts
+++ b/src/hooks/useExportDialog.test.ts
@@ -37,6 +37,18 @@ describe('useExportDialog', () => {
     });
   });
 
+  it('should default video export to the standard MP4 preset', () => {
+    const { result } = renderHook(() =>
+      useExportDialog({
+        isOpen: true,
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+      }),
+    );
+
+    expect(result.current.selectedPreset).toBe('youtube_1080p');
+  });
+
   it('should call render_range when range export is enabled', async () => {
     vi.mocked(invoke).mockResolvedValue({
       jobId: 'job-1',
@@ -68,6 +80,11 @@ describe('useExportDialog', () => {
       sequenceId: 'sequence-1',
       outputPath: '/tmp/out.mp4',
       preset: 'youtube_1080p',
+      settings: expect.objectContaining({
+        container: 'mp4',
+        videoCodec: 'h264',
+        qualityTier: 'standard',
+      }),
       inPoint: 3,
       outPoint: 7.5,
     });
@@ -139,6 +156,117 @@ describe('useExportDialog', () => {
     });
   });
 
+  it('should call start_render with structured video settings for video export', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      jobId: 'job-1',
+      outputPath: '/tmp/out.mp4',
+      status: 'started',
+    });
+
+    const { result } = renderHook(() =>
+      useExportDialog({
+        isOpen: true,
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+      }),
+    );
+
+    act(() => {
+      result.current.setOutputPath('/tmp/out.mp4');
+      result.current.setSelectedPreset('mp4_high');
+    });
+
+    await act(async () => {
+      await result.current.handleExport();
+    });
+
+    expect(invoke).toHaveBeenCalledWith('start_render', {
+      sequenceId: 'sequence-1',
+      outputPath: '/tmp/out.mp4',
+      preset: 'mp4_high',
+      settings: expect.objectContaining({
+        container: 'mp4',
+        videoCodec: 'h264',
+        qualityTier: 'high',
+        crf: 18,
+      }),
+    });
+  });
+
+  it('should route editable timeline exports to FCPXML without starting a render job', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      format: 'fcpxml',
+      outputPath: '/tmp/sequence.fcpxml',
+      eventCount: 2,
+      trackCount: 1,
+      durationSec: 10,
+    });
+
+    const { result } = renderHook(() =>
+      useExportDialog({
+        isOpen: true,
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+        initialExportKind: 'timeline',
+      }),
+    );
+
+    act(() => {
+      result.current.setOutputPath('/tmp/sequence.fcpxml');
+      result.current.setSelectedTimelineFormat('fcpxml');
+    });
+
+    await act(async () => {
+      await result.current.handleExport();
+    });
+
+    expect(invoke).toHaveBeenCalledWith('export_fcpxml', {
+      sequenceId: 'sequence-1',
+      outputPath: '/tmp/sequence.fcpxml',
+    });
+    expect(invoke).not.toHaveBeenCalledWith('start_render', expect.anything());
+  });
+
+  it('should ignore invalid render ranges when exporting editable timelines', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      format: 'fcpxml',
+      outputPath: '/tmp/sequence.fcpxml',
+      eventCount: 2,
+      trackCount: 1,
+      durationSec: 10,
+    });
+
+    const { result } = renderHook(() =>
+      useExportDialog({
+        isOpen: true,
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+        initialExportKind: 'timeline',
+        useRange: true,
+        inPoint: 8,
+        outPoint: 4,
+      }),
+    );
+
+    act(() => {
+      result.current.setOutputPath('/tmp/sequence.fcpxml');
+    });
+
+    await act(async () => {
+      await result.current.handleExport();
+    });
+
+    expect(invoke).toHaveBeenCalledWith('export_fcpxml', {
+      sequenceId: 'sequence-1',
+      outputPath: '/tmp/sequence.fcpxml',
+    });
+    expect(result.current.status).toEqual({
+      type: 'completed',
+      outputPath: '/tmp/sequence.fcpxml',
+      duration: 0,
+    });
+  });
+
   it('should browse with audio-specific filters when audio export is selected', async () => {
     vi.mocked(save).mockResolvedValue('/tmp/out.ogg');
 
@@ -185,6 +313,25 @@ describe('useExportDialog', () => {
 
     await waitFor(() => {
       expect(result.current.outputPath).toBe('/tmp/final.wav');
+    });
+  });
+
+  it('should update the output extension when switching to editable timeline export', async () => {
+    const { result } = renderHook(() =>
+      useExportDialog({
+        isOpen: true,
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+      }),
+    );
+
+    act(() => {
+      result.current.setOutputPath('/tmp/final.mp4');
+      result.current.setExportKind('timeline');
+    });
+
+    await waitFor(() => {
+      expect(result.current.outputPath).toBe('/tmp/final.fcpxml');
     });
   });
 

--- a/src/hooks/useExportDialog.ts
+++ b/src/hooks/useExportDialog.ts
@@ -16,12 +16,17 @@ import type {
   RenderProgressEvent,
   RenderCompleteEvent,
   RenderErrorEvent,
+  TimelineExportFormat,
 } from '@/components/features/export/types';
 import {
   AUDIO_EXPORT_FORMATS,
   EXPORT_PRESETS,
+  TIMELINE_EXPORT_FORMATS,
   getAudioFormatExtension,
   getAudioFormatOption,
+  getTimelineFormatExtension,
+  getTimelineFormatOption,
+  getVideoExportRequest,
   getPresetExtension,
 } from '@/components/features/export/constants';
 
@@ -75,6 +80,10 @@ export interface UseExportDialogResult {
   selectedAudioFormat: AudioExportFormat;
   /** Set the selected audio format */
   setSelectedAudioFormat: (format: AudioExportFormat) => void;
+  /** Currently selected editable timeline format */
+  selectedTimelineFormat: TimelineExportFormat;
+  /** Set the selected editable timeline format */
+  setSelectedTimelineFormat: (format: TimelineExportFormat) => void;
   /** Output file path */
   outputPath: string;
   /** Set the output path */
@@ -116,6 +125,9 @@ export function useExportDialog({
   const [selectedAudioFormat, setSelectedAudioFormat] = useState<AudioExportFormat>(
     AUDIO_EXPORT_FORMATS[0].id,
   );
+  const [selectedTimelineFormat, setSelectedTimelineFormat] = useState<TimelineExportFormat>(
+    TIMELINE_EXPORT_FORMATS[0].id,
+  );
   const [outputPath, setOutputPath] = useState('');
   const [status, setStatus] = useState<ExportStatus>({ type: 'idle' });
   const [currentJobId, setCurrentJobId] = useState<string | null>(null);
@@ -134,6 +146,7 @@ export function useExportDialog({
       setExportKind(initialExportKind);
       setSelectedPreset(EXPORT_PRESETS[0].id);
       setSelectedAudioFormat(AUDIO_EXPORT_FORMATS[0].id);
+      setSelectedTimelineFormat(TIMELINE_EXPORT_FORMATS[0].id);
       setOutputPath('');
       setStatus({ type: 'idle' });
       setCurrentJobId(null);
@@ -154,13 +167,15 @@ export function useExportDialog({
     const nextExtension =
       exportKind === 'audio'
         ? getAudioFormatExtension(selectedAudioFormat)
-        : getPresetExtension(selectedPreset);
+        : exportKind === 'timeline'
+          ? getTimelineFormatExtension(selectedTimelineFormat)
+          : getPresetExtension(selectedPreset);
     const nextOutputPath = replaceOutputPathExtension(outputPath, nextExtension);
 
     if (nextOutputPath !== outputPath) {
       setOutputPath(nextOutputPath);
     }
-  }, [exportKind, outputPath, selectedAudioFormat, selectedPreset]);
+  }, [exportKind, outputPath, selectedAudioFormat, selectedPreset, selectedTimelineFormat]);
 
   // ===========================================================================
   // Tauri Event Listeners
@@ -264,6 +279,23 @@ export function useExportDialog({
       return;
     }
 
+    if (exportKind === 'timeline') {
+      const option = getTimelineFormatOption(selectedTimelineFormat);
+      const extension = getTimelineFormatExtension(selectedTimelineFormat);
+
+      const selected = await save({
+        defaultPath: `${sequenceName}.${extension}`,
+        filters: [{ name: option.name, extensions: [extension] }],
+        title: 'Export Editable Timeline',
+      });
+
+      if (selected) {
+        setOutputPath(selected);
+      }
+
+      return;
+    }
+
     const extension = getPresetExtension(selectedPreset);
 
     const selected = await save({
@@ -275,14 +307,14 @@ export function useExportDialog({
     if (selected) {
       setOutputPath(selected);
     }
-  }, [exportKind, selectedAudioFormat, selectedPreset, sequenceName]);
+  }, [exportKind, selectedAudioFormat, selectedPreset, selectedTimelineFormat, sequenceName]);
 
   /**
    * Start the export process.
    */
   const handleExport = useCallback(async () => {
     if (!sequenceId || !outputPath) return;
-    if (useRange && (inPoint < 0 || inPoint >= outPoint)) {
+    if (exportKind !== 'timeline' && useRange && (inPoint < 0 || inPoint >= outPoint)) {
       setStatus({ type: 'failed', error: 'In point must be before Out point.' });
       return;
     }
@@ -290,10 +322,38 @@ export function useExportDialog({
     setStatus({
       type: 'exporting',
       progress: 0,
-      message: exportKind === 'audio' ? 'Starting audio export...' : 'Starting export...',
+      message:
+        exportKind === 'audio'
+          ? 'Starting audio export...'
+          : exportKind === 'timeline'
+            ? 'Exporting editable timeline...'
+            : 'Starting export...',
     });
 
     try {
+      if (exportKind === 'timeline') {
+        const res =
+          selectedTimelineFormat === 'edl'
+            ? await commands.exportEdl(sequenceId, outputPath)
+            : await commands.exportFcpxml(sequenceId, outputPath);
+
+        if (res.status === 'error') {
+          setStatus({ type: 'failed', error: String(res.error) });
+          currentJobIdRef.current = null;
+          setCurrentJobId(null);
+          return;
+        }
+
+        setStatus({
+          type: 'completed',
+          outputPath: res.data.outputPath,
+          duration: 0,
+        });
+        currentJobIdRef.current = null;
+        setCurrentJobId(null);
+        return;
+      }
+
       const res =
         exportKind === 'audio'
           ? await commands.exportAudioOnly(
@@ -306,8 +366,20 @@ export function useExportDialog({
               useRange ? outPoint : null,
             )
           : useRange
-            ? await commands.renderRange(sequenceId, outputPath, selectedPreset, inPoint, outPoint)
-            : await commands.startRender(sequenceId, outputPath, selectedPreset);
+            ? await commands.renderRange(
+                sequenceId,
+                outputPath,
+                selectedPreset,
+                getVideoExportRequest(selectedPreset),
+                inPoint,
+                outPoint,
+              )
+            : await commands.startRender(
+                sequenceId,
+                outputPath,
+                selectedPreset,
+                getVideoExportRequest(selectedPreset),
+              );
 
       if (res.status === 'error') {
         setStatus({ type: 'failed', error: String(res.error) });
@@ -342,6 +414,7 @@ export function useExportDialog({
     outputPath,
     selectedAudioFormat,
     selectedPreset,
+    selectedTimelineFormat,
     sequenceId,
     useRange,
   ]);
@@ -375,6 +448,8 @@ export function useExportDialog({
     setSelectedPreset,
     selectedAudioFormat,
     setSelectedAudioFormat,
+    selectedTimelineFormat,
+    setSelectedTimelineFormat,
     outputPath,
     setOutputPath,
     status,

--- a/src/hooks/useRenderQueue.test.ts
+++ b/src/hooks/useRenderQueue.test.ts
@@ -177,8 +177,42 @@ describe('useRenderQueue', () => {
           outputPath: '/tmp/out.mp4',
           inPoint: 1,
           outPoint: 5,
+          settings: expect.objectContaining({
+            container: 'mp4',
+            videoCodec: 'h264',
+            qualityTier: 'standard',
+          }),
         },
       ],
     });
+  });
+
+  it('should preserve the full structured request when adding high quality exports to the queue', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      batchId: 'batch-1',
+      jobIds: ['job-1'],
+      totalItems: 1,
+      status: 'started',
+    });
+
+    const { result } = renderHook(() =>
+      useRenderQueue({
+        sequenceId: 'sequence-1',
+        sequenceName: 'Sequence',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.addToQueue('mp4_high');
+    });
+
+    expect(result.current.queue[0]?.settings).toEqual(
+      expect.objectContaining({
+        container: 'mp4',
+        videoCodec: 'h264',
+        qualityTier: 'high',
+        crf: 18,
+      }),
+    );
   });
 });

--- a/src/hooks/useRenderQueue.ts
+++ b/src/hooks/useRenderQueue.ts
@@ -11,7 +11,11 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { commands } from '@/bindings';
 import type { BatchRenderItemDto } from '@/bindings';
 import { save } from '@tauri-apps/plugin-dialog';
-import { EXPORT_PRESETS, getPresetExtension } from '@/components/features/export/constants';
+import {
+  EXPORT_PRESETS,
+  getPresetExtension,
+  getVideoExportRequest,
+} from '@/components/features/export/constants';
 import type {
   RenderQueueItem,
   RenderQueueItemStatus,
@@ -223,6 +227,7 @@ export function useRenderQueue({
         jobId: `queue_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
         presetId,
         presetName: preset.name,
+        settings: getVideoExportRequest(presetId),
         outputPath: selected,
         status: 'pending',
         progress: 0,
@@ -288,6 +293,7 @@ export function useRenderQueue({
       outputPath: item.outputPath,
       inPoint: item.inPoint ?? null,
       outPoint: item.outPoint ?? null,
+      settings: item.settings,
     }));
 
     try {

--- a/src/stores/workspaceLayoutStore.test.ts
+++ b/src/stores/workspaceLayoutStore.test.ts
@@ -14,6 +14,8 @@ import {
   WORKSPACE_PRESETS,
   MIN_ZONE_SIZES,
   MAX_ZONE_SIZES,
+  type WorkspaceLayout,
+  type WorkspacePreset,
 } from './workspaceLayoutStore';
 
 describe('WorkspaceLayoutStore', () => {
@@ -135,6 +137,15 @@ describe('WorkspaceLayoutStore', () => {
 
       const { layout } = useWorkspaceLayoutStore.getState();
       expect(layout.zones.bottom.panelIds).toContain('terminal');
+    });
+
+    it('should not restore the internal agent review panel into the dock layout', () => {
+      const store = useWorkspaceLayoutStore.getState();
+      store.restorePanel('agent-review', 'bottom');
+
+      const { layout } = useWorkspaceLayoutStore.getState();
+      expect(layout.zones.bottom.panelIds).not.toContain('agent-review');
+      expect(layout.zones.bottom.activePanelId).toBe('history');
     });
 
     it('should hide a panel and update the active tab when removed', () => {
@@ -295,6 +306,16 @@ describe('WorkspaceLayoutStore', () => {
       expect(layout.zones.bottom.collapsed).toBe(false);
     });
 
+    it('should not reveal the internal agent review panel as a dock tab', () => {
+      const zoneId = revealWorkspacePanel('agent-review', 'bottom');
+
+      const { layout } = useWorkspaceLayoutStore.getState();
+      expect(zoneId).toBeNull();
+      expect(layout.zones.bottom.panelIds).not.toContain('agent-review');
+      expect(layout.zones.bottom.activePanelId).toBe('history');
+      expect(layout.zones.bottom.collapsed).toBe(true);
+    });
+
     it('should move a panel back to its canonical zone when requested', () => {
       const store = useWorkspaceLayoutStore.getState();
       store.movePanel('explorer', 'right');
@@ -347,6 +368,34 @@ describe('WorkspaceLayoutStore', () => {
         expect(layout.zones.left.panelIds).toEqual(['explorer']);
         expect(layout.zones['center-top'].activePanelId).toBe('source-monitor');
         expect(layout.sizes.centerSplitRatio).toBe(0.4);
+      });
+
+      it('should strip internal review panels from custom preset layouts', () => {
+        const staleLayout = createDefaultLayout();
+        staleLayout.zones.bottom = {
+          panelIds: ['history', 'agent-review', 'transcript'],
+          activePanelId: 'agent-review',
+          collapsed: false,
+        };
+        const stalePreset: WorkspacePreset = {
+          id: 'custom-agent-review',
+          name: 'Stale Agent Review',
+          description: '',
+          layout: staleLayout,
+          builtIn: false,
+        };
+
+        useWorkspaceLayoutStore.setState((state) => ({
+          ...state,
+          customPresets: [stalePreset],
+        }));
+
+        const store = useWorkspaceLayoutStore.getState();
+        store.applyPreset('custom-agent-review');
+
+        const { layout } = useWorkspaceLayoutStore.getState();
+        expect(layout.zones.bottom.panelIds).toEqual(['history', 'transcript']);
+        expect(layout.zones.bottom.activePanelId).toBe('history');
       });
 
       it('should apply the Color preset with inspector and comparison in right zone', () => {
@@ -671,6 +720,45 @@ describe('WorkspaceLayoutStore', () => {
         const { activePresetId, customPresets } = useWorkspaceLayoutStore.getState();
         expect(activePresetId).not.toBeNull();
         expect(customPresets).toHaveLength(1);
+      });
+
+      it('should migrate persisted layouts without internal review dock tabs', async () => {
+        const staleLayout = createDefaultLayout();
+        staleLayout.zones.bottom = {
+          panelIds: ['history', 'agent-review', 'transcript'],
+          activePanelId: 'agent-review',
+          collapsed: false,
+        };
+        const stalePreset: WorkspacePreset = {
+          id: 'custom-agent-review',
+          name: 'Stale Agent Review',
+          description: '',
+          layout: staleLayout,
+          builtIn: false,
+        };
+        const migrate = useWorkspaceLayoutStore.persist.getOptions().migrate;
+
+        expect(useWorkspaceLayoutStore.persist.getOptions().version).toBe(3);
+        expect(migrate).toBeDefined();
+
+        const migrated = (await migrate?.(
+          {
+            layout: staleLayout,
+            activePresetId: 'custom-agent-review',
+            customPresets: [stalePreset],
+          },
+          2,
+        )) as {
+          layout: WorkspaceLayout;
+          customPresets: WorkspacePreset[];
+        };
+
+        expect(migrated.layout.zones.bottom.panelIds).toEqual(['history', 'transcript']);
+        expect(migrated.layout.zones.bottom.activePanelId).toBe('history');
+        expect(migrated.customPresets[0].layout.zones.bottom.panelIds).toEqual([
+          'history',
+          'transcript',
+        ]);
       });
     });
   });

--- a/src/stores/workspaceLayoutStore.test.ts
+++ b/src/stores/workspaceLayoutStore.test.ts
@@ -722,6 +722,45 @@ describe('WorkspaceLayoutStore', () => {
         expect(customPresets).toHaveLength(1);
       });
 
+      it('should strip non-persisted panels before saving state', () => {
+        const staleLayout = createDefaultLayout();
+        staleLayout.zones.bottom = {
+          panelIds: ['history', 'terminal', 'agent-review', 'transcript'],
+          activePanelId: 'terminal',
+          collapsed: false,
+        };
+        const stalePreset: WorkspacePreset = {
+          id: 'custom-transient-panels',
+          name: 'Transient Panels',
+          description: '',
+          layout: staleLayout,
+          builtIn: false,
+        };
+        const partialize = useWorkspaceLayoutStore.persist.getOptions().partialize as (state: {
+          layout: WorkspaceLayout;
+          activePresetId?: string | null;
+          customPresets?: WorkspacePreset[];
+        }) => {
+          layout: WorkspaceLayout;
+          activePresetId: string | null;
+          customPresets: WorkspacePreset[];
+        };
+
+        const persisted = partialize({
+          layout: staleLayout,
+          activePresetId: undefined,
+          customPresets: [stalePreset],
+        });
+
+        expect(persisted.activePresetId).toBeNull();
+        expect(persisted.layout.zones.bottom.panelIds).toEqual(['history', 'transcript']);
+        expect(persisted.layout.zones.bottom.activePanelId).toBe('history');
+        expect(persisted.customPresets[0].layout.zones.bottom.panelIds).toEqual([
+          'history',
+          'transcript',
+        ]);
+      });
+
       it('should migrate persisted layouts without internal review dock tabs', async () => {
         const staleLayout = createDefaultLayout();
         staleLayout.zones.bottom = {

--- a/src/stores/workspaceLayoutStore.ts
+++ b/src/stores/workspaceLayoutStore.ts
@@ -770,9 +770,9 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
       name: 'openreelio-workspace-layout',
       version: 3,
       partialize: (state) => ({
-        layout: state.layout,
-        activePresetId: state.activePresetId,
-        customPresets: state.customPresets,
+        layout: normalizeWorkspaceLayout(state.layout),
+        activePresetId: state.activePresetId ?? null,
+        customPresets: normalizeCustomPresets(state.customPresets),
       }),
       migrate: (persisted, version) => {
         if (version === 1) {

--- a/src/stores/workspaceLayoutStore.ts
+++ b/src/stores/workspaceLayoutStore.ts
@@ -126,6 +126,8 @@ export const MIN_ZONE_SIZES = {
 
 const DEFAULT_BOTTOM_PANEL_IDS: PanelId[] = ['history', 'transcript'];
 const DEFAULT_BOTTOM_ACTIVE_PANEL: PanelId = 'history';
+const NON_PERSISTED_PANEL_IDS = new Set<PanelId>(['terminal', 'agent-review']);
+const INTERNAL_ONLY_PANEL_IDS = new Set<PanelId>(['agent-review']);
 
 /** Maximum zone sizes */
 export const MAX_ZONE_SIZES = {
@@ -417,6 +419,10 @@ export function revealWorkspacePanel(
   defaultZoneId: DockZoneId,
   options: { moveToDefaultZone?: boolean } = {},
 ): DockZoneId | null {
+  if (INTERNAL_ONLY_PANEL_IDS.has(panelId)) {
+    return null;
+  }
+
   let store = useWorkspaceLayoutStore.getState();
   let targetZoneId = findPanelZone(store.layout, panelId);
 
@@ -450,6 +456,9 @@ function normalizeZone(zone: DockZone): void {
       return false;
     }
     if (panelId === 'generation' && !videoGenerationEnabled) {
+      return false;
+    }
+    if (NON_PERSISTED_PANEL_IDS.has(panelId)) {
       return false;
     }
     if (seen.has(panelId)) {
@@ -490,8 +499,7 @@ function normalizeWorkspaceLayout(layout: WorkspaceLayout): WorkspaceLayout {
 
   for (const zone of Object.values(normalized.zones)) {
     normalizeZone(zone);
-    zone.panelIds = zone.panelIds.filter((panelId) => panelId !== 'terminal');
-    if (zone.activePanelId === 'terminal') {
+    if (zone.activePanelId && NON_PERSISTED_PANEL_IDS.has(zone.activePanelId)) {
       zone.activePanelId = zone.panelIds[0] ?? null;
     }
   }
@@ -499,6 +507,13 @@ function normalizeWorkspaceLayout(layout: WorkspaceLayout): WorkspaceLayout {
   ensurePanelInLayout(normalized, 'ai-assistant', 'right');
 
   return normalized;
+}
+
+function normalizeCustomPresets(customPresets: WorkspacePreset[] | undefined): WorkspacePreset[] {
+  return (customPresets ?? []).map((preset) => ({
+    ...preset,
+    layout: normalizeWorkspaceLayout(preset.layout),
+  }));
 }
 
 // =============================================================================
@@ -568,6 +583,10 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
 
       restorePanel: (panelId, targetZoneId = 'right') => {
         set((state) => {
+          if (INTERNAL_ONLY_PANEL_IDS.has(panelId)) {
+            return;
+          }
+
           if (panelId === 'generation' && !isVideoGenerationEnabled()) {
             return;
           }
@@ -749,7 +768,7 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
     })),
     {
       name: 'openreelio-workspace-layout',
-      version: 2,
+      version: 3,
       partialize: (state) => ({
         layout: state.layout,
         activePresetId: state.activePresetId,
@@ -777,7 +796,7 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
             ...state,
             layout: normalizeWorkspaceLayout(state.layout),
             activePresetId: state.activePresetId ?? null,
-            customPresets: state.customPresets ?? [],
+            customPresets: normalizeCustomPresets(state.customPresets),
           };
         }
         return persisted;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1195,6 +1195,8 @@ export interface AudioStreamInfo {
 /** Export preset options */
 export type ExportPreset =
   | 'youtube_1080p'
+  | 'mp4_draft'
+  | 'mp4_high'
   | 'youtube_4k'
   | 'youtube_shorts'
   | 'twitter'


### PR DESCRIPTION
### **User description**
## Description

Add structured video export settings across the frontend export dialog, generated Tauri bindings, render IPC commands, final render job payloads, and batch render queue. This also adds editable timeline export selection for FCPXML and EDL, fixes final render timeline gap preservation with black video filler segments, and keeps agent artifact review scoped inline to the agent sidebar instead of restoring it as a persisted workspace dock panel.

## Related Issue

Closes #642, closes #643, closes #644

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added structured `VideoExportRequest` settings, explicit preset metadata, backend validation, and generated TypeScript bindings for video export settings.
- Added editable timeline export selection for FCPXML and EDL in the export dialog, including output extension handling and direct command routing.
- Fixed final render filter generation so visual timeline gaps and trailing audio-only duration are represented by normalized black video filler segments.
- Kept artifact review inline in the agent sidebar, added compact review layout support, and prevented the internal `agent-review` panel from being restored or persisted in workspace layouts.
- Added regression coverage for export settings, timeline export routing, render queue payloads, render gap preservation, inline artifact review, and workspace layout normalization.

## Screenshots / Videos

N/A

## Testing

Validated locally on branch `fix/render-export-panel-state` after committing and pushing the branch.

### Test Environment

- OS: Other Linux
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Local checks completed: `git diff --check`, `npm run type-check`, focused Vitest coverage for export and agent layout changes, and `cargo test --manifest-path src-tauri/Cargo.toml --lib`. ESLint completed with 0 errors and the existing 18 warnings.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Added structured `VideoExportRequest` for precise control over container, codec, and quality.

- Introduced editable timeline exports for FCPXML and EDL formats in the UI.

- Fixed export rendering to preserve timeline gaps using black video filler segments.

- Scoped agent artifact review inline to the sidebar, preventing persistent dock tabs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Export Dialog"] -- "VideoExportRequest" --> IPC["Tauri IPC Commands"]
  IPC -- "Render Job" --> Worker["Render Worker"]
  Worker -- "FFmpeg Filter" --> GapFix["Black Video Filler (Gap Preservation)"]
  Sidebar["Agent Sidebar"] -- "Inline Review" --> Review["Artifact Review Panel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>constants.ts</strong><dd><code>Define structured export presets and timeline format metadata</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-fbe20e6f1a2c9505b07d4c1ba56f38c91c40eeac8c1463efbddf3a1f00a63766">+192/-9</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ExportDialog.tsx</strong><dd><code>Update export UI with timeline options and kind selection</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-435be970dfffe7fa90ce2c85836395abde148304581bf3d5f8f1b5bdb9b673ff">+76/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useExportDialog.ts</strong><dd><code>Handle structured video and timeline export logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-100a1cde52e3715f4addc673c125cd63085a97836165b45cc23bd47bbf36c4ed">+82/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentArtifactReviewPanel.tsx</strong><dd><code>Add compact layout support for inline artifact review</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-7cd59fc83410568aeac29cff33f1b64411e58af4988fe50f426850630fbfdb10">+32/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>worker.rs</strong><dd><code>Process structured export settings in render jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-698f85a82a42a143fbeb1e262f70ca49bd20962595288210b54b7e84602ad6b3">+65/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Extend export types for timeline and structured settings</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-e24ba796c7f8e7f49b7813bbc101c378c32af6676f72ce6396aae099d8017929">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRenderQueue.ts</strong><dd><code>Pass structured settings to the batch render queue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-3716c1fdec2c95cbfbd5cd196cedf6eea71fc6a02e889970153b34e3933115eb">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Update export preset type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AgenticSidebarContent.tsx</strong><dd><code>Implement inline artifact review within the agent sidebar</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-31a5ed8d8fa2f4f532c6a9a1e0293c8235f7a0d2fc2283cc993b9d03cc347d00">+85/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceLayoutStore.ts</strong><dd><code>Prevent internal review panels from persisting in layouts</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-c5e395cad348500983c4afd97ac7f1231526646759b22f34c21ca47cf6ef92d2">+23/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.rs</strong><dd><code>Implement video gap preservation and structured export validation</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+1064/-84</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Update generated bindings for structured export requests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+62/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>useExportDialog.test.ts</strong><dd><code>Add tests for structured settings and timeline routing</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-3796e2cd9baf4a19931f854a9170f2434b76d91307d7579e9ed1028ded66abf4">+147/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceLayoutStore.test.ts</strong><dd><code>Verify layout normalization and review panel exclusion</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-c1d0d7dd985c79782311335e52f9aa870e2715231250d28f8f85a29de425c216">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.test.tsx</strong><dd><code>Update tests for inline artifact review behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-969b5e31db360c6d5fc816fb11979bd7020a7e0e24223f25032b805ca9b1bcac">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExportDialog.test.tsx</strong><dd><code>Test timeline export range validation bypass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-c4084e10be3133b45cd2190b1617f709d8d59645aff5989c792a812f4224659a">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRenderQueue.test.ts</strong><dd><code>Verify structured request preservation in queue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-bf71c4f20a26dc188429ae72348eac1945b5c594bb2fbf9b3ebe98006b6a731e">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgenticSidebarContent.test.tsx</strong><dd><code>Test inline review panel visibility and closing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-77f56605bd10cfd30db19f8998584f0d71dd041b76724a023c5886a946699cc0">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentArtifactReviewPanel.test.tsx</strong><dd><code>Test empty state for artifact review panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-cb307e5b44f1f014e51fa92bc5cdc201ec93208b05b5cee4545b49697f8b15db">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>EditorPanels.tsx</strong><dd><code>Wrap agent review panel in error boundary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-09c35f0f54628a35f51a56137bc0b05240002f64fdda095117d3a61af500c67f">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>payloads.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-f3daed66476f499b447507a35f59f5c54dad36ab5ee106928eba958c37bf55f3">+41/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+56/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/645/files#diff-cfbd011a7c5d0d30bcefdf80916bd1a897e3da724bc64d6bf16e4fc2430c9233">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MP4 presets: Draft and High quality options
  * Timeline export support (EDL, FCPXML) and a Timeline export mode in the dialog
  * Per-request structured video export settings (codec, container, quality, dimensions, CRF)

* **UI Improvements**
  * Artifact review now renders inline in the sidebar for a streamlined workflow
  * Export dialog shows a Timeline option and updates export button/labels accordingly

* **Behavior & Fixes**
  * Timeline exports bypass in/out range blocking; exports fill timeline gaps with black segments

* **Tests**
  * Added comprehensive unit and UI tests covering exports, presets, timeline routing, and panels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->