### PR TITLE
feat: expose backend command surface to CLI and agent tools

### DIFF
--- a/crates/openreelio-cli/src/commands/command.rs
+++ b/crates/openreelio-cli/src/commands/command.rs
@@ -1,0 +1,132 @@
+//! Generic backend command execution for agent-native CLI clients.
+//!
+//! This exposes the same strict `CommandPayload` parser used by the GUI IPC and
+//! backend agent plan executor, so headless agents are not limited to the
+//! hand-written convenience subcommands.
+
+use crate::output;
+use clap::Subcommand;
+use openreelio_core::ipc::CommandPayload;
+use std::path::PathBuf;
+
+#[derive(Subcommand)]
+pub enum CommandAction {
+    /// Execute any supported backend edit command from a JSON payload
+    Execute {
+        /// Project directory path
+        #[arg(long)]
+        path: PathBuf,
+
+        /// Backend command type, e.g. SplitClip, AddMask, CreateCompoundClip
+        #[arg(long = "type")]
+        command_type: String,
+
+        /// Inline JSON object payload
+        #[arg(long, conflicts_with = "payload_file")]
+        payload: Option<String>,
+
+        /// Path to a JSON file containing the payload object
+        #[arg(long = "payload-file", conflicts_with = "payload")]
+        payload_file: Option<PathBuf>,
+    },
+
+    /// Validate a backend command payload without executing it
+    Validate {
+        /// Backend command type, e.g. SplitClip, AddMask, CreateCompoundClip
+        #[arg(long = "type")]
+        command_type: String,
+
+        /// Inline JSON object payload
+        #[arg(long, conflicts_with = "payload_file")]
+        payload: Option<String>,
+
+        /// Path to a JSON file containing the payload object
+        #[arg(long = "payload-file", conflicts_with = "payload")]
+        payload_file: Option<PathBuf>,
+    },
+
+    /// Print the backend command surface available to headless agents
+    Schema,
+}
+
+pub fn execute(action: CommandAction) -> anyhow::Result<()> {
+    match action {
+        CommandAction::Execute {
+            path,
+            command_type,
+            payload,
+            payload_file,
+        } => {
+            let payload = read_payload(payload, payload_file)?;
+            let typed_payload = CommandPayload::parse(command_type.clone(), payload)
+                .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+            let mut project = super::load_project(&path)?;
+            let command = typed_payload.build_command(&project.path);
+            let result = project
+                .executor
+                .execute(command, &mut project.state)
+                .map_err(|error| anyhow::anyhow!("Command '{}' failed: {}", command_type, error))?;
+            super::save_project(&mut project)?;
+
+            output::print_json(&serde_json::json!({
+                "status": "ok",
+                "commandType": command_type,
+                "opId": result.op_id,
+                "createdIds": result.created_ids,
+                "deletedIds": result.deleted_ids,
+            }))
+        }
+
+        CommandAction::Validate {
+            command_type,
+            payload,
+            payload_file,
+        } => {
+            let payload = read_payload(payload, payload_file)?;
+            CommandPayload::parse(command_type.clone(), payload)
+                .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+            output::print_json(&serde_json::json!({
+                "status": "ok",
+                "commandType": command_type,
+                "message": "Command payload is valid",
+            }))
+        }
+
+        CommandAction::Schema => output::print_json_pretty(&serde_json::json!({
+            "commands": CommandPayload::SUPPORTED_COMMAND_TYPES,
+            "count": CommandPayload::SUPPORTED_COMMAND_TYPES.len(),
+            "payloadFormat": {
+                "commandType": "PascalCase backend command type",
+                "payload": "camelCase JSON object matching the command payload"
+            }
+        })),
+    }
+}
+
+fn read_payload(
+    payload: Option<String>,
+    payload_file: Option<PathBuf>,
+) -> anyhow::Result<serde_json::Value> {
+    let content = match (payload, payload_file) {
+        (Some(inline), None) => inline,
+        (None, Some(file)) => std::fs::read_to_string(&file).map_err(|error| {
+            anyhow::anyhow!(
+                "Failed to read payload file '{}': {}",
+                file.display(),
+                error
+            )
+        })?,
+        (None, None) => "{}".to_string(),
+        (Some(_), Some(_)) => unreachable!("clap enforces payload conflicts"),
+    };
+
+    let value: serde_json::Value =
+        serde_json::from_str(&content).map_err(|error| anyhow::anyhow!("Invalid JSON: {error}"))?;
+    if !value.is_object() {
+        return Err(anyhow::anyhow!("Command payload must be a JSON object"));
+    }
+
+    Ok(value)
+}

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -347,6 +347,30 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 },
                 "example": "openreelio-cli plan template --type split-and-move"
             },
+            "command.execute": {
+                "description": "Execute any supported backend edit command using the shared CommandPayload parser",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "type": { "type": "string", "required": true, "desc": "Backend command type, e.g. SplitClip or AddMask" },
+                    "payload": { "type": "string", "required": false, "desc": "Inline JSON object payload" },
+                    "payload-file": { "type": "string", "required": false, "desc": "Path to a JSON object payload file" }
+                },
+                "example": "openreelio-cli command execute --path ./project --type SplitClip --payload '{\"sequenceId\":\"seq_1\",\"trackId\":\"track_v1\",\"clipId\":\"clip_1\",\"splitTime\":5}'"
+            },
+            "command.validate": {
+                "description": "Validate a backend command payload without executing it",
+                "params": {
+                    "type": { "type": "string", "required": true, "desc": "Backend command type" },
+                    "payload": { "type": "string", "required": false, "desc": "Inline JSON object payload" },
+                    "payload-file": { "type": "string", "required": false, "desc": "Path to a JSON object payload file" }
+                },
+                "example": "openreelio-cli command validate --type RenameTrack --payload '{\"sequenceId\":\"seq_1\",\"trackId\":\"track_v1\",\"name\":\"Main Video\"}'"
+            },
+            "command.schema": {
+                "description": "Print the backend command surface available to headless agents",
+                "params": {},
+                "example": "openreelio-cli command schema"
+            },
             "state.dump": {
                 "description": "Dump full project state as JSON",
                 "params": {

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@
 mod analysis;
 mod asset;
 mod caption;
+mod command;
 mod help_json;
 mod plan;
 mod project;
@@ -79,6 +80,12 @@ pub enum Commands {
         action: plan::PlanAction,
     },
 
+    /// Generic backend command execution and schema inspection
+    Command {
+        #[command(subcommand)]
+        action: command::CommandAction,
+    },
+
     /// State inspection and debugging
     State {
         #[command(subcommand)]
@@ -99,6 +106,7 @@ pub fn execute(cli: Cli) -> anyhow::Result<()> {
         Commands::Caption { action } => caption::execute(action),
         Commands::Render { action } => render::execute(action),
         Commands::Plan { action } => plan::execute(action),
+        Commands::Command { action } => command::execute(action),
         Commands::State { action } => state::execute(action),
         Commands::HelpJson => help_json::execute(),
     }

--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -149,6 +149,16 @@ pub fn execute(action: PlanAction) -> anyhow::Result<()> {
                         ));
                     }
                 }
+
+                if let Err(error) = openreelio_core::ipc::CommandPayload::parse(
+                    step.command_type.clone(),
+                    step.payload.clone(),
+                ) {
+                    errors.push(format!(
+                        "Step '{}' has invalid command payload for '{}': {}",
+                        step.id, step.command_type, error
+                    ));
+                }
             }
 
             // Cycle detection
@@ -236,53 +246,12 @@ fn execute_step(
     project: &mut openreelio_core::ActiveProject,
     step: &PlanStep,
 ) -> anyhow::Result<openreelio_core::commands::CommandResult> {
-    use openreelio_core::commands::*;
-
-    let payload = &step.payload;
-    let cmd: Box<dyn Command> = match step.command_type.as_str() {
-        "InsertClip" => Box::new(serde_json::from_value::<InsertClipCommand>(
-            payload.clone(),
-        )?),
-        "RemoveClip" => Box::new(serde_json::from_value::<RemoveClipCommand>(
-            payload.clone(),
-        )?),
-        "MoveClip" => Box::new(serde_json::from_value::<MoveClipCommand>(payload.clone())?),
-        "TrimClip" => Box::new(serde_json::from_value::<TrimClipCommand>(payload.clone())?),
-        "SplitClip" => Box::new(serde_json::from_value::<SplitClipCommand>(payload.clone())?),
-        "SetClipSpeed" => Box::new(serde_json::from_value::<SetClipSpeedCommand>(
-            payload.clone(),
-        )?),
-        "AddTrack" => Box::new(serde_json::from_value::<AddTrackCommand>(payload.clone())?),
-        "RemoveTrack" => Box::new(serde_json::from_value::<RemoveTrackCommand>(
-            payload.clone(),
-        )?),
-        "AddEffect" => Box::new(serde_json::from_value::<AddEffectCommand>(payload.clone())?),
-        "RemoveEffect" => Box::new(serde_json::from_value::<RemoveEffectCommand>(
-            payload.clone(),
-        )?),
-        "CreateCaption" => Box::new(serde_json::from_value::<CreateCaptionCommand>(
-            payload.clone(),
-        )?),
-        "DeleteCaption" => Box::new(serde_json::from_value::<DeleteCaptionCommand>(
-            payload.clone(),
-        )?),
-        "UpdateCaption" => Box::new(serde_json::from_value::<UpdateCaptionCommand>(
-            payload.clone(),
-        )?),
-        "ImportAsset" => Box::new(serde_json::from_value::<ImportAssetCommand>(
-            payload.clone(),
-        )?),
-        "RemoveAsset" => Box::new(serde_json::from_value::<RemoveAssetCommand>(
-            payload.clone(),
-        )?),
-        "AddMarker" => Box::new(serde_json::from_value::<AddMarkerCommand>(payload.clone())?),
-        "RemoveMarker" => Box::new(serde_json::from_value::<RemoveMarkerCommand>(
-            payload.clone(),
-        )?),
-        other => {
-            return Err(anyhow::anyhow!("Unknown command type: '{}'", other));
-        }
-    };
+    let typed_payload = openreelio_core::ipc::CommandPayload::parse(
+        step.command_type.clone(),
+        step.payload.clone(),
+    )
+    .map_err(|error| anyhow::anyhow!("Invalid command '{}': {}", step.command_type, error))?;
+    let cmd = typed_payload.build_command(&project.path);
 
     project
         .executor

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -789,7 +789,7 @@ fn test_plan_validate_valid() {
             {
                 "id": "step_1",
                 "commandType": "AddTrack",
-                "payload": { "sequenceId": "seq_1", "name": "New Track", "kind": "Video" },
+                "payload": { "sequenceId": "seq_1", "name": "New Track", "kind": "video" },
                 "dependsOn": []
             }
         ]
@@ -922,6 +922,9 @@ fn test_help_json_contains_all_commands() {
         "plan.execute",
         "plan.validate",
         "plan.template",
+        "command.execute",
+        "command.validate",
+        "command.schema",
         "state.dump",
         "state.ops",
         "state.snapshot",
@@ -937,6 +940,89 @@ fn test_help_json_contains_all_commands() {
             cmd
         );
     }
+}
+
+#[test]
+fn test_command_schema_exposes_backend_payload_surface() {
+    let result = run_cli_ok(&["command", "schema"]);
+    assert_eq!(result["count"].as_u64().unwrap(), 70);
+    let commands = result["commands"].as_array().unwrap();
+    assert!(commands.iter().any(|value| value == "AddMask"));
+    assert!(commands.iter().any(|value| value == "CreateCompoundClip"));
+    assert!(commands.iter().any(|value| value == "RenameTrack"));
+}
+
+#[test]
+fn test_command_validate_uses_shared_payload_aliases() {
+    let result = run_cli_ok(&[
+        "command",
+        "validate",
+        "--type",
+        "RenameTrack",
+        "--payload",
+        r#"{"sequenceId":"seq_1","trackId":"track_v1","name":"Main Video"}"#,
+    ]);
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["commandType"], "RenameTrack");
+}
+
+#[test]
+fn test_command_execute_runs_generic_backend_command() {
+    let dir = create_temp_project("command_execute_test");
+    let path = project_path(&dir, "command_execute_test");
+    let info = run_cli_ok(&["project", "info", "--path", &path]);
+    let sequence_id = info["activeSequenceId"].as_str().unwrap();
+
+    let result = run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "AddMarker",
+        "--payload",
+        &format!(
+            r#"{{"sequenceId":"{}","time":1.5,"label":"Hook"}}"#,
+            sequence_id
+        ),
+    ]);
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["commandType"], "AddMarker");
+    assert!(!result["opId"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn test_plan_validate_rejects_invalid_command_payload() {
+    let dir = create_temp_project("plan_payload_invalid_test");
+    let path = project_path(&dir, "plan_payload_invalid_test");
+
+    let plan = serde_json::json!({
+        "id": "invalid_payload_plan",
+        "steps": [
+            {
+                "id": "step_1",
+                "commandType": "AddTrack",
+                "payload": { "sequenceId": "seq_1", "name": "New Track", "kind": "invalid-kind" },
+                "dependsOn": []
+            }
+        ]
+    });
+    let plan_file = dir.path().join("invalid_payload_plan.json");
+    std::fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let result = run_cli_ok(&[
+        "plan",
+        "validate",
+        "--path",
+        &path,
+        "--file",
+        plan_file.to_str().unwrap(),
+    ]);
+    assert_eq!(result["status"], "error");
+    assert!(result["errors"][0]
+        .as_str()
+        .unwrap()
+        .contains("invalid command payload"));
 }
 
 // =============================================================================

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -3,6 +3,7 @@
 //! These tests exercise the CLI through the actual binary using `std::process::Command`.
 //! Each test creates a temporary project directory and runs CLI commands against it.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -945,8 +946,24 @@ fn test_help_json_contains_all_commands() {
 #[test]
 fn test_command_schema_exposes_backend_payload_surface() {
     let result = run_cli_ok(&["command", "schema"]);
-    assert_eq!(result["count"].as_u64().unwrap(), 70);
     let commands = result["commands"].as_array().unwrap();
+    assert!(
+        commands.len() >= 3,
+        "expected command schema to expose backend commands"
+    );
+    assert_eq!(result["count"].as_u64().unwrap(), commands.len() as u64);
+
+    let mut unique_commands = HashSet::new();
+    for command in commands {
+        let command = command
+            .as_str()
+            .expect("command schema entries should be strings");
+        assert!(
+            unique_commands.insert(command),
+            "command schema should not contain duplicate entry: {command}"
+        );
+    }
+
     assert!(commands.iter().any(|value| value == "AddMask"));
     assert!(commands.iter().any(|value| value == "CreateCompoundClip"));
     assert!(commands.iter().any(|value| value == "RenameTrack"));

--- a/crates/openreelio-core/src/lib.rs
+++ b/crates/openreelio-core/src/lib.rs
@@ -27,5 +27,8 @@ pub use events::{ChannelBroadcaster, EventBroadcaster, NullBroadcaster};
 // Re-export all core modules from the main library
 pub use openreelio_lib::core::*;
 
+// Re-export command payload parsing for headless clients and the CLI.
+pub use openreelio_lib::ipc;
+
 // Re-export the ActiveProject struct
 pub use openreelio_lib::ActiveProject;

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -3,21 +3,25 @@
 //! Handles communication between Tauri backend and React frontend.
 //! All Tauri commands and events are defined here.
 
+#[cfg(feature = "gui")]
 mod ai_command_defaults;
-#[cfg(not(test))]
+#[cfg(all(not(test), feature = "gui"))]
 mod commands;
+#[cfg(feature = "gui")]
 mod dto;
-#[cfg(not(test))]
+#[cfg(all(not(test), feature = "gui"))]
 mod events;
 mod payloads;
 
 #[allow(unused_imports)]
+#[cfg(feature = "gui")]
 pub(crate) use ai_command_defaults::*;
-#[cfg(not(test))]
+#[cfg(all(not(test), feature = "gui"))]
 pub use commands::*;
 #[allow(unused_imports)]
+#[cfg(feature = "gui")]
 pub(crate) use dto::*;
-#[cfg(not(test))]
+#[cfg(all(not(test), feature = "gui"))]
 pub use events::*;
 pub use payloads::*;
 

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -468,6 +468,7 @@ pub struct RemoveTrackPayload {
 pub struct RenameTrackPayload {
     pub sequence_id: SequenceId,
     pub track_id: TrackId,
+    #[serde(alias = "name")]
     pub new_name: String,
 }
 
@@ -510,6 +511,7 @@ pub struct ToggleTrackVisibilityPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AddMarkerPayload {
     pub sequence_id: SequenceId,
+    #[serde(alias = "time")]
     pub time_sec: TimeSec,
     pub label: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1209,6 +1211,79 @@ pub enum CommandPayload {
 }
 
 impl CommandPayload {
+    pub const SUPPORTED_COMMAND_TYPES: &'static [&'static str] = &[
+        "InsertClip",
+        "InsertEdit",
+        "OverwriteEdit",
+        "RippleDelete",
+        "Lift",
+        "ExtractEdit",
+        "CloseGap",
+        "CloseAllGaps",
+        "RemoveClip",
+        "MoveClip",
+        "TrimClip",
+        "SplitClip",
+        "SetClipTransform",
+        "SetClipSpeed",
+        "ReverseClip",
+        "SetClipEnabled",
+        "LinkClips",
+        "UnlinkClips",
+        "GroupClips",
+        "UngroupClips",
+        "DetachAudio",
+        "CreateFreezeFrame",
+        "SetTimeRemap",
+        "ClearTimeRemap",
+        "SetClipMute",
+        "SetClipAudio",
+        "AddAudioKeyframe",
+        "RemoveAudioKeyframe",
+        "MoveAudioKeyframe",
+        "SetAudioKeyframeValue",
+        "SetAudioFadeIn",
+        "SetAudioFadeOut",
+        "SetTrackBlendMode",
+        "SetClipBlendMode",
+        "ImportAsset",
+        "RemoveAsset",
+        "CreateSequence",
+        "SetMasterVolume",
+        "CreateTrack",
+        "RemoveTrack",
+        "RenameTrack",
+        "ReorderTracks",
+        "ToggleTrackMute",
+        "ToggleTrackLock",
+        "ToggleTrackVisibility",
+        "AddMarker",
+        "RemoveMarker",
+        "CreateCaption",
+        "DeleteCaption",
+        "UpdateCaption",
+        "AddEffect",
+        "RemoveEffect",
+        "UpdateEffect",
+        "AddMask",
+        "UpdateMask",
+        "RemoveMask",
+        "AddTextClip",
+        "UpdateTextClip",
+        "RemoveTextClip",
+        "CreateFolder",
+        "RenameFile",
+        "MoveFile",
+        "DeleteFile",
+        "ApplyAudioDucking",
+        "CreateCompoundClip",
+        "UnnestCompoundClip",
+        "CreateAdjustmentLayer",
+        "PasteEffects",
+        "PasteAttributes",
+        "RemoveAttributes",
+    ];
+
     /// Hard limit to prevent DoS via massive IPC payloads.
     ///
     /// This is intentionally conservative: edit commands should remain small and

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -1856,6 +1856,28 @@ impl CommandPayload {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn supported_command_types_are_unique_and_recognized_by_parser() {
+        let mut seen = HashSet::new();
+
+        for command_type in CommandPayload::SUPPORTED_COMMAND_TYPES {
+            assert!(
+                seen.insert(*command_type),
+                "duplicate supported command type: {command_type}"
+            );
+
+            if let Err(error) =
+                CommandPayload::parse((*command_type).to_string(), serde_json::json!({}))
+            {
+                assert!(
+                    !error.contains("unknown variant"),
+                    "{command_type} is listed but not recognized by CommandPayload::parse: {error}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn parse_update_caption_payload_is_supported() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,6 @@
 //! Run `cargo run --manifest-path src-tauri/Cargo.toml --bin export_bindings` to regenerate `src/bindings.ts`.
 
 pub mod core;
-#[cfg(feature = "gui")]
 pub mod ipc;
 
 use std::path::{Path, PathBuf};

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -184,6 +184,12 @@ const TOOL_DEFS: TestToolDef[] = [
     parameters: { type: 'object', properties: {} },
   },
   {
+    name: 'add_marker',
+    description: 'Add a timeline marker',
+    category: 'timeline',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
     name: 'analyze_video',
     description: 'Analyze video content',
     category: 'analysis',
@@ -469,13 +475,24 @@ describe('BackendToolExecutor', () => {
       });
     });
 
-    it('should fall back to frontend execution when an edit meta-tool action is not backend-safe', async () => {
+    it('should route backend-safe edit meta-tool actions to backend IPC', async () => {
       const extendedTools = [
         ...TOOL_DEFS,
         { name: 'edit', description: 'Editing meta-tool', category: 'timeline', parameters: {} },
       ];
       const extendedFrontend = createMockFrontendExecutor(extendedTools);
       const extendedBackend = createBackendToolExecutor(extendedFrontend);
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'plan-edit-rename',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { trackId: 'track-1' }, durationMs: 5 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 5,
+      });
 
       const result = await extendedBackend.execute(
         'edit',
@@ -484,12 +501,18 @@ describe('BackendToolExecutor', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(extendedFrontend.execute).toHaveBeenCalledWith(
-        'edit',
-        { action: 'rename_track', sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
-        CONTEXT,
-      );
-      expect(mockInvoke).not.toHaveBeenCalled();
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          goal: 'Execute rename_track',
+          steps: [
+            expect.objectContaining({
+              toolName: 'renameTrack',
+              params: { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
+            }),
+          ],
+        }),
+      });
+      expect(extendedFrontend.execute).not.toHaveBeenCalled();
     });
 
     it('should fall back to frontend execution for mutating transition tools that are not backend-safe', async () => {
@@ -508,7 +531,19 @@ describe('BackendToolExecutor', () => {
       expect(mockInvoke).not.toHaveBeenCalled();
     });
 
-    it('should fall back to frontend execution for mutating track tools that are not backend-safe', async () => {
+    it('should route backend-safe track tools to backend IPC', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'plan-rename-track',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { trackId: 'track-1' }, durationMs: 5 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 5,
+      });
+
       const result = await backend.execute(
         'rename_track',
         { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
@@ -516,12 +551,70 @@ describe('BackendToolExecutor', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(frontend.execute).toHaveBeenCalledWith(
-        'rename_track',
-        { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          goal: 'Execute rename_track',
+          steps: [
+            expect.objectContaining({
+              toolName: 'renameTrack',
+              params: { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
+            }),
+          ],
+        }),
+      });
+      expect(frontend.execute).not.toHaveBeenCalled();
+    });
+
+    it('should normalize marker string colors before backend IPC', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'plan-add-marker',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { markerId: 'marker-1' }, durationMs: 5 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 5,
+      });
+
+      const result = await backend.execute(
+        'add_marker',
+        { sequenceId: 'seq-1', time: 1.5, label: 'Hook', color: '#FF000080' },
         CONTEXT,
       );
+
+      expect(result.success).toBe(true);
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          goal: 'Execute add_marker',
+          steps: [
+            expect.objectContaining({
+              toolName: 'addMarker',
+              params: {
+                sequenceId: 'seq-1',
+                time: 1.5,
+                label: 'Hook',
+                color: { r: 1, g: 0, b: 0, a: 128 / 255 },
+              },
+            }),
+          ],
+        }),
+      });
+      expect(frontend.execute).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid marker colors before backend IPC', async () => {
+      const result = await backend.execute(
+        'add_marker',
+        { sequenceId: 'seq-1', time: 1.5, label: 'Hook', color: 'not-a-color' },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid marker color');
       expect(mockInvoke).not.toHaveBeenCalled();
+      expect(frontend.execute).not.toHaveBeenCalled();
     });
 
     it('should route analysis tool to frontend executor', async () => {
@@ -892,6 +985,53 @@ describe('BackendToolExecutor', () => {
       expect(extendedFrontend.execute).not.toHaveBeenCalled();
     });
 
+    it('should normalize marker colors when promoting legacy execute_plan batches', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'legacy-marker-plan',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'marker-step', success: true, data: { markerId: 'm1' }, durationMs: 4 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 4,
+      });
+
+      const result = await backend.execute(
+        'execute_plan',
+        {
+          steps: [
+            {
+              id: 'marker-step',
+              toolName: 'add_marker',
+              params: { sequenceId: 'seq-1', time: 2, label: 'Beat', color: 'blue' },
+            },
+          ],
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          steps: [
+            expect.objectContaining({
+              id: 'marker-step',
+              toolName: 'addMarker',
+              params: {
+                sequenceId: 'seq-1',
+                time: 2,
+                label: 'Beat',
+                color: { r: 0, g: 0, b: 1 },
+              },
+            }),
+          ],
+        }),
+      });
+      expect(frontend.execute).not.toHaveBeenCalled();
+    });
+
     it('should fail fast when a legacy execute_plan includes frontend-only mutation tools', async () => {
       const extendedTools = [
         ...TOOL_DEFS,
@@ -910,8 +1050,13 @@ describe('BackendToolExecutor', () => {
           { id: 'step-a', toolName: 'split_clip', params: { clipId: 'clip-1', atTimelineSec: 5 } },
           {
             id: 'step-b',
-            toolName: 'rename_track',
-            params: { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
+            toolName: 'add_transition',
+            params: {
+              sequenceId: 'seq-1',
+              trackId: 'track-1',
+              clipId: 'clip-1',
+              transitionType: 'dissolve',
+            },
           },
         ],
       };
@@ -993,8 +1138,13 @@ describe('BackendToolExecutor', () => {
           tools: [
             { name: 'split_clip', args: { clipId: 'c1', atTimelineSec: 5 } },
             {
-              name: 'rename_track',
-              args: { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
+              name: 'add_transition',
+              args: {
+                sequenceId: 'seq-1',
+                trackId: 'track-1',
+                clipId: 'clip-1',
+                transitionType: 'dissolve',
+              },
             },
           ],
           mode: 'sequential',
@@ -1006,10 +1156,15 @@ describe('BackendToolExecutor', () => {
       expect(result.success).toBe(true);
       expect(result.successCount).toBe(2);
       expect(result.failureCount).toBe(0);
-      expect(result.results.map((entry) => entry.tool)).toEqual(['split_clip', 'rename_track']);
+      expect(result.results.map((entry) => entry.tool)).toEqual(['split_clip', 'add_transition']);
       expect(frontend.execute).toHaveBeenCalledWith(
-        'rename_track',
-        { sequenceId: 'seq-1', trackId: 'track-1', name: 'Main Video' },
+        'add_transition',
+        {
+          sequenceId: 'seq-1',
+          trackId: 'track-1',
+          clipId: 'clip-1',
+          transitionType: 'dissolve',
+        },
         CONTEXT,
       );
     });

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -1169,6 +1169,31 @@ describe('BackendToolExecutor', () => {
       );
     });
 
+    it('should reject invalid marker colors before backend IPC in batch', async () => {
+      const result = await backend.executeBatch(
+        {
+          tools: [
+            {
+              name: 'add_marker',
+              args: { sequenceId: 'seq-1', time: 1.5, label: 'Hook', color: 'not-a-color' },
+            },
+            { name: 'split_clip', args: { clipId: 'c1', atTimelineSec: 5 } },
+          ],
+          mode: 'sequential',
+          stopOnError: true,
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.failureCount).toBe(1);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].tool).toBe('add_marker');
+      expect(result.results[0].result.error).toContain('Invalid marker color');
+      expect(mockInvoke).not.toHaveBeenCalled();
+      expect(frontend.execute).not.toHaveBeenCalled();
+    });
+
     it('should batch backend-safe edit meta-tool actions through one backend plan', async () => {
       const extendedTools = [
         ...TOOL_DEFS,
@@ -1615,6 +1640,54 @@ describe('BackendToolExecutor', () => {
       });
     });
 
+    it('should normalize backend-style marker sub-steps for single compound execute', async () => {
+      registerCompoundExpander('ripple_edit', () => [
+        {
+          toolName: 'addMarker',
+          params: { sequenceId: 'seq-1', time: 2, label: 'Beat', color: 'blue' },
+        },
+      ]);
+
+      const extendedTools = [
+        ...TOOL_DEFS,
+        { name: 'ripple_edit', description: 'Ripple edit', category: 'clip', parameters: {} },
+      ];
+      const extendedFrontend = createMockFrontendExecutor(extendedTools);
+      const extendedBackend = createBackendToolExecutor(extendedFrontend);
+
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'compound-marker',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { markerId: 'marker-1' }, durationMs: 4 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 4,
+      });
+
+      const result = await extendedBackend.execute('ripple_edit', { clipId: 'clip-1' }, CONTEXT);
+
+      expect(result.success).toBe(true);
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          steps: [
+            expect.objectContaining({
+              toolName: 'addMarker',
+              params: {
+                sequenceId: 'seq-1',
+                time: 2,
+                label: 'Beat',
+                color: { r: 0, g: 0, b: 1 },
+              },
+            }),
+          ],
+        }),
+      });
+      expect(extendedFrontend.execute).not.toHaveBeenCalled();
+    });
+
     it('should expand compound tool in batch and map results back', async () => {
       registerCompoundExpander('ripple_edit', (args) => [
         { toolName: 'trimClip', params: { clipId: args.clipId, newSourceOut: args.trimEnd } },
@@ -1686,6 +1759,61 @@ describe('BackendToolExecutor', () => {
           ]),
         }),
       });
+    });
+
+    it('should normalize backend-style marker sub-steps for compound batch execution', async () => {
+      registerCompoundExpander('ripple_edit', () => [
+        {
+          toolName: 'addMarker',
+          params: { sequenceId: 'seq-1', time: 2, label: 'Beat', color: '#FF000080' },
+        },
+      ]);
+
+      const extendedTools = [
+        ...TOOL_DEFS,
+        { name: 'ripple_edit', description: 'Ripple edit', category: 'clip', parameters: {} },
+      ];
+      const extendedFrontend = createMockFrontendExecutor(extendedTools);
+      const extendedBackend = createBackendToolExecutor(extendedFrontend);
+
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'batch-compound-marker',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { markerId: 'marker-1' }, durationMs: 4 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 4,
+      });
+
+      const result = await extendedBackend.executeBatch(
+        {
+          tools: [{ name: 'ripple_edit', args: { clipId: 'clip-1' } }],
+          mode: 'sequential',
+          stopOnError: true,
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          steps: [
+            expect.objectContaining({
+              toolName: 'addMarker',
+              params: {
+                sequenceId: 'seq-1',
+                time: 2,
+                label: 'Beat',
+                color: { r: 1, g: 0, b: 0, a: 128 / 255 },
+              },
+            }),
+          ],
+        }),
+      });
+      expect(extendedFrontend.executeBatch).not.toHaveBeenCalled();
     });
 
     it('should return validation failure when compound expander throws', async () => {

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -403,7 +403,7 @@ describe('BackendToolExecutor', () => {
       expect(frontend.execute).not.toHaveBeenCalled();
     });
 
-    it('should route backend-safe edit meta-tool actions to backend IPC', async () => {
+    it('should route backend-safe edit meta-tool split_clip action to backend IPC', async () => {
       const extendedTools = [
         ...TOOL_DEFS,
         { name: 'edit', description: 'Editing meta-tool', category: 'timeline', parameters: {} },
@@ -475,7 +475,7 @@ describe('BackendToolExecutor', () => {
       });
     });
 
-    it('should route backend-safe edit meta-tool actions to backend IPC', async () => {
+    it('should route backend-safe edit meta-tool rename_track action to backend IPC', async () => {
       const extendedTools = [
         ...TOOL_DEFS,
         { name: 'edit', description: 'Editing meta-tool', category: 'timeline', parameters: {} },

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -77,7 +77,8 @@ function normalizeBackendParamsForBackend(
   toolName: string,
   params: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (toolName !== 'add_marker' || !Object.prototype.hasOwnProperty.call(params, 'color')) {
+  const isAddMarker = toolName === 'add_marker' || toolName === 'addMarker';
+  if (!isAddMarker || !Object.prototype.hasOwnProperty.call(params, 'color')) {
     return params;
   }
 
@@ -690,15 +691,18 @@ export class BackendToolExecutor implements IToolExecutor {
     let steps: AgentPlan['steps'];
     try {
       steps = expander
-        ? expander(executionTarget.params).map((sub, i) => ({
-            id: `step-${i + 1}`,
-            toolName: normalizeToolNameForBackend(sub.toolName),
-            params: sub.params as Record<string, never>,
-            description: `Execute ${sub.toolName}`,
-            riskLevel: 'low' as const,
-            dependsOn: sub.dependsOn ?? (i > 0 ? [`step-${i}`] : []),
-            optional: false,
-          }))
+        ? expander(executionTarget.params).map((sub, i) => {
+            const normalizedParams = normalizeBackendParamsForBackend(sub.toolName, sub.params);
+            return {
+              id: `step-${i + 1}`,
+              toolName: normalizeToolNameForBackend(sub.toolName),
+              params: normalizedParams as Record<string, never>,
+              description: `Execute ${sub.toolName}`,
+              riskLevel: 'low' as const,
+              dependsOn: sub.dependsOn ?? (i > 0 ? [`step-${i}`] : []),
+              optional: false,
+            };
+          })
         : [
             {
               id: 'step-1',
@@ -914,10 +918,14 @@ export class BackendToolExecutor implements IToolExecutor {
             } else {
               dependsOn = [];
             }
+            const normalizedParams = normalizeBackendParamsForBackend(
+              subSteps[j].toolName,
+              subSteps[j].params,
+            );
             allSteps.push({
               id: `step-${stepCounter + 1}`,
               toolName: normalizeToolNameForBackend(subSteps[j].toolName),
-              params: subSteps[j].params as Record<string, never>,
+              params: normalizedParams as Record<string, never>,
               description: `Execute ${subSteps[j].toolName}`,
               riskLevel: 'low' as const,
               dependsOn,

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -29,6 +29,7 @@ import type { RiskLevel, ValidationResult } from '../../core/types';
 import type { AgentPlan, AgentPlanResult } from '@/bindings';
 import { createLogger } from '@/services/logger';
 import { isMetaToolsEnabled } from '@/config/featureFlags';
+import { normalizeMarkerColor } from '@/agents/tools/markerColor';
 import { getVisibleMetaToolNames } from '@/agents/tools/metaTools';
 import { getWorkspaceToolNames } from '@/agents/tools/workspaceTools';
 import { useProjectStore } from '@/stores/projectStore';
@@ -52,6 +53,8 @@ const logger = createLogger('BackendToolExecutor');
  * command-shaped and do not rely on extra frontend orchestration.
  */
 const BACKEND_DIRECT_TOOLS = new Set([
+  'add_effect',
+  'add_marker',
   'move_clip',
   'trim_clip',
   'split_clip',
@@ -59,6 +62,8 @@ const BACKEND_DIRECT_TOOLS = new Set([
   'change_clip_speed',
   'add_track',
   'remove_track',
+  'rename_track',
+  'remove_effect',
   'remove_marker',
 ]);
 
@@ -66,6 +71,29 @@ function normalizeToolNameForBackend(toolName: string): string {
   // Backend CommandPayload parsing uses camelCase aliases. Agent tool names are
   // snake_case, so normalize before sending to execute_agent_plan.
   return toolName.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+}
+
+function normalizeBackendParamsForBackend(
+  toolName: string,
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  if (toolName !== 'add_marker' || !Object.prototype.hasOwnProperty.call(params, 'color')) {
+    return params;
+  }
+
+  const nextParams = { ...params };
+  const color = normalizeMarkerColor(nextParams.color);
+  if (color) {
+    nextParams.color = color;
+  } else {
+    delete nextParams.color;
+  }
+
+  return nextParams;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /**
@@ -330,7 +358,7 @@ export class BackendToolExecutor implements IToolExecutor {
       return {
         requestedToolName: toolName,
         effectiveToolName: action,
-        params: metaToolArgs,
+        params: normalizeBackendParamsForBackend(action, metaToolArgs),
         metaAction: action,
       };
     }
@@ -342,7 +370,7 @@ export class BackendToolExecutor implements IToolExecutor {
     return {
       requestedToolName: toolName,
       effectiveToolName: toolName,
-      params: args,
+      params: normalizeBackendParamsForBackend(toolName, args),
     };
   }
 
@@ -404,10 +432,14 @@ export class BackendToolExecutor implements IToolExecutor {
           const backendStepId = `${step.id}__${index + 1}`;
           const dependsOn = index === 0 ? firstStepDependsOn : [generatedIds[index - 1]];
 
+          const normalizedParams = normalizeBackendParamsForBackend(
+            subStep.toolName,
+            subStep.params,
+          );
           backendSteps.push({
             id: backendStepId,
             toolName: normalizeToolNameForBackend(subStep.toolName),
-            params: subStep.params as Record<string, never>,
+            params: normalizedParams as Record<string, never>,
             description: `Execute ${subStep.toolName}`,
             riskLevel: 'low',
             dependsOn,
@@ -429,10 +461,11 @@ export class BackendToolExecutor implements IToolExecutor {
         continue;
       }
 
+      const normalizedParams = normalizeBackendParamsForBackend(step.toolName, step.params);
       backendSteps.push({
         id: step.id,
         toolName: normalizeToolNameForBackend(step.toolName),
-        params: step.params as Record<string, never>,
+        params: normalizedParams as Record<string, never>,
         description: `Execute ${step.toolName}`,
         riskLevel: 'low',
         dependsOn: firstStepDependsOn,
@@ -518,7 +551,13 @@ export class BackendToolExecutor implements IToolExecutor {
     context: ExecutionContext,
   ): Promise<ToolExecutionResult> {
     if (toolName === 'execute_plan') {
-      const legacyRoute = this.tryBuildLegacyExecutePlanRoute(args, context);
+      let legacyRoute: LegacyExecutePlanRoute | null;
+      try {
+        legacyRoute = this.tryBuildLegacyExecutePlanRoute(args, context);
+      } catch (err) {
+        return createFailureResult(`execute_plan validation failed: ${getErrorMessage(err)}`, 0);
+      }
+
       if (legacyRoute) {
         for (const step of legacyRoute.plan.steps) {
           if ((step.dependsOn?.length ?? 0) > 0) {
@@ -617,7 +656,13 @@ export class BackendToolExecutor implements IToolExecutor {
       return this.buildUnsupportedMutationFailure(toolName);
     }
 
-    const executionTarget = this.resolveBackendExecutionTarget(toolName, args);
+    let executionTarget: BackendExecutionTarget | null;
+    try {
+      executionTarget = this.resolveBackendExecutionTarget(toolName, args);
+    } catch (err) {
+      return createFailureResult(`${toolName} validation failed: ${getErrorMessage(err)}`, 0);
+    }
+
     if (!executionTarget) {
       if (this.isUnsafeMutatingFallback(toolName)) {
         const preflightFailure = this.getMutationPreflightFailure(toolName, args, context);
@@ -667,7 +712,7 @@ export class BackendToolExecutor implements IToolExecutor {
           ];
     } catch (err) {
       const duration = performance.now() - start;
-      const errorMsg = err instanceof Error ? err.message : String(err);
+      const errorMsg = getErrorMessage(err);
       logger.warn('Compound tool expansion failed', {
         requestedToolName: toolName,
         effectiveToolName: executionTarget.effectiveToolName,
@@ -746,11 +791,35 @@ export class BackendToolExecutor implements IToolExecutor {
     let successCount = 0;
     let failureCount = 0;
 
-    // Resolve each tool's execution target while preserving original order
-    const resolvedTools = request.tools.map((tool) => ({
-      requestTool: tool,
-      executionTarget: this.resolveBackendExecutionTarget(tool.name, tool.args),
-    }));
+    // Resolve each tool's execution target while preserving original order.
+    const resolvedTools: Array<{
+      requestTool: BatchExecutionRequest['tools'][number];
+      executionTarget: BackendExecutionTarget | null;
+    }> = [];
+    for (const tool of request.tools) {
+      try {
+        resolvedTools.push({
+          requestTool: tool,
+          executionTarget: this.resolveBackendExecutionTarget(tool.name, tool.args),
+        });
+      } catch (err) {
+        return {
+          success: false,
+          results: [
+            {
+              tool: tool.name,
+              result: createFailureResult(
+                `${tool.name} validation failed: ${getErrorMessage(err)}`,
+                performance.now() - start,
+              ),
+            },
+          ],
+          totalDuration: performance.now() - start,
+          successCount: 0,
+          failureCount: 1,
+        };
+      }
+    }
 
     const allBackend = resolvedTools.every((t) => t.executionTarget !== null);
 
@@ -819,7 +888,7 @@ export class BackendToolExecutor implements IToolExecutor {
           try {
             subSteps = exp(executionTarget.params);
           } catch (err) {
-            const errorMsg = err instanceof Error ? err.message : String(err);
+            const errorMsg = getErrorMessage(err);
             expansionError = `${executionTarget.effectiveToolName} validation failed: ${errorMsg}`;
             logger.warn('Batch compound expansion failed', {
               requestedToolName: requestTool.name,
@@ -955,7 +1024,7 @@ export class BackendToolExecutor implements IToolExecutor {
             }
           }
         } catch (err) {
-          const errorMsg = err instanceof Error ? err.message : String(err);
+          const errorMsg = getErrorMessage(err);
           for (const t of backendTools) {
             results.push({
               tool: t.requestTool.name,
@@ -977,12 +1046,16 @@ export class BackendToolExecutor implements IToolExecutor {
   }
 
   canExecuteBatchAtomically(request: BatchExecutionRequest): boolean {
-    return (
-      request.tools.length > 1 &&
-      request.tools.every(
-        (tool) => this.resolveBackendExecutionTarget(tool.name, tool.args) !== null,
-      )
-    );
+    try {
+      return (
+        request.tools.length > 1 &&
+        request.tools.every(
+          (tool) => this.resolveBackendExecutionTarget(tool.name, tool.args) !== null,
+        )
+      );
+    } catch {
+      return false;
+    }
   }
 
   // Delegate all metadata methods to the frontend executor

--- a/src/agents/tools/editingTools.ts
+++ b/src/agents/tools/editingTools.ts
@@ -11,6 +11,7 @@ import { createLogger } from '@/services/logger';
 import { invoke } from '@tauri-apps/api/core';
 import { getTimelineSnapshot, findWorkspaceFile } from './storeAccessor';
 import { executeAgentCommand } from './commandExecutor';
+import { normalizeMarkerColor } from './markerColor';
 import { useProjectStore } from '@/stores/projectStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { probeMedia } from '@/utils/ffmpeg';
@@ -23,7 +24,7 @@ import {
   buildSlideEditPlan,
   type PlannedCommandStep,
 } from './compoundEditPlanning';
-import type { Asset, Color, Sequence, Track, CommandResult } from '@/types';
+import type { Asset, Sequence, Track, CommandResult } from '@/types';
 import type { AgentPlanResult, StylePlanResult } from '@/bindings';
 
 const logger = createLogger('EditingTools');
@@ -31,19 +32,6 @@ const DEFAULT_INSERT_CLIP_DURATION_SEC = 10;
 const DEFAULT_FREEZE_FRAME_RATE = 30;
 const SPLIT_TIME_EPSILON = 1e-6;
 const MAX_INTERVAL_SPLIT_OPERATIONS = 5000;
-
-const MARKER_COLOR_PRESETS: Record<string, Color> = {
-  red: { r: 1, g: 0, b: 0 },
-  orange: { r: 1, g: 0.5, b: 0 },
-  yellow: { r: 1, g: 0.8, b: 0 },
-  green: { r: 0, g: 1, b: 0 },
-  blue: { r: 0, g: 0, b: 1 },
-  purple: { r: 0.5, g: 0, b: 0.5 },
-  pink: { r: 1, g: 0.4, b: 0.7 },
-  cyan: { r: 0, g: 1, b: 1 },
-  white: { r: 1, g: 1, b: 1 },
-  black: { r: 0, g: 0, b: 0 },
-};
 
 type IntervalSplitOperation = {
   trackId: string;
@@ -194,74 +182,6 @@ function estimateTimelineIntervalSplitOperations(
   }
 
   return estimatedOperations;
-}
-
-function parseHexMarkerColor(input: string): Color | undefined {
-  const normalized = input.trim().replace(/^#/, '');
-  if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(normalized)) {
-    return undefined;
-  }
-
-  const color: Color = {
-    r: parseInt(normalized.slice(0, 2), 16) / 255,
-    g: parseInt(normalized.slice(2, 4), 16) / 255,
-    b: parseInt(normalized.slice(4, 6), 16) / 255,
-  };
-
-  if (normalized.length === 8) {
-    color.a = parseInt(normalized.slice(6, 8), 16) / 255;
-  }
-
-  return color;
-}
-
-function normalizeMarkerColor(input: unknown): Color | undefined {
-  if (input === undefined || input === null) {
-    return undefined;
-  }
-
-  if (typeof input === 'string') {
-    const normalized = input.trim().toLowerCase();
-    if (!normalized) {
-      return undefined;
-    }
-
-    const preset = MARKER_COLOR_PRESETS[normalized];
-    if (preset) {
-      return { ...preset };
-    }
-
-    const parsedHex = parseHexMarkerColor(input);
-    if (parsedHex) {
-      return parsedHex;
-    }
-
-    throw new Error('Invalid marker color. Use a named color or hex (#RRGGBB or #RRGGBBAA).');
-  }
-
-  if (typeof input === 'object') {
-    const raw = input as Partial<Color>;
-    const r = Number(raw.r);
-    const g = Number(raw.g);
-    const b = Number(raw.b);
-
-    if (![r, g, b].every((value) => Number.isFinite(value) && value >= 0 && value <= 1)) {
-      throw new Error('Invalid marker color. RGB values must be numbers between 0 and 1.');
-    }
-
-    const color: Color = { r, g, b };
-    if (raw.a !== undefined) {
-      const a = Number(raw.a);
-      if (!Number.isFinite(a) || a < 0 || a > 1) {
-        throw new Error('Invalid marker color. Alpha must be a number between 0 and 1.');
-      }
-      color.a = a;
-    }
-
-    return color;
-  }
-
-  throw new Error('Invalid marker color. Use a named color, hex string, or an RGBA object.');
 }
 
 function getAssetInsertDurationSec(asset: Asset): number {

--- a/src/agents/tools/markerColor.test.ts
+++ b/src/agents/tools/markerColor.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMarkerColor } from './markerColor';
+
+describe('normalizeMarkerColor', () => {
+  it('should normalize named marker colors', () => {
+    expect(normalizeMarkerColor('blue')).toEqual({ r: 0, g: 0, b: 1 });
+  });
+
+  it('should normalize hex marker colors with alpha', () => {
+    expect(normalizeMarkerColor('#FF000080')).toEqual({ r: 1, g: 0, b: 0, a: 128 / 255 });
+  });
+
+  it('should reject invalid marker color strings', () => {
+    expect(() => normalizeMarkerColor('not-a-color')).toThrow('Invalid marker color');
+  });
+});

--- a/src/agents/tools/markerColor.test.ts
+++ b/src/agents/tools/markerColor.test.ts
@@ -6,8 +6,33 @@ describe('normalizeMarkerColor', () => {
     expect(normalizeMarkerColor('blue')).toEqual({ r: 0, g: 0, b: 1 });
   });
 
+  it('should accept named colors case-insensitively with surrounding whitespace', () => {
+    expect(normalizeMarkerColor('  RED  ')).toEqual({ r: 1, g: 0, b: 0 });
+  });
+
   it('should normalize hex marker colors with alpha', () => {
     expect(normalizeMarkerColor('#FF000080')).toEqual({ r: 1, g: 0, b: 0, a: 128 / 255 });
+  });
+
+  it('should accept RGBA objects with values in range', () => {
+    expect(normalizeMarkerColor({ r: 1, g: 0.5, b: 0, a: 0.25 })).toEqual({
+      r: 1,
+      g: 0.5,
+      b: 0,
+      a: 0.25,
+    });
+  });
+
+  it('should reject RGBA objects with out-of-range alpha', () => {
+    expect(() => normalizeMarkerColor({ r: 0, g: 0, b: 0, a: 1.5 })).toThrow(
+      'Invalid marker color',
+    );
+  });
+
+  it('should return undefined for nullish or empty inputs', () => {
+    expect(normalizeMarkerColor(undefined)).toBeUndefined();
+    expect(normalizeMarkerColor(null)).toBeUndefined();
+    expect(normalizeMarkerColor('   ')).toBeUndefined();
   });
 
   it('should reject invalid marker color strings', () => {

--- a/src/agents/tools/markerColor.ts
+++ b/src/agents/tools/markerColor.ts
@@ -1,0 +1,82 @@
+import type { Color } from '@/types';
+
+const MARKER_COLOR_PRESETS: Record<string, Color> = {
+  red: { r: 1, g: 0, b: 0 },
+  orange: { r: 1, g: 0.5, b: 0 },
+  yellow: { r: 1, g: 0.8, b: 0 },
+  green: { r: 0, g: 1, b: 0 },
+  blue: { r: 0, g: 0, b: 1 },
+  purple: { r: 0.5, g: 0, b: 0.5 },
+  pink: { r: 1, g: 0.4, b: 0.7 },
+  cyan: { r: 0, g: 1, b: 1 },
+  white: { r: 1, g: 1, b: 1 },
+  black: { r: 0, g: 0, b: 0 },
+};
+
+function parseHexMarkerColor(input: string): Color | undefined {
+  const normalized = input.trim().replace(/^#/, '');
+  if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(normalized)) {
+    return undefined;
+  }
+
+  const color: Color = {
+    r: parseInt(normalized.slice(0, 2), 16) / 255,
+    g: parseInt(normalized.slice(2, 4), 16) / 255,
+    b: parseInt(normalized.slice(4, 6), 16) / 255,
+  };
+
+  if (normalized.length === 8) {
+    color.a = parseInt(normalized.slice(6, 8), 16) / 255;
+  }
+
+  return color;
+}
+
+export function normalizeMarkerColor(input: unknown): Color | undefined {
+  if (input === undefined || input === null) {
+    return undefined;
+  }
+
+  if (typeof input === 'string') {
+    const normalized = input.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+
+    const preset = MARKER_COLOR_PRESETS[normalized];
+    if (preset) {
+      return { ...preset };
+    }
+
+    const parsedHex = parseHexMarkerColor(input);
+    if (parsedHex) {
+      return parsedHex;
+    }
+
+    throw new Error('Invalid marker color. Use a named color or hex (#RRGGBB or #RRGGBBAA).');
+  }
+
+  if (typeof input === 'object' && input !== null && !Array.isArray(input)) {
+    const raw = input as Partial<Color>;
+    const r = Number(raw.r);
+    const g = Number(raw.g);
+    const b = Number(raw.b);
+
+    if (![r, g, b].every((value) => Number.isFinite(value) && value >= 0 && value <= 1)) {
+      throw new Error('Invalid marker color. RGB values must be numbers between 0 and 1.');
+    }
+
+    const color: Color = { r, g, b };
+    if (raw.a !== undefined) {
+      const a = Number(raw.a);
+      if (!Number.isFinite(a) || a < 0 || a > 1) {
+        throw new Error('Invalid marker color. Alpha must be a number between 0 and 1.');
+      }
+      color.a = a;
+    }
+
+    return color;
+  }
+
+  throw new Error('Invalid marker color. Use a named color, hex string, or an RGBA object.');
+}

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -463,7 +463,7 @@ const META_TOOLS: ToolDefinition[] = [
   {
     name: 'execute_plan',
     description:
-      'Execute a batch of editing operations sequentially. Stops on first failure; already-executed steps are NOT rolled back. ' +
+      'Execute a batch of editing operations sequentially. Backend-safe steps run atomically with rollback on failure; unsupported mutating steps are rejected. ' +
       'Each step specifies a tool name and its parameters. Use this for complex multi-step edits.',
     category: 'timeline',
     parameters: {


### PR DESCRIPTION
### **User description**
## Description

Expose the shared backend command payload surface to headless CLI clients and route additional backend-safe agent editing tools through atomic backend IPC plans. This keeps CLI plan execution, generic command execution, and agent tool routing aligned with the same CommandPayload parser.

## Related Issue

Closes #668
Closes #669

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added openreelio-cli command execute, command validate, and command schema using the shared backend CommandPayload parser.
- Reused shared command payload validation for CLI plan validation/execution and exposed supported backend command types through the core facade and help JSON.
- Routed backend-safe agent tools through execute_agent_plan, normalized marker colors for IPC payloads, and added focused Rust/Vitest coverage.

## Screenshots / Videos

Not applicable. This change affects CLI, backend IPC routing, and agent execution behavior without UI changes.

## Testing

Validated locally before opening this PR. The repository scripts are npm-based, so Vitest was run through npm rather than pnpm.

### Test Environment

- OS: Ubuntu 24.04.4 LTS
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Local commands run: cargo test -p openreelio-cli, cargo fmt --check, npm run type-check, and npm run test:run -- src/agents/tools/markerColor.test.ts src/agents/engine/adapters/tools/BackendToolExecutor.test.ts. Pre-commit hooks also passed for each commit; ESLint reported existing warnings in unrelated files.


___

### **PR Type**
Enhancement, Tests, Refactoring


___

### **Description**
- Exposes backend `CommandPayload` parser to CLI and agent tools.

- Adds `command` subcommands to CLI for generic execution and validation.

- Routes backend-safe agent tools through atomic IPC plans.

- Normalizes marker colors and adds validation for agent-driven edits.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["openreelio-cli"] -- "CommandPayload::parse" --> Core["openreelio-core"]
  Agent["Agent Tools"] -- "execute_agent_plan" --> IPC["Backend IPC"]
  IPC -- "Atomic Rollback" --> Project["Project State"]
  Core -- "Shared Validation" --> Project
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>command.rs</strong><dd><code>Add generic backend command execution and schema subcommands</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-da6fa89f2f6c8aee3cedb48486bf666042e5833fe03e547f4e34602d45e8618a">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BackendToolExecutor.ts</strong><dd><code>Route additional tools to backend and add parameter normalization</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-a3aff75bdd811b11db7655a08b69d97087140aed6185e0824612b7f32326f54a">+93/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>payloads.rs</strong><dd><code>Expose supported command types and add field aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-1efed79e6d1ef23a178231ecb231d1034cfafe2660c00fc389179577224de950">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Re-export IPC module for external CLI consumption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-f33d40ed3acfece74f17e47ab52905e6a7575489b2de99e983a4bd5377f96c91">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Register new command module in CLI dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-5b9d832050317ee19c5b11dfd82342a39d32e794582b5e554fee74ab8c753827">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Expose IPC module regardless of GUI feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>plan.rs</strong><dd><code>Use shared CommandPayload parser for CLI plan validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-f785809d35119699191fc261c8b8eee110c5be15fcf0bb5cadb1da8c4bcd1792">+16/-47</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>markerColor.ts</strong><dd><code>Extract marker color normalization to shared utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-01e6818a2477b687deb5bf555e4674697e96b0ae74dbed13fc56e7c3cf2d7bcd">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>editingTools.ts</strong><dd><code>Remove redundant marker color logic in favor of shared utility</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-feff783abcf967fed37830f7fe4794b447012a538bea6a9d96f778cd37b01c7d">+2/-82</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>integration.rs</strong><dd><code>Add integration tests for generic command CLI surface</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+87/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BackendToolExecutor.test.ts</strong><dd><code>Test backend-safe tool routing and color normalization</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-8e592e61f08c2f6dd01675f9d5577677dfe5ee2cb85c6da9fb3a916b9bb413a0">+173/-18</a></td>

</tr>

<tr>
  <td><strong>markerColor.test.ts</strong><dd><code>Add unit tests for marker color normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-9b9c3504d8d9d7eb5be5cc59148c0fda8942b7f03bee4ae920aebabc251a5b61">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>help_json.rs</strong><dd><code>Update CLI help schema with new command subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.ts</strong><dd><code>Update execute_plan description to reflect atomic behavior</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-842f7132c091ca5476d87b73a280cb7192ba997487dfea06a0bd4e097e1a19b7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Adjust feature flags for GUI-specific IPC modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/670/files#diff-420147daf49471d2e951a6c66a1594825dc876fde7016e2f9bcd76e5705ec9d1">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI agent commands to execute backend commands, validate payloads, and list supported command types.
  * Marker color normalization utility for consistent handling.

* **Improvements**
  * Plan validation now checks command payload compatibility before execution.
  * Tighter error handling and more predictable backend vs frontend routing for tools.
  * More flexible payload formats and clearer command schemas surfaced to clients.

* **Tests**
  * Expanded integration and unit tests covering CLI commands, plan validation, and marker colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->