### PR TITLE
feat: add OpenAI perception source analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,6 +3420,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3836,6 +3846,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "async-trait",
+ "base64 0.22.1",
  "chacha20poly1305",
  "chrono",
  "dirs 5.0.1",
@@ -4743,6 +4754,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6799,6 +6811,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -130,7 +130,8 @@ portable-pty = "0.9"
 trash = "5"
 
 # FFmpeg bundler and AI providers (optional)
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json"], optional = true }
+base64 = { version = "0.22", optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json", "multipart"], optional = true }
 sha2 = { version = "0.10", optional = true }
 zip = { version = "2.2", optional = true }
 flate2 = { version = "1.0", optional = true }
@@ -170,7 +171,7 @@ whisper = ["dep:whisper-rs"]
 # Enable Meilisearch full-text search
 meilisearch = ["dep:meilisearch-sdk", "dep:futures", "dep:reqwest"]
 # Enable AI providers (OpenAI, Anthropic, Ollama)
-ai-providers = ["dep:reqwest"]
+ai-providers = ["dep:base64", "dep:reqwest"]
 # Full AI bundle (for production builds with all features)
 ai-full = ["whisper", "meilisearch", "ai-providers"]
 # Development build with all features enabled (for contributors)

--- a/src-tauri/src/core/analysis/esd.rs
+++ b/src-tauri/src/core/analysis/esd.rs
@@ -573,7 +573,7 @@ fn compute_median(values: &[f64]) -> f64 {
     let mut sorted = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let n = sorted.len();
-    if n % 2 == 0 {
+    if n.is_multiple_of(2) {
         (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
     } else {
         sorted[n / 2]

--- a/src-tauri/src/core/analysis/mod.rs
+++ b/src-tauri/src/core/analysis/mod.rs
@@ -66,6 +66,8 @@ const BUNDLE_FILENAME: &str = "bundle.json";
 /// Name of the generated contact-sheet image
 const CONTACT_SHEET_FILENAME: &str = "contact-sheet.jpg";
 
+const LOCAL_WHISPER_MODEL: WhisperModel = WhisperModel::Base;
+
 // =============================================================================
 // Analysis Job Runner
 // =============================================================================
@@ -275,11 +277,13 @@ impl AnalysisJobRunner {
                         .unwrap_or(&[]),
                 );
                 bundle.transcript = Some(transcript.clone());
-                bundle.transcript_detail = Some(build_transcript_detail_from_segments(
-                    &transcript,
-                    "whisper",
-                    "base",
-                ));
+                if !transcript.is_empty() {
+                    bundle.transcript_detail = Some(build_transcript_detail_from_segments(
+                        &transcript,
+                        "whisper",
+                        LOCAL_WHISPER_MODEL.name(),
+                    ));
+                }
                 emit_progress(
                     "transcript",
                     "completed",
@@ -516,7 +520,7 @@ impl AnalysisJobRunner {
             ));
         }
 
-        let model = WhisperModel::Base;
+        let model = LOCAL_WHISPER_MODEL;
         let model_path = default_models_dir().join(model.filename());
         if !model_path.exists() {
             return Err(CoreError::NotFound(format!(
@@ -708,7 +712,7 @@ fn build_transcript_detail_from_segments(
                     start_sec: segment.start_sec,
                     end_sec: segment.end_sec,
                     speaker_id: speaker_id.clone(),
-                    text: segment.text.clone(),
+                    text: segment.text.trim().to_string(),
                     confidence: Some(segment.confidence),
                 })
         })

--- a/src-tauri/src/core/analysis/mod.rs
+++ b/src-tauri/src/core/analysis/mod.rs
@@ -30,6 +30,8 @@ pub mod diarization_runner;
 pub mod dtw;
 pub mod ducking;
 pub mod esd;
+#[cfg(feature = "ai-providers")]
+pub mod openai_perception;
 pub mod segmentation;
 pub mod speaker_turns;
 pub mod style_planner;
@@ -40,7 +42,7 @@ pub use types::*;
 
 use std::path::{Path, PathBuf};
 
-use crate::core::annotations::models::{ShotResult, TranscriptSegment};
+use crate::core::annotations::models::{estimate_word_timings, ShotResult, TranscriptSegment};
 use crate::core::captions::{
     audio::{extract_audio_for_transcription, load_audio_samples},
     whisper::{
@@ -273,6 +275,11 @@ impl AnalysisJobRunner {
                         .unwrap_or(&[]),
                 );
                 bundle.transcript = Some(transcript.clone());
+                bundle.transcript_detail = Some(build_transcript_detail_from_segments(
+                    &transcript,
+                    "whisper",
+                    "base",
+                ));
                 emit_progress(
                     "transcript",
                     "completed",
@@ -676,6 +683,42 @@ impl AnalysisJobRunner {
         // Default to local analysis; vision API results can update the bundle later
         let frames = analyzer.analyze_frames_local(video_path, shots_ref).await?;
         Ok(Some(frames))
+    }
+}
+
+fn build_transcript_detail_from_segments(
+    transcript: &[TranscriptSegment],
+    provider: &str,
+    model: &str,
+) -> types::TranscriptDetail {
+    let full = transcript
+        .iter()
+        .map(|segment| segment.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let words = estimate_word_timings(transcript);
+    let speaker_segments = transcript
+        .iter()
+        .filter_map(|segment| {
+            segment
+                .speaker_id
+                .as_ref()
+                .map(|speaker_id| types::SpeakerSegment {
+                    start_sec: segment.start_sec,
+                    end_sec: segment.end_sec,
+                    speaker_id: speaker_id.clone(),
+                    text: segment.text.clone(),
+                    confidence: Some(segment.confidence),
+                })
+        })
+        .collect();
+
+    types::TranscriptDetail {
+        full,
+        words,
+        speaker_segments,
+        provider: Some(types::PerceptionProviderMetadata::new(provider, model)),
     }
 }
 

--- a/src-tauri/src/core/analysis/openai_perception.rs
+++ b/src-tauri/src/core/analysis/openai_perception.rs
@@ -1,0 +1,700 @@
+//! OpenAI-backed perception helpers for source video analysis.
+//!
+//! This module is intentionally kept out of the core FFmpeg pipeline. The worker
+//! pipeline remains local and deterministic; cloud perception is an optional
+//! post-processing pass that enriches an `AnalysisBundle` with semantic frame
+//! observations and speaker-aware transcript detail.
+
+use std::path::{Path, PathBuf};
+
+use base64::{engine::general_purpose, Engine as _};
+use reqwest::multipart;
+use serde::Deserialize;
+use tokio::process::Command;
+
+use crate::core::annotations::models::{estimate_word_timings, ShotResult, TranscriptSegment};
+use crate::core::process::configure_tokio_command;
+use crate::core::{CoreError, CoreResult};
+
+use super::types::{
+    CameraAngle, FrameAnalysis, FrameObservation, MotionDirection, PerceptionProviderMetadata,
+    SpeakerSegment, SubjectPosition, TranscriptDetail,
+};
+
+const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_VISION_MODEL: &str = "gpt-4.1-mini";
+const DEFAULT_TRANSCRIPT_MODEL: &str = "gpt-4o-transcribe-diarize";
+const MAX_VISION_FRAMES_PER_REQUEST: usize = 24;
+const AUDIO_CHUNK_SECONDS: u32 = 600;
+const AUDIO_CHUNK_BITRATE: &str = "64k";
+
+/// OpenAI perception configuration resolved from app settings and credential vault.
+#[derive(Clone, Debug)]
+pub struct OpenAiPerceptionConfig {
+    pub api_key: String,
+    pub vision_model: String,
+    pub transcript_model: String,
+    pub base_url: String,
+}
+
+impl OpenAiPerceptionConfig {
+    pub fn new(api_key: String, vision_model: Option<String>) -> Self {
+        Self {
+            api_key,
+            vision_model: vision_model.unwrap_or_else(|| DEFAULT_VISION_MODEL.to_string()),
+            transcript_model: DEFAULT_TRANSCRIPT_MODEL.to_string(),
+            base_url: OPENAI_BASE_URL.to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VisionInputFrame {
+    shot_index: usize,
+    time_sec: f64,
+    image_path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatResponse {
+    choices: Vec<OpenAiChatChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatChoice {
+    message: OpenAiChatMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatMessage {
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VisionJsonEnvelope {
+    frames: Vec<VisionJsonFrame>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VisionJsonFrame {
+    shot_index: usize,
+    #[serde(default)]
+    camera_angle: Option<String>,
+    #[serde(default)]
+    subject_position: Option<String>,
+    #[serde(default)]
+    motion_direction: Option<String>,
+    #[serde(default)]
+    visual_complexity: Option<f64>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    subjects: Vec<String>,
+    #[serde(default)]
+    actions: Vec<String>,
+    #[serde(default)]
+    setting: Option<String>,
+    #[serde(default)]
+    visible_text: Vec<String>,
+    #[serde(default)]
+    objects: Vec<String>,
+    #[serde(default)]
+    edit_usefulness: Option<String>,
+    #[serde(default)]
+    confidence: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DiarizedTranscriptResponse {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    segments: Vec<DiarizedTranscriptSegment>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DiarizedTranscriptSegment {
+    start: f64,
+    end: f64,
+    text: String,
+    #[serde(default)]
+    speaker: Option<String>,
+    #[serde(default)]
+    confidence: Option<f64>,
+}
+
+/// Runs OpenAI vision over extracted shot keyframes and returns legacy frame
+/// classifications plus v2 semantic frame observations.
+pub async fn analyze_keyframes_with_openai(
+    config: &OpenAiPerceptionConfig,
+    shots: &[ShotResult],
+    contact_sheet_path: Option<&Path>,
+) -> CoreResult<(Vec<FrameAnalysis>, Vec<FrameObservation>)> {
+    let inputs = collect_vision_inputs(shots);
+    if inputs.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let response_text = request_openai_vision(config, &inputs, contact_sheet_path).await?;
+    parse_openai_vision_response(&response_text, shots, &inputs, config)
+}
+
+/// Runs OpenAI speaker diarization transcription on compressed audio chunks.
+pub async fn transcribe_with_openai(
+    config: &OpenAiPerceptionConfig,
+    video_path: &Path,
+    output_dir: &Path,
+    ffmpeg_path: &Path,
+) -> CoreResult<(Vec<TranscriptSegment>, TranscriptDetail)> {
+    let chunk_dir = output_dir.join("openai-audio-chunks");
+    let chunk_paths = extract_audio_chunks(video_path, &chunk_dir, ffmpeg_path).await?;
+    if chunk_paths.is_empty() {
+        return Err(CoreError::AnalysisFailed(
+            "OpenAI transcription could not extract any audio chunks".to_string(),
+        ));
+    }
+
+    let mut segments = Vec::new();
+    let mut speaker_segments = Vec::new();
+
+    for (index, chunk_path) in chunk_paths.iter().enumerate() {
+        let offset_sec = index as f64 * AUDIO_CHUNK_SECONDS as f64;
+        let chunk_response = request_openai_diarized_transcript(config, chunk_path).await?;
+        let (chunk_segments, chunk_speaker_segments) =
+            parse_diarized_transcript_response(&chunk_response, offset_sec);
+        segments.extend(chunk_segments);
+        speaker_segments.extend(chunk_speaker_segments);
+    }
+
+    if segments.is_empty() {
+        return Err(CoreError::AnalysisFailed(
+            "OpenAI transcription returned no timed segments".to_string(),
+        ));
+    }
+
+    let full = segments
+        .iter()
+        .map(|segment| segment.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let words = estimate_word_timings(&segments);
+    let detail = TranscriptDetail {
+        full,
+        words,
+        speaker_segments,
+        provider: Some(PerceptionProviderMetadata::new(
+            "openai",
+            &config.transcript_model,
+        )),
+    };
+
+    Ok((segments, detail))
+}
+
+fn collect_vision_inputs(shots: &[ShotResult]) -> Vec<VisionInputFrame> {
+    shots
+        .iter()
+        .enumerate()
+        .filter_map(|(shot_index, shot)| {
+            let image_path = shot.keyframe_path.as_ref().map(PathBuf::from)?;
+            if !image_path.is_file() {
+                return None;
+            }
+
+            Some(VisionInputFrame {
+                shot_index,
+                time_sec: (shot.start_sec + shot.end_sec) / 2.0,
+                image_path,
+            })
+        })
+        .take(MAX_VISION_FRAMES_PER_REQUEST)
+        .collect()
+}
+
+async fn request_openai_vision(
+    config: &OpenAiPerceptionConfig,
+    inputs: &[VisionInputFrame],
+    contact_sheet_path: Option<&Path>,
+) -> CoreResult<String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|error| CoreError::Internal(format!("Failed to create OpenAI client: {error}")))?;
+
+    let mut content = vec![serde_json::json!({
+        "type": "text",
+        "text": build_vision_prompt(inputs),
+    })];
+
+    for input in inputs {
+        content.push(build_openai_image_content(&input.image_path, "keyframe").await?);
+    }
+
+    if let Some(path) = contact_sheet_path.filter(|path| path.is_file()) {
+        content.push(build_openai_image_content(path, "contact sheet").await?);
+    }
+
+    let body = serde_json::json!({
+        "model": config.vision_model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You analyze video source keyframes for a professional editing agent. Return compact, valid JSON only."
+            },
+            {
+                "role": "user",
+                "content": content
+            }
+        ],
+        "response_format": { "type": "json_object" },
+        "temperature": 0
+    });
+
+    let response = client
+        .post(format!("{}/chat/completions", config.base_url))
+        .bearer_auth(&config.api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| {
+            CoreError::AIRequestFailed(format!("OpenAI vision request failed: {error}"))
+        })?;
+
+    let status = response.status();
+    let body = response.text().await.map_err(|error| {
+        CoreError::AIRequestFailed(format!("OpenAI vision response read failed: {error}"))
+    })?;
+    if !status.is_success() {
+        return Err(CoreError::AIRequestFailed(format!(
+            "OpenAI vision request failed with status {status}: {body}"
+        )));
+    }
+
+    let parsed: OpenAiChatResponse = serde_json::from_str(&body).map_err(|error| {
+        CoreError::AnalysisFailed(format!(
+            "OpenAI vision response was not valid JSON: {error}"
+        ))
+    })?;
+    parsed
+        .choices
+        .first()
+        .and_then(|choice| choice.message.content.as_deref())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            CoreError::AnalysisFailed("OpenAI vision response did not include content".to_string())
+        })
+}
+
+async fn build_openai_image_content(path: &Path, label: &str) -> CoreResult<serde_json::Value> {
+    let bytes = tokio::fs::read(path).await.map_err(|error| {
+        CoreError::AnalysisFailed(format!(
+            "Failed to read {label} {}: {}",
+            path.display(),
+            error
+        ))
+    })?;
+    let encoded = general_purpose::STANDARD.encode(bytes);
+
+    Ok(serde_json::json!({
+        "type": "image_url",
+        "image_url": {
+            "url": format!("data:image/jpeg;base64,{encoded}"),
+            "detail": "low"
+        }
+    }))
+}
+
+fn build_vision_prompt(inputs: &[VisionInputFrame]) -> String {
+    let shot_map = inputs
+        .iter()
+        .map(|input| {
+            format!(
+                "- shot_index {} at {:.3}s",
+                input.shot_index, input.time_sec
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "Analyze the attached keyframes. They correspond to these source-video shots:\n{shot_map}\n\nA final contact sheet image may also be attached for global context; do not invent extra shot indexes from it.\n\nReturn exactly this JSON shape:\n{{\"frames\":[{{\"shot_index\":0,\"camera_angle\":\"wide|medium|close|extreme_close|unknown\",\"subject_position\":\"center|left|right|top|bottom|unknown\",\"motion_direction\":\"static|pan_left|pan_right|tilt_up|tilt_down|zoom_in|zoom_out|unknown\",\"visual_complexity\":0.0,\"description\":\"one sentence\",\"subjects\":[\"person\"],\"actions\":[\"speaking\"],\"setting\":\"studio\",\"visible_text\":[\"text\"],\"objects\":[\"microphone\"],\"edit_usefulness\":\"how an editor could use it\",\"confidence\":0.0}}]}}\nUse the provided shot_index values. Keep arrays short and omit guesses when uncertain."
+    )
+}
+
+fn parse_openai_vision_response(
+    response_text: &str,
+    shots: &[ShotResult],
+    inputs: &[VisionInputFrame],
+    config: &OpenAiPerceptionConfig,
+) -> CoreResult<(Vec<FrameAnalysis>, Vec<FrameObservation>)> {
+    let json_text = extract_json_object(response_text).unwrap_or(response_text);
+    let parsed: VisionJsonEnvelope = serde_json::from_str(json_text).map_err(|error| {
+        CoreError::AnalysisFailed(format!("OpenAI vision JSON did not match schema: {error}"))
+    })?;
+    let input_by_shot = inputs
+        .iter()
+        .map(|input| (input.shot_index, input))
+        .collect::<std::collections::HashMap<_, _>>();
+    let provider = PerceptionProviderMetadata::new("openai", &config.vision_model);
+    let mut frame_analysis = shots
+        .iter()
+        .enumerate()
+        .map(|(index, _)| FrameAnalysis::local_fallback(index, 0.5))
+        .collect::<Vec<_>>();
+    let mut observations = Vec::new();
+
+    for frame in parsed.frames {
+        if frame.shot_index >= shots.len() {
+            continue;
+        }
+
+        let input = match input_by_shot.get(&frame.shot_index) {
+            Some(input) => *input,
+            None => continue,
+        };
+        let confidence = frame.confidence.unwrap_or(0.75).clamp(0.0, 1.0);
+        frame_analysis[frame.shot_index] = FrameAnalysis {
+            shot_index: frame.shot_index,
+            camera_angle: parse_camera_angle(frame.camera_angle.as_deref()),
+            subject_position: parse_subject_position(frame.subject_position.as_deref()),
+            motion_direction: parse_motion_direction(frame.motion_direction.as_deref()),
+            visual_complexity: frame.visual_complexity.unwrap_or(0.5).clamp(0.0, 1.0),
+        };
+        observations.push(FrameObservation {
+            shot_index: frame.shot_index,
+            time_sec: input.time_sec,
+            image_path: input.image_path.to_string_lossy().to_string(),
+            description: normalize_optional_text(frame.description)
+                .unwrap_or_else(|| "No reliable visual description returned.".to_string()),
+            subjects: normalize_string_vec(frame.subjects, 8),
+            actions: normalize_string_vec(frame.actions, 8),
+            setting: normalize_optional_text(frame.setting),
+            visible_text: normalize_string_vec(frame.visible_text, 12),
+            objects: normalize_string_vec(frame.objects, 12),
+            edit_usefulness: normalize_optional_text(frame.edit_usefulness),
+            confidence,
+            provider: provider.clone(),
+        });
+    }
+
+    Ok((frame_analysis, observations))
+}
+
+async fn extract_audio_chunks(
+    video_path: &Path,
+    chunk_dir: &Path,
+    ffmpeg_path: &Path,
+) -> CoreResult<Vec<PathBuf>> {
+    if chunk_dir.exists() {
+        tokio::fs::remove_dir_all(chunk_dir)
+            .await
+            .map_err(|error| {
+                CoreError::AnalysisFailed(format!(
+                    "Failed to clear stale OpenAI audio chunk directory {}: {}",
+                    chunk_dir.display(),
+                    error
+                ))
+            })?;
+    }
+    tokio::fs::create_dir_all(chunk_dir).await?;
+    let output_pattern = chunk_dir.join("chunk-%03d.mp3");
+
+    let mut cmd = Command::new(ffmpeg_path);
+    configure_tokio_command(&mut cmd);
+    cmd.arg("-hide_banner")
+        .arg("-nostdin")
+        .arg("-y")
+        .arg("-i")
+        .arg(video_path)
+        .arg("-vn")
+        .arg("-ac")
+        .arg("1")
+        .arg("-ar")
+        .arg("16000")
+        .arg("-b:a")
+        .arg(AUDIO_CHUNK_BITRATE)
+        .arg("-f")
+        .arg("segment")
+        .arg("-segment_time")
+        .arg(AUDIO_CHUNK_SECONDS.to_string())
+        .arg("-reset_timestamps")
+        .arg("1")
+        .arg(output_pattern)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped());
+
+    let output = cmd.output().await.map_err(|error| {
+        CoreError::Internal(format!(
+            "Failed to spawn FFmpeg for audio chunking: {error}"
+        ))
+    })?;
+    if !output.status.success() {
+        return Err(CoreError::AnalysisFailed(format!(
+            "FFmpeg audio chunk extraction failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let mut paths = Vec::new();
+    let mut entries = tokio::fs::read_dir(chunk_dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("mp3") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+async fn request_openai_diarized_transcript(
+    config: &OpenAiPerceptionConfig,
+    chunk_path: &Path,
+) -> CoreResult<String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(180))
+        .build()
+        .map_err(|error| CoreError::Internal(format!("Failed to create OpenAI client: {error}")))?;
+    let bytes = tokio::fs::read(chunk_path).await.map_err(|error| {
+        CoreError::AnalysisFailed(format!(
+            "Failed to read audio chunk {}: {}",
+            chunk_path.display(),
+            error
+        ))
+    })?;
+    let filename = chunk_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("chunk.mp3")
+        .to_string();
+    let file_part = multipart::Part::bytes(bytes)
+        .file_name(filename)
+        .mime_str("audio/mpeg")
+        .map_err(|error| CoreError::Internal(format!("Invalid multipart MIME type: {error}")))?;
+    let form = multipart::Form::new()
+        .part("file", file_part)
+        .text("model", config.transcript_model.clone())
+        .text("response_format", "diarized_json")
+        .text("chunking_strategy", "auto");
+
+    let response = client
+        .post(format!("{}/audio/transcriptions", config.base_url))
+        .bearer_auth(&config.api_key)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|error| {
+            CoreError::AIRequestFailed(format!("OpenAI transcription request failed: {error}"))
+        })?;
+    let status = response.status();
+    let body = response.text().await.map_err(|error| {
+        CoreError::AIRequestFailed(format!(
+            "OpenAI transcription response read failed: {error}"
+        ))
+    })?;
+    if !status.is_success() {
+        return Err(CoreError::AIRequestFailed(format!(
+            "OpenAI transcription failed with status {status}: {body}"
+        )));
+    }
+
+    Ok(body)
+}
+
+fn parse_diarized_transcript_response(
+    response_text: &str,
+    offset_sec: f64,
+) -> (Vec<TranscriptSegment>, Vec<SpeakerSegment>) {
+    let parsed = match serde_json::from_str::<DiarizedTranscriptResponse>(response_text) {
+        Ok(parsed) => parsed,
+        Err(_) => return (Vec::new(), Vec::new()),
+    };
+    let mut segments = Vec::new();
+    let mut speaker_segments = Vec::new();
+
+    for (index, segment) in parsed.segments.into_iter().enumerate() {
+        let speaker = segment
+            .speaker
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| format!("speaker_{}", index + 1));
+        let confidence = segment.confidence.unwrap_or(0.9).clamp(0.0, 1.0);
+        let start_sec = offset_sec + segment.start.max(0.0);
+        let end_sec = offset_sec + segment.end.max(segment.start);
+        let transcript_segment =
+            TranscriptSegment::new(start_sec, end_sec, &segment.text, confidence)
+                .with_speaker(&speaker);
+
+        speaker_segments.push(SpeakerSegment {
+            start_sec,
+            end_sec,
+            speaker_id: speaker,
+            text: segment.text,
+            confidence: Some(confidence),
+        });
+        segments.push(transcript_segment);
+    }
+
+    if segments.is_empty() {
+        if let Some(text) = parsed
+            .text
+            .and_then(|text| normalize_optional_text(Some(text)))
+        {
+            let segment = TranscriptSegment::new(offset_sec, offset_sec, &text, 0.5);
+            segments.push(segment);
+        }
+    }
+
+    (segments, speaker_segments)
+}
+
+fn parse_camera_angle(value: Option<&str>) -> CameraAngle {
+    match value
+        .unwrap_or("unknown")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "wide" => CameraAngle::Wide,
+        "medium" => CameraAngle::Medium,
+        "close" => CameraAngle::Close,
+        "extreme_close" => CameraAngle::ExtremeClose,
+        _ => CameraAngle::Unknown,
+    }
+}
+
+fn parse_subject_position(value: Option<&str>) -> SubjectPosition {
+    match value
+        .unwrap_or("unknown")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "center" => SubjectPosition::Center,
+        "left" => SubjectPosition::Left,
+        "right" => SubjectPosition::Right,
+        "top" => SubjectPosition::Top,
+        "bottom" => SubjectPosition::Bottom,
+        _ => SubjectPosition::Unknown,
+    }
+}
+
+fn parse_motion_direction(value: Option<&str>) -> MotionDirection {
+    match value
+        .unwrap_or("unknown")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "static" => MotionDirection::Static,
+        "pan_left" => MotionDirection::PanLeft,
+        "pan_right" => MotionDirection::PanRight,
+        "tilt_up" => MotionDirection::TiltUp,
+        "tilt_down" => MotionDirection::TiltDown,
+        "zoom_in" => MotionDirection::ZoomIn,
+        "zoom_out" => MotionDirection::ZoomOut,
+        _ => MotionDirection::Unknown,
+    }
+}
+
+fn normalize_string_vec(values: Vec<String>, limit: usize) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for value in values {
+        if let Some(text) = normalize_optional_text(Some(value)) {
+            if !normalized.contains(&text) {
+                normalized.push(text);
+            }
+        }
+        if normalized.len() >= limit {
+            break;
+        }
+    }
+    normalized
+}
+
+fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn extract_json_object(text: &str) -> Option<&str> {
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    if start <= end {
+        Some(&text[start..=end])
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_vision_json_into_frame_observations() {
+        let shots = vec![ShotResult::new(0.0, 4.0, 0.9)];
+        let inputs = vec![VisionInputFrame {
+            shot_index: 0,
+            time_sec: 2.0,
+            image_path: PathBuf::from("/tmp/keyframe.jpg"),
+        }];
+        let config = OpenAiPerceptionConfig::new("sk-test".to_string(), None);
+        let response = r#"```json
+        {
+          "frames": [{
+            "shot_index": 0,
+            "camera_angle": "medium",
+            "subject_position": "center",
+            "motion_direction": "static",
+            "visual_complexity": 0.4,
+            "description": "A presenter speaks to camera.",
+            "subjects": ["presenter"],
+            "actions": ["speaking"],
+            "setting": "studio",
+            "visible_text": ["LIVE"],
+            "objects": ["microphone"],
+            "edit_usefulness": "Good explanatory beat.",
+            "confidence": 0.87
+          }]
+        }
+        ```"#;
+
+        let (frames, observations) =
+            parse_openai_vision_response(response, &shots, &inputs, &config).unwrap();
+
+        assert_eq!(frames[0].camera_angle, CameraAngle::Medium);
+        assert_eq!(observations[0].description, "A presenter speaks to camera.");
+        assert_eq!(observations[0].visible_text, vec!["LIVE"]);
+        assert_eq!(observations[0].provider.provider, "openai");
+    }
+
+    #[test]
+    fn should_parse_diarized_transcript_with_offset() {
+        let response = r#"{
+          "text": "Hello there",
+          "segments": [
+            { "start": 1.0, "end": 2.5, "speaker": "speaker_a", "text": "Hello there", "confidence": 0.91 }
+          ]
+        }"#;
+
+        let (segments, speaker_segments) = parse_diarized_transcript_response(response, 600.0);
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].start_sec, 601.0);
+        assert_eq!(segments[0].speaker_id.as_deref(), Some("speaker_a"));
+        assert_eq!(speaker_segments[0].end_sec, 602.5);
+    }
+
+    #[test]
+    fn should_estimate_words_for_openai_transcript_detail() {
+        let segments =
+            vec![TranscriptSegment::new(0.0, 2.0, "Hello there", 0.9).with_speaker("speaker_a")];
+        let words = estimate_word_timings(&segments);
+
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].speaker_id.as_deref(), Some("speaker_a"));
+    }
+}

--- a/src-tauri/src/core/analysis/segmentation.rs
+++ b/src-tauri/src/core/analysis/segmentation.rs
@@ -375,7 +375,7 @@ impl ContentSegmenter {
         }
 
         finite_values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let median_db = if finite_values.len() % 2 == 0 {
+        let median_db = if finite_values.len().is_multiple_of(2) {
             let upper = finite_values.len() / 2;
             (finite_values[upper - 1] + finite_values[upper]) / 2.0
         } else {

--- a/src-tauri/src/core/analysis/types.rs
+++ b/src-tauri/src/core/analysis/types.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use crate::core::annotations::models::{ShotResult, TranscriptSegment};
+use crate::core::annotations::models::{ShotResult, TranscriptSegment, TranscriptWord};
 
 /// Finite decibel floor used for silent audio serialization.
 pub const SILENCE_FLOOR_DB: f64 = -90.0;
@@ -274,6 +274,103 @@ impl FrameAnalysis {
 }
 
 // =============================================================================
+// Perception Provider Metadata
+// =============================================================================
+
+/// Metadata describing the model that produced semantic perception signals.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PerceptionProviderMetadata {
+    /// Provider identifier, e.g. "openai" or "local"
+    pub provider: String,
+    /// Model identifier used by the provider
+    pub model: String,
+    /// ISO 8601 timestamp when this perception result was produced
+    pub analyzed_at: String,
+}
+
+impl PerceptionProviderMetadata {
+    /// Creates provider metadata with the current timestamp.
+    pub fn new(provider: &str, model: &str) -> Self {
+        Self {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            analyzed_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+/// Semantic visual observation for a representative frame/keyframe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameObservation {
+    /// Index of the shot this observation describes
+    pub shot_index: usize,
+    /// Source-relative timestamp represented by the observed image
+    pub time_sec: f64,
+    /// Absolute or workspace-relative path to the analyzed image
+    pub image_path: String,
+    /// Natural-language description of what is visible
+    pub description: String,
+    /// People or subject categories visible in the frame
+    #[serde(default)]
+    pub subjects: Vec<String>,
+    /// Observable actions or motion implied by the frame
+    #[serde(default)]
+    pub actions: Vec<String>,
+    /// Setting or environment label
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setting: Option<String>,
+    /// OCR text visible in the frame
+    #[serde(default)]
+    pub visible_text: Vec<String>,
+    /// Object or prop labels visible in the frame
+    #[serde(default)]
+    pub objects: Vec<String>,
+    /// Short note explaining how this shot may be useful in an edit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edit_usefulness: Option<String>,
+    /// Provider confidence (0.0 - 1.0)
+    pub confidence: f64,
+    /// Provider/model that produced this observation
+    pub provider: PerceptionProviderMetadata,
+}
+
+/// Speaker-aware transcript range used by `TranscriptDetail`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeakerSegment {
+    /// Start time in seconds
+    pub start_sec: f64,
+    /// End time in seconds
+    pub end_sec: f64,
+    /// Speaker identifier
+    pub speaker_id: String,
+    /// Segment text
+    pub text: String,
+    /// Provider confidence (0.0 - 1.0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+}
+
+/// Full transcript details beyond the legacy segment list.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptDetail {
+    /// Complete transcript text
+    pub full: String,
+    /// Word-level timings, estimated or provider supplied
+    #[serde(default)]
+    pub words: Vec<TranscriptWord>,
+    /// Speaker-aware transcript ranges
+    #[serde(default)]
+    pub speaker_segments: Vec<SpeakerSegment>,
+    /// Provider/model that produced this transcript detail
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<PerceptionProviderMetadata>,
+}
+
+// =============================================================================
 // Video Metadata
 // =============================================================================
 
@@ -419,6 +516,9 @@ pub struct ContactSheetArtifact {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalysisBundle {
+    /// Analysis schema version. Version 2 adds transcript detail and frame observations.
+    #[serde(default = "default_analysis_schema_version")]
+    pub schema_version: u32,
     /// Asset ID this bundle belongs to
     pub asset_id: String,
     /// Shot detection results
@@ -431,6 +531,12 @@ pub struct AnalysisBundle {
     pub segments: Option<Vec<ContentSegment>>,
     /// Visual frame analysis results
     pub frame_analysis: Option<Vec<FrameAnalysis>>,
+    /// Semantic observations produced by a vision-capable provider.
+    #[serde(default)]
+    pub frame_observations: Option<Vec<FrameObservation>>,
+    /// Full transcript, words, and speaker-aware segments when available.
+    #[serde(default)]
+    pub transcript_detail: Option<TranscriptDetail>,
     /// Representative-frame contact sheet artifact
     #[serde(default)]
     pub contact_sheet: Option<ContactSheetArtifact>,
@@ -447,12 +553,15 @@ impl AnalysisBundle {
     /// Creates a new empty bundle for an asset
     pub fn new(asset_id: &str, metadata: VideoMetadata) -> Self {
         Self {
+            schema_version: default_analysis_schema_version(),
             asset_id: asset_id.to_string(),
             shots: None,
             transcript: None,
             audio_profile: None,
             segments: None,
             frame_analysis: None,
+            frame_observations: None,
+            transcript_detail: None,
             contact_sheet: None,
             metadata,
             errors: HashMap::new(),
@@ -469,9 +578,11 @@ impl AnalysisBundle {
     pub fn has_results(&self) -> bool {
         self.shots.is_some()
             || self.transcript.is_some()
+            || self.transcript_detail.is_some()
             || self.audio_profile.is_some()
             || self.segments.is_some()
             || self.frame_analysis.is_some()
+            || self.frame_observations.is_some()
             || self.contact_sheet.is_some()
     }
 
@@ -479,6 +590,10 @@ impl AnalysisBundle {
     pub fn is_complete(&self) -> bool {
         self.errors.is_empty()
     }
+}
+
+fn default_analysis_schema_version() -> u32 {
+    2
 }
 
 // =============================================================================
@@ -694,11 +809,14 @@ mod tests {
     fn should_create_empty_bundle() {
         let bundle = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
         assert_eq!(bundle.asset_id, "asset_001");
+        assert_eq!(bundle.schema_version, 2);
         assert!(bundle.shots.is_none());
         assert!(bundle.transcript.is_none());
+        assert!(bundle.transcript_detail.is_none());
         assert!(bundle.audio_profile.is_none());
         assert!(bundle.segments.is_none());
         assert!(bundle.frame_analysis.is_none());
+        assert!(bundle.frame_observations.is_none());
         assert!(bundle.errors.is_empty());
         assert!(!bundle.has_results());
         assert!(bundle.is_complete());
@@ -760,15 +878,52 @@ mod tests {
             columns: 2,
             rows: 1,
         });
+        bundle.frame_observations = Some(vec![FrameObservation {
+            shot_index: 0,
+            time_sec: 2.5,
+            image_path: "/tmp/keyframes/0.jpg".to_string(),
+            description: "A host is speaking to camera in a studio.".to_string(),
+            subjects: vec!["host".to_string()],
+            actions: vec!["speaking".to_string()],
+            setting: Some("studio".to_string()),
+            visible_text: vec!["OPENREELIO".to_string()],
+            objects: vec!["microphone".to_string()],
+            edit_usefulness: Some("Strong opener or explanation beat.".to_string()),
+            confidence: 0.86,
+            provider: PerceptionProviderMetadata::new("openai", "gpt-4.1-mini"),
+        }]);
+        bundle.transcript_detail = Some(TranscriptDetail {
+            full: "Hello from the studio".to_string(),
+            words: crate::core::annotations::models::estimate_word_timings(&[
+                TranscriptSegment::new(0.0, 2.0, "Hello from the studio", 0.9),
+            ]),
+            speaker_segments: vec![SpeakerSegment {
+                start_sec: 0.0,
+                end_sec: 2.0,
+                speaker_id: "speaker_1".to_string(),
+                text: "Hello from the studio".to_string(),
+                confidence: Some(0.9),
+            }],
+            provider: Some(PerceptionProviderMetadata::new(
+                "openai",
+                "gpt-4o-transcribe-diarize",
+            )),
+        });
 
         let json = serde_json::to_string_pretty(&bundle).unwrap();
         let parsed: AnalysisBundle = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.asset_id, "asset_001");
+        assert_eq!(parsed.schema_version, 2);
         assert_eq!(parsed.shots.as_ref().unwrap().len(), 2);
         assert_eq!(parsed.audio_profile.as_ref().unwrap().bpm, Some(128.0));
         assert_eq!(parsed.segments.as_ref().unwrap().len(), 2);
         assert_eq!(parsed.frame_analysis.as_ref().unwrap().len(), 2);
+        assert_eq!(parsed.frame_observations.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            parsed.transcript_detail.as_ref().unwrap().speaker_segments[0].speaker_id,
+            "speaker_1"
+        );
         assert_eq!(parsed.contact_sheet.as_ref().unwrap().frame_count, 2);
         assert!(parsed.errors.is_empty());
     }
@@ -783,6 +938,8 @@ mod tests {
         assert!(json.contains("\"audioProfile\":null"));
         assert!(json.contains("\"segments\":null"));
         assert!(json.contains("\"frameAnalysis\":null"));
+        assert!(json.contains("\"frameObservations\":null"));
+        assert!(json.contains("\"transcriptDetail\":null"));
         assert!(json.contains("\"contactSheet\":null"));
         assert!(json.contains("\"errors\":{}"));
 
@@ -793,7 +950,31 @@ mod tests {
         assert!(parsed.audio_profile.is_none());
         assert!(parsed.segments.is_none());
         assert!(parsed.frame_analysis.is_none());
+        assert!(parsed.frame_observations.is_none());
+        assert!(parsed.transcript_detail.is_none());
         assert!(parsed.contact_sheet.is_none());
+    }
+
+    #[test]
+    fn should_read_legacy_bundle_without_v2_fields() {
+        let json = r#"{
+            "assetId": "asset_legacy",
+            "shots": null,
+            "transcript": null,
+            "audioProfile": null,
+            "segments": null,
+            "frameAnalysis": null,
+            "contactSheet": null,
+            "metadata": { "durationSec": 10.0, "hasAudio": true },
+            "errors": {},
+            "analyzedAt": "2026-03-07T00:00:00Z"
+        }"#;
+
+        let parsed: AnalysisBundle = serde_json::from_str(json).unwrap();
+
+        assert_eq!(parsed.schema_version, 2);
+        assert!(parsed.frame_observations.is_none());
+        assert!(parsed.transcript_detail.is_none());
     }
 
     #[test]

--- a/src-tauri/src/core/analysis/types.rs
+++ b/src-tauri/src/core/analysis/types.rs
@@ -517,7 +517,7 @@ pub struct ContactSheetArtifact {
 #[serde(rename_all = "camelCase")]
 pub struct AnalysisBundle {
     /// Analysis schema version. Version 2 adds transcript detail and frame observations.
-    #[serde(default = "default_analysis_schema_version")]
+    #[serde(default = "legacy_analysis_schema_version")]
     pub schema_version: u32,
     /// Asset ID this bundle belongs to
     pub asset_id: String,
@@ -553,7 +553,7 @@ impl AnalysisBundle {
     /// Creates a new empty bundle for an asset
     pub fn new(asset_id: &str, metadata: VideoMetadata) -> Self {
         Self {
-            schema_version: default_analysis_schema_version(),
+            schema_version: current_analysis_schema_version(),
             asset_id: asset_id.to_string(),
             shots: None,
             transcript: None,
@@ -592,8 +592,12 @@ impl AnalysisBundle {
     }
 }
 
-fn default_analysis_schema_version() -> u32 {
+fn current_analysis_schema_version() -> u32 {
     2
+}
+
+fn legacy_analysis_schema_version() -> u32 {
+    1
 }
 
 // =============================================================================
@@ -972,7 +976,7 @@ mod tests {
 
         let parsed: AnalysisBundle = serde_json::from_str(json).unwrap();
 
-        assert_eq!(parsed.schema_version, 2);
+        assert_eq!(parsed.schema_version, 1);
         assert!(parsed.frame_observations.is_none());
         assert!(parsed.transcript_detail.is_none());
     }

--- a/src-tauri/src/core/indexing/report_chunks.rs
+++ b/src-tauri/src/core/indexing/report_chunks.rs
@@ -403,7 +403,7 @@ fn encode_embedding(vector: &[f32]) -> Vec<u8> {
 }
 
 fn decode_embedding(bytes: &[u8]) -> CoreResult<Vec<f32>> {
-    if bytes.len() % std::mem::size_of::<f32>() != 0 {
+    if !bytes.len().is_multiple_of(std::mem::size_of::<f32>()) {
         return Err(CoreError::Internal(
             "Stored embedding bytes are not aligned to f32 size".to_string(),
         ));

--- a/src-tauri/src/core/tracking/tracker.rs
+++ b/src-tauri/src/core/tracking/tracker.rs
@@ -539,7 +539,7 @@ pub fn track_frames(
 
         // Template drift correction: refresh template periodically
         if config.template_refresh_interval > 0
-            && i as u32 % config.template_refresh_interval == 0
+            && (i as u32).is_multiple_of(config.template_refresh_interval)
             && conf >= config.template_refresh_min_confidence
         {
             let (new_tpl, new_w, new_h, rx0, ry0) = extract_template(

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -287,6 +287,7 @@ async fn resolve_openai_perception_config(
 async fn maybe_enhance_bundle_with_openai(
     app: &tauri::AppHandle,
     state: &State<'_, AppState>,
+    ffmpeg_state: &State<'_, SharedFFmpegState>,
     asset_context: &ResolvedAssetContext,
     options: &AnalysisOptions,
     bundle: &mut AnalysisBundle,
@@ -295,8 +296,12 @@ async fn maybe_enhance_bundle_with_openai(
         return Ok(());
     }
 
+    let mut changed = false;
     let config = match resolve_openai_perception_config(app, state).await {
-        Ok(Some(config)) => config,
+        Ok(Some(config)) => {
+            changed |= bundle.errors.remove("perception_provider").is_some();
+            config
+        }
         Ok(None) => return Ok(()),
         Err(error) => {
             bundle.add_error("perception_provider", error);
@@ -307,7 +312,6 @@ async fn maybe_enhance_bundle_with_openai(
         }
     };
 
-    let mut changed = false;
     if options.visual && needs_openai_frame_observations(bundle) {
         match bundle.shots.as_deref() {
             Some(shots) if !shots.is_empty() => {
@@ -319,6 +323,8 @@ async fn maybe_enhance_bundle_with_openai(
                     .await
                 {
                     Ok((frames, observations)) => {
+                        bundle.errors.remove("perception_provider");
+                        bundle.errors.remove("openai_vision");
                         if !frames.is_empty() {
                             bundle.frame_analysis = Some(frames);
                         }
@@ -343,15 +349,18 @@ async fn maybe_enhance_bundle_with_openai(
         let analysis_dir = AnalysisJobRunner::new(&asset_context.project_path)
             .asset_analysis_dir(&bundle.asset_id)
             .map_err(|error| format!("Failed to resolve analysis artifact directory: {error}"))?;
-        match transcribe_with_openai(
-            &config,
-            &video_path,
-            &analysis_dir,
-            &PathBuf::from("ffmpeg"),
-        )
-        .await
-        {
+        let ffmpeg_path = {
+            let ffmpeg = ffmpeg_state.read().await;
+            ffmpeg
+                .info()
+                .ok_or_else(|| "FFmpeg is not available for OpenAI transcription".to_string())?
+                .ffmpeg_path
+                .clone()
+        };
+        match transcribe_with_openai(&config, &video_path, &analysis_dir, &ffmpeg_path).await {
             Ok((segments, detail)) => {
+                bundle.errors.remove("perception_provider");
+                bundle.errors.remove("openai_transcript");
                 bundle.transcript = Some(segments);
                 bundle.transcript_detail = Some(detail);
                 bundle.errors.remove("transcript");
@@ -377,6 +386,7 @@ async fn maybe_enhance_bundle_with_openai(
 async fn maybe_enhance_bundle_with_openai(
     _app: &tauri::AppHandle,
     _state: &State<'_, AppState>,
+    _ffmpeg_state: &State<'_, SharedFFmpegState>,
     _asset_context: &ResolvedAssetContext,
     _options: &AnalysisOptions,
     _bundle: &mut AnalysisBundle,
@@ -386,33 +396,15 @@ async fn maybe_enhance_bundle_with_openai(
 
 #[cfg(feature = "ai-providers")]
 fn needs_openai_frame_observations(bundle: &AnalysisBundle) -> bool {
-    let has_openai_observations = bundle
+    !bundle
         .frame_observations
         .as_ref()
         .is_some_and(|observations| {
             observations
                 .iter()
                 .any(|observation| observation.provider.provider == "openai")
-        });
-    if has_openai_observations {
-        return false;
-    }
-
-    bundle.frame_analysis.as_ref().is_none_or(|frames| {
-        frames.is_empty()
-            || frames.iter().all(|frame| {
-                matches!(
-                    frame.camera_angle,
-                    crate::core::analysis::CameraAngle::Unknown
-                ) && matches!(
-                    frame.subject_position,
-                    crate::core::analysis::SubjectPosition::Unknown
-                ) && matches!(
-                    frame.motion_direction,
-                    crate::core::analysis::MotionDirection::Unknown
-                )
-            })
-    })
+        })
+        && bundle.frame_observations.as_ref().is_none_or(Vec::is_empty)
 }
 
 #[cfg(feature = "ai-providers")]
@@ -460,7 +452,15 @@ pub async fn analyze_video_full(
     )
     .await?;
 
-    maybe_enhance_bundle_with_openai(&app, &state, &asset_context, &options, &mut bundle).await?;
+    maybe_enhance_bundle_with_openai(
+        &app,
+        &state,
+        &ffmpeg_state,
+        &asset_context,
+        &options,
+        &mut bundle,
+    )
+    .await?;
 
     Ok(bundle)
 }

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -30,10 +30,21 @@ use crate::core::analysis::esd::{self, EditingStyleDocument, EsdGenerator, EsdSu
 use crate::core::analysis::style_planner::{StylePlanResult, StylePlanner, StylePlanningContext};
 use crate::core::analysis::{AnalysisBundle, AnalysisJobRunner, AnalysisOptions, VideoMetadata};
 use crate::core::commands::AddEffectCommand;
+#[cfg(feature = "ai-providers")]
+use crate::core::credentials::{CredentialType, CredentialVault};
 use crate::core::effects::{curve_points_to_json, CurvePoint, EffectType, ParamValue};
 use crate::core::ffmpeg::{MediaInfo, SharedFFmpegState};
 use crate::core::jobs::{Job, JobStatus, JobType, Priority};
+#[cfg(feature = "ai-providers")]
+use crate::core::settings::{ProviderType, SettingsManager};
+#[cfg(feature = "ai-providers")]
+use crate::ipc::commands::system::get_app_data_dir;
 use crate::AppState;
+
+#[cfg(feature = "ai-providers")]
+use crate::core::analysis::openai_perception::{
+    analyze_keyframes_with_openai, transcribe_with_openai, OpenAiPerceptionConfig,
+};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -218,6 +229,203 @@ async fn submit_analysis_job_and_wait(
     }
 }
 
+#[cfg(feature = "ai-providers")]
+async fn resolve_openai_perception_config(
+    app: &tauri::AppHandle,
+    state: &State<'_, AppState>,
+) -> Result<Option<OpenAiPerceptionConfig>, String> {
+    let app_data_dir = get_app_data_dir(app)?;
+    let settings = SettingsManager::new(app_data_dir.clone()).load();
+    if settings.ai.local_only_mode {
+        return Ok(None);
+    }
+
+    let provider = settings
+        .ai
+        .vision_provider
+        .unwrap_or(settings.ai.primary_provider);
+    if provider != ProviderType::OpenAI {
+        return Ok(None);
+    }
+
+    let vault_path = app_data_dir.join("credentials.vault");
+    if !vault_path.exists() {
+        return Err(
+            "OpenAI perception provider is selected but the OpenAI credential is missing"
+                .to_string(),
+        );
+    }
+
+    let api_key = {
+        let mut guard = state.credential_vault.lock().await;
+        if guard.is_none() {
+            *guard = Some(
+                CredentialVault::new(vault_path)
+                    .map_err(|error| format!("Failed to initialize credential vault: {error}"))?,
+            );
+        }
+        let vault = guard
+            .as_ref()
+            .ok_or_else(|| "Credential vault unavailable".to_string())?;
+        vault
+            .retrieve(CredentialType::OpenaiApiKey)
+            .await
+            .map_err(|error| {
+                format!(
+                    "OpenAI perception provider is selected but credential lookup failed: {error}"
+                )
+            })?
+    };
+
+    Ok(Some(OpenAiPerceptionConfig::new(
+        api_key,
+        settings.ai.vision_model,
+    )))
+}
+
+#[cfg(feature = "ai-providers")]
+async fn maybe_enhance_bundle_with_openai(
+    app: &tauri::AppHandle,
+    state: &State<'_, AppState>,
+    asset_context: &ResolvedAssetContext,
+    options: &AnalysisOptions,
+    bundle: &mut AnalysisBundle,
+) -> Result<(), String> {
+    if options.local_only {
+        return Ok(());
+    }
+
+    let config = match resolve_openai_perception_config(app, state).await {
+        Ok(Some(config)) => config,
+        Ok(None) => return Ok(()),
+        Err(error) => {
+            bundle.add_error("perception_provider", error);
+            AnalysisJobRunner::new(&asset_context.project_path)
+                .save_bundle(bundle)
+                .map_err(|error| format!("Failed to save provider warning: {error}"))?;
+            return Ok(());
+        }
+    };
+
+    let mut changed = false;
+    if options.visual && needs_openai_frame_observations(bundle) {
+        match bundle.shots.as_deref() {
+            Some(shots) if !shots.is_empty() => {
+                let contact_sheet_path = bundle
+                    .contact_sheet
+                    .as_ref()
+                    .map(|artifact| PathBuf::from(&artifact.path));
+                match analyze_keyframes_with_openai(&config, shots, contact_sheet_path.as_deref())
+                    .await
+                {
+                    Ok((frames, observations)) => {
+                        if !frames.is_empty() {
+                            bundle.frame_analysis = Some(frames);
+                        }
+                        if !observations.is_empty() {
+                            bundle.frame_observations = Some(observations);
+                        }
+                        changed = true;
+                    }
+                    Err(error) => {
+                        bundle.add_error("openai_vision", error.to_string());
+                        changed = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if options.transcript && bundle.metadata.has_audio && needs_openai_transcript_detail(bundle) {
+        let video_path =
+            resolve_asset_media_path(&asset_context.project_path, &asset_context.asset_path);
+        let analysis_dir = AnalysisJobRunner::new(&asset_context.project_path)
+            .asset_analysis_dir(&bundle.asset_id)
+            .map_err(|error| format!("Failed to resolve analysis artifact directory: {error}"))?;
+        match transcribe_with_openai(
+            &config,
+            &video_path,
+            &analysis_dir,
+            &PathBuf::from("ffmpeg"),
+        )
+        .await
+        {
+            Ok((segments, detail)) => {
+                bundle.transcript = Some(segments);
+                bundle.transcript_detail = Some(detail);
+                bundle.errors.remove("transcript");
+                changed = true;
+            }
+            Err(error) => {
+                bundle.add_error("openai_transcript", error.to_string());
+                changed = true;
+            }
+        }
+    }
+
+    if changed {
+        AnalysisJobRunner::new(&asset_context.project_path)
+            .save_bundle(bundle)
+            .map_err(|error| format!("Failed to save OpenAI-enhanced analysis bundle: {error}"))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "ai-providers"))]
+async fn maybe_enhance_bundle_with_openai(
+    _app: &tauri::AppHandle,
+    _state: &State<'_, AppState>,
+    _asset_context: &ResolvedAssetContext,
+    _options: &AnalysisOptions,
+    _bundle: &mut AnalysisBundle,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(feature = "ai-providers")]
+fn needs_openai_frame_observations(bundle: &AnalysisBundle) -> bool {
+    let has_openai_observations = bundle
+        .frame_observations
+        .as_ref()
+        .is_some_and(|observations| {
+            observations
+                .iter()
+                .any(|observation| observation.provider.provider == "openai")
+        });
+    if has_openai_observations {
+        return false;
+    }
+
+    bundle.frame_analysis.as_ref().is_none_or(|frames| {
+        frames.is_empty()
+            || frames.iter().all(|frame| {
+                matches!(
+                    frame.camera_angle,
+                    crate::core::analysis::CameraAngle::Unknown
+                ) && matches!(
+                    frame.subject_position,
+                    crate::core::analysis::SubjectPosition::Unknown
+                ) && matches!(
+                    frame.motion_direction,
+                    crate::core::analysis::MotionDirection::Unknown
+                )
+            })
+    })
+}
+
+#[cfg(feature = "ai-providers")]
+fn needs_openai_transcript_detail(bundle: &AnalysisBundle) -> bool {
+    !bundle.transcript_detail.as_ref().is_some_and(|detail| {
+        detail
+            .provider
+            .as_ref()
+            .is_some_and(|provider| provider.provider == "openai")
+            && !detail.speaker_segments.is_empty()
+    })
+}
+
 // =============================================================================
 // Commands
 // =============================================================================
@@ -234,6 +442,7 @@ async fn submit_analysis_job_and_wait(
 #[specta::specta]
 #[tracing::instrument(skip(state, ffmpeg_state))]
 pub async fn analyze_video_full(
+    app: tauri::AppHandle,
     asset_id: String,
     options: AnalysisOptions,
     state: State<'_, AppState>,
@@ -241,7 +450,7 @@ pub async fn analyze_video_full(
 ) -> Result<AnalysisBundle, String> {
     let asset_context = resolve_asset_context(&asset_id, &state, &ffmpeg_state).await?;
 
-    submit_analysis_job_and_wait(
+    let mut bundle = submit_analysis_job_and_wait(
         &asset_id,
         &asset_context.project_path,
         &asset_context.asset_path,
@@ -249,7 +458,11 @@ pub async fn analyze_video_full(
         &options,
         &state,
     )
-    .await
+    .await?;
+
+    maybe_enhance_bundle_with_openai(&app, &state, &asset_context, &options, &mut bundle).await?;
+
+    Ok(bundle)
 }
 
 /// Retrieves a cached analysis bundle for an asset.

--- a/src/agents/engine/phases/Thinker.ts
+++ b/src/agents/engine/phases/Thinker.ts
@@ -246,6 +246,7 @@ export class Thinker {
         '- Do not assume timeline clips are the only available media. Imported assets may exist without timeline placement.',
         '- When the request implies searching or selecting moments from source footage, prefer using source-discovery analysis tools before asking for clarification.',
         '- For deep source-video inspection, prefer the canonical source-analysis report reader so transcript, frame, OCR, and highlight signals are consolidated in one read step.',
+        '- Before source-footage edit actions, inspect the source-analysis quality status. If it is partial or insufficient and the edit depends on dialogue, sound, visible action, people, or text, refresh/regenerate analysis or use source selects with analyzeMissing enabled instead of editing from weak metadata.',
         '- Use timeline-only reasoning only when the request explicitly limits scope to existing timeline clips.',
       ].join('\n'),
     );

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -62,7 +62,7 @@ const QUERY_ACTIONS = `## Query Actions (meta-tool: query)
 - search_source_analysis_report(assetId, query) → search report moments/chapters/highlights/speaker turns/visual breakdown/frame-observation entries and return ranked source ranges
 - search_source_library(query) → search report moments/chapters/highlights/speaker turns/visual breakdown/frame-observation entries across multiple source assets and return ranked ranges
 - search_indexed_source_library(query) → index report chunks, including visual breakdown and frame-observation entries, and search them through backend lexical or hybrid semantic retrieval across multiple source assets
-- build_source_selects(query) → turn ranked source matches (including speaker turns and frame observations when relevant) into a timeline-ready selects stringout plan, automatically analyzing missing/low-quality source reports by default, optionally applying it to a selects track
+- build_source_selects(query) → turn ranked source matches (including speaker turns and frame observations when relevant) into a timeline-ready selects stringout plan, optionally analyzing missing source reports when analyzeMissing=true, optionally applying it to a selects track
 - generate_style_document(assetId) → build/reuse an editing style document (ESD)
 - compare_edit_structure(sequenceId?, esdId) → compare current cut structure to a reference style`;
 

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -56,13 +56,13 @@ const QUERY_ACTIONS = `## Query Actions (meta-tool: query)
 - get_analysis_cost_estimate(assetId) → cost estimate for cloud analysis
 - get_analysis_providers → available analysis backends
 - analyze_reference_video(assetId) → extract edit/style signals from a reference video
-- read_source_analysis_report(assetId|file, outputPath?) → read the canonical Markdown source-analysis report for a source video; the report now leads with semantic scene-by-scene understanding (what is happening, who is present, what is heard, visible text, likely setting, useful moments). It auto-generates/refreshes analysis and saves "<asset-name>.analysis.md" beside the asset by default, or to outputPath when provided. Key outputs: data.content, data.relativePath
-- generate_source_analysis_report(assetId, outputPath?) → build/reuse the structured source-footage report (JSON + Markdown) with semantic overview, scene timeline, useful moments, and supporting signals, then persist the Markdown report beside the asset by default. Key outputs: data.content, data.reportPath
+- read_source_analysis_report(assetId|file, outputPath?) → read the canonical Markdown source-analysis report for a source video; the report leads with quality status plus semantic scene-by-scene understanding, frame observations, timed transcript, visible text, likely setting, and useful moments. It auto-generates/refreshes analysis and saves "<asset-name>.analysis.md" beside the asset by default, or to outputPath when provided. Key outputs: data.content, data.relativePath, data.quality
+- generate_source_analysis_report(assetId, outputPath?) → build/reuse the structured source-footage report (JSON + Markdown) with quality gate, semantic overview, full transcript, frame observations, scene timeline, useful moments, and supporting signals, then persist the Markdown report beside the asset by default. Key outputs: data.content, data.reportPath, data.quality
 - import_external_diarization(assetId, inputPath) → import external diarization JSON and merge true speaker IDs into the cached transcript bundle
-- search_source_analysis_report(assetId, query) → search report moments/chapters/highlights/speaker turns/visual breakdown entries and return ranked source ranges
-- search_source_library(query) → search report moments/chapters/highlights/speaker turns/visual breakdown entries across multiple source assets and return ranked ranges
-- search_indexed_source_library(query) → index report chunks, including visual breakdown entries, and search them through backend lexical or hybrid semantic retrieval across multiple source assets
-- build_source_selects(query) → turn ranked source matches (including speaker turns when relevant) into a timeline-ready selects stringout plan, optionally applying it to a selects track
+- search_source_analysis_report(assetId, query) → search report moments/chapters/highlights/speaker turns/visual breakdown/frame-observation entries and return ranked source ranges
+- search_source_library(query) → search report moments/chapters/highlights/speaker turns/visual breakdown/frame-observation entries across multiple source assets and return ranked ranges
+- search_indexed_source_library(query) → index report chunks, including visual breakdown and frame-observation entries, and search them through backend lexical or hybrid semantic retrieval across multiple source assets
+- build_source_selects(query) → turn ranked source matches (including speaker turns and frame observations when relevant) into a timeline-ready selects stringout plan, automatically analyzing missing/low-quality source reports by default, optionally applying it to a selects track
 - generate_style_document(assetId) → build/reuse an editing style document (ESD)
 - compare_edit_structure(sequenceId?, esdId) → compare current cut structure to a reference style`;
 
@@ -154,7 +154,7 @@ const COMMON_WORKFLOWS = `## Common Workflows
 6. Segment an inserted clip: insert_clip → split_clip using data.clipId for the first cut → later split_clip steps use the previous split's data.newClipId
 7. Track-specific clip lookup: get_track_clips(trackId) → reference clip IDs via data.clips[n].id
 8. Time-based clip lookup across tracks: get_clips_at_time(time) → reference clip IDs via data[n].id (never data[n].clipId)
-9. Deep source inspection: find_workspace_file or get_asset_catalog → read_source_analysis_report (this already writes the default ".analysis.md" report beside the asset) → search_source_analysis_report / search_source_library → build_source_selects or edit actions
+9. Deep source inspection/editing: find_workspace_file or get_asset_catalog → read_source_analysis_report (this already writes the default ".analysis.md" report beside the asset) → check data.quality.status and do not silently edit from an insufficient/partial report; refresh or use build_source_selects with analyzeMissing=true when source selection depends on transcript or frame semantics → search_source_analysis_report / search_source_library → build_source_selects or edit actions
 10. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
 
 const CLI_REFERENCE = `## CLI (headless alternative)

--- a/src/agents/toolOutputContracts.test.ts
+++ b/src/agents/toolOutputContracts.test.ts
@@ -8,6 +8,7 @@ describe('toolOutputContracts', () => {
 
     expect(contract?.validatePath?.('data.metadata.durationSec')).toBe(true);
     expect(contract?.validatePath?.('data.coverage.annotation')).toBe(true);
+    expect(contract?.validatePath?.('data.quality.status')).toBe(true);
     expect(contract?.validatePath?.('data.sectionCounts.highlights')).toBe(true);
     expect(contract?.validatePath?.('data.requestedFile')).toBe(true);
     expect(contract?.validatePath?.('data.warnings[0]')).toBe(true);
@@ -21,6 +22,8 @@ describe('toolOutputContracts', () => {
     expect(contract?.validatePath?.('data.metadata.codec')).toBe(true);
     expect(contract?.validatePath?.('data.coverage.visual')).toBe(true);
     expect(contract?.validatePath?.('data.errors.visual')).toBe(true);
+    expect(contract?.validatePath?.('data.quality.score')).toBe(true);
+    expect(contract?.validatePath?.('data.transcript.segments[0].text')).toBe(true);
     expect(contract?.validatePath?.('data.visual.items[0].cameraAngle')).toBe(true);
     expect(contract?.validatePath?.('data.visual.items[0].summary')).toBe(true);
     expect(contract?.validatePath?.('data.semantic.sceneTimeline[0].summary')).toBe(true);
@@ -32,6 +35,7 @@ describe('toolOutputContracts', () => {
     const generateContract = getToolOutputContract('generate_source_analysis_report');
 
     expect(readContract?.validatePath?.('data.visual.items[0].cameraAngle')).toBe(false);
+    expect(readContract?.validatePath?.('data.transcript.segments[0].text')).toBe(false);
     expect(readContract?.validatePath?.('data.semantic.sceneTimeline[0].summary')).toBe(false);
     expect(readContract?.validatePath?.('data.markdown')).toBe(false);
     expect(generateContract?.validatePath?.('data.markdown')).toBe(true);

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -116,6 +116,7 @@ function matchesReadSourceAnalysisReportPath(path: string): boolean {
     path === 'data.bundleSource' ||
     matchesObjectPath('data.metadata') ||
     matchesObjectPath('data.coverage') ||
+    matchesObjectPath('data.quality') ||
     matchesObjectPath('data.sectionCounts') ||
     matchesObjectPath('data.document') ||
     path === 'data.warnings' ||
@@ -131,6 +132,8 @@ function matchesGenerateSourceAnalysisReportPath(path: string): boolean {
     path === 'data.markdown' ||
     path === 'data.semantic' ||
     path.startsWith('data.semantic.') ||
+    path === 'data.transcript' ||
+    path.startsWith('data.transcript.') ||
     path === 'data.visual' ||
     path.startsWith('data.visual.')
   );

--- a/src/agents/tools/analysisTools.test.ts
+++ b/src/agents/tools/analysisTools.test.ts
@@ -2682,6 +2682,94 @@ describe('reference style transfer analysis tools', () => {
       expect(String(data.matches[0].preview)).toContain('wide angle');
     });
 
+    it('should keep same-shot frame observations distinct in direct visual search', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'search-visual-observations',
+            name: 'visual-observations.mp4',
+            kind: 'video',
+            uri: '/media/visual-observations.mp4',
+            durationSec: 6,
+            video: {
+              width: 1920,
+              height: 1080,
+              fps: { num: 30, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce({
+          assetId: 'search-visual-observations',
+          shots: [
+            {
+              startSec: 0,
+              endSec: 6,
+              confidence: 0.9,
+              keyframePath: 'shots/0001.jpg',
+              keyframeSelectionMethod: 'thumbnail',
+            },
+          ],
+          transcript: [],
+          audioProfile: {
+            bpm: 100,
+            spectralCentroidHz: 1000,
+            loudnessProfile: [-18.2],
+            peakDb: -4,
+            silenceRegions: [],
+          },
+          segments: [],
+          frameAnalysis: [],
+          frameObservations: [
+            {
+              ...semanticFrameObservations()[0],
+              description: 'A product slide fills the presentation screen.',
+            },
+            {
+              ...semanticFrameObservations()[0],
+              timeSec: 4,
+              description: 'A close-up reaction shot shows the presenter smiling.',
+              subjects: ['presenter'],
+              actions: ['smiling'],
+            },
+          ],
+          metadata: {
+            durationSec: 6,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            codec: 'h264',
+            hasAudio: true,
+          },
+          analyzedAt: '2026-03-07T00:00:00Z',
+          errors: {},
+        })
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+
+      const result = await globalToolRegistry.execute('search_source_analysis_report', {
+        assetId: 'search-visual-observations',
+        query: 'close-up reaction presenter',
+        sections: ['visual'],
+      });
+
+      const data = getToolResult<Record<string, any>>(result);
+      expect(data.matches[0]).toEqual(
+        expect.objectContaining({
+          sectionType: 'visual',
+          index: 1,
+          preview: 'A close-up reaction shot shows the presenter smiling.',
+          metadata: expect.objectContaining({
+            shotIndex: 0,
+            subjects: ['presenter'],
+          }),
+        }),
+      );
+    });
+
     it('should search moments beyond the twelfth shot', async () => {
       setupStores({
         assets: [
@@ -3552,6 +3640,24 @@ describe('reference style transfer analysis tools', () => {
                 analyzedAt: '2026-03-07T00:00:00Z',
               },
             },
+            {
+              shotIndex: 0,
+              timeSec: 4,
+              imagePath: 'shots/0001-alt.jpg',
+              description: 'A close-up reaction shot shows the presenter smiling.',
+              subjects: ['presenter'],
+              actions: ['smiling'],
+              setting: 'conference stage',
+              visibleText: [],
+              objects: ['microphone'],
+              editUsefulness: 'Useful as audience reaction context.',
+              confidence: 0.86,
+              provider: {
+                provider: 'openai',
+                model: 'gpt-4.1-mini',
+                analyzedAt: '2026-03-07T00:00:00Z',
+              },
+            },
           ],
           contactSheet: null,
           metadata: {
@@ -3615,8 +3721,10 @@ describe('reference style transfer analysis tools', () => {
           expect.objectContaining({
             id: 'idx-visual:visualObservation:0',
             sectionType: 'visual',
+            sectionIndex: 0,
             searchText: expect.stringContaining('keynote speaker'),
             metadata: expect.objectContaining({
+              shotIndex: 0,
               keyframePath: 'shots/0001.jpg',
               description: 'A keynote speaker points at a product screen.',
               subjects: ['keynote speaker'],
@@ -3625,6 +3733,18 @@ describe('reference style transfer analysis tools', () => {
                 provider: 'openai',
                 model: 'gpt-4.1-mini',
               }),
+            }),
+          }),
+          expect.objectContaining({
+            id: 'idx-visual:visualObservation:1',
+            sectionType: 'visual',
+            sectionIndex: 1,
+            searchText: expect.stringContaining('close-up reaction'),
+            metadata: expect.objectContaining({
+              shotIndex: 0,
+              keyframePath: 'shots/0001-alt.jpg',
+              description: 'A close-up reaction shot shows the presenter smiling.',
+              subjects: ['presenter'],
             }),
           }),
         ]),

--- a/src/agents/tools/analysisTools.test.ts
+++ b/src/agents/tools/analysisTools.test.ts
@@ -126,6 +126,29 @@ function semanticFrameAnalysis(shotIndex = 0) {
   ];
 }
 
+function semanticFrameObservations(shotIndex = 0) {
+  return [
+    {
+      shotIndex,
+      timeSec: 2,
+      imagePath: `shots/${shotIndex + 1}.jpg`,
+      description: 'Semantic source frame observation.',
+      subjects: ['subject'],
+      actions: ['action'],
+      setting: 'setting',
+      visibleText: [],
+      objects: [],
+      editUsefulness: 'Useful source context.',
+      confidence: 0.9,
+      provider: {
+        provider: 'openai',
+        model: 'gpt-4.1-mini',
+        analyzedAt: '2026-03-07T00:00:00Z',
+      },
+    },
+  ];
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1014,6 +1037,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -1098,6 +1122,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 6, segmentType: 'broll', confidence: 0.85, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 6,
@@ -1158,6 +1183,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 5,
@@ -1218,6 +1244,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 5,
@@ -1278,6 +1305,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 5,
@@ -1796,6 +1824,10 @@ describe('reference style transfer analysis tools', () => {
             motionDirection: 'static',
             visualComplexity: 0.5,
           })),
+          frameObservations: Array.from({ length: 13 }, (_, index) => ({
+            ...semanticFrameObservations(index)[0],
+            timeSec: index * 2 + 1,
+          })),
           contactSheet: null,
           metadata: {
             durationSec: 26,
@@ -1885,6 +1917,7 @@ describe('reference style transfer analysis tools', () => {
               visualComplexity: 0.7,
             },
           ],
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 4,
@@ -2200,6 +2233,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 10, segmentType: 'talk', confidence: 0.8, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 10,
             width: null,
@@ -2345,6 +2379,7 @@ describe('reference style transfer analysis tools', () => {
               visualComplexity: 0.4,
             },
           ],
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 8,
             width: 1920,
@@ -2455,6 +2490,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 6, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -2539,6 +2575,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 6, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -2617,6 +2654,7 @@ describe('reference style transfer analysis tools', () => {
               visualComplexity: 0.42,
             },
           ],
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -2696,6 +2734,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 26, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 26,
             width: 1920,
@@ -2771,6 +2810,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 50, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 50,
             width: 1920,
@@ -2862,6 +2902,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -2898,6 +2939,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -2980,6 +3022,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 8, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 8,
             width: 1920,
@@ -3054,6 +3097,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 6, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -3173,6 +3217,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -3298,6 +3343,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -3402,6 +3448,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -3631,6 +3678,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -3748,6 +3796,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 10,
             width: 1920,
@@ -3826,6 +3875,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           contactSheet: null,
           metadata: {
             durationSec: 10,
@@ -3911,6 +3961,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -3966,6 +4017,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -4023,6 +4075,7 @@ describe('reference style transfer analysis tools', () => {
           },
           segments: [],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -4106,6 +4159,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 10,
             width: 1920,
@@ -4213,6 +4267,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 4, endSec: 8, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
           frameAnalysis: semanticFrameAnalysis(),
+          frameObservations: semanticFrameObservations(),
           metadata: {
             durationSec: 10,
             width: 1920,

--- a/src/agents/tools/analysisTools.test.ts
+++ b/src/agents/tools/analysisTools.test.ts
@@ -114,6 +114,18 @@ function getToolResult<T>(result: ToolExecutionResult): T {
   return result.result;
 }
 
+function semanticFrameAnalysis(shotIndex = 0) {
+  return [
+    {
+      shotIndex,
+      cameraAngle: 'wide',
+      subjectPosition: 'center',
+      motionDirection: 'static',
+      visualComplexity: 0.5,
+    },
+  ];
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1001,7 +1013,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -1085,7 +1097,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 6, segmentType: 'broll', confidence: 0.85, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 6,
@@ -1145,7 +1157,7 @@ describe('reference style transfer analysis tools', () => {
             speechRegions: [],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 5,
@@ -1205,7 +1217,7 @@ describe('reference style transfer analysis tools', () => {
             speechRegions: [],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 5,
@@ -1265,7 +1277,7 @@ describe('reference style transfer analysis tools', () => {
             speechRegions: [],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 5,
@@ -1329,6 +1341,7 @@ describe('reference style transfer analysis tools', () => {
 
       const mockBundle = {
         assetId: 'source-1',
+        schemaVersion: 2,
         shots: [
           {
             startSec: 0,
@@ -1355,6 +1368,75 @@ describe('reference style transfer analysis tools', () => {
             speakerId: 'speaker_1',
           },
         ],
+        transcriptDetail: {
+          full: 'Hello crowd and welcome back',
+          words: [
+            {
+              text: 'Hello',
+              startSec: 0,
+              endSec: 0.6,
+              segmentIndex: 0,
+              wordIndex: 0,
+              confidence: 0.97,
+              speakerId: 'speaker_1',
+              speakerTurnId: null,
+            },
+            {
+              text: 'crowd',
+              startSec: 0.6,
+              endSec: 1.2,
+              segmentIndex: 0,
+              wordIndex: 1,
+              confidence: 0.97,
+              speakerId: 'speaker_1',
+              speakerTurnId: null,
+            },
+            {
+              text: 'and',
+              startSec: 1.2,
+              endSec: 1.8,
+              segmentIndex: 0,
+              wordIndex: 2,
+              confidence: 0.97,
+              speakerId: 'speaker_1',
+              speakerTurnId: null,
+            },
+            {
+              text: 'welcome',
+              startSec: 1.8,
+              endSec: 2.4,
+              segmentIndex: 0,
+              wordIndex: 3,
+              confidence: 0.97,
+              speakerId: 'speaker_1',
+              speakerTurnId: null,
+            },
+            {
+              text: 'back',
+              startSec: 2.4,
+              endSec: 3,
+              segmentIndex: 0,
+              wordIndex: 4,
+              confidence: 0.97,
+              speakerId: 'speaker_1',
+              speakerTurnId: null,
+            },
+          ],
+          speakerSegments: [
+            {
+              startSec: 0,
+              endSec: 3,
+              speakerId: 'speaker_1',
+              text: 'Hello crowd and welcome back',
+              confidence: 0.97,
+            },
+          ],
+          provider: {
+            provider: 'openai',
+            model: 'gpt-4o-transcribe-diarize',
+            analyzedAt: '2026-03-07T00:00:30Z',
+          },
+        },
         audioProfile: {
           bpm: 120,
           spectralCentroidHz: 1400,
@@ -1382,6 +1464,26 @@ describe('reference style transfer analysis tools', () => {
             subjectPosition: 'center',
             motionDirection: 'static',
             visualComplexity: 0.42,
+          },
+        ],
+        frameObservations: [
+          {
+            shotIndex: 0,
+            timeSec: 2,
+            imagePath: 'shots/0001.jpg',
+            description: 'A singer faces a live crowd on a bright concert stage.',
+            subjects: ['singer', 'crowd'],
+            actions: ['singing', 'addressing audience'],
+            setting: 'concert stage',
+            visibleText: ['LIVE'],
+            objects: ['microphone'],
+            editUsefulness: 'Use as opening performance context.',
+            confidence: 0.91,
+            provider: {
+              provider: 'openai',
+              model: 'gpt-4.1-mini',
+              analyzedAt: '2026-03-07T00:00:20Z',
+            },
           },
         ],
         contactSheet: {
@@ -1480,9 +1582,67 @@ describe('reference style transfer analysis tools', () => {
       expect(data.audio.speechDurationSec).toBe(11);
       expect(data.audio.speechSharePercent).toBeCloseTo(91.67, 1);
       expect(data.transcript.speakerTurnCount).toBe(1);
+      expect(data.transcript.fullText).toBe('Hello crowd and welcome back');
+      expect(data.transcript.provider.provider).toBe('openai');
+      expect(data.transcript.wordTimingCount).toBe(5);
+      expect(data.transcript.speakerSegmentCount).toBe(1);
+      expect(data.transcript.speakerSegments[0].speakerId).toBe('speaker_1');
+      expect(data.transcript.segments).toEqual([
+        {
+          index: 0,
+          startSec: 0,
+          endSec: 3,
+          speakerId: 'speaker_1',
+          speakerTurnId: null,
+          language: 'en',
+          confidence: 0.97,
+          text: 'Hello crowd and welcome back',
+        },
+      ]);
       expect(data.speakerTurns.count).toBe(1);
       expect(data.speakerTurns.items[0].label).toBe('speaker_1');
       expect(data.visual.contactSheet.path).toBe('/analysis/source-1/contact-sheet.jpg');
+      expect(data.visual.semanticCoverage).toBe('semantic');
+      expect(data.visual.observationCount).toBe(1);
+      expect(data.visual.observations[0]).toEqual(
+        expect.objectContaining({
+          shotIndex: 0,
+          startSec: 0,
+          endSec: 4,
+          timeSec: 2,
+          imagePath: 'shots/0001.jpg',
+          description: 'A singer faces a live crowd on a bright concert stage.',
+          subjects: ['singer', 'crowd'],
+          actions: ['singing', 'addressing audience'],
+          setting: 'concert stage',
+          visibleText: ['LIVE'],
+          objects: ['microphone'],
+          editUsefulness: 'Use as opening performance context.',
+          confidence: 0.91,
+          provider: expect.objectContaining({
+            provider: 'openai',
+            model: 'gpt-4.1-mini',
+          }),
+        }),
+      );
+      expect(data.visual.keyframes).toEqual([
+        {
+          shotIndex: 0,
+          startSec: 0,
+          endSec: 4,
+          keyframePath: 'shots/0001.jpg',
+          keyframeSelectionMethod: 'thumbnail',
+          label: 'Shot 1 keyframe',
+        },
+        {
+          shotIndex: 1,
+          startSec: 4,
+          endSec: 12,
+          keyframePath: 'shots/0002.jpg',
+          keyframeSelectionMethod: 'thumbnail',
+          label: 'Shot 2 keyframe',
+        },
+      ]);
       expect(data.visual.items).toEqual([
         {
           shotIndex: 0,
@@ -1498,7 +1658,7 @@ describe('reference style transfer analysis tools', () => {
           summary: 'Shot 1 | wide angle | center subject | static motion | complexity 0.42',
         },
       ]);
-      expect(String(data.summary)).toContain('Performance or stage moment');
+      expect(String(data.summary)).toContain('A singer faces a live crowd');
       expect(data.moments.items[0].sceneLabel).toBe('Performance moment');
       expect(String(data.moments.items[0].summary)).toContain('Performance or stage moment');
       expect(String(data.moments.items[0].summary)).toContain(
@@ -1506,12 +1666,17 @@ describe('reference style transfer analysis tools', () => {
       );
       expect(String(data.moments.items[0].summary)).toContain('Text: on-screen text reads "LIVE"');
       expect(data.semantic.whatIsHappening.length).toBeGreaterThan(0);
+      expect(data.semantic.whatIsHappening[0]).toContain('A singer faces a live crowd');
       expect(data.semantic.whoIsPresent.length).toBeGreaterThan(0);
       expect(data.semantic.whatIsHeard.length).toBeGreaterThan(0);
       expect(data.semantic.onScreenText.length).toBeGreaterThan(0);
       expect(data.semantic.likelySetting).toContain('stage or live event setting');
       expect(data.semantic.sceneTimeline[0].title).toBe('Performance moment');
       expect(data.semantic.usefulMoments[0].kind).toBe('text');
+      expect(data.quality.status).toBe('ready');
+      expect(data.quality.score).toBe(100);
+      expect(data.quality.criticalSignals).toContain('timed transcript');
+      expect(data.quality.criticalSignals).toContain('semantic visual cues');
       expect(data.chapters.count).toBeGreaterThan(0);
       expect(data.highlights.count).toBeGreaterThan(0);
       expect(data.annotations.objectDetectionCount).toBe(1);
@@ -1521,6 +1686,8 @@ describe('reference style transfer analysis tools', () => {
       expect(data.reportPath).toBe('media/concert.analysis.md');
       expect(String(data.content)).toContain('# Source Analysis Report: concert.mp4');
       expect(String(data.markdown)).toContain('# Source Analysis Report: concert.mp4');
+      expect(String(data.markdown)).toContain('## Analysis Quality');
+      expect(String(data.markdown)).toContain('- Status: ready');
       expect(String(data.markdown)).toContain('## Executive Summary');
       expect(String(data.markdown)).toContain('## Scene Timeline');
       expect(String(data.markdown)).toContain('## Useful Moments');
@@ -1533,6 +1700,18 @@ describe('reference style transfer analysis tools', () => {
       expect(String(data.markdown)).toContain('Likely setting: stage or live event setting');
       expect(String(data.markdown)).toContain('Best usable moment: 00:00-00:03 | text |');
       expect(String(data.markdown)).toContain('00:00-00:03 | Performance moment |');
+      expect(String(data.markdown)).toContain('## Full Transcript');
+      expect(String(data.markdown)).toContain(
+        '00:00-00:03 | speaker_1 | Hello crowd and welcome back',
+      );
+      expect(String(data.markdown)).toContain(
+        '- Provider: openai/gpt-4o-transcribe-diarize at 2026-03-07T00:00:30Z',
+      );
+      expect(String(data.markdown)).toContain('- Word timings: 5');
+      expect(String(data.markdown)).toContain('## Speaker-Aware Transcript Segments');
+      expect(String(data.markdown)).toContain(
+        '00:00-00:03 | speaker_1 | Hello crowd and welcome back',
+      );
       expect(String(data.markdown)).toContain('## Visual Breakdown');
       expect(String(data.markdown).match(/Dominant camera angles:/g)?.length ?? 0).toBe(1);
       expect(String(data.markdown).match(/Dominant motion:/g)?.length ?? 0).toBe(1);
@@ -1540,7 +1719,22 @@ describe('reference style transfer analysis tools', () => {
         '00:00-00:04 | Shot 1 | wide angle | center subject | static motion | complexity 0.42',
       );
       expect(String(data.markdown)).toContain('Keyframe: shots/0001.jpg');
+      expect(String(data.markdown)).toContain('## Frame Observations');
+      expect(String(data.markdown)).toContain(
+        'A singer faces a live crowd on a bright concert stage.',
+      );
+      expect(String(data.markdown)).toContain('- Subjects: singer, crowd');
+      expect(String(data.markdown)).toContain('- Visible text: LIVE');
+      expect(String(data.markdown)).toContain(
+        '- Provider: openai/gpt-4.1-mini at 2026-03-07T00:00:20Z | confidence 0.91',
+      );
+      expect(String(data.markdown)).toContain('![Shot 1 observation](shots/0001.jpg)');
       expect(String(data.markdown)).toContain('## Visual Artifacts');
+      expect(String(data.markdown)).toContain(
+        '![Contact sheet](/analysis/source-1/contact-sheet.jpg)',
+      );
+      expect(String(data.markdown)).toContain('## Keyframe Gallery');
+      expect(String(data.markdown)).toContain('![Shot 1 keyframe](shots/0001.jpg)');
       expect(String(data.markdown)).toContain('## Chapters');
       expect(String(data.markdown)).toContain('## Candidate Highlights');
       expect(vi.mocked(invoke)).toHaveBeenNthCalledWith(1, 'get_analysis_bundle', {
@@ -1729,6 +1923,118 @@ describe('reference style transfer analysis tools', () => {
       expect(String(data.markdown)).not.toContain('Shot 101');
     });
 
+    it('should regenerate cached local visual fallback and mark final report as partial', async () => {
+      setupStores({
+        assets: [
+          createAsset({
+            id: 'source-local-fallback',
+            name: 'local-fallback.mp4',
+            kind: 'video',
+            uri: '/media/local-fallback.mp4',
+            relativePath: 'media/local-fallback.mp4',
+            durationSec: 5,
+            video: {
+              width: 1920,
+              height: 1080,
+              fps: { num: 30, den: 1 },
+              codec: 'h264',
+              hasAlpha: false,
+            },
+          }),
+        ],
+      });
+
+      const localFallbackBundle = {
+        assetId: 'source-local-fallback',
+        shots: [
+          {
+            startSec: 0,
+            endSec: 5,
+            confidence: 0.91,
+            keyframePath: 'shots/0001.jpg',
+            keyframeSelectionMethod: 'midpoint',
+          },
+        ],
+        transcript: [],
+        audioProfile: null,
+        segments: [
+          {
+            startSec: 0,
+            endSec: 5,
+            segmentType: 'establishing',
+            confidence: 0.82,
+            features: {},
+          },
+        ],
+        frameAnalysis: [
+          {
+            shotIndex: 0,
+            cameraAngle: 'unknown',
+            subjectPosition: 'unknown',
+            motionDirection: 'unknown',
+            visualComplexity: 0.5,
+          },
+        ],
+        contactSheet: null,
+        metadata: {
+          durationSec: 5,
+          width: 1920,
+          height: 1080,
+          fps: 30,
+          codec: 'h264',
+          hasAudio: false,
+        },
+        analyzedAt: '2026-03-07T00:00:00Z',
+        errors: {},
+      };
+
+      vi.mocked(invoke)
+        .mockResolvedValueOnce(localFallbackBundle)
+        .mockResolvedValueOnce(localFallbackBundle)
+        .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
+
+      const result = await globalToolRegistry.execute('generate_source_analysis_report', {
+        assetId: 'source-local-fallback',
+        options: {
+          transcript: false,
+          audio: false,
+        },
+      });
+
+      const data = getToolResult<Record<string, any>>(result);
+      expect(data.bundleSource).toBe('generated');
+      expect(data.visual.semanticCoverage).toBe('local_fallback');
+      expect(data.quality.status).toBe('partial');
+      expect(data.quality.score).toBe(76);
+      expect(data.quality.degradedSignals).toContain('semantic visual descriptions');
+      expect(data.warnings).toContain(
+        'Visual semantic analysis is local fallback only. Frame descriptions contain composition metrics, not true scene understanding.',
+      );
+      expect(String(data.markdown)).toContain('## Analysis Quality');
+      expect(String(data.markdown)).toContain('- Status: partial');
+      expect(String(data.markdown)).toContain(
+        'Run a vision-capable provider over the extracted keyframes/contact sheet for actual scene descriptions.',
+      );
+      expect(String(data.markdown)).toContain('![Shot 1 keyframe](shots/0001.jpg)');
+      expect(vi.mocked(invoke)).toHaveBeenNthCalledWith(1, 'get_analysis_bundle', {
+        assetId: 'source-local-fallback',
+      });
+      expect(vi.mocked(invoke)).toHaveBeenNthCalledWith(2, 'analyze_video_full', {
+        assetId: 'source-local-fallback',
+        options: {
+          shots: true,
+          transcript: false,
+          audio: false,
+          segments: true,
+          visual: true,
+          localOnly: false,
+        },
+      });
+      expect(vi.mocked(invoke)).toHaveBeenNthCalledWith(3, 'get_annotation', {
+        assetId: 'source-local-fallback',
+      });
+    });
+
     it('should regenerate the bundle when cached coverage is incomplete', async () => {
       setupStores({
         assets: [
@@ -1893,7 +2199,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 10, segmentType: 'talk', confidence: 0.8, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 10,
             width: null,
@@ -2148,7 +2454,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 6, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -2232,7 +2538,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 6, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -2389,7 +2695,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 26, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 26,
             width: 1920,
@@ -2464,7 +2770,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 50, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 50,
             width: 1920,
@@ -2555,7 +2861,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -2591,7 +2897,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -2673,7 +2979,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 8, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 8,
             width: 1920,
@@ -2747,7 +3053,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 6, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 6,
             width: 1920,
@@ -2866,7 +3172,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -2991,7 +3297,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -3095,7 +3401,7 @@ describe('reference style transfer analysis tools', () => {
             speechRegions: [{ startSec: 0, endSec: 4 }],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -3180,6 +3486,26 @@ describe('reference style transfer analysis tools', () => {
               visualComplexity: 0.42,
             },
           ],
+          frameObservations: [
+            {
+              shotIndex: 0,
+              timeSec: 3,
+              imagePath: 'shots/0001.jpg',
+              description: 'A keynote speaker points at a product screen.',
+              subjects: ['keynote speaker'],
+              actions: ['pointing at screen'],
+              setting: 'conference stage',
+              visibleText: ['Launch'],
+              objects: ['screen', 'microphone'],
+              editUsefulness: 'Useful as product reveal b-roll.',
+              confidence: 0.88,
+              provider: {
+                provider: 'openai',
+                model: 'gpt-4.1-mini',
+                analyzedAt: '2026-03-07T00:00:00Z',
+              },
+            },
+          ],
           contactSheet: null,
           metadata: {
             durationSec: 6,
@@ -3239,6 +3565,21 @@ describe('reference style transfer analysis tools', () => {
               cameraAngle: 'wide',
             }),
           }),
+          expect.objectContaining({
+            id: 'idx-visual:visualObservation:0',
+            sectionType: 'visual',
+            searchText: expect.stringContaining('keynote speaker'),
+            metadata: expect.objectContaining({
+              keyframePath: 'shots/0001.jpg',
+              description: 'A keynote speaker points at a product screen.',
+              subjects: ['keynote speaker'],
+              visibleText: ['Launch'],
+              provider: expect.objectContaining({
+                provider: 'openai',
+                model: 'gpt-4.1-mini',
+              }),
+            }),
+          }),
         ]),
       });
     });
@@ -3289,7 +3630,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 8,
@@ -3406,7 +3747,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'performance', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 10,
             width: 1920,
@@ -3484,7 +3825,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           contactSheet: null,
           metadata: {
             durationSec: 10,
@@ -3569,7 +3910,7 @@ describe('reference style transfer analysis tools', () => {
             silenceRegions: [],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -3624,7 +3965,7 @@ describe('reference style transfer analysis tools', () => {
             silenceRegions: [],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -3681,7 +4022,7 @@ describe('reference style transfer analysis tools', () => {
             silenceRegions: [],
           },
           segments: [],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 4,
             width: 1920,
@@ -3764,7 +4105,7 @@ describe('reference style transfer analysis tools', () => {
           segments: [
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 10,
             width: 1920,
@@ -3871,7 +4212,7 @@ describe('reference style transfer analysis tools', () => {
             { startSec: 0, endSec: 4, segmentType: 'talk', confidence: 0.9, features: {} },
             { startSec: 4, endSec: 8, segmentType: 'talk', confidence: 0.9, features: {} },
           ],
-          frameAnalysis: [],
+          frameAnalysis: semanticFrameAnalysis(),
           metadata: {
             durationSec: 10,
             width: 1920,

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -217,6 +217,46 @@ function buildTranscriptExcerpt(segments: Array<{ text: string }>, maxLength = 2
   return `${joined.slice(0, maxLength - 3).trimEnd()}...`;
 }
 
+function buildFullTranscriptText(segments: Array<{ text: string }>): string | null {
+  const joined = segments
+    .map((segment) => normalizeText(segment.text))
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  return joined.length > 0 ? joined : null;
+}
+
+function buildTranscriptLines(
+  segments: Array<
+    TranscriptLikeSegment & {
+      confidence?: number | null;
+      language?: string | null;
+    }
+  >,
+): Array<{
+  index: number;
+  startSec: number;
+  endSec: number;
+  speakerId: string | null;
+  speakerTurnId: string | null;
+  language: string | null;
+  confidence: number | null;
+  text: string;
+}> {
+  return segments.map((segment, index) => ({
+    index,
+    startSec: roundTo(segment.startSec) ?? 0,
+    endSec: roundTo(segment.endSec) ?? 0,
+    speakerId: segment.speakerId ?? null,
+    speakerTurnId: segment.speakerTurnId ?? null,
+    language:
+      typeof segment.language === 'string' && segment.language.length > 0 ? segment.language : null,
+    confidence: roundTo(segment.confidence, 3),
+    text: normalizeText(segment.text),
+  }));
+}
+
 type TimedRange = {
   startSec: number;
   endSec: number;
@@ -231,6 +271,8 @@ type TranscriptLikeSegment = TimedRange & {
   speakerId?: string | null;
   speakerTurnId?: string | null;
 };
+
+type FrameObservationLike = NonNullable<AnalysisBundle['frameObservations']>[number];
 
 type SegmentLike = TimedRange & {
   segmentType: string;
@@ -907,6 +949,38 @@ function buildSourceReportChunks(report: SourceAnalysisReport): SourceReportChun
         subjectPosition: item.subjectPosition,
         motionDirection: item.motionDirection,
         visualComplexity: item.visualComplexity,
+      },
+    })),
+    ...report.visual.observations.map((observation) => ({
+      id: `${report.assetId}:visualObservation:${observation.shotIndex}`,
+      sectionType: 'visual' as const,
+      sectionIndex: observation.shotIndex,
+      startSec: observation.startSec,
+      endSec: observation.endSec,
+      searchText: [
+        observation.description,
+        observation.subjects.join(' '),
+        observation.actions.join(' '),
+        observation.setting,
+        observation.visibleText.join(' '),
+        observation.objects.join(' '),
+        observation.editUsefulness,
+      ]
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .join(' '),
+      metadata: {
+        preview: observation.description,
+        keyframePath: observation.imagePath,
+        durationSec: observation.endSec - observation.startSec,
+        description: observation.description,
+        subjects: observation.subjects,
+        actions: observation.actions,
+        setting: observation.setting,
+        visibleText: observation.visibleText,
+        objects: observation.objects,
+        editUsefulness: observation.editUsefulness,
+        confidence: observation.confidence,
+        provider: observation.provider,
       },
     })),
   ];
@@ -1773,6 +1847,296 @@ function buildReportVisualItems(
   });
 }
 
+function buildFrameObservationItems(
+  observations: FrameObservationLike[],
+  shots: Array<
+    TimedRange & {
+      keyframePath?: string | null;
+    }
+  >,
+): Array<{
+  shotIndex: number;
+  startSec: number;
+  endSec: number;
+  timeSec: number;
+  imagePath: string | null;
+  description: string;
+  subjects: string[];
+  actions: string[];
+  setting: string | null;
+  visibleText: string[];
+  objects: string[];
+  editUsefulness: string | null;
+  confidence: number | null;
+  provider: {
+    provider: string;
+    model: string;
+    analyzedAt: string;
+  } | null;
+}> {
+  return observations.flatMap((observation, fallbackIndex) => {
+    const resolvedShotIndex = shots[observation.shotIndex] ? observation.shotIndex : fallbackIndex;
+    const shot = shots[resolvedShotIndex] ?? null;
+    const timeSec =
+      roundTo(observation.timeSec) ??
+      (shot ? (roundTo((shot.startSec + shot.endSec) / 2) ?? 0) : 0);
+    const description = normalizeText(observation.description);
+
+    if (!description && !shot) {
+      return [];
+    }
+
+    const provider = observation.provider
+      ? {
+          provider: normalizeText(observation.provider.provider) || 'unknown',
+          model: normalizeText(observation.provider.model) || 'unknown',
+          analyzedAt: normalizeText(observation.provider.analyzedAt) || 'unknown',
+        }
+      : null;
+
+    return [
+      {
+        shotIndex: resolvedShotIndex,
+        startSec: shot ? (roundTo(shot.startSec) ?? timeSec) : timeSec,
+        endSec: shot ? (roundTo(shot.endSec) ?? timeSec) : timeSec,
+        timeSec,
+        imagePath: observation.imagePath || shot?.keyframePath || null,
+        description,
+        subjects: uniqueStrings(observation.subjects ?? [], 8),
+        actions: uniqueStrings(observation.actions ?? [], 8),
+        setting:
+          typeof observation.setting === 'string' && observation.setting.trim().length > 0
+            ? normalizeText(observation.setting)
+            : null,
+        visibleText: uniqueStrings(observation.visibleText ?? [], 8),
+        objects: uniqueStrings(observation.objects ?? [], 10),
+        editUsefulness:
+          typeof observation.editUsefulness === 'string' &&
+          observation.editUsefulness.trim().length > 0
+            ? normalizeText(observation.editUsefulness)
+            : null,
+        confidence: roundTo(observation.confidence, 3),
+        provider,
+      },
+    ];
+  });
+}
+
+function isUnknownVisualValue(value: string | null | undefined): boolean {
+  return !value || value === 'unknown';
+}
+
+function isLocalVisualFallbackOnly(
+  frameAnalysis: Array<{
+    cameraAngle?: string | null;
+    subjectPosition?: string | null;
+    motionDirection?: string | null;
+  }>,
+): boolean {
+  return (
+    frameAnalysis.length > 0 &&
+    frameAnalysis.every(
+      (entry) =>
+        isUnknownVisualValue(entry.cameraAngle) &&
+        isUnknownVisualValue(entry.subjectPosition) &&
+        isUnknownVisualValue(entry.motionDirection),
+    )
+  );
+}
+
+function resolveVisualSemanticCoverage(
+  frameAnalysis: Array<{
+    cameraAngle?: string | null;
+    subjectPosition?: string | null;
+    motionDirection?: string | null;
+  }>,
+  frameObservations: unknown[] = [],
+): 'semantic' | 'local_fallback' | 'missing' {
+  if (frameObservations.length > 0) {
+    return 'semantic';
+  }
+
+  if (frameAnalysis.length === 0) {
+    return 'missing';
+  }
+
+  return isLocalVisualFallbackOnly(frameAnalysis) ? 'local_fallback' : 'semantic';
+}
+
+function buildKeyframeGallery(
+  shots: Array<
+    TimedRange & {
+      keyframePath?: string | null;
+      keyframeSelectionMethod?: string | null;
+    }
+  >,
+): Array<{
+  shotIndex: number;
+  startSec: number;
+  endSec: number;
+  keyframePath: string;
+  keyframeSelectionMethod: string | null;
+  label: string;
+}> {
+  return shots.flatMap((shot, index) => {
+    if (!shot.keyframePath) {
+      return [];
+    }
+
+    return [
+      {
+        shotIndex: index,
+        startSec: roundTo(shot.startSec) ?? 0,
+        endSec: roundTo(shot.endSec) ?? 0,
+        keyframePath: shot.keyframePath,
+        keyframeSelectionMethod: shot.keyframeSelectionMethod ?? null,
+        label: `Shot ${index + 1} keyframe`,
+      },
+    ];
+  });
+}
+
+function buildSourceReportQuality(report: {
+  coverage: {
+    shots: boolean;
+    transcript: boolean;
+    audio: boolean;
+    segments: boolean;
+    visual: boolean;
+    annotation: boolean;
+  };
+  metadata: {
+    hasAudioStream: boolean;
+  };
+  visual: {
+    semanticCoverage: 'semantic' | 'local_fallback' | 'missing';
+    keyframes: unknown[];
+    contactSheet: unknown | null;
+  };
+  transcript: {
+    segmentCount: number;
+  };
+  annotations: {
+    objectDetectionCount: number;
+    faceDetectionCount: number;
+    ocrTextCount: number;
+  };
+  errors: Record<string, string>;
+}): {
+  status: 'ready' | 'partial' | 'insufficient';
+  score: number;
+  criticalSignals: string[];
+  missingSignals: string[];
+  degradedSignals: string[];
+  recommendedActions: string[];
+} {
+  let score = 100;
+  const criticalSignals: string[] = [];
+  const missingSignals: string[] = [];
+  const degradedSignals: string[] = [];
+  const recommendedActions: string[] = [];
+
+  const requireSignal = (
+    available: boolean,
+    signal: string,
+    penalty: number,
+    recommendation: string,
+  ) => {
+    if (available) {
+      criticalSignals.push(signal);
+      return;
+    }
+
+    score -= penalty;
+    missingSignals.push(signal);
+    recommendedActions.push(recommendation);
+  };
+
+  requireSignal(
+    report.coverage.shots,
+    'shot boundaries',
+    20,
+    'Run shot detection so the report can align transcript and visuals to edit-ready ranges.',
+  );
+  if (report.metadata.hasAudioStream) {
+    requireSignal(
+      report.coverage.transcript,
+      'timed transcript',
+      25,
+      'Run transcription so dialogue, searchable quotes, and subtitles are available.',
+    );
+    requireSignal(
+      report.coverage.audio,
+      'audio profile',
+      12,
+      'Run audio profiling so speech, silence, loudness, and pacing cues are available.',
+    );
+  }
+  requireSignal(
+    report.coverage.visual,
+    'visual frame analysis',
+    20,
+    'Run visual analysis so keyframe-level framing and motion cues are available.',
+  );
+
+  if (report.visual.semanticCoverage === 'local_fallback') {
+    score -= 12;
+    degradedSignals.push('semantic visual descriptions');
+    recommendedActions.push(
+      'Run a vision-capable provider over the extracted keyframes/contact sheet for actual scene descriptions.',
+    );
+  } else if (report.visual.semanticCoverage === 'semantic') {
+    criticalSignals.push('semantic visual cues');
+  }
+
+  if (!report.coverage.annotation) {
+    score -= 8;
+    missingSignals.push('object, face, and OCR annotations');
+    recommendedActions.push(
+      'Run object/OCR/face annotation if the edit depends on people, props, screens, or visible text.',
+    );
+  } else if (
+    report.annotations.objectDetectionCount +
+      report.annotations.faceDetectionCount +
+      report.annotations.ocrTextCount >
+    0
+  ) {
+    criticalSignals.push('annotation cues');
+  }
+
+  if (report.visual.keyframes.length === 0) {
+    score -= 8;
+    degradedSignals.push('keyframe gallery');
+    recommendedActions.push(
+      'Regenerate shot keyframes so agents can inspect representative stills.',
+    );
+  }
+
+  if (!report.visual.contactSheet) {
+    score -= 4;
+    degradedSignals.push('contact sheet');
+  }
+
+  const errorCount = Object.keys(report.errors).length;
+  if (errorCount > 0) {
+    score -= Math.min(20, errorCount * 6);
+    degradedSignals.push('failed analysis sub-jobs');
+  }
+
+  const normalizedScore = Math.max(0, Math.min(100, Math.round(score)));
+  const status =
+    normalizedScore >= 80 ? 'ready' : normalizedScore >= 50 ? 'partial' : 'insufficient';
+
+  return {
+    status,
+    score: normalizedScore,
+    criticalSignals: uniqueStrings(criticalSignals),
+    missingSignals: uniqueStrings(missingSignals),
+    degradedSignals: uniqueStrings(degradedSignals),
+    recommendedActions: uniqueStrings(recommendedActions),
+  };
+}
+
 function formatProviderLabel(provider: unknown): string {
   if (typeof provider === 'string') {
     return provider;
@@ -1789,12 +2153,20 @@ function formatProviderLabel(provider: unknown): string {
 }
 
 function bundleSatisfiesOptions(bundle: AnalysisBundle, options: AnalysisOptions): boolean {
+  const frameObservations = bundle.frameObservations ?? [];
+  const hasFrameAnalysis = (bundle.frameAnalysis?.length ?? 0) > 0;
+  const hasVisualSignals = hasFrameAnalysis || frameObservations.length > 0;
+
   return (
     (!options.shots || hasValue(bundle.shots)) &&
     (!options.transcript || hasValue(bundle.transcript)) &&
     (!options.audio || hasValue(bundle.audioProfile)) &&
     (!options.segments || hasValue(bundle.segments)) &&
-    (!options.visual || hasValue(bundle.frameAnalysis))
+    (!options.visual ||
+      (hasVisualSignals &&
+        (options.localOnly ||
+          !isLocalVisualFallbackOnly(bundle.frameAnalysis ?? []) ||
+          frameObservations.length > 0)))
   );
 }
 
@@ -1879,6 +2251,15 @@ type SourceLibraryMatch = {
     subjectPosition?: string | null;
     motionDirection?: string | null;
     visualComplexity?: number;
+    description?: string;
+    subjects?: string[];
+    actions?: string[];
+    setting?: string | null;
+    visibleText?: string[];
+    objects?: string[];
+    editUsefulness?: string | null;
+    confidence?: number | null;
+    provider?: Record<string, unknown> | null;
   };
 };
 
@@ -1909,6 +2290,15 @@ type SemanticReportInput = {
   };
   visual: {
     topCameraAngles: Array<{ label: string; count: number }>;
+    observations: Array<{
+      description: string;
+      subjects: string[];
+      actions: string[];
+      setting: string | null;
+      visibleText: string[];
+      objects: string[];
+      editUsefulness: string | null;
+    }>;
   };
   speakerTurns: {
     items: ReportSpeakerTurn[];
@@ -2107,12 +2497,20 @@ function buildSemanticReportData(report: SemanticReportInput): SemanticReportDat
       };
     });
 
+  const observationDescriptions = report.visual.observations
+    .map((observation) => observation.description)
+    .filter((value) => value.length > 0);
   const whatIsHappening = uniqueStrings(
-    sceneTimeline.map((item) => item.summary),
+    [...observationDescriptions, ...sceneTimeline.map((item) => item.summary)],
     SEMANTIC_OVERVIEW_LIMIT,
   );
   const likelySetting = uniqueStrings(
-    report.moments.items.flatMap((moment) => moment.settingHints),
+    [
+      ...report.visual.observations
+        .map((observation) => observation.setting)
+        .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ...report.moments.items.flatMap((moment) => moment.settingHints),
+    ],
     SEMANTIC_OVERVIEW_LIMIT,
   );
   const whoIsPresent = uniqueStrings(
@@ -2126,6 +2524,9 @@ function buildSemanticReportData(report: SemanticReportInput): SemanticReportDat
       ...report.moments.items
         .map((moment) => moment.peopleSummary)
         .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ...report.visual.observations
+        .flatMap((observation) => observation.subjects)
+        .map((subject) => `Visible subject: ${subject}.`),
       report.annotations.topObjectLabels.length > 0
         ? `Recurring visible cues include ${formatNaturalList(
             report.annotations.topObjectLabels.slice(0, 4).map((entry) => entry.label),
@@ -2166,6 +2567,9 @@ function buildSemanticReportData(report: SemanticReportInput): SemanticReportDat
       ...report.moments.items
         .map((moment) => moment.textSummary)
         .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ...report.visual.observations
+        .flatMap((observation) => observation.visibleText)
+        .map((text) => `Vision-visible text reads ${quoteSnippet(text, 64)}.`),
     ],
     SEMANTIC_OVERVIEW_LIMIT,
   );
@@ -2420,6 +2824,44 @@ function searchSourceAnalysisReport(
           subjectPosition: item.subjectPosition,
           motionDirection: item.motionDirection,
           visualComplexity: item.visualComplexity,
+        },
+      });
+    }
+
+    for (const observation of report.visual.observations) {
+      const match = scoreSearchTextFields(normalizedQuery, queryTokens, [
+        { field: 'description', value: observation.description, weight: 4 },
+        { field: 'subjects', value: observation.subjects, weight: 3 },
+        { field: 'actions', value: observation.actions, weight: 3 },
+        { field: 'setting', value: observation.setting, weight: 2 },
+        { field: 'visibleText', value: observation.visibleText, weight: 3 },
+        { field: 'objects', value: observation.objects, weight: 2 },
+        { field: 'editUsefulness', value: observation.editUsefulness, weight: 2 },
+      ]);
+      if (match.score <= 0) {
+        continue;
+      }
+
+      candidates.push({
+        sectionType: 'visual',
+        index: observation.shotIndex,
+        startSec: observation.startSec,
+        endSec: observation.endSec,
+        score: match.score,
+        whyMatched: match.whyMatched,
+        preview: observation.description,
+        keyframePath: observation.imagePath,
+        metadata: {
+          durationSec: roundTo(observation.endSec - observation.startSec) ?? 0,
+          description: observation.description,
+          subjects: observation.subjects,
+          actions: observation.actions,
+          setting: observation.setting,
+          visibleText: observation.visibleText,
+          objects: observation.objects,
+          editUsefulness: observation.editUsefulness,
+          confidence: observation.confidence,
+          provider: observation.provider,
         },
       });
     }
@@ -3065,8 +3507,23 @@ function buildSourceAnalysisReportPayload({
     : (annotationAnalysis?.transcript?.results ?? []);
   const segments = bundle.segments ?? [];
   const frameAnalysis = bundle.frameAnalysis ?? [];
+  const frameObservationItems = buildFrameObservationItems(bundle.frameObservations ?? [], shots);
   const visualItems = buildReportVisualItems(shots, frameAnalysis);
+  const visualSemanticCoverage = resolveVisualSemanticCoverage(frameAnalysis, frameObservationItems);
+  const keyframes = buildKeyframeGallery(shots);
   const audioProfile = bundle.audioProfile;
+  const transcriptDetail = bundle.transcriptDetail ?? null;
+  const transcriptDetailWords = transcriptDetail?.words ?? [];
+  const transcriptDetailSpeakerSegments = (transcriptDetail?.speakerSegments ?? []).map(
+    (segment, index) => ({
+      index,
+      startSec: roundTo(segment.startSec) ?? 0,
+      endSec: roundTo(segment.endSec) ?? 0,
+      speakerId: normalizeText(segment.speakerId),
+      text: normalizeText(segment.text),
+      confidence: roundTo(segment.confidence, 3),
+    }),
+  );
   const objectDetections = annotationAnalysis?.objects?.results ?? [];
   const faceDetections = annotationAnalysis?.faces?.results ?? [];
   const textDetections = annotationAnalysis?.textOcr?.results ?? [];
@@ -3090,10 +3547,19 @@ function buildSourceAnalysisReportPayload({
     (sum, region) => sum + (region.endSec - region.startSec),
     0,
   );
-  const transcriptWordCount = transcriptSegments.reduce((count, segment) => {
+  const transcriptWordCountFromSegments = transcriptSegments.reduce((count, segment) => {
     const words = segment.text.trim().split(/\s+/).filter(Boolean).length;
     return count + words;
   }, 0);
+  const transcriptFullText =
+    typeof transcriptDetail?.full === 'string' && transcriptDetail.full.trim().length > 0
+      ? normalizeText(transcriptDetail.full)
+      : buildFullTranscriptText(transcriptSegments);
+  const transcriptWordCount =
+    transcriptDetailWords.length > 0
+      ? transcriptDetailWords.length
+      : transcriptWordCountFromSegments ||
+        (transcriptFullText?.split(/\s+/).filter(Boolean).length ?? 0);
   const transcriptLanguages = Array.from(
     new Set(
       transcriptSegments
@@ -3103,9 +3569,12 @@ function buildSourceAnalysisReportPayload({
         ),
     ),
   );
+  const transcriptLines = buildTranscriptLines(transcriptSegments);
   const speakerCount = new Set(
-    transcriptSegments
-      .map((segment) => segment.speakerId)
+    [
+      ...transcriptSegments.map((segment) => segment.speakerId),
+      ...transcriptDetailSpeakerSegments.map((segment) => segment.speakerId),
+    ]
       .filter(
         (speakerId): speakerId is string => typeof speakerId === 'string' && speakerId.length > 0,
       ),
@@ -3195,15 +3664,19 @@ function buildSourceAnalysisReportPayload({
     ([analysisType, message]) => `${analysisType}: ${message}`,
   );
 
-  if (transcriptSegments.length === 0) {
+  if (transcriptSegments.length === 0 && !transcriptFullText) {
     warnings.push(
       'Transcript data is missing. Enable transcript analysis for searchable dialogue.',
     );
   }
 
-  if (frameAnalysis.length === 0) {
+  if (frameAnalysis.length === 0 && frameObservationItems.length === 0) {
     warnings.push(
       'Visual composition analysis is missing. Enable visual analysis for framing and motion cues.',
+    );
+  } else if (visualSemanticCoverage === 'local_fallback') {
+    warnings.push(
+      'Visual semantic analysis is local fallback only. Frame descriptions contain composition metrics, not true scene understanding.',
     );
   }
 
@@ -3213,10 +3686,10 @@ function buildSourceAnalysisReportPayload({
 
   const coverage = {
     shots: shots.length > 0,
-    transcript: transcriptSegments.length > 0,
+    transcript: transcriptSegments.length > 0 || Boolean(transcriptFullText),
     audio: hasValue(audioProfile),
     segments: segments.length > 0,
-    visual: frameAnalysis.length > 0,
+    visual: frameAnalysis.length > 0 || frameObservationItems.length > 0,
     annotation: Boolean(annotation),
   };
   const report = {
@@ -3240,7 +3713,7 @@ function buildSourceAnalysisReportPayload({
       codec,
       hasAudio: bundle.metadata.hasAudio,
       hasVideoStream: asset?.hasVideoStream ?? width !== null,
-      hasAudioStream: asset?.hasAudioStream ?? bundle.metadata.hasAudio,
+      hasAudioStream: bundle.metadata.hasAudio || (asset?.hasAudioStream ?? false),
       onTimeline: asset?.onTimeline ?? false,
       timelineClipCount: asset?.timelineClipCount ?? 0,
     },
@@ -3265,8 +3738,14 @@ function buildSourceAnalysisReportPayload({
       wordCount: transcriptWordCount,
       speakerCount,
       speakerTurnCount: speakerTurns.length,
+      speakerSegmentCount: transcriptDetailSpeakerSegments.length,
+      wordTimingCount: transcriptDetailWords.length,
+      provider: transcriptDetail?.provider ?? null,
       languages: transcriptLanguages,
       excerpt: buildTranscriptExcerpt(transcriptSegments),
+      fullText: transcriptFullText,
+      segments: transcriptLines,
+      speakerSegments: transcriptDetailSpeakerSegments,
       firstSegments: transcriptSegments.slice(0, 8).map((segment, index) => ({
         index,
         startSec: roundTo(segment.startSec),
@@ -3320,6 +3799,7 @@ function buildSourceAnalysisReportPayload({
     },
     visual: {
       sampleCount: frameAnalysis.length,
+      observationCount: frameObservationItems.length,
       averageComplexity:
         frameAnalysis.length > 0
           ? roundTo(
@@ -3330,7 +3810,10 @@ function buildSourceAnalysisReportPayload({
       topCameraAngles,
       topMotionDirections,
       contactSheet: bundle.contactSheet ?? null,
+      semanticCoverage: visualSemanticCoverage,
+      keyframes,
       items: visualItems,
+      observations: frameObservationItems,
     },
     moments: {
       count: moments.length,
@@ -3362,9 +3845,13 @@ function buildSourceAnalysisReportPayload({
     errors: bundle.errors ?? {},
   };
 
+  const reportWithQuality = {
+    ...report,
+    quality: buildSourceReportQuality(report),
+  };
   const semantic = buildSemanticReportData(report);
   return {
-    ...report,
+    ...reportWithQuality,
     summary: semantic.summaryLine,
     semantic,
   };
@@ -3383,6 +3870,31 @@ function buildSourceAnalysisMarkdown(
   ];
 
   const semantic = report.semantic;
+  const quality = report.quality;
+
+  lines.push(
+    '',
+    '## Analysis Quality',
+    '',
+    `- Status: ${quality.status}`,
+    `- Score: ${quality.score}/100`,
+    `- Critical signals: ${
+      quality.criticalSignals.length > 0 ? quality.criticalSignals.join(', ') : 'none'
+    }`,
+    `- Missing signals: ${
+      quality.missingSignals.length > 0 ? quality.missingSignals.join(', ') : 'none'
+    }`,
+    `- Degraded signals: ${
+      quality.degradedSignals.length > 0 ? quality.degradedSignals.join(', ') : 'none'
+    }`,
+  );
+
+  if (quality.recommendedActions.length > 0) {
+    lines.push('', '### Recommended Follow-Up', '');
+    for (const action of quality.recommendedActions) {
+      lines.push(`- ${action}`);
+    }
+  }
 
   if (
     semantic.whatIsHappening.length > 0 ||
@@ -3429,6 +3941,7 @@ function buildSourceAnalysisMarkdown(
       );
       if (scene.keyframePath) {
         lines.push(`- Keyframe: ${scene.keyframePath}`);
+        lines.push(formatMarkdownImage(`${scene.title} keyframe`, scene.keyframePath));
       }
     }
   }
@@ -3441,6 +3954,7 @@ function buildSourceAnalysisMarkdown(
       );
       if (moment.keyframePath) {
         lines.push(`- Keyframe: ${moment.keyframePath}`);
+        lines.push(formatMarkdownImage(`${moment.kind} moment keyframe`, moment.keyframePath));
       }
       lines.push(`- Why it stands out: ${moment.reason}`);
     }
@@ -3507,17 +4021,48 @@ function buildSourceAnalysisMarkdown(
     `- Longest shot: ${report.shots.maxDurationSec ?? 'unknown'}s`,
   );
 
-  if (report.transcript.segmentCount > 0) {
+  if (report.transcript.segmentCount > 0 || report.transcript.fullText) {
     lines.push('', '## Transcript Summary', '');
+    const providerLabel = formatPerceptionProvider(report.transcript.provider);
+    if (providerLabel) {
+      lines.push(`- Provider: ${providerLabel}`);
+    }
     lines.push(`- Segment count: ${report.transcript.segmentCount}`);
     lines.push(`- Estimated word count: ${report.transcript.wordCount}`);
+    lines.push(`- Word timings: ${report.transcript.wordTimingCount}`);
     lines.push(`- Speakers detected: ${report.transcript.speakerCount}`);
     lines.push(`- Speaker turns: ${report.transcript.speakerTurnCount}`);
+    lines.push(`- Speaker segments: ${report.transcript.speakerSegmentCount}`);
     lines.push(
       `- Languages: ${report.transcript.languages.length > 0 ? report.transcript.languages.join(', ') : 'unknown'}`,
     );
     if (report.transcript.excerpt) {
       lines.push(`- Excerpt: ${report.transcript.excerpt}`);
+    }
+  }
+
+  if (report.transcript.segments.length > 0) {
+    lines.push('', '## Full Transcript', '');
+    for (const line of report.transcript.segments) {
+      lines.push(
+        `- ${formatTimecode(line.startSec)}-${formatTimecode(line.endSec)} | ${formatTranscriptSpeaker(line)} | ${line.text}`,
+      );
+    }
+  } else if (report.transcript.fullText) {
+    lines.push('', '## Full Transcript', '', report.transcript.fullText);
+  }
+
+  if (report.transcript.speakerSegments.length > 0) {
+    lines.push('', '## Speaker-Aware Transcript Segments', '');
+    for (const segment of report.transcript.speakerSegments.slice(0, 24)) {
+      lines.push(
+        `- ${formatTimecode(segment.startSec)}-${formatTimecode(segment.endSec)} | ${segment.speakerId || 'unknown speaker'} | ${segment.text}`,
+      );
+    }
+    if (report.transcript.speakerSegments.length > 24) {
+      lines.push(
+        `- ... ${report.transcript.speakerSegments.length - 24} more speaker-aware transcript segments omitted from Markdown preview`,
+      );
     }
   }
 
@@ -3599,6 +4144,7 @@ function buildSourceAnalysisMarkdown(
       );
       if (item.keyframePath) {
         lines.push(`- Keyframe: ${item.keyframePath}`);
+        lines.push(formatMarkdownImage(`Shot ${item.shotIndex + 1} keyframe`, item.keyframePath));
       }
     }
     if (report.visual.items.length > VISUAL_BREAKDOWN_MARKDOWN_LIMIT) {
@@ -3608,12 +4154,72 @@ function buildSourceAnalysisMarkdown(
     }
   }
 
+  if (report.visual.observations.length > 0) {
+    lines.push('', '## Frame Observations', '');
+    for (const observation of report.visual.observations.slice(0, 24)) {
+      lines.push(
+        `- ${formatTimecode(observation.startSec)}-${formatTimecode(observation.endSec)} | Shot ${observation.shotIndex + 1} | ${observation.description || 'No description available'}`,
+      );
+      if (observation.subjects.length > 0) {
+        lines.push(`- Subjects: ${observation.subjects.join(', ')}`);
+      }
+      if (observation.actions.length > 0) {
+        lines.push(`- Actions: ${observation.actions.join(', ')}`);
+      }
+      if (observation.setting) {
+        lines.push(`- Setting: ${observation.setting}`);
+      }
+      if (observation.visibleText.length > 0) {
+        lines.push(`- Visible text: ${observation.visibleText.join(' | ')}`);
+      }
+      if (observation.objects.length > 0) {
+        lines.push(`- Objects: ${observation.objects.join(', ')}`);
+      }
+      if (observation.editUsefulness) {
+        lines.push(`- Edit usefulness: ${observation.editUsefulness}`);
+      }
+      const providerLabel = formatPerceptionProvider(observation.provider);
+      if (providerLabel) {
+        lines.push(
+          `- Provider: ${providerLabel}${observation.confidence !== null ? ` | confidence ${observation.confidence}` : ''}`,
+        );
+      }
+      if (observation.imagePath) {
+        lines.push(`- Image: ${observation.imagePath}`);
+        lines.push(
+          formatMarkdownImage(`Shot ${observation.shotIndex + 1} observation`, observation.imagePath),
+        );
+      }
+    }
+    if (report.visual.observations.length > 24) {
+      lines.push(
+        `- ... ${report.visual.observations.length - 24} more frame observations omitted from Markdown preview`,
+      );
+    }
+  }
+
   if (report.visual.contactSheet) {
     lines.push('', '## Visual Artifacts', '');
     lines.push(`- Contact sheet: ${report.visual.contactSheet.path}`);
+    lines.push(formatMarkdownImage('Contact sheet', report.visual.contactSheet.path));
     lines.push(
       `- Layout: ${report.visual.contactSheet.frameCount} frames in ${report.visual.contactSheet.columns}x${report.visual.contactSheet.rows} grid`,
     );
+  }
+
+  if (report.visual.keyframes.length > 0) {
+    lines.push('', '## Keyframe Gallery', '');
+    for (const keyframe of report.visual.keyframes.slice(0, 24)) {
+      lines.push(
+        `- ${formatTimecode(keyframe.startSec)}-${formatTimecode(keyframe.endSec)} | ${keyframe.label}${keyframe.keyframeSelectionMethod ? ` | ${keyframe.keyframeSelectionMethod}` : ''}`,
+      );
+      lines.push(formatMarkdownImage(keyframe.label, keyframe.keyframePath));
+    }
+    if (report.visual.keyframes.length > 24) {
+      lines.push(
+        `- ... ${report.visual.keyframes.length - 24} more keyframes omitted from Markdown preview`,
+      );
+    }
   }
 
   if (report.chapters.count > 0) {
@@ -3702,6 +4308,64 @@ function buildDefaultSourceAnalysisReportRelativePath(report: SourceAnalysisRepo
   }
 
   return `analysis-reports/${sanitizeReportFileStem(report.assetName || report.assetId)}${SOURCE_ANALYSIS_REPORT_SUFFIX}`;
+}
+
+function formatMarkdownImagePath(path: string): string {
+  const normalized = path.trim();
+  if (/[\s()]/.test(normalized)) {
+    return `<${normalized.replace(/>/g, '%3E')}>`;
+  }
+
+  return normalized;
+}
+
+function formatMarkdownImage(alt: string, path: string): string {
+  return `![${alt.replace(/\[|\]/g, '')}](${formatMarkdownImagePath(path)})`;
+}
+
+function formatTranscriptSpeaker(line: {
+  speakerId: string | null;
+  speakerTurnId: string | null;
+}): string {
+  if (line.speakerId) {
+    return line.speakerId;
+  }
+
+  if (line.speakerTurnId) {
+    return line.speakerTurnId;
+  }
+
+  return 'unknown speaker';
+}
+
+function formatPerceptionProvider(
+  provider:
+    | {
+        provider?: string;
+        model?: string;
+        analyzedAt?: string;
+      }
+    | null
+    | undefined,
+): string | null {
+  if (!provider) {
+    return null;
+  }
+
+  const providerName =
+    typeof provider.provider === 'string' && provider.provider.trim().length > 0
+      ? provider.provider.trim()
+      : 'unknown';
+  const model =
+    typeof provider.model === 'string' && provider.model.trim().length > 0
+      ? provider.model.trim()
+      : 'unknown';
+  const analyzedAt =
+    typeof provider.analyzedAt === 'string' && provider.analyzedAt.trim().length > 0
+      ? provider.analyzedAt.trim()
+      : null;
+
+  return analyzedAt ? `${providerName}/${model} at ${analyzedAt}` : `${providerName}/${model}`;
 }
 
 async function persistSourceAnalysisMarkdownReport(
@@ -4558,12 +5222,13 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
             summary: report.summary,
             metadata: report.metadata,
             coverage: report.coverage,
+            quality: report.quality,
             sectionCounts: {
               moments: report.moments.count,
               chapters: report.chapters.count,
               highlights: report.highlights.count,
               speakerTurns: report.speakerTurns.count,
-              visual: report.visual.items.length,
+              visual: report.visual.items.length + report.visual.observations.length,
             },
             warnings: report.warnings,
             errors: report.errors,
@@ -4926,7 +5591,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
         analyzeMissing: {
           type: 'boolean',
           description:
-            'Generate fresh analysis for assets without cached bundle data (default: false)',
+            'Generate fresh analysis for missing or low-quality source reports before selecting (default: true)',
         },
         useSemantic: {
           type: 'boolean',
@@ -5148,16 +5813,15 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
           typeof args.gapSec === 'number' && Number.isFinite(args.gapSec) && args.gapSec >= 0
             ? args.gapSec
             : 0.25;
+        const sourceSearchArgs = {
+          ...args,
+          analyzeMissing: args.analyzeMissing !== false,
+          limit: Math.min(requestedSelectCount * 3, 50),
+        } as Record<string, unknown>;
         const searchResult =
           args.useIndexedSearch === true
-            ? await searchIndexedSourceLibraryMatches({
-                ...args,
-                limit: Math.min(requestedSelectCount * 3, 50),
-              } as Record<string, unknown>)
-            : await searchSourceLibraryMatches({
-                ...args,
-                limit: Math.min(requestedSelectCount * 3, 50),
-              } as Record<string, unknown>);
+            ? await searchIndexedSourceLibraryMatches(sourceSearchArgs)
+            : await searchSourceLibraryMatches(sourceSearchArgs);
         const selects = buildSourceSelectSegments(searchResult.matches, {
           paddingSec,
           gapSec,

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -952,9 +952,9 @@ function buildSourceReportChunks(report: SourceAnalysisReport): SourceReportChun
       },
     })),
     ...report.visual.observations.map((observation) => ({
-      id: `${report.assetId}:visualObservation:${observation.shotIndex}`,
+      id: `${report.assetId}:visualObservation:${observation.observationIndex}`,
       sectionType: 'visual' as const,
-      sectionIndex: observation.shotIndex,
+      sectionIndex: observation.observationIndex,
       startSec: observation.startSec,
       endSec: observation.endSec,
       searchText: [
@@ -972,6 +972,7 @@ function buildSourceReportChunks(report: SourceAnalysisReport): SourceReportChun
         preview: observation.description,
         keyframePath: observation.imagePath,
         durationSec: observation.endSec - observation.startSec,
+        shotIndex: observation.shotIndex,
         description: observation.description,
         subjects: observation.subjects,
         actions: observation.actions,
@@ -1855,6 +1856,7 @@ function buildFrameObservationItems(
     }
   >,
 ): Array<{
+  observationIndex: number;
   shotIndex: number;
   startSec: number;
   endSec: number;
@@ -1896,6 +1898,7 @@ function buildFrameObservationItems(
 
     return [
       {
+        observationIndex: fallbackIndex,
         shotIndex: resolvedShotIndex,
         startSec: shot ? (roundTo(shot.startSec) ?? timeSec) : timeSec,
         endSec: shot ? (roundTo(shot.endSec) ?? timeSec) : timeSec,
@@ -2235,6 +2238,7 @@ type SourceLibraryMatch = {
     subjectPosition?: string | null;
     motionDirection?: string | null;
     visualComplexity?: number;
+    shotIndex?: number;
     description?: string;
     subjects?: string[];
     actions?: string[];
@@ -2828,7 +2832,7 @@ function searchSourceAnalysisReport(
 
       candidates.push({
         sectionType: 'visual',
-        index: observation.shotIndex,
+        index: observation.observationIndex,
         startSec: observation.startSec,
         endSec: observation.endSec,
         score: match.score,
@@ -2837,6 +2841,7 @@ function searchSourceAnalysisReport(
         keyframePath: observation.imagePath,
         metadata: {
           durationSec: roundTo(observation.endSec - observation.startSec) ?? 0,
+          shotIndex: observation.shotIndex,
           description: observation.description,
           subjects: observation.subjects,
           actions: observation.actions,

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -1922,10 +1922,6 @@ function buildFrameObservationItems(
   });
 }
 
-function isUnknownVisualValue(value: string | null | undefined): boolean {
-  return !value || value === 'unknown';
-}
-
 function isLocalVisualFallbackOnly(
   frameAnalysis: Array<{
     cameraAngle?: string | null;
@@ -1933,15 +1929,7 @@ function isLocalVisualFallbackOnly(
     motionDirection?: string | null;
   }>,
 ): boolean {
-  return (
-    frameAnalysis.length > 0 &&
-    frameAnalysis.every(
-      (entry) =>
-        isUnknownVisualValue(entry.cameraAngle) &&
-        isUnknownVisualValue(entry.subjectPosition) &&
-        isUnknownVisualValue(entry.motionDirection),
-    )
-  );
+  return frameAnalysis.length > 0;
 }
 
 function resolveVisualSemanticCoverage(
@@ -1956,11 +1944,7 @@ function resolveVisualSemanticCoverage(
     return 'semantic';
   }
 
-  if (frameAnalysis.length === 0) {
-    return 'missing';
-  }
-
-  return isLocalVisualFallbackOnly(frameAnalysis) ? 'local_fallback' : 'semantic';
+  return isLocalVisualFallbackOnly(frameAnalysis) ? 'local_fallback' : 'missing';
 }
 
 function buildKeyframeGallery(
@@ -5591,7 +5575,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
         analyzeMissing: {
           type: 'boolean',
           description:
-            'Generate fresh analysis for missing or low-quality source reports before selecting (default: true)',
+            'Generate fresh analysis for assets without cached bundle data (default: false)',
         },
         useSemantic: {
           type: 'boolean',
@@ -5815,7 +5799,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
             : 0.25;
         const sourceSearchArgs = {
           ...args,
-          analyzeMissing: args.analyzeMissing !== false,
+          analyzeMissing: args.analyzeMissing === true,
           limit: Math.min(requestedSelectCount * 3, 50),
         } as Record<string, unknown>;
         const searchResult =

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2541,7 +2541,11 @@ export type AgentSessionLineageDto = { parentSessionId: string | null; branchFro
  * This is the primary output artifact of the analysis pipeline.
  * Stored at `{project}/.openreelio/analysis/{asset_id}/bundle.json`.
  */
-export type AnalysisBundle = { 
+export type AnalysisBundle = {
+/**
+ * Analysis schema version. Version 2 adds transcript detail and frame observations.
+ */
+schemaVersion?: number;
 /**
  * Asset ID this bundle belongs to
  */
@@ -2566,6 +2570,14 @@ segments: ContentSegment[] | null;
  * Visual frame analysis results
  */
 frameAnalysis: FrameAnalysis[] | null; 
+/**
+ * Semantic observations produced by a vision-capable provider.
+ */
+frameObservations?: FrameObservation[] | null;
+/**
+ * Full transcript, words, and speaker-aware segments when available.
+ */
+transcriptDetail?: TranscriptDetail | null;
 /**
  * Representative-frame contact sheet artifact
  */
@@ -4228,6 +4240,58 @@ width: number;
  */
 height: number }
 /**
+ * Semantic visual observation for a representative frame/keyframe.
+ */
+export type FrameObservation = {
+/**
+ * Index of the shot this observation describes
+ */
+shotIndex: number;
+/**
+ * Source-relative timestamp represented by the observed image
+ */
+timeSec: number;
+/**
+ * Absolute or workspace-relative path to the analyzed image
+ */
+imagePath: string;
+/**
+ * Natural-language description of what is visible
+ */
+description: string;
+/**
+ * People or subject categories visible in the frame
+ */
+subjects?: string[];
+/**
+ * Observable actions or motion implied by the frame
+ */
+actions?: string[];
+/**
+ * Setting or environment label
+ */
+setting?: string | null;
+/**
+ * OCR text visible in the frame
+ */
+visibleText?: string[];
+/**
+ * Object or prop labels visible in the frame
+ */
+objects?: string[];
+/**
+ * Short note explaining how this shot may be useful in an edit
+ */
+editUsefulness?: string | null;
+/**
+ * Provider confidence (0.0 - 1.0)
+ */
+confidence: number;
+/**
+ * Provider/model that produced this observation
+ */
+provider: PerceptionProviderMetadata }
+/**
  * Describes a gap (empty region) between clips on a track.
  */
 export type GapInfo = { 
@@ -4801,6 +4865,22 @@ normalizedDuration: number }
  * A content part within a message (text, tool call, tool result, etc.).
  */
 export type PartDto = { id: string; messageId: string; sortOrder: number; partType: string; dataJson: string; compactedAt: number | null }
+/**
+ * Metadata describing the model that produced semantic perception signals.
+ */
+export type PerceptionProviderMetadata = {
+/**
+ * Provider identifier, e.g. "openai" or "local"
+ */
+provider: string;
+/**
+ * Model identifier used by the provider
+ */
+model: string;
+/**
+ * ISO 8601 timestamp when this perception result was produced
+ */
+analyzedAt: string }
 export type PerformanceSettingsDto = { hardwareAcceleration: boolean; gpuDeviceId: string | null; proxyGeneration: boolean; proxyResolution: string; maxConcurrentJobs: number; memoryLimitMb: number; cacheSizeMb: number }
 /**
  * Persisted permission decision DTO aligned with the frontend session kernel vocabulary.
@@ -5911,6 +5991,30 @@ playheadSec: number;
  */
 markedDuration: number | null }
 /**
+ * Speaker-aware transcript range used by `TranscriptDetail`.
+ */
+export type SpeakerSegment = {
+/**
+ * Start time in seconds
+ */
+startSec: number;
+/**
+ * End time in seconds
+ */
+endSec: number;
+/**
+ * Speaker identifier
+ */
+speakerId: string;
+/**
+ * Segment text
+ */
+text: string;
+/**
+ * Provider confidence (0.0 - 1.0)
+ */
+confidence?: number | null }
+/**
  * A detected region of speech / non-silence in the audio track.
  */
 export type SpeechRegion = { 
@@ -6714,6 +6818,26 @@ pointsCount: number;
  * Average confidence score across all tracked points.
  */
 averageConfidence: number }
+/**
+ * Full transcript details beyond the legacy segment list.
+ */
+export type TranscriptDetail = {
+/**
+ * Complete transcript text
+ */
+full: string;
+/**
+ * Word-level timings, estimated or provider supplied
+ */
+words?: TranscriptWord[];
+/**
+ * Speaker-aware transcript ranges
+ */
+speakerSegments?: SpeakerSegment[];
+/**
+ * Provider/model that produced this transcript detail
+ */
+provider?: PerceptionProviderMetadata | null }
 /**
  * Search result for a transcript segment.
  */

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2541,11 +2541,11 @@ export type AgentSessionLineageDto = { parentSessionId: string | null; branchFro
  * This is the primary output artifact of the analysis pipeline.
  * Stored at `{project}/.openreelio/analysis/{asset_id}/bundle.json`.
  */
-export type AnalysisBundle = {
+export type AnalysisBundle = { 
 /**
  * Analysis schema version. Version 2 adds transcript detail and frame observations.
  */
-schemaVersion?: number;
+schemaVersion?: number; 
 /**
  * Asset ID this bundle belongs to
  */
@@ -2573,11 +2573,11 @@ frameAnalysis: FrameAnalysis[] | null;
 /**
  * Semantic observations produced by a vision-capable provider.
  */
-frameObservations?: FrameObservation[] | null;
+frameObservations?: FrameObservation[] | null; 
 /**
  * Full transcript, words, and speaker-aware segments when available.
  */
-transcriptDetail?: TranscriptDetail | null;
+transcriptDetail?: TranscriptDetail | null; 
 /**
  * Representative-frame contact sheet artifact
  */
@@ -4242,51 +4242,51 @@ height: number }
 /**
  * Semantic visual observation for a representative frame/keyframe.
  */
-export type FrameObservation = {
+export type FrameObservation = { 
 /**
  * Index of the shot this observation describes
  */
-shotIndex: number;
+shotIndex: number; 
 /**
  * Source-relative timestamp represented by the observed image
  */
-timeSec: number;
+timeSec: number; 
 /**
  * Absolute or workspace-relative path to the analyzed image
  */
-imagePath: string;
+imagePath: string; 
 /**
  * Natural-language description of what is visible
  */
-description: string;
+description: string; 
 /**
  * People or subject categories visible in the frame
  */
-subjects?: string[];
+subjects?: string[]; 
 /**
  * Observable actions or motion implied by the frame
  */
-actions?: string[];
+actions?: string[]; 
 /**
  * Setting or environment label
  */
-setting?: string | null;
+setting?: string | null; 
 /**
  * OCR text visible in the frame
  */
-visibleText?: string[];
+visibleText?: string[]; 
 /**
  * Object or prop labels visible in the frame
  */
-objects?: string[];
+objects?: string[]; 
 /**
  * Short note explaining how this shot may be useful in an edit
  */
-editUsefulness?: string | null;
+editUsefulness?: string | null; 
 /**
  * Provider confidence (0.0 - 1.0)
  */
-confidence: number;
+confidence: number; 
 /**
  * Provider/model that produced this observation
  */
@@ -4868,15 +4868,15 @@ export type PartDto = { id: string; messageId: string; sortOrder: number; partTy
 /**
  * Metadata describing the model that produced semantic perception signals.
  */
-export type PerceptionProviderMetadata = {
+export type PerceptionProviderMetadata = { 
 /**
  * Provider identifier, e.g. "openai" or "local"
  */
-provider: string;
+provider: string; 
 /**
  * Model identifier used by the provider
  */
-model: string;
+model: string; 
 /**
  * ISO 8601 timestamp when this perception result was produced
  */
@@ -5993,23 +5993,23 @@ markedDuration: number | null }
 /**
  * Speaker-aware transcript range used by `TranscriptDetail`.
  */
-export type SpeakerSegment = {
+export type SpeakerSegment = { 
 /**
  * Start time in seconds
  */
-startSec: number;
+startSec: number; 
 /**
  * End time in seconds
  */
-endSec: number;
+endSec: number; 
 /**
  * Speaker identifier
  */
-speakerId: string;
+speakerId: string; 
 /**
  * Segment text
  */
-text: string;
+text: string; 
 /**
  * Provider confidence (0.0 - 1.0)
  */
@@ -6821,19 +6821,19 @@ averageConfidence: number }
 /**
  * Full transcript details beyond the legacy segment list.
  */
-export type TranscriptDetail = {
+export type TranscriptDetail = { 
 /**
  * Complete transcript text
  */
-full: string;
+full: string; 
 /**
  * Word-level timings, estimated or provider supplied
  */
-words?: TranscriptWord[];
+words?: TranscriptWord[]; 
 /**
  * Speaker-aware transcript ranges
  */
-speakerSegments?: SpeakerSegment[];
+speakerSegments?: SpeakerSegment[]; 
 /**
  * Provider/model that produced this transcript detail
  */


### PR DESCRIPTION
### **User description**
## Description

Add optional OpenAI-backed perception enrichment to source-footage analysis. The branch extends analysis bundle data with semantic frame observations, provider metadata, and speaker-aware transcript detail, then exposes those signals through source-analysis reports, search, source-select generation, prompt guidance, and generated frontend bindings.

## Related Issue

Closes #666

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added analysis bundle schema version 2 with provider metadata, semantic frame observations, transcript detail, speaker-aware transcript segments, legacy bundle compatibility, and generated TypeScript bindings.
- Added optional OpenAI keyframe vision and diarized transcript enrichment when OpenAI vision is configured, preserving local-only behavior and saving provider failures as non-fatal bundle errors.
- Updated source-analysis reports, search, source-select defaults, tool output contracts, and agent guidance to surface quality status, full transcript detail, frame observations, keyframe/contact-sheet images, and low-quality analysis follow-up cues.

## Screenshots / Videos

N/A. This change updates backend analysis enrichment and agent source-analysis report outputs.

## Testing

Validated Rust formatting, Rust tests, TypeScript type checks, linting, generated bindings, and focused agent analysis tests for the changed behavior.

### Test Environment

- OS: Linux / WSL2
- Node.js version: v22.22.0 (npm 10.9.4)
- Rust version: rustc 1.88.0 / cargo 1.88.0 for validation commands

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Validation commands run:

- `cargo +1.88.0 fmt --all -- --check`
- `npx vitest run src/agents/tools/analysisTools.test.ts src/agents/toolOutputContracts.test.ts`
- `npm run type-check`
- `npm run lint` (completed with 18 existing warnings and 0 errors)
- `cargo +1.88.0 clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo +1.88.0 test --locked --manifest-path src-tauri/Cargo.toml --all-features`
- `cargo +1.88.0 run --locked --manifest-path src-tauri/Cargo.toml --bin export_bindings`
- `git diff --exit-code -- src/bindings.ts`
- `git diff --check`


___

### **PR Type**
Enhancement, Refactoring, Tests


___

### **Description**
- Adds OpenAI-backed perception enrichment for source analysis.

- Introduces Analysis Bundle V2 with semantic observations.

- Implements quality gating for source analysis reports.

- Enhances search and agent tools with semantic signals.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local Analysis"] -- "Optional Enrichment" --> B["OpenAI Perception"]
  B -- "Frame Observations" --> C["Analysis Bundle V2"]
  B -- "Diarized Transcript" --> C
  C -- "Quality Scoring" --> D["Source Report"]
  D -- "Semantic Search" --> E["Agent Tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>openai_perception.rs</strong><dd><code>Implement OpenAI vision and diarization perception logic</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-080081e3351a39671e64049d5313660dd1c9190f9dff3d28988ad02e7be8f895">+700/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Define Analysis Bundle V2 schema and perception types</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-e33aba73781a8b128f924476cc5fafe5ccbe73349a6889a4c5b04aed75cca639">+182/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>analysisTools.ts</strong><dd><code>Update agent tools to handle semantic observations and quality</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-717609a79d522c08834e29f962677b6c063796dd112f1c4bf93d697292f48a4a">+687/-23</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Integrate transcript detail building into analysis runner</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-ee1ec68a6c16498846fbdeed6ee57a511828e681c5493aee1cd5b746fbfe8312">+44/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Thinker.ts</strong><dd><code>Add agent guidance for inspecting analysis quality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-7f12369d7b758f64f123f12df982012da3927808cf541e8ffe178b50c2044732">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolOutputContracts.ts</strong><dd><code>Update tool contracts to include quality and transcript fields</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-2fe279e63827a652ff07a52579998fb029ad15e9604be67586e5659c39ddc75f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Sync TypeScript bindings for new analysis schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+124/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add base64 and multipart dependencies for AI providers</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>analysisTools.test.ts</strong><dd><code>Add tests for semantic analysis and quality gating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-ebc3842977d35600a53a65876d8082c469318e39e66177c38b0353647045f040">+367/-26</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>toolReference.ts</strong><dd><code>Update agent prompt guidance for quality-aware analysis</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>segmentation.rs</strong><dd><code>Refactor to use integer multiple helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-64e01c608e49b2341f40ba3416b46bee21c3d7853e587db8307e00e2f7802029">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>esd.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-79cc8f3826c25a7a19ccbe05e74255bfd29618e0db7256f45d9051a49adb3d3e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>report_chunks.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-83ac176b3f43f1d9cafb13ca5d11ece6a9d2d15d881884a4b9d5e89dfe9c5679">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tracker.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-6e97e9bf8496be7237f6252403e2d4bbe5f462776f1fe8d875c6a91e5cbc935c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysis.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-27ee8d77b931eb5265b4548b8b912173ea914870e28c0a6e0ecba9a971e37f5f">+215/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>toolOutputContracts.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/667/files#diff-fd4cc4238e2cbcae4a0d795b13e3e84896c5f1ac224ffa394ae5c14b944c99f0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered video analysis with OpenAI for richer keyframe vision and diarized transcription.
  * Transcript detail now includes word-level timings, speaker segments, and provider metadata.
  * Frame observations added with descriptive metadata, confidence, and image references.
  * Source-analysis tools and reports enhanced with quality metrics, expanded markdown outputs, and deeper search/indexing.

* **Tests**
  * Updated and added tests to cover new transcript, observation, and report behaviors.

* **Chores**
  * Updated dependencies to enable multipart requests and base64 handling for AI features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->