### PR TITLE
feat(ai): add OpenReelio Codex dynamic tools

### DIFF
--- a/src/agents/external/adapters/CodexAppServerClient.test.ts
+++ b/src/agents/external/adapters/CodexAppServerClient.test.ts
@@ -57,7 +57,7 @@ describe('CodexAppServerClient', () => {
       id: 1,
       params: {
         clientInfo: { name: 'openreelio', title: 'OpenReelio', version: '0.1.0' },
-        capabilities: null,
+        capabilities: { experimentalApi: true },
       },
     });
 
@@ -90,7 +90,7 @@ describe('CodexAppServerClient', () => {
       id: 1,
       params: {
         clientInfo: { name: 'openreelio', title: 'OpenReelio', version: '0.1.0' },
-        capabilities: null,
+        capabilities: { experimentalApi: true },
       },
     });
 

--- a/src/agents/external/adapters/CodexAppServerClient.ts
+++ b/src/agents/external/adapters/CodexAppServerClient.ts
@@ -6,18 +6,30 @@ export interface CodexAppServerClientInfo {
   version?: string;
 }
 
+export interface CodexInitializeCapabilities {
+  experimentalApi: boolean;
+  optOutNotificationMethods?: string[] | null;
+}
+
 export interface CodexAppServerClientOptions {
   clientInfo?: CodexAppServerClientInfo;
+  capabilities?: CodexInitializeCapabilities;
 }
 
 export interface CodexStartThreadInput {
   cwd?: string;
   model?: string;
   approvalPolicy?: string;
+  approvalsReviewer?: string;
   sandbox?: string | CodexJsonObject;
   sandboxPolicy?: CodexJsonObject;
+  permissions?: CodexJsonObject;
+  config?: CodexJsonObject;
+  baseInstructions?: string;
+  developerInstructions?: string;
   personality?: string;
   serviceName?: string;
+  dynamicTools?: CodexDynamicToolSpec[];
 }
 
 export interface CodexResumeThreadInput extends CodexStartThreadInput {
@@ -29,9 +41,29 @@ export interface CodexStartTurnInput {
   model?: string;
   effort?: string;
   approvalPolicy?: string;
+  approvalsReviewer?: string;
   sandboxPolicy?: CodexJsonObject;
+  permissions?: CodexJsonObject;
   personality?: string;
   summary?: string;
+}
+
+export interface CodexDynamicToolSpec {
+  namespace?: string;
+  name: string;
+  description: string;
+  inputSchema: CodexJsonObject;
+  deferLoading?: boolean;
+}
+
+export interface CodexDynamicToolCallOutputContentItem {
+  type: 'inputText';
+  text: string;
+}
+
+export interface CodexDynamicToolCallResponse {
+  contentItems: CodexDynamicToolCallOutputContentItem[];
+  success: boolean;
 }
 
 export interface CodexThread {
@@ -133,6 +165,7 @@ export class CodexAppServerClient {
   private readonly requestHandlers = new Set<CodexAppServerRequestHandler>();
   private readonly unsubscribeTransport: () => void;
   private readonly clientInfo: CodexAppServerClientInfo;
+  private readonly capabilities: CodexInitializeCapabilities;
 
   constructor(
     private readonly transport: CodexAppServerTransport,
@@ -142,6 +175,9 @@ export class CodexAppServerClient {
       name: 'openreelio',
       title: 'OpenReelio',
       version: '0.1.0',
+    };
+    this.capabilities = options.capabilities ?? {
+      experimentalApi: true,
     };
     this.unsubscribeTransport = this.transport.onMessage((message) => this.handleMessage(message));
   }
@@ -154,7 +190,7 @@ export class CodexAppServerClient {
     if (!this.initializePromise) {
       this.initializePromise = this.request('initialize', {
         clientInfo: this.clientInfo,
-        capabilities: null,
+        capabilities: this.capabilities,
       }).then(async () => {
         await this.notify('initialized', {});
         this.initialized = true;
@@ -172,9 +208,15 @@ export class CodexAppServerClient {
         cwd: input.cwd,
         model: input.model,
         approvalPolicy: input.approvalPolicy,
+        approvalsReviewer: input.approvalsReviewer,
         sandbox: input.sandbox ?? input.sandboxPolicy,
+        permissions: input.permissions,
+        config: input.config,
+        baseInstructions: input.baseInstructions,
+        developerInstructions: input.developerInstructions,
         personality: input.personality,
         serviceName: input.serviceName ?? 'openreelio',
+        dynamicTools: input.dynamicTools,
       }),
     );
 
@@ -190,7 +232,12 @@ export class CodexAppServerClient {
         cwd: input.cwd,
         model: input.model,
         approvalPolicy: input.approvalPolicy,
+        approvalsReviewer: input.approvalsReviewer,
         sandbox: input.sandbox ?? input.sandboxPolicy,
+        permissions: input.permissions,
+        config: input.config,
+        baseInstructions: input.baseInstructions,
+        developerInstructions: input.developerInstructions,
         personality: input.personality,
       }),
     );
@@ -213,7 +260,9 @@ export class CodexAppServerClient {
         model: input.model,
         effort: input.effort,
         approvalPolicy: input.approvalPolicy,
+        approvalsReviewer: input.approvalsReviewer,
         sandboxPolicy: input.sandboxPolicy,
+        permissions: input.permissions,
         personality: input.personality,
         summary: input.summary,
       }),

--- a/src/agents/external/adapters/CodexNotificationMapper.test.ts
+++ b/src/agents/external/adapters/CodexNotificationMapper.test.ts
@@ -84,6 +84,37 @@ describe('mapCodexNotificationToExternalEvents', () => {
     ]);
   });
 
+  it('should format dynamic OpenReelio tool calls with their namespace', () => {
+    const events = mapCodexNotificationToExternalEvents({
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      notification: {
+        method: 'item/started',
+        params: {
+          item: {
+            id: 'tool_1',
+            type: 'dynamicToolCall',
+            namespace: 'openreelio',
+            tool: 'host_context',
+            arguments: {},
+          },
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        type: 'tool_started',
+        runtimeId: 'codex',
+        sessionId: 'thr_123',
+        itemId: 'tool_1',
+        tool: 'openreelio.host_context',
+        description: 'Run openreelio.host_context',
+        args: {},
+      },
+    ]);
+  });
+
   it('should normalize Codex JSON error payload strings into readable messages', () => {
     const events = mapCodexNotificationToExternalEvents({
       runtimeId: 'codex',

--- a/src/agents/external/adapters/CodexNotificationMapper.ts
+++ b/src/agents/external/adapters/CodexNotificationMapper.ts
@@ -273,10 +273,15 @@ function mapFileChangeItem(
 
 function formatToolName(item: CodexJsonObject, fallback: string): string {
   const server = getString(item, 'server');
+  const namespace = getString(item, 'namespace');
   const tool = getString(item, 'tool');
 
   if (server && tool) {
     return `${server}/${tool}`;
+  }
+
+  if (namespace && tool) {
+    return `${namespace}.${tool}`;
   }
 
   return tool ?? fallback;

--- a/src/agents/external/adapters/CodexReferenceAdapter.test.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.test.ts
@@ -1,9 +1,30 @@
-import { describe, expect, it } from 'vitest';
-import { vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CodexReferenceAdapter } from './CodexReferenceAdapter';
 
+const projectStoreMocks = vi.hoisted(() => ({
+  refreshFromBackendMutation: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@/stores/projectStore', () => ({
+  useProjectStore: {
+    getState: () => ({
+      refreshFromBackendMutation: projectStoreMocks.refreshFromBackendMutation,
+    }),
+  },
+}));
+
 describe('CodexReferenceAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStoreMocks.refreshFromBackendMutation.mockResolvedValue(1);
+  });
+
   it('should expose app-server and MCP capabilities without starting Codex', async () => {
     const adapter = new CodexReferenceAdapter(async () => ({
       installed: true,
@@ -81,15 +102,27 @@ describe('CodexReferenceAdapter', () => {
         cwd: '/project',
       }),
     ).resolves.toEqual({ sessionId: 'thr_123', runtimeId: 'codex' });
-    expect(appServerClient.startThread).toHaveBeenCalledWith({
-      serviceName: 'openreelio',
-      cwd: '/project',
-      model: 'gpt-5.4',
-    });
+    expect(appServerClient.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceName: 'openreelio',
+        cwd: '/project',
+        model: 'gpt-5.4',
+        approvalPolicy: 'on-request',
+        approvalsReviewer: 'user',
+        sandbox: 'workspace-write',
+        developerInstructions: expect.stringContaining('OpenReelio'),
+        dynamicTools: expect.arrayContaining([
+          expect.objectContaining({ namespace: 'openreelio', name: 'host_context' }),
+          expect.objectContaining({ namespace: 'openreelio', name: 'command_execute' }),
+        ]),
+      }),
+    );
     expect(appServerClient.startTurn).toHaveBeenCalledWith('thr_123', 'Inspect this timeline', {
       cwd: '/project',
       model: 'gpt-5.4',
       effort: 'medium',
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
     });
   });
 
@@ -111,6 +144,8 @@ describe('CodexReferenceAdapter', () => {
       cwd: '/project',
       model: 'gpt-5.4',
       effort: 'medium',
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
     });
     expect(appServerClient.interruptTurn).toHaveBeenCalledWith('thr_123', 'turn_2');
     expect(appServerClient.unsubscribeThread).toHaveBeenCalledWith('thr_123');
@@ -135,16 +170,24 @@ describe('CodexReferenceAdapter', () => {
     ).resolves.toEqual({ sessionId: 'thr_existing', runtimeId: 'codex' });
     await adapter.sendMessage('thr_existing', { content: 'Continue', cwd: '/project' });
 
-    expect(appServerClient.resumeThread).toHaveBeenCalledWith({
-      threadId: 'thr_existing',
-      cwd: '/project',
-      model: 'gpt-5.4',
-    });
+    expect(appServerClient.resumeThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'thr_existing',
+        cwd: '/project',
+        model: 'gpt-5.4',
+        approvalPolicy: 'on-request',
+        approvalsReviewer: 'user',
+        sandbox: 'workspace-write',
+        developerInstructions: expect.stringContaining('OpenReelio'),
+      }),
+    );
     expect(appServerClient.startThread).not.toHaveBeenCalled();
     expect(appServerClient.startTurn).toHaveBeenCalledWith('thr_existing', 'Continue', {
       cwd: '/project',
       model: 'gpt-5.4',
       effort: 'medium',
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
     });
   });
 
@@ -179,11 +222,14 @@ describe('CodexReferenceAdapter', () => {
       projectId: 'project-1',
       cwd: '/project',
     });
-    expect(appServerClient.startThread).toHaveBeenCalledWith({
-      serviceName: 'openreelio',
-      cwd: '/project',
-      model: 'gpt-5.4',
-    });
+    expect(appServerClient.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceName: 'openreelio',
+        cwd: '/project',
+        model: 'gpt-5.4',
+        developerInstructions: expect.stringContaining('OpenReelio'),
+      }),
+    );
   });
 
   it('should forward app-server notifications as external runtime events', async () => {
@@ -316,5 +362,179 @@ describe('CodexReferenceAdapter', () => {
         }),
       }),
     );
+  });
+
+  it('should answer OpenReelio dynamic host context calls from the active app project', async () => {
+    const requestHandlers: Array<(request: any) => unknown> = [];
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onServerRequest: vi.fn((handler: (request: any) => unknown) => {
+        requestHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_project_info') {
+        return {
+          id: 'project-1',
+          name: 'Launch Cut',
+          path: '/project',
+          createdAt: '2026-05-13T00:00:00Z',
+        };
+      }
+      if (command === 'get_project_state') {
+        return {
+          meta: {
+            name: 'Launch Cut',
+            version: '1',
+            createdAt: '2026-05-13T00:00:00Z',
+            modifiedAt: '2026-05-13T00:00:00Z',
+            description: null,
+            author: null,
+          },
+          assets: [],
+          sequences: [],
+          effects: [],
+          activeSequenceId: null,
+          textClips: [],
+          isDirty: false,
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const adapter = new CodexReferenceAdapter(undefined, { appServerClient });
+
+    await adapter.startSession({ projectId: 'project-1', cwd: '/project' });
+    const respondToRequest = requestHandlers[0];
+    if (!respondToRequest) {
+      throw new Error('Expected Codex server request handler to be registered');
+    }
+    const response = await respondToRequest({
+      id: 12,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_1',
+        namespace: 'openreelio',
+        tool: 'host_context',
+        arguments: {},
+      },
+    });
+
+    expect(response).toMatchObject({
+      success: true,
+      contentItems: [
+        {
+          type: 'inputText',
+          text: expect.stringContaining('"appName": "OpenReelio"'),
+        },
+      ],
+    });
+    expect(response).toMatchObject({
+      contentItems: [
+        {
+          text: expect.stringContaining('"projectName": "Launch Cut"'),
+        },
+      ],
+    });
+  });
+
+  it('should require approval before executing an OpenReelio dynamic edit command', async () => {
+    const requestHandlers: Array<(request: any) => unknown> = [];
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onServerRequest: vi.fn((handler: (request: any) => unknown) => {
+        requestHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    vi.mocked(invoke).mockResolvedValue({
+      opId: 'op_1',
+      createdIds: ['track_1'],
+      deletedIds: [],
+    });
+    projectStoreMocks.refreshFromBackendMutation.mockResolvedValue(7);
+    const approvalDecisionProvider = vi.fn().mockResolvedValue('accept');
+    const adapter = new CodexReferenceAdapter(undefined, {
+      appServerClient,
+      approvalDecisionProvider,
+    });
+
+    await adapter.startSession({ projectId: 'project-1', cwd: '/project' });
+    const respondToRequest = requestHandlers[0];
+    if (!respondToRequest) {
+      throw new Error('Expected Codex server request handler to be registered');
+    }
+    const response = await respondToRequest({
+      id: 13,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_2',
+        namespace: 'openreelio',
+        tool: 'command_execute',
+        arguments: {
+          commandType: 'CreateTrack',
+          payload: {
+            sequenceId: 'seq_1',
+            name: 'B-roll',
+            kind: 'video',
+          },
+          reason: 'Add a B-roll track',
+        },
+      },
+    });
+
+    expect(approvalDecisionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'codex:openreelio:13:tool_2',
+        runtimeId: 'codex',
+        sessionId: 'thr_123',
+        turnId: 'turn_1',
+        itemId: 'tool_2',
+        requestId: 13,
+        approvalType: 'command',
+        tool: 'OpenReelio command',
+        description: 'Add a B-roll track',
+        args: expect.objectContaining({
+          commandType: 'CreateTrack',
+          projectId: 'project-1',
+          cwd: '/project',
+        }),
+      }),
+    );
+    expect(invoke).toHaveBeenCalledWith('execute_command', {
+      commandType: 'CreateTrack',
+      payload: {
+        sequenceId: 'seq_1',
+        name: 'B-roll',
+        kind: 'video',
+      },
+    });
+    expect(projectStoreMocks.refreshFromBackendMutation).toHaveBeenCalled();
+    expect(response).toMatchObject({
+      success: true,
+      contentItems: [
+        {
+          type: 'inputText',
+          text: expect.stringContaining('"status": "ok"'),
+        },
+      ],
+    });
+    expect(response).toMatchObject({
+      contentItems: [
+        {
+          text: expect.stringContaining('"stateVersion": 7'),
+        },
+      ],
+    });
   });
 });

--- a/src/agents/external/adapters/CodexReferenceAdapter.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.ts
@@ -15,6 +15,7 @@ import type {
 } from '../types';
 import type {
   CodexAppServerClient,
+  CodexDynamicToolCallResponse,
   CodexAppServerNotification,
   CodexAppServerRequest,
   CodexJsonObject,
@@ -22,6 +23,12 @@ import type {
 } from './CodexAppServerClient';
 import { mapCodexNotificationToExternalEvents } from './CodexNotificationMapper';
 import { createCodexTauriAppServerClient } from './CodexTauriAppServerTransport';
+import {
+  OPENREELIO_CODEX_DYNAMIC_TOOLS,
+  buildOpenReelioCodexDeveloperInstructions,
+  handleOpenReelioCodexDynamicToolCall,
+  type OpenReelioCodexSessionContext,
+} from './openreelioCodexTools';
 
 export interface CodexStatusProbeResult {
   installed: boolean;
@@ -37,6 +44,13 @@ type CodexAppServerClientPort = Pick<
   'startThread' | 'startTurn' | 'interruptTurn' | 'unsubscribeThread'
 > &
   Partial<Pick<CodexAppServerClient, 'resumeThread' | 'onNotification' | 'onServerRequest'>>;
+
+interface CodexSessionState {
+  threadId: string;
+  lastTurnId: string | null;
+  projectId: string;
+  cwd: string | null;
+}
 
 export interface CodexReferenceAdapterOptions {
   appServerClient?: CodexAppServerClientPort;
@@ -62,7 +76,7 @@ const CODEX_CAPABILITIES: ExternalAgentRuntimeCapabilities = {
 export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
   readonly id = 'codex' as const;
   readonly displayName = 'Codex';
-  private readonly sessions = new Map<string, { threadId: string; lastTurnId: string | null }>();
+  private readonly sessions = new Map<string, CodexSessionState>();
   private readonly turnSessionIds = new Map<string, string>();
   private readonly runtimeEventHandlers = new Set<ExternalAgentRuntimeEventHandler>();
   private readonly attachedClients = new Set<CodexAppServerClientPort>();
@@ -109,15 +123,27 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
       serviceName: 'openreelio',
       cwd: input.cwd ?? undefined,
       model: this.resolveModel(),
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+      sandbox: 'workspace-write',
+      developerInstructions: this.buildDeveloperInstructions(input),
+      dynamicTools: OPENREELIO_CODEX_DYNAMIC_TOOLS,
     });
     const sessionId = thread.id;
-    this.sessions.set(sessionId, { threadId: thread.id, lastTurnId: null });
+    this.sessions.set(sessionId, {
+      threadId: thread.id,
+      lastTurnId: null,
+      projectId: input.projectId,
+      cwd: input.cwd ?? null,
+    });
 
     if (input.prompt?.trim()) {
       const turn = await client.startTurn(thread.id, input.prompt, {
         cwd: input.cwd ?? undefined,
         model: this.resolveModel(),
         effort: this.resolveReasoningEffort(),
+        approvalPolicy: 'on-request',
+        approvalsReviewer: 'user',
       });
       this.rememberTurn(sessionId, turn);
     }
@@ -138,8 +164,17 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
       threadId: input.externalSessionId,
       cwd: input.cwd ?? undefined,
       model: this.resolveModel(),
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+      sandbox: 'workspace-write',
+      developerInstructions: this.buildDeveloperInstructions(input),
     });
-    this.sessions.set(thread.id, { threadId: thread.id, lastTurnId: null });
+    this.sessions.set(thread.id, {
+      threadId: thread.id,
+      lastTurnId: null,
+      projectId: input.projectId,
+      cwd: input.cwd ?? null,
+    });
 
     return { sessionId: thread.id, runtimeId: this.id };
   }
@@ -147,10 +182,13 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
   async sendMessage(sessionId: string, message: AgentUserMessage): Promise<void> {
     const client = await this.getAppServerClient();
     const session = this.requireSession(sessionId);
+    session.cwd = message.cwd ?? session.cwd;
     const turn = await client.startTurn(session.threadId, message.content, {
       cwd: message.cwd ?? undefined,
       model: this.resolveModel(),
       effort: this.resolveReasoningEffort(),
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
     });
     this.rememberTurn(sessionId, turn);
   }
@@ -216,7 +254,7 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     return client;
   }
 
-  private requireSession(sessionId: string): { threadId: string; lastTurnId: string | null } {
+  private requireSession(sessionId: string): CodexSessionState {
     const session = this.sessions.get(sessionId);
     if (!session) {
       throw new Error(`Codex session ${sessionId} is not active`);
@@ -231,6 +269,13 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
 
   private resolveReasoningEffort(): string {
     return this.options.reasoningEffort?.trim() || DEFAULT_CODEX_REASONING_EFFORT;
+  }
+
+  private buildDeveloperInstructions(context: OpenReelioCodexSessionContext): string {
+    return buildOpenReelioCodexDeveloperInstructions({
+      projectId: context.projectId,
+      cwd: context.cwd ?? null,
+    });
   }
 
   private rememberTurn(sessionId: string, turn: CodexTurn): void {
@@ -267,6 +312,10 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
 
   private async handleServerRequest(request: CodexAppServerRequest): Promise<unknown> {
     const sessionId = this.resolveSessionIdFromParams(request.params);
+    const dynamicToolResponse = await this.handleDynamicToolRequest(request, sessionId);
+    if (dynamicToolResponse) {
+      return dynamicToolResponse;
+    }
 
     if (request.method.endsWith('/requestApproval')) {
       const approvalRequest = this.toApprovalRequest(request, sessionId);
@@ -291,6 +340,22 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     }
 
     throw new Error(`Unsupported Codex app-server request: ${request.method}`);
+  }
+
+  private async handleDynamicToolRequest(
+    request: CodexAppServerRequest,
+    sessionId: string | null,
+  ): Promise<CodexDynamicToolCallResponse | null> {
+    const params = request.params ?? {};
+    const resolvedSessionId = sessionId ?? getString(params, 'threadId') ?? 'unknown';
+    const session = this.sessions.get(resolvedSessionId);
+    return await handleOpenReelioCodexDynamicToolCall(request, {
+      runtimeId: this.id,
+      sessionId: resolvedSessionId,
+      projectId: session?.projectId ?? 'unknown',
+      cwd: session?.cwd ?? getString(params, 'cwd'),
+      approvalDecisionProvider: this.options.approvalDecisionProvider,
+    });
   }
 
   private toApprovalRequest(

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1,0 +1,510 @@
+import { invoke } from '@tauri-apps/api/core';
+
+import type { CommandResultDto, ProjectInfo, ProjectStateDto } from '@/bindings';
+
+import type { ExternalAgentApprovalDecisionProvider, ExternalAgentApprovalRequest } from '../types';
+import type {
+  CodexAppServerRequest,
+  CodexDynamicToolCallResponse,
+  CodexDynamicToolSpec,
+  CodexJsonObject,
+} from './CodexAppServerClient';
+
+export interface OpenReelioCodexSessionContext {
+  projectId: string;
+  cwd?: string | null;
+}
+
+export interface OpenReelioCodexToolContext extends OpenReelioCodexSessionContext {
+  runtimeId: 'codex';
+  sessionId: string;
+  approvalDecisionProvider?: ExternalAgentApprovalDecisionProvider;
+}
+
+const OPENREELIO_COMMAND_TYPES = [
+  'InsertClip',
+  'InsertEdit',
+  'OverwriteEdit',
+  'RippleDelete',
+  'Lift',
+  'ExtractEdit',
+  'CloseGap',
+  'CloseAllGaps',
+  'RemoveClip',
+  'MoveClip',
+  'TrimClip',
+  'SplitClip',
+  'SetClipTransform',
+  'SetClipSpeed',
+  'ReverseClip',
+  'SetClipEnabled',
+  'LinkClips',
+  'UnlinkClips',
+  'GroupClips',
+  'UngroupClips',
+  'DetachAudio',
+  'CreateFreezeFrame',
+  'SetTimeRemap',
+  'ClearTimeRemap',
+  'SetClipMute',
+  'SetClipAudio',
+  'AddAudioKeyframe',
+  'RemoveAudioKeyframe',
+  'MoveAudioKeyframe',
+  'SetAudioKeyframeValue',
+  'SetAudioFadeIn',
+  'SetAudioFadeOut',
+  'SetTrackBlendMode',
+  'SetClipBlendMode',
+  'ImportAsset',
+  'RemoveAsset',
+  'CreateSequence',
+  'SetMasterVolume',
+  'CreateTrack',
+  'RemoveTrack',
+  'RenameTrack',
+  'ReorderTracks',
+  'ToggleTrackMute',
+  'ToggleTrackLock',
+  'ToggleTrackVisibility',
+  'AddMarker',
+  'RemoveMarker',
+  'CreateCaption',
+  'DeleteCaption',
+  'UpdateCaption',
+  'AddEffect',
+  'RemoveEffect',
+  'UpdateEffect',
+  'AddMask',
+  'UpdateMask',
+  'RemoveMask',
+  'AddTextClip',
+  'UpdateTextClip',
+  'RemoveTextClip',
+  'CreateFolder',
+  'RenameFile',
+  'MoveFile',
+  'DeleteFile',
+  'ApplyAudioDucking',
+  'CreateCompoundClip',
+  'UnnestCompoundClip',
+  'CreateAdjustmentLayer',
+  'PasteEffects',
+  'PasteAttributes',
+  'RemoveAttributes',
+] as const;
+
+const EMPTY_OBJECT_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+};
+
+const COMMAND_EXECUTE_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['commandType', 'payload', 'reason'],
+  properties: {
+    commandType: {
+      type: 'string',
+      enum: OPENREELIO_COMMAND_TYPES,
+      description: 'PascalCase OpenReelio backend command type.',
+    },
+    payload: {
+      type: 'object',
+      description: 'CamelCase JSON payload matching the command type.',
+    },
+    reason: {
+      type: 'string',
+      description: 'Short user-facing reason for the edit approval prompt.',
+    },
+  },
+  additionalProperties: false,
+};
+
+export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
+  {
+    namespace: 'openreelio',
+    name: 'host_context',
+    description:
+      'Read the OpenReelio desktop host context, active project identity, editing policy, and available app control capabilities.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'project_state',
+    description:
+      'Read the current OpenReelio project state, including assets, sequences, active sequence, and dirty state.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'timeline_snapshot',
+    description:
+      'Read a concise snapshot of the active OpenReelio timeline, tracks, clips, markers, and current sequence.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'assets_list',
+    description: 'Read OpenReelio asset metadata and offline/missing status.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'command_schema',
+    description:
+      'Read the supported OpenReelio event-sourced edit command types and payload conventions.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'command_execute',
+    description:
+      'Execute one schema-validated OpenReelio edit command through the app command log after explicit user approval.',
+    inputSchema: COMMAND_EXECUTE_SCHEMA,
+  },
+];
+
+export function buildOpenReelioCodexDeveloperInstructions(
+  context: OpenReelioCodexSessionContext,
+): string {
+  const projectPath = context.cwd?.trim() || 'not provided';
+  return [
+    'You are Codex running embedded inside OpenReelio, a Tauri desktop video-editing IDE.',
+    'This is not a standalone terminal chat. Treat OpenReelio as the host application and the active video project as your primary workspace.',
+    '',
+    'Current OpenReelio session:',
+    `- appSurface: tauri-desktop`,
+    `- projectId: ${context.projectId}`,
+    `- projectPath: ${projectPath}`,
+    '',
+    'OpenReelio editing rules:',
+    '- Project truth is the OpenReelio command log, not direct JSON state mutation.',
+    '- Use OpenReelio dynamic tools before claiming project, timeline, asset, or selection facts.',
+    '- Use openreelio.host_context first when the user asks where you are, what you can use, or what environment this is.',
+    '- Use openreelio.timeline_snapshot, openreelio.assets_list, and openreelio.command_schema before proposing concrete edits.',
+    '- Apply edits through openreelio.command_execute so the app can validate, approve, persist, undo, and refresh the UI.',
+    '- Do not manually edit .openreelio state files or invent command payloads without checking the schema and current IDs.',
+    '- Shell and filesystem tools are secondary; prefer OpenReelio tools for video-editing state and mutations.',
+    '',
+    'Available OpenReelio dynamic tools:',
+    OPENREELIO_CODEX_DYNAMIC_TOOLS.map((tool) => `- openreelio.${tool.name}`).join('\n'),
+  ].join('\n');
+}
+
+export async function handleOpenReelioCodexDynamicToolCall(
+  request: CodexAppServerRequest,
+  context: OpenReelioCodexToolContext,
+): Promise<CodexDynamicToolCallResponse | null> {
+  if (request.method !== 'item/tool/call') {
+    return null;
+  }
+
+  const params = request.params ?? {};
+  const namespace = getString(params, 'namespace');
+  const tool = getString(params, 'tool');
+  if (namespace !== 'openreelio' || !tool) {
+    return null;
+  }
+
+  try {
+    switch (tool) {
+      case 'host_context':
+        return toolResponse(await buildHostContext(context));
+      case 'project_state':
+        return toolResponse(await readProjectState());
+      case 'timeline_snapshot':
+        return toolResponse(buildTimelineSnapshot(await readProjectState()));
+      case 'assets_list':
+        return toolResponse(buildAssetsList(await readProjectState()));
+      case 'command_schema':
+        return toolResponse(buildCommandSchema());
+      case 'command_execute':
+        return toolResponse(await executeApprovedCommand(request, context));
+      default:
+        return toolResponse(
+          {
+            status: 'error',
+            message: `OpenReelio dynamic tool '${tool}' is not available.`,
+          },
+          false,
+        );
+    }
+  } catch (error) {
+    return toolResponse(
+      {
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      },
+      false,
+    );
+  }
+}
+
+async function buildHostContext(context: OpenReelioCodexToolContext): Promise<CodexJsonObject> {
+  const projectInfo = await readOptionalProjectInfo();
+  const projectState = await readOptionalProjectState();
+  return {
+    host: {
+      appId: 'openreelio',
+      appName: 'OpenReelio',
+      surface: 'tauri-desktop',
+      runtime: 'codex-app-server',
+      controlMode: 'dynamic-tools',
+    },
+    project: {
+      available: Boolean(projectInfo ?? projectState),
+      projectId: projectInfo?.id ?? context.projectId,
+      projectName: projectInfo?.name ?? projectState?.meta?.name ?? null,
+      projectPath: projectInfo?.path ?? context.cwd ?? null,
+      activeSequenceId: projectState?.activeSequenceId ?? null,
+      assetCount: projectState?.assets?.length ?? null,
+      sequenceCount: projectState?.sequences?.length ?? null,
+      isDirty: projectState?.isDirty ?? null,
+    },
+    ui: {
+      activePanel: 'agent-chat',
+      previewFrameAccess: false,
+      rawMediaAccess: 'not-exposed',
+    },
+    capabilities: {
+      projectStateRead: true,
+      timelineRead: true,
+      assetRead: true,
+      commandSchemaRead: true,
+      commandExecuteWithApproval: true,
+      undoableCommandLog: true,
+    },
+    policy: {
+      mutationPath: 'openreelio.command_execute',
+      approvalRequiredForMutations: true,
+      directStateFileEdits: 'forbidden',
+    },
+  };
+}
+
+async function executeApprovedCommand(
+  request: CodexAppServerRequest,
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
+  const params = request.params ?? {};
+  const args = asObject(params.arguments);
+  if (!args) {
+    throw new Error('OpenReelio command_execute requires object arguments.');
+  }
+
+  const commandType = getString(args, 'commandType')?.trim();
+  if (!commandType) {
+    throw new Error('OpenReelio command_execute requires commandType.');
+  }
+
+  const payload = asObject(args.payload);
+  if (!payload) {
+    throw new Error('OpenReelio command_execute requires an object payload.');
+  }
+
+  const reason = getString(args, 'reason')?.trim() || `Execute ${commandType}`;
+  const decision = context.approvalDecisionProvider
+    ? await context.approvalDecisionProvider(
+        buildCommandApprovalRequest({
+          request,
+          context,
+          commandType,
+          payload,
+          reason,
+        }),
+      )
+    : 'decline';
+
+  if (decision !== 'accept' && decision !== 'acceptForSession') {
+    return {
+      status: 'denied',
+      commandType,
+      message: 'The OpenReelio command was not approved by the user.',
+    };
+  }
+
+  const result = await invoke<CommandResultDto>('execute_command', {
+    commandType,
+    payload,
+  });
+  const refresh = await refreshProjectStoreAfterMutation();
+
+  return {
+    status: 'ok',
+    commandType,
+    result,
+    refresh,
+  };
+}
+
+function buildCommandApprovalRequest(input: {
+  request: CodexAppServerRequest;
+  context: OpenReelioCodexToolContext;
+  commandType: string;
+  payload: CodexJsonObject;
+  reason: string;
+}): ExternalAgentApprovalRequest {
+  const params = input.request.params ?? {};
+  return {
+    id: `codex:openreelio:${input.request.id}:${getString(params, 'callId') ?? input.commandType}`,
+    runtimeId: input.context.runtimeId,
+    sessionId: input.context.sessionId,
+    turnId: getString(params, 'turnId'),
+    itemId: getString(params, 'callId'),
+    requestId: input.request.id,
+    approvalType: 'command',
+    tool: 'OpenReelio command',
+    description: input.reason,
+    args: {
+      commandType: input.commandType,
+      payload: input.payload,
+      projectId: input.context.projectId,
+      cwd: input.context.cwd ?? null,
+    },
+    reason: input.reason,
+    requestedAt: Date.now(),
+  };
+}
+
+async function readProjectState(): Promise<ProjectStateDto> {
+  return await invoke<ProjectStateDto>('get_project_state');
+}
+
+async function readOptionalProjectState(): Promise<ProjectStateDto | null> {
+  try {
+    return await readProjectState();
+  } catch {
+    return null;
+  }
+}
+
+async function readOptionalProjectInfo(): Promise<ProjectInfo | null> {
+  try {
+    return await invoke<ProjectInfo | null>('get_project_info');
+  } catch {
+    return null;
+  }
+}
+
+function buildTimelineSnapshot(state: ProjectStateDto): CodexJsonObject {
+  const activeSequence = state.sequences.find((sequence) => sequence.id === state.activeSequenceId);
+  return {
+    available: true,
+    activeSequenceId: state.activeSequenceId,
+    activeSequence: activeSequence ? summarizeSequence(activeSequence) : null,
+    sequences: state.sequences.map(summarizeSequence),
+  };
+}
+
+function summarizeSequence(sequence: unknown): CodexJsonObject {
+  const sequenceObject = asObject(sequence) ?? {};
+  const tracks = Array.isArray(sequenceObject.tracks) ? sequenceObject.tracks : [];
+  return {
+    id: sequenceObject.id,
+    name: sequenceObject.name,
+    trackCount: tracks.length,
+    markerCount: Array.isArray(sequenceObject.markers) ? sequenceObject.markers.length : 0,
+    tracks: tracks.map((track) => {
+      const trackObject = asObject(track) ?? {};
+      const clips = Array.isArray(trackObject.clips) ? trackObject.clips : [];
+      return {
+        id: trackObject.id,
+        name: trackObject.name,
+        kind: trackObject.kind,
+        muted: trackObject.muted,
+        locked: trackObject.locked,
+        visible: trackObject.visible,
+        clipCount: clips.length,
+        clips: clips.map((clip) => {
+          const clipObject = asObject(clip) ?? {};
+          const place = asObject(clipObject.place) ?? {};
+          const range = asObject(clipObject.range) ?? {};
+          return {
+            id: clipObject.id,
+            assetId: clipObject.assetId,
+            timelineInSec: place.timelineInSec,
+            durationSec: place.durationSec,
+            sourceInSec: range.sourceInSec,
+            sourceOutSec: range.sourceOutSec,
+            speed: clipObject.speed,
+            enabled: clipObject.enabled,
+          };
+        }),
+      };
+    }),
+  };
+}
+
+function buildAssetsList(state: ProjectStateDto): CodexJsonObject {
+  return {
+    available: true,
+    count: state.assets.length,
+    assets: state.assets.map((asset) => ({
+      id: asset.id,
+      name: asset.name,
+      kind: asset.kind,
+      durationSec: asset.durationSec,
+      missing: asset.missing,
+      workspaceManaged: asset.workspaceManaged,
+      tags: asset.tags,
+    })),
+  };
+}
+
+function buildCommandSchema(): CodexJsonObject {
+  return {
+    commands: OPENREELIO_COMMAND_TYPES,
+    count: OPENREELIO_COMMAND_TYPES.length,
+    payloadFormat: {
+      commandType: 'PascalCase OpenReelio backend command type',
+      payload: 'CamelCase JSON object matching the selected command type',
+      mutationTool: 'openreelio.command_execute',
+    },
+    rules: [
+      'Read project_state or timeline_snapshot before using IDs.',
+      'Never edit .openreelio state files directly.',
+      'command_execute prompts the user for approval and persists through the OpenReelio command log.',
+    ],
+  };
+}
+
+async function refreshProjectStoreAfterMutation(): Promise<CodexJsonObject> {
+  try {
+    const module = await import('@/stores/projectStore');
+    const version = await module.useProjectStore.getState().refreshFromBackendMutation();
+    return { status: 'ok', stateVersion: version };
+  } catch (error) {
+    return {
+      status: 'warning',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Command executed, but the frontend project store could not be refreshed.',
+    };
+  }
+}
+
+function toolResponse(value: unknown, success = true): CodexDynamicToolCallResponse {
+  return {
+    contentItems: [
+      {
+        type: 'inputText',
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+    success,
+  };
+}
+
+function asObject(value: unknown): CodexJsonObject | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as CodexJsonObject;
+}
+
+function getString(input: CodexJsonObject | null | undefined, key: string): string | null {
+  const value = input?.[key];
+  return typeof value === 'string' ? value : null;
+}

--- a/src/agents/external/chatRuntime.test.ts
+++ b/src/agents/external/chatRuntime.test.ts
@@ -267,7 +267,11 @@ describe('ExternalAgentChatRuntimeController', () => {
     const conversation = new FakeConversationGateway();
     const adapter = new FakeExternalAgentAdapter();
     const sessionPersistence = new FakeExternalAgentSessionPersistence();
-    sessionPersistence.nextLoadResult = { sessionId: 'thr_existing', runtimeId: 'codex' };
+    sessionPersistence.nextLoadResult = {
+      sessionId: 'thr_existing',
+      runtimeId: 'codex',
+      metadata: { openReelioToolProtocolVersion: 2 },
+    };
     const controller = new ExternalAgentChatRuntimeController({
       adapter,
       conversation,
@@ -301,7 +305,11 @@ describe('ExternalAgentChatRuntimeController', () => {
     const adapter = new FakeExternalAgentAdapter();
     adapter.resumeSession.mockRejectedValueOnce(new Error('thread not found'));
     const sessionPersistence = new FakeExternalAgentSessionPersistence();
-    sessionPersistence.nextLoadResult = { sessionId: 'thr_stale', runtimeId: 'codex' };
+    sessionPersistence.nextLoadResult = {
+      sessionId: 'thr_stale',
+      runtimeId: 'codex',
+      metadata: { openReelioToolProtocolVersion: 2 },
+    };
     const controller = new ExternalAgentChatRuntimeController({
       adapter,
       conversation,
@@ -326,11 +334,40 @@ describe('ExternalAgentChatRuntimeController', () => {
       conversationSessionId: 'session-1',
       runtimeId: 'codex',
       externalSession: { sessionId: 'thr_123', runtimeId: 'codex' },
-      metadata: { source: 'appServer' },
+      metadata: { source: 'appServer', openReelioToolProtocolVersion: 2 },
     });
     expect(adapter.sendMessage).toHaveBeenCalledWith('thr_123', {
       content: 'Start over if needed',
       cwd: '/project',
+    });
+  });
+
+  it('should start a fresh Codex session when the persisted link predates OpenReelio dynamic tools', async () => {
+    const conversation = new FakeConversationGateway();
+    const adapter = new FakeExternalAgentAdapter();
+    const sessionPersistence = new FakeExternalAgentSessionPersistence();
+    sessionPersistence.nextLoadResult = { sessionId: 'thr_legacy', runtimeId: 'codex' };
+    const controller = new ExternalAgentChatRuntimeController({
+      adapter,
+      conversation,
+      projectId: 'project-1',
+      cwd: '/project',
+      sessionPersistence,
+    });
+
+    await controller.sendMessage('Use the current OpenReelio context');
+
+    expect(adapter.resumeSession).not.toHaveBeenCalled();
+    expect(adapter.startSession).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      cwd: '/project',
+    });
+    expect(sessionPersistence.save).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      conversationSessionId: 'session-1',
+      runtimeId: 'codex',
+      externalSession: { sessionId: 'thr_123', runtimeId: 'codex' },
+      metadata: { source: 'appServer', openReelioToolProtocolVersion: 2 },
     });
   });
 

--- a/src/agents/external/chatRuntime.ts
+++ b/src/agents/external/chatRuntime.ts
@@ -77,6 +77,8 @@ const INITIAL_STATE: ExternalAgentChatRuntimeState = {
   pendingToolPermissionRequest: null,
 };
 
+const CODEX_OPENREELIO_TOOL_PROTOCOL_VERSION = 2;
+
 export class ExternalAgentChatRuntimeController {
   private projectId: string | null;
   private cwd: string | null;
@@ -248,7 +250,11 @@ export class ExternalAgentChatRuntimeController {
     }
 
     const persisted = await this.loadPersistedExternalSession(conversationSessionId);
-    if (persisted && this.options.adapter.resumeSession) {
+    if (
+      persisted &&
+      this.isPersistedExternalSessionCompatible(persisted) &&
+      this.options.adapter.resumeSession
+    ) {
       try {
         const resumed = await this.options.adapter.resumeSession({
           projectId: this.projectId ?? 'unknown',
@@ -298,8 +304,32 @@ export class ExternalAgentChatRuntimeController {
       conversationSessionId,
       runtimeId: this.options.adapter.id,
       externalSession,
-      metadata: { source: 'appServer' },
+      metadata: this.buildExternalSessionMetadata(),
     });
+  }
+
+  private buildExternalSessionMetadata(): Record<string, unknown> {
+    if (this.options.adapter.id === 'codex') {
+      return {
+        source: 'appServer',
+        openReelioToolProtocolVersion: CODEX_OPENREELIO_TOOL_PROTOCOL_VERSION,
+      };
+    }
+
+    return { source: 'appServer' };
+  }
+
+  private isPersistedExternalSessionCompatible(
+    externalSession: ExternalAgentSessionHandle,
+  ): boolean {
+    if (this.options.adapter.id !== 'codex') {
+      return true;
+    }
+
+    return (
+      externalSession.metadata?.openReelioToolProtocolVersion ===
+      CODEX_OPENREELIO_TOOL_PROTOCOL_VERSION
+    );
   }
 
   private async persistExternalSessionAfterTurnStart(

--- a/src/agents/external/sessionPersistence.test.ts
+++ b/src/agents/external/sessionPersistence.test.ts
@@ -9,7 +9,7 @@ describe('TauriExternalAgentSessionPersistence', () => {
       projectId: 'project-1',
       runtimeId: 'codex',
       externalSessionId: 'thr_123',
-      metadataJson: null,
+      metadataJson: '{"source":"appServer"}',
       createdAt: 1_000,
       updatedAt: 1_000,
     });
@@ -21,7 +21,11 @@ describe('TauriExternalAgentSessionPersistence', () => {
         conversationSessionId: 'session-1',
         runtimeId: 'codex',
       }),
-    ).resolves.toEqual({ sessionId: 'thr_123', runtimeId: 'codex' });
+    ).resolves.toEqual({
+      sessionId: 'thr_123',
+      runtimeId: 'codex',
+      metadata: { source: 'appServer' },
+    });
 
     expect(invokeCommand).toHaveBeenCalledWith('get_external_agent_session_link', {
       input: {

--- a/src/agents/external/sessionPersistence.ts
+++ b/src/agents/external/sessionPersistence.ts
@@ -51,6 +51,7 @@ export class TauriExternalAgentSessionPersistence implements ExternalAgentSessio
     return {
       sessionId: link.externalSessionId,
       runtimeId: link.runtimeId,
+      metadata: parseMetadata(link.metadataJson),
     };
   }
 
@@ -70,6 +71,22 @@ export class TauriExternalAgentSessionPersistence implements ExternalAgentSessio
         metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
       },
     });
+  }
+}
+
+function parseMetadata(metadataJson: string | null): Record<string, unknown> | null {
+  if (!metadataJson) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(metadataJson);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
   }
 }
 

--- a/src/agents/external/types.ts
+++ b/src/agents/external/types.ts
@@ -41,6 +41,7 @@ export interface AgentRuntimeReadiness {
 export interface ExternalAgentSessionHandle {
   sessionId: string;
   runtimeId: ExternalAgentRuntimeId | string;
+  metadata?: Record<string, unknown> | null;
 }
 
 export type ExternalAgentApprovalScope = 'openreelio.plan.apply';

--- a/src/components/features/editor/EditorPanels.tsx
+++ b/src/components/features/editor/EditorPanels.tsx
@@ -1,22 +1,22 @@
 import { lazy, Suspense, type ReactNode, type RefObject } from 'react';
-import { Camera, Sliders } from 'lucide-react';
+import { Camera } from 'lucide-react';
 import { AISidebar, type AISidebarProps } from '@/components/features/ai';
 import type { AudioMixerPanelProps } from '@/components/features/mixer';
 import { Inspector, type InspectorProps } from '@/components/features/inspector';
 import { ProjectExplorer } from '@/components/explorer';
 import { UnifiedPreviewPlayer } from '@/components/preview';
 import { SourceMonitor } from '@/components/features/preview/SourceMonitor';
-import { Timeline, type TimelineProps } from '@/components/timeline';
+import type { TimelineProps } from '@/components/timeline';
 import {
   AIErrorBoundary,
   ExplorerErrorBoundary,
   InspectorErrorBoundary,
   PreviewErrorBoundary,
-  TimelineErrorBoundary,
 } from '@/components/shared';
 import { type Logger } from '@/services/logger';
 import type { Sequence } from '@/types';
 import type { PanelId } from '@/stores/workspaceLayoutStore';
+import { EditorTimelineDockPanel } from './EditorTimelineDockPanel';
 
 const BOTTOM_PANEL_LOADING_FALLBACK = (
   <div className="flex h-full items-center justify-center text-xs text-editor-text-muted">
@@ -63,96 +63,6 @@ const TerminalPanelLazy = lazy(async () => {
   const module = await import('@/components/features/terminal');
   return { default: module.TerminalPanel };
 });
-
-interface EditorTimelineDockPanelProps {
-  logger: Logger;
-  sequence: Sequence | null;
-  sequenceNavigationStack: string[];
-  sequences: Map<string, Sequence>;
-  onPopSequence: () => void;
-  showMixer: boolean;
-  onToggleMixer: () => void;
-  timelineProps: TimelineProps;
-  audioMixerProps: AudioMixerPanelProps;
-}
-
-function EditorTimelineDockPanel({
-  logger,
-  sequence,
-  sequenceNavigationStack,
-  sequences,
-  onPopSequence,
-  showMixer,
-  onToggleMixer,
-  timelineProps,
-  audioMixerProps,
-}: EditorTimelineDockPanelProps): JSX.Element {
-  return (
-    <div className="h-full min-h-0 p-3">
-      <section className="flex h-full flex-col overflow-hidden rounded-xl border border-editor-border bg-editor-panel">
-        <div className="flex items-center justify-between border-b border-editor-border px-3 py-2">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-editor-text-muted">
-            Timeline
-          </h2>
-          <button
-            type="button"
-            onClick={onToggleMixer}
-            className={`rounded p-1 transition-colors ${
-              showMixer
-                ? 'bg-editor-border text-editor-text'
-                : 'text-editor-text-muted hover:text-editor-text hover:bg-editor-border/50'
-            }`}
-            title={showMixer ? 'Hide Mixer' : 'Show Mixer'}
-            aria-label={showMixer ? 'Hide Mixer' : 'Show Mixer'}
-            aria-pressed={showMixer}
-          >
-            <Sliders className="h-3.5 w-3.5" />
-          </button>
-        </div>
-
-        {sequenceNavigationStack.length > 0 && (
-          <div className="flex items-center gap-1 border-b border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300">
-            <button
-              className="hover:text-white transition-colors"
-              onClick={onPopSequence}
-              title="Back to parent sequence"
-            >
-              &larr; Back
-            </button>
-            <span className="text-gray-500">/</span>
-            {sequenceNavigationStack.map((seqId) => {
-              const parentSequence = sequences.get(seqId);
-              return (
-                <span key={seqId} className="text-gray-400">
-                  {parentSequence?.name ?? seqId}
-                  <span className="mx-1 text-gray-500">/</span>
-                </span>
-              );
-            })}
-            <span className="font-medium text-white">{sequence?.name ?? 'Inner Sequence'}</span>
-          </div>
-        )}
-
-        <div className="min-h-0 flex-1">
-          <TimelineErrorBoundary onError={(error) => logger.error('Timeline error', { error })}>
-            <Timeline {...timelineProps} />
-          </TimelineErrorBoundary>
-        </div>
-
-        {showMixer && (
-          <div
-            className="shrink-0 border-t border-editor-border bg-editor-sidebar"
-            style={{ height: '220px' }}
-          >
-            <Suspense fallback={BOTTOM_PANEL_LOADING_FALLBACK}>
-              <AudioMixerPanelLazy {...audioMixerProps} compact className="h-full" />
-            </Suspense>
-          </div>
-        )}
-      </section>
-    </div>
-  );
-}
 
 export interface EditorPanelContentOptions {
   logger: Logger;

--- a/src/components/features/editor/EditorTimelineDockPanel.tsx
+++ b/src/components/features/editor/EditorTimelineDockPanel.tsx
@@ -1,0 +1,108 @@
+import { lazy, Suspense } from 'react';
+import { Sliders } from 'lucide-react';
+import type { AudioMixerPanelProps } from '@/components/features/mixer';
+import { Timeline, type TimelineProps } from '@/components/timeline';
+import { TimelineErrorBoundary } from '@/components/shared';
+import type { Logger } from '@/services/logger';
+import type { Sequence } from '@/types';
+
+const BOTTOM_PANEL_LOADING_FALLBACK = (
+  <div className="flex h-full items-center justify-center text-xs text-editor-text-muted">
+    Loading panel...
+  </div>
+);
+
+const AudioMixerPanelLazy = lazy(async () => {
+  const module = await import('@/components/features/mixer');
+  return { default: module.AudioMixerPanel };
+});
+
+interface EditorTimelineDockPanelProps {
+  logger: Logger;
+  sequence: Sequence | null;
+  sequenceNavigationStack: string[];
+  sequences: Map<string, Sequence>;
+  onPopSequence: () => void;
+  showMixer: boolean;
+  onToggleMixer: () => void;
+  timelineProps: TimelineProps;
+  audioMixerProps: AudioMixerPanelProps;
+}
+
+export function EditorTimelineDockPanel({
+  logger,
+  sequence,
+  sequenceNavigationStack,
+  sequences,
+  onPopSequence,
+  showMixer,
+  onToggleMixer,
+  timelineProps,
+  audioMixerProps,
+}: EditorTimelineDockPanelProps): JSX.Element {
+  return (
+    <div className="h-full min-h-0 p-3">
+      <section className="flex h-full flex-col overflow-hidden rounded-xl border border-editor-border bg-editor-panel">
+        <div className="flex items-center justify-between border-b border-editor-border px-3 py-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-editor-text-muted">
+            Timeline
+          </h2>
+          <button
+            type="button"
+            onClick={onToggleMixer}
+            className={`rounded p-1 transition-colors ${
+              showMixer
+                ? 'bg-editor-border text-editor-text'
+                : 'text-editor-text-muted hover:text-editor-text hover:bg-editor-border/50'
+            }`}
+            title={showMixer ? 'Hide Mixer' : 'Show Mixer'}
+            aria-label={showMixer ? 'Hide Mixer' : 'Show Mixer'}
+            aria-pressed={showMixer}
+          >
+            <Sliders className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        {sequenceNavigationStack.length > 0 && (
+          <div className="flex items-center gap-1 border-b border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300">
+            <button
+              className="hover:text-white transition-colors"
+              onClick={onPopSequence}
+              title="Back to parent sequence"
+            >
+              &larr; Back
+            </button>
+            <span className="text-gray-500">/</span>
+            {sequenceNavigationStack.map((seqId) => {
+              const parentSequence = sequences.get(seqId);
+              return (
+                <span key={seqId} className="text-gray-400">
+                  {parentSequence?.name ?? seqId}
+                  <span className="mx-1 text-gray-500">/</span>
+                </span>
+              );
+            })}
+            <span className="font-medium text-white">{sequence?.name ?? 'Inner Sequence'}</span>
+          </div>
+        )}
+
+        <div className="min-h-0 flex-1">
+          <TimelineErrorBoundary onError={(error) => logger.error('Timeline error', { error })}>
+            <Timeline {...timelineProps} />
+          </TimelineErrorBoundary>
+        </div>
+
+        {showMixer && (
+          <div
+            className="shrink-0 border-t border-editor-border bg-editor-sidebar"
+            style={{ height: '220px' }}
+          >
+            <Suspense fallback={BOTTOM_PANEL_LOADING_FALLBACK}>
+              <AudioMixerPanelLazy {...audioMixerProps} compact className="h-full" />
+            </Suspense>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/features/editor/EditorView.tsx
+++ b/src/components/features/editor/EditorView.tsx
@@ -161,15 +161,14 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
   const handleToggleMixer = useCallback(() => setShowMixer((prev) => !prev), []);
 
   useEffect(() => {
-    const validClipIds = sequence?.tracks.flatMap((track) => track.clips.map((clip) => clip.id)) ?? [];
+    const validClipIds =
+      sequence?.tracks.flatMap((track) => track.clips.map((clip) => clip.id)) ?? [];
     const validTrackIds = sequence?.tracks.map((track) => track.id) ?? [];
     sanitizeSelection(validClipIds, validTrackIds);
   }, [sanitizeSelection, sequence]);
 
   // AI Sidebar state
-  const {
-    toggle: toggleAiSidebar,
-  } = useDockableAIPanel({
+  const { toggle: toggleAiSidebar } = useDockableAIPanel({
     autoCollapseBreakpoint: AI_AUTO_COLLAPSE_BREAKPOINT,
     initialWidth: 320,
   });
@@ -1259,7 +1258,6 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
       />
     ),
     [
-      sequence?.name,
       appVersion,
       handleOpenExport,
       handleExportEdl,

--- a/src/components/features/effects/EffectsBrowser.tsx
+++ b/src/components/features/effects/EffectsBrowser.tsx
@@ -9,16 +9,8 @@ import { memo, type ReactNode } from 'react';
 import { Wand2, Search, Star } from 'lucide-react';
 import type { EffectCategory } from '@/types';
 import { EFFECT_CATEGORY_LABELS } from '@/types';
-import {
-  useEffectSearch,
-  getEffectTypeKey,
-  type EffectEntry,
-} from '@/hooks/useEffectSearch';
-import {
-  EFFECT_CATEGORIES,
-  CATEGORY_ICONS,
-  TOTAL_EFFECT_COUNT,
-} from './effectCategoryData';
+import { useEffectSearch, getEffectTypeKey, type EffectEntry } from '@/hooks/useEffectSearch';
+import { EFFECT_CATEGORIES, CATEGORY_ICONS, totalEffectCount } from './effectCategoryData';
 
 // =============================================================================
 // Types
@@ -89,7 +81,9 @@ export const EffectsBrowser = memo(function EffectsBrowser({
         </button>
         <button
           type="button"
-          aria-label={favorited ? `Remove ${effect.label} from favorites` : `Add ${effect.label} to favorites`}
+          aria-label={
+            favorited ? `Remove ${effect.label} from favorites` : `Add ${effect.label} to favorites`
+          }
           className={`p-1 mr-1 rounded transition-opacity focus-visible:ring-1 focus-visible:ring-primary-500 focus-visible:outline-none ${
             favorited
               ? 'opacity-100 text-yellow-400'
@@ -168,9 +162,7 @@ export const EffectsBrowser = memo(function EffectsBrowser({
                       {EFFECT_CATEGORY_LABELS[catId] ?? category.id}
                     </span>
                   </div>
-                  <div className="space-y-0.5">
-                    {category.effects.map(renderEffectButton)}
-                  </div>
+                  <div className="space-y-0.5">{category.effects.map(renderEffectButton)}</div>
                 </div>
               );
             })}
@@ -181,7 +173,7 @@ export const EffectsBrowser = memo(function EffectsBrowser({
       {/* Footer */}
       <div className="p-3 border-t border-editor-border mt-4">
         <p className="text-xs text-editor-text-muted text-center italic">
-          {TOTAL_EFFECT_COUNT} effects available
+          {totalEffectCount} effects available
         </p>
       </div>
     </div>

--- a/src/components/features/effects/effectCategoryData.tsx
+++ b/src/components/features/effects/effectCategoryData.tsx
@@ -170,8 +170,5 @@ export const EFFECT_CATEGORIES: CategoryWithIcon[] = [
   },
 ];
 
-/** Total effect count (constant, computed once) */
-export const TOTAL_EFFECT_COUNT = EFFECT_CATEGORIES.reduce(
-  (acc, cat) => acc + cat.effects.length,
-  0,
-);
+/** Total effect count (computed once) */
+export const totalEffectCount = EFFECT_CATEGORIES.reduce((acc, cat) => acc + cat.effects.length, 0);

--- a/src/components/features/settings/sections/ExternalAgentRuntimeSettings.test.tsx
+++ b/src/components/features/settings/sections/ExternalAgentRuntimeSettings.test.tsx
@@ -141,6 +141,54 @@ describe('ExternalAgentRuntimeSettings', () => {
     });
   });
 
+  it('should treat native Codex app tools as ready even when optional MCP setup fails', async () => {
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === 'get_codex_status') {
+        return Promise.resolve({
+          installed: true,
+          version: 'codex-cli 0.130.0',
+          authStatus: 'signed-in',
+          reason: null,
+        });
+      }
+      if (command === 'configure_codex_agent_runtime') {
+        return Promise.resolve({
+          installed: true,
+          version: 'codex-cli 0.130.0',
+          authStatus: 'signed-in',
+          ready: false,
+          requiresLogin: false,
+          pluginMarketplaceConfigured: true,
+          mcpConfigured: false,
+          message: 'Codex MCP setup failed.',
+        });
+      }
+      if (command === 'get_codex_model_catalog') {
+        return Promise.resolve({
+          installed: true,
+          defaultModel: 'gpt-5.4',
+          defaultReasoningEffort: 'medium',
+          models: [],
+          reason: null,
+        });
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    render(
+      <ExternalAgentRuntimeSettings
+        settings={{ ...defaultSettings, assistantRuntime: 'codex' }}
+        onUpdate={vi.fn()}
+        disabled={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/Codex is ready with OpenReelio app tools/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Codex MCP setup failed.')).not.toBeInTheDocument();
+  });
+
   it('should start Codex login from the settings panel when sign-in is required', async () => {
     vi.mocked(invoke).mockImplementation((command) => {
       if (command === 'get_codex_status') {

--- a/src/components/features/settings/sections/ExternalAgentRuntimeSettings.tsx
+++ b/src/components/features/settings/sections/ExternalAgentRuntimeSettings.tsx
@@ -149,10 +149,13 @@ export function ExternalAgentRuntimeSettings({
     setupResult?.installed ?? codexRuntime?.installStatus === 'installed',
   );
   const authenticated = isAuthenticated(effectiveAuthStatus);
-  const toolsReady = Boolean(
-    setupResult?.pluginMarketplaceConfigured && setupResult?.mcpConfigured,
+  const nativeToolsReady = Boolean(
+    codexRuntime?.ready && codexRuntime.capabilities.structuredToolCalls,
   );
-  const runtimeReady = Boolean(setupResult?.ready || (codexRuntime?.ready && toolsReady));
+  const toolsReady = Boolean(
+    nativeToolsReady || (setupResult?.pluginMarketplaceConfigured && setupResult?.mcpConfigured),
+  );
+  const runtimeReady = Boolean(setupResult?.ready || nativeToolsReady);
   const requiresLogin = Boolean(
     codexInstalled &&
     (setupResult?.requiresLogin ||
@@ -182,7 +185,13 @@ export function ExternalAgentRuntimeSettings({
         },
       );
       setSetupResult(result);
-      if (!result.ready && result.installed && !result.requiresLogin && result.message) {
+      if (
+        !result.ready &&
+        !nativeToolsReady &&
+        result.installed &&
+        !result.requiresLogin &&
+        result.message
+      ) {
         setActionError(result.message);
       }
       refreshExternalAgentStatus();
@@ -191,7 +200,7 @@ export function ExternalAgentRuntimeSettings({
     } finally {
       setIsConfiguring(false);
     }
-  }, [codexSelected, projectPath, refreshExternalAgentStatus]);
+  }, [codexSelected, nativeToolsReady, projectPath, refreshExternalAgentStatus]);
 
   useEffect(() => {
     if (!codexSelected) {
@@ -295,7 +304,7 @@ export function ExternalAgentRuntimeSettings({
     if (!codexInstalled) {
       return setupResult?.message ?? codexRuntime?.reason ?? 'Codex CLI was not found.';
     }
-    if (runtimeReady) return 'Codex is ready with OpenReelio tools.';
+    if (runtimeReady) return 'Codex is ready with OpenReelio app tools.';
     if (requiresLogin) return 'Sign in to Codex to continue.';
     if (effectiveAuthStatus === 'error') {
       return (
@@ -438,7 +447,7 @@ export function ExternalAgentRuntimeSettings({
             </div>
           </div>
 
-          {actionError && (
+          {actionError && !runtimeReady && (
             <p className="mt-2 rounded border border-yellow-600/20 bg-yellow-600/10 px-2 py-1.5 text-xs leading-5 text-yellow-200">
               {actionError}
             </p>

--- a/src/components/shared/ErrorOverlay.test.tsx
+++ b/src/components/shared/ErrorOverlay.test.tsx
@@ -7,11 +7,9 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import {
-  ErrorOverlay,
-  useErrorOverlay,
-  categorizeError,
-} from './ErrorOverlay';
+import { ErrorOverlay } from './ErrorOverlay';
+import { categorizeError } from './errorOverlayModel';
+import { useErrorOverlay } from './useErrorOverlay';
 
 describe('ErrorOverlay', () => {
   beforeEach(() => {
@@ -39,12 +37,7 @@ describe('ErrorOverlay', () => {
     });
 
     it('should display custom title', () => {
-      render(
-        <ErrorOverlay
-          error={new Error('Test')}
-          title="Custom Error Title"
-        />
-      );
+      render(<ErrorOverlay error={new Error('Test')} title="Custom Error Title" />);
       expect(screen.getByText('Custom Error Title')).toBeInTheDocument();
     });
   });
@@ -55,25 +48,19 @@ describe('ErrorOverlay', () => {
 
   describe('severity levels', () => {
     it('should render warning severity with correct styling', () => {
-      render(
-        <ErrorOverlay error={new Error('Warning')} severity="warning" />
-      );
+      render(<ErrorOverlay error={new Error('Warning')} severity="warning" />);
       const dialog = screen.getByRole('alertdialog');
       expect(dialog).toHaveClass('warning');
     });
 
     it('should render error severity with correct styling', () => {
-      render(
-        <ErrorOverlay error={new Error('Error')} severity="error" />
-      );
+      render(<ErrorOverlay error={new Error('Error')} severity="error" />);
       const dialog = screen.getByRole('alertdialog');
       expect(dialog).toHaveClass('error');
     });
 
     it('should render critical severity with correct styling', () => {
-      render(
-        <ErrorOverlay error={new Error('Critical')} severity="critical" />
-      );
+      render(<ErrorOverlay error={new Error('Critical')} severity="critical" />);
       const dialog = screen.getByRole('alertdialog');
       expect(dialog).toHaveClass('critical');
     });
@@ -92,12 +79,7 @@ describe('ErrorOverlay', () => {
   describe('dismiss behavior', () => {
     it('should call onDismiss when dismiss button is clicked', () => {
       const onDismiss = vi.fn();
-      render(
-        <ErrorOverlay
-          error={new Error('Test')}
-          onDismiss={onDismiss}
-        />
-      );
+      render(<ErrorOverlay error={new Error('Test')} onDismiss={onDismiss} />);
 
       fireEvent.click(screen.getByText('Dismiss'));
       expect(onDismiss).toHaveBeenCalledTimes(1);
@@ -105,11 +87,7 @@ describe('ErrorOverlay', () => {
 
     it('should not show dismiss button for critical errors', () => {
       render(
-        <ErrorOverlay
-          error={new Error('Critical')}
-          severity="critical"
-          onDismiss={vi.fn()}
-        />
+        <ErrorOverlay error={new Error('Critical')} severity="critical" onDismiss={vi.fn()} />,
       );
 
       expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
@@ -117,13 +95,7 @@ describe('ErrorOverlay', () => {
 
     it('should close on Escape key for non-critical errors', () => {
       const onDismiss = vi.fn();
-      render(
-        <ErrorOverlay
-          error={new Error('Test')}
-          severity="warning"
-          onDismiss={onDismiss}
-        />
-      );
+      render(<ErrorOverlay error={new Error('Test')} severity="warning" onDismiss={onDismiss} />);
 
       fireEvent.keyDown(document, { key: 'Escape' });
       expect(onDismiss).toHaveBeenCalledTimes(1);
@@ -132,11 +104,7 @@ describe('ErrorOverlay', () => {
     it('should not close on Escape key for critical errors', () => {
       const onDismiss = vi.fn();
       render(
-        <ErrorOverlay
-          error={new Error('Critical')}
-          severity="critical"
-          onDismiss={onDismiss}
-        />
+        <ErrorOverlay error={new Error('Critical')} severity="critical" onDismiss={onDismiss} />,
       );
 
       fireEvent.keyDown(document, { key: 'Escape' });
@@ -151,48 +119,27 @@ describe('ErrorOverlay', () => {
   describe('retry/recovery action', () => {
     it('should show retry button when onRetry is provided', () => {
       const onRetry = vi.fn();
-      render(
-        <ErrorOverlay
-          error={new Error('Test')}
-          onRetry={onRetry}
-        />
-      );
+      render(<ErrorOverlay error={new Error('Test')} onRetry={onRetry} />);
 
       expect(screen.getByText('Retry')).toBeInTheDocument();
     });
 
     it('should call onRetry when retry button is clicked', () => {
       const onRetry = vi.fn();
-      render(
-        <ErrorOverlay
-          error={new Error('Test')}
-          onRetry={onRetry}
-        />
-      );
+      render(<ErrorOverlay error={new Error('Test')} onRetry={onRetry} />);
 
       fireEvent.click(screen.getByText('Retry'));
       expect(onRetry).toHaveBeenCalledTimes(1);
     });
 
     it('should show custom recovery label', () => {
-      render(
-        <ErrorOverlay
-          error={new Error('Test')}
-          onRetry={vi.fn()}
-          retryLabel="Try Again"
-        />
-      );
+      render(<ErrorOverlay error={new Error('Test')} onRetry={vi.fn()} retryLabel="Try Again" />);
 
       expect(screen.getByText('Try Again')).toBeInTheDocument();
     });
 
     it('should show reload button for critical errors', () => {
-      render(
-        <ErrorOverlay
-          error={new Error('Critical')}
-          severity="critical"
-        />
-      );
+      render(<ErrorOverlay error={new Error('Critical')} severity="critical" />);
 
       expect(screen.getByText('Reload Application')).toBeInTheDocument();
     });
@@ -207,12 +154,7 @@ describe('ErrorOverlay', () => {
       const error = new Error('Test error');
       error.stack = 'Error: Test error\n    at test.ts:1:1';
 
-      render(
-        <ErrorOverlay
-          error={error}
-          showDetails={true}
-        />
-      );
+      render(<ErrorOverlay error={error} showDetails={true} />);
 
       expect(screen.getByText(/Error Details/i)).toBeInTheDocument();
     });
@@ -221,12 +163,7 @@ describe('ErrorOverlay', () => {
       const error = new Error('Test error');
       error.stack = 'Error: Test error\n    at test.ts:1:1';
 
-      render(
-        <ErrorOverlay
-          error={error}
-          showDetails={true}
-        />
-      );
+      render(<ErrorOverlay error={error} showDetails={true} />);
 
       // Click to expand details
       fireEvent.click(screen.getByText(/Error Details/i));
@@ -234,9 +171,7 @@ describe('ErrorOverlay', () => {
     });
 
     it('should not show details by default', () => {
-      render(
-        <ErrorOverlay error={new Error('Test')} />
-      );
+      render(<ErrorOverlay error={new Error('Test')} />);
 
       expect(screen.queryByText(/Error Details/i)).not.toBeInTheDocument();
     });
@@ -253,7 +188,7 @@ describe('ErrorOverlay', () => {
           error={new Error('Test')}
           componentStack="in MyComponent\nin ParentComponent"
           showDetails={true}
-        />
+        />,
       );
 
       fireEvent.click(screen.getByText(/Error Details/i));

--- a/src/components/shared/ErrorOverlay.tsx
+++ b/src/components/shared/ErrorOverlay.tsx
@@ -14,139 +14,14 @@
  * @module components/shared/ErrorOverlay
  */
 
+import { useCallback, useEffect, useId } from 'react';
 import {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useState,
-} from 'react';
-
-// =============================================================================
-// Types
-// =============================================================================
-
-export type ErrorSeverity = 'warning' | 'error' | 'critical';
-
-export type ErrorCategory = 'network' | 'ffmpeg' | 'render' | 'ipc' | 'unknown';
-
-export interface ErrorOverlayProps {
-  /** The error to display */
-  error: Error | null;
-  /** Error severity level */
-  severity?: ErrorSeverity;
-  /** Custom title for the error */
-  title?: string;
-  /** Callback when dismissed */
-  onDismiss?: () => void;
-  /** Callback for retry action */
-  onRetry?: () => void;
-  /** Custom label for retry button */
-  retryLabel?: string;
-  /** Whether to show error details (stack trace) */
-  showDetails?: boolean;
-  /** React component stack (from error boundary) */
-  componentStack?: string;
-}
-
-export interface UseErrorOverlayOptions {
-  /** Default severity for errors */
-  defaultSeverity?: ErrorSeverity;
-}
-
-export interface ErrorState {
-  error: Error;
-  severity: ErrorSeverity;
-  title?: string;
-}
-
-// =============================================================================
-// Error Categorization
-// =============================================================================
-
-/**
- * Categorizes an error based on its message and name.
- * Used to provide more helpful error messages and recovery suggestions.
- */
-export function categorizeError(error: Error): ErrorCategory {
-  const message = error.message.toLowerCase();
-  const name = error.name.toLowerCase();
-
-  // Network errors
-  if (
-    message.includes('fetch') ||
-    message.includes('network') ||
-    message.includes('cors') ||
-    message.includes('timeout')
-  ) {
-    return 'network';
-  }
-
-  // FFmpeg errors
-  if (
-    message.includes('ffmpeg') ||
-    message.includes('encoder') ||
-    message.includes('codec')
-  ) {
-    return 'ffmpeg';
-  }
-
-  // Render/chunk errors
-  if (
-    name === 'chunkloaderror' ||
-    message.includes('chunk') ||
-    message.includes('loading')
-  ) {
-    return 'render';
-  }
-
-  // Tauri IPC errors
-  if (
-    message.includes('ipc') ||
-    message.includes('invoke') ||
-    message.includes('tauri')
-  ) {
-    return 'ipc';
-  }
-
-  return 'unknown';
-}
-
-/**
- * Get user-friendly title based on error category.
- */
-function getErrorTitle(category: ErrorCategory): string {
-  switch (category) {
-    case 'network':
-      return 'Network Error';
-    case 'ffmpeg':
-      return 'Video Processing Error';
-    case 'render':
-      return 'Render Error';
-    case 'ipc':
-      return 'Application Error';
-    default:
-      return 'Error';
-  }
-}
-
-/**
- * Get recovery suggestion based on error category.
- */
-function getRecoverySuggestion(category: ErrorCategory): string {
-  switch (category) {
-    case 'network':
-      return 'Please check your internet connection and try again.';
-    case 'ffmpeg':
-      return 'There was an issue processing the video. Try a different format or codec.';
-    case 'render':
-      return 'The application encountered a rendering issue. Please reload.';
-    case 'ipc':
-      return 'Communication with the backend failed. Please restart the application.';
-    default:
-      return 'An unexpected error occurred.';
-  }
-}
+  categorizeError,
+  getErrorTitle,
+  getRecoverySuggestion,
+  type ErrorOverlayProps,
+  type ErrorSeverity,
+} from './errorOverlayModel';
 
 // =============================================================================
 // Styles
@@ -411,9 +286,7 @@ export function ErrorOverlay({
               <pre style={styles.stack}>{error.stack}</pre>
               {componentStack && (
                 <>
-                  <p style={{ ...styles.summary, marginTop: '12px' }}>
-                    Component Stack
-                  </p>
+                  <p style={{ ...styles.summary, marginTop: '12px' }}>Component Stack</p>
                   <pre style={styles.componentStack}>{componentStack}</pre>
                 </>
               )}
@@ -454,74 +327,6 @@ export function ErrorOverlay({
       </div>
     </div>
   );
-}
-
-// =============================================================================
-// useErrorOverlay Hook
-// =============================================================================
-
-interface ShowErrorOptions {
-  severity?: ErrorSeverity;
-  title?: string;
-}
-
-/**
- * Hook for managing error overlay state.
- *
- * @example
- * ```tsx
- * const { showError, clearError, ErrorOverlayComponent } = useErrorOverlay();
- *
- * try {
- *   await riskyOperation();
- * } catch (error) {
- *   showError(error as Error, { severity: 'error' });
- * }
- *
- * return <ErrorOverlayComponent />;
- * ```
- */
-export function useErrorOverlay(options: UseErrorOverlayOptions = {}) {
-  const { defaultSeverity = 'error' } = options;
-  const [errorState, setErrorState] = useState<ErrorState | null>(null);
-
-  const showError = useCallback(
-    (error: Error, opts: ShowErrorOptions = {}) => {
-      setErrorState({
-        error,
-        severity: opts.severity ?? defaultSeverity,
-        title: opts.title,
-      });
-    },
-    [defaultSeverity]
-  );
-
-  const clearError = useCallback(() => {
-    setErrorState(null);
-  }, []);
-
-  const ErrorOverlayComponent = useMemo(
-    () =>
-      function ErrorOverlayWrapper() {
-        return (
-          <ErrorOverlay
-            error={errorState?.error ?? null}
-            severity={errorState?.severity}
-            title={errorState?.title}
-            onDismiss={clearError}
-          />
-        );
-      },
-    [errorState, clearError]
-  );
-
-  return {
-    error: errorState?.error ?? null,
-    errorState,
-    showError,
-    clearError,
-    ErrorOverlayComponent,
-  };
 }
 
 // =============================================================================

--- a/src/components/shared/errorOverlayModel.ts
+++ b/src/components/shared/errorOverlayModel.ts
@@ -1,0 +1,106 @@
+export type ErrorSeverity = 'warning' | 'error' | 'critical';
+
+export type ErrorCategory = 'network' | 'ffmpeg' | 'render' | 'ipc' | 'unknown';
+
+export interface ErrorOverlayProps {
+  /** The error to display */
+  error: Error | null;
+  /** Error severity level */
+  severity?: ErrorSeverity;
+  /** Custom title for the error */
+  title?: string;
+  /** Callback when dismissed */
+  onDismiss?: () => void;
+  /** Callback for retry action */
+  onRetry?: () => void;
+  /** Custom label for retry button */
+  retryLabel?: string;
+  /** Whether to show error details (stack trace) */
+  showDetails?: boolean;
+  /** React component stack (from error boundary) */
+  componentStack?: string;
+}
+
+export interface UseErrorOverlayOptions {
+  /** Default severity for errors */
+  defaultSeverity?: ErrorSeverity;
+}
+
+export interface ErrorState {
+  error: Error;
+  severity: ErrorSeverity;
+  title?: string;
+}
+
+export interface ShowErrorOptions {
+  severity?: ErrorSeverity;
+  title?: string;
+}
+
+/**
+ * Categorizes an error based on its message and name.
+ * Used to provide more helpful error messages and recovery suggestions.
+ */
+export function categorizeError(error: Error): ErrorCategory {
+  const message = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+
+  if (
+    message.includes('fetch') ||
+    message.includes('network') ||
+    message.includes('cors') ||
+    message.includes('timeout')
+  ) {
+    return 'network';
+  }
+
+  if (message.includes('ffmpeg') || message.includes('encoder') || message.includes('codec')) {
+    return 'ffmpeg';
+  }
+
+  if (name === 'chunkloaderror' || message.includes('chunk') || message.includes('loading')) {
+    return 'render';
+  }
+
+  if (message.includes('ipc') || message.includes('invoke') || message.includes('tauri')) {
+    return 'ipc';
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Get user-friendly title based on error category.
+ */
+export function getErrorTitle(category: ErrorCategory): string {
+  switch (category) {
+    case 'network':
+      return 'Network Error';
+    case 'ffmpeg':
+      return 'Video Processing Error';
+    case 'render':
+      return 'Render Error';
+    case 'ipc':
+      return 'Application Error';
+    default:
+      return 'Error';
+  }
+}
+
+/**
+ * Get recovery suggestion based on error category.
+ */
+export function getRecoverySuggestion(category: ErrorCategory): string {
+  switch (category) {
+    case 'network':
+      return 'Please check your internet connection and try again.';
+    case 'ffmpeg':
+      return 'There was an issue processing the video. Try a different format or codec.';
+    case 'render':
+      return 'The application encountered a rendering issue. Please reload.';
+    case 'ipc':
+      return 'Communication with the backend failed. Please restart the application.';
+    default:
+      return 'An unexpected error occurred.';
+  }
+}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -4,11 +4,7 @@
  * Components used across multiple features.
  */
 
-export {
-  ErrorBoundary,
-  type ErrorBoundaryProps,
-  type FallbackProps,
-} from './ErrorBoundary';
+export { ErrorBoundary, type ErrorBoundaryProps, type FallbackProps } from './ErrorBoundary';
 
 export { withErrorBoundary, type WithErrorBoundaryOptions } from './withErrorBoundary';
 
@@ -22,15 +18,13 @@ export {
   ExportErrorBoundary,
 } from './FeatureErrorBoundaries';
 
-export {
-  ErrorOverlay,
-  useErrorOverlay,
-  categorizeError,
-} from './ErrorOverlay';
+export { ErrorOverlay } from './ErrorOverlay';
+export { useErrorOverlay } from './useErrorOverlay';
+export { categorizeError } from './errorOverlayModel';
 export type {
   ErrorSeverity,
   ErrorCategory,
   ErrorOverlayProps,
   UseErrorOverlayOptions,
   ErrorState,
-} from './ErrorOverlay';
+} from './errorOverlayModel';

--- a/src/components/shared/useErrorOverlay.ts
+++ b/src/components/shared/useErrorOverlay.ts
@@ -1,0 +1,60 @@
+import { createElement, useCallback, useMemo, useState, type ComponentType } from 'react';
+import { ErrorOverlay } from './ErrorOverlay';
+import type { ErrorState, ShowErrorOptions, UseErrorOverlayOptions } from './errorOverlayModel';
+
+/**
+ * Hook for managing error overlay state.
+ *
+ * @example
+ * ```tsx
+ * const { showError, clearError, ErrorOverlayComponent } = useErrorOverlay();
+ *
+ * try {
+ *   await riskyOperation();
+ * } catch (error) {
+ *   showError(error as Error, { severity: 'error' });
+ * }
+ *
+ * return <ErrorOverlayComponent />;
+ * ```
+ */
+export function useErrorOverlay(options: UseErrorOverlayOptions = {}) {
+  const { defaultSeverity = 'error' } = options;
+  const [errorState, setErrorState] = useState<ErrorState | null>(null);
+
+  const showError = useCallback(
+    (error: Error, opts: ShowErrorOptions = {}) => {
+      setErrorState({
+        error,
+        severity: opts.severity ?? defaultSeverity,
+        title: opts.title,
+      });
+    },
+    [defaultSeverity],
+  );
+
+  const clearError = useCallback(() => {
+    setErrorState(null);
+  }, []);
+
+  const ErrorOverlayComponent = useMemo<ComponentType>(
+    () =>
+      function ErrorOverlayWrapper() {
+        return createElement(ErrorOverlay, {
+          error: errorState?.error ?? null,
+          severity: errorState?.severity,
+          title: errorState?.title,
+          onDismiss: clearError,
+        });
+      },
+    [errorState, clearError],
+  );
+
+  return {
+    error: errorState?.error ?? null,
+    errorState,
+    showError,
+    clearError,
+    ErrorOverlayComponent,
+  };
+}

--- a/src/components/timeline/TimelineOperationsContext.ts
+++ b/src/components/timeline/TimelineOperationsContext.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, createElement, useContext, type ReactElement, type ReactNode } from 'react';
 import type {
   AssetDropData,
   ClipMoveData,
@@ -95,12 +95,8 @@ export interface TimelineOperationsProviderProps {
 export function TimelineOperationsProvider({
   children,
   operations,
-}: TimelineOperationsProviderProps): JSX.Element {
-  return (
-    <TimelineOperationsContext.Provider value={operations}>
-      {children}
-    </TimelineOperationsContext.Provider>
-  );
+}: TimelineOperationsProviderProps): ReactElement {
+  return createElement(TimelineOperationsContext.Provider, { value: operations }, children);
 }
 
 // =============================================================================

--- a/src/hooks/useAudioPlayback.ts
+++ b/src/hooks/useAudioPlayback.ts
@@ -486,7 +486,7 @@ export function useAudioPlayback({
 
       return buffer !== null;
     },
-    [assets, loadAudioBuffer],
+    [assets, loadAudioBuffer, syncFailedAssetIds],
   );
 
   /**

--- a/src/hooks/useKeyboardScope.ts
+++ b/src/hooks/useKeyboardScope.ts
@@ -16,6 +16,7 @@
 
 import {
   createContext,
+  createElement,
   useCallback,
   useContext,
   useEffect,
@@ -23,6 +24,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
   type ReactNode,
 } from 'react';
 
@@ -160,7 +162,7 @@ const KeyboardScopeContext = createContext<KeyboardScopeContextValue | null>(nul
  * Manages all registered keyboard scopes and dispatches events
  * to the scope with the highest z-index.
  */
-export function KeyboardScopeProvider({ children }: { children: ReactNode }) {
+export function KeyboardScopeProvider({ children }: { children: ReactNode }): ReactElement {
   const scopesRef = useRef<Map<string, KeyboardScope>>(new Map());
   const [, setUpdateCounter] = useState(0);
 
@@ -168,15 +170,21 @@ export function KeyboardScopeProvider({ children }: { children: ReactNode }) {
     setUpdateCounter((c) => c + 1);
   }, []);
 
-  const registerScope = useCallback((scope: KeyboardScope) => {
-    scopesRef.current.set(scope.id, scope);
-    forceUpdate();
-  }, [forceUpdate]);
+  const registerScope = useCallback(
+    (scope: KeyboardScope) => {
+      scopesRef.current.set(scope.id, scope);
+      forceUpdate();
+    },
+    [forceUpdate],
+  );
 
-  const unregisterScope = useCallback((scopeId: string) => {
-    scopesRef.current.delete(scopeId);
-    forceUpdate();
-  }, [forceUpdate]);
+  const unregisterScope = useCallback(
+    (scopeId: string) => {
+      scopesRef.current.delete(scopeId);
+      forceUpdate();
+    },
+    [forceUpdate],
+  );
 
   const getActiveScope = useCallback((): KeyboardScope | null => {
     let highest: KeyboardScope | null = null;
@@ -228,14 +236,10 @@ export function KeyboardScopeProvider({ children }: { children: ReactNode }) {
       getActiveScope,
       _forceUpdate: forceUpdate,
     }),
-    [forceUpdate, getActiveScope, registerScope, unregisterScope]
+    [forceUpdate, getActiveScope, registerScope, unregisterScope],
   );
 
-  return (
-    <KeyboardScopeContext.Provider value={contextValue}>
-      {children}
-    </KeyboardScopeContext.Provider>
-  );
+  return createElement(KeyboardScopeContext.Provider, { value: contextValue }, children);
 }
 
 // =============================================================================
@@ -284,7 +288,7 @@ export function useScopedShortcuts(
   scopeId: string,
   zIndex: number,
   shortcuts: Record<string, ShortcutHandler>,
-  options: ScopedShortcutsOptions = {}
+  options: ScopedShortcutsOptions = {},
 ): void {
   const context = useContext(KeyboardScopeContext);
   const { allowInInputs = false, enabled = true } = options;
@@ -319,7 +323,7 @@ export function useRegisterShortcuts(
   scopeId: string,
   priority: ScopePriorityLevel,
   shortcuts: Record<string, ShortcutHandler>,
-  options: ShortcutOptions = {}
+  options: ShortcutOptions = {},
 ): void {
   useScopedShortcuts(scopeId, priority, shortcuts, options);
 }
@@ -352,7 +356,7 @@ export function useIsShortcutsActive(scopeId?: string): boolean {
 export function useScopedKeyHandler(
   scopeId: string,
   shortcuts: Record<string, ShortcutHandler>,
-  options: ShortcutOptions = {}
+  options: ShortcutOptions = {},
 ): (event: ReactKeyboardEvent) => void {
   const context = useContext(KeyboardScopeContext);
   const { allowInInputs = false, enabled = true } = options;
@@ -378,7 +382,7 @@ export function useScopedKeyHandler(
         handler();
       }
     },
-    [allowInInputs, context, enabled, scopeId, shortcuts]
+    [allowInInputs, context, enabled, scopeId, shortcuts],
   );
 }
 

--- a/src/hooks/useTranscriptEditing.ts
+++ b/src/hooks/useTranscriptEditing.ts
@@ -12,7 +12,10 @@ import { usePlaybackStore } from '@/stores/playbackStore';
 import { useProjectStore } from '@/stores/projectStore';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { applyProjectState, refreshProjectState } from '@/utils/stateRefreshHelper';
-import { getClipSourceTimeAtTimelineTime, getClipTimelineTimeAtSourceTime } from '@/utils/clipTiming';
+import {
+  getClipSourceTimeAtTimelineTime,
+  getClipTimelineTimeAtSourceTime,
+} from '@/utils/clipTiming';
 
 const logger = createLogger('useTranscriptEditing');
 
@@ -116,9 +119,11 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
     setSelection(null);
   }, [clipInfo?.clipId]);
 
+  const selectedAssetId = clipInfo?.assetId ?? null;
+
   // Load transcript words when clip selection changes
   useEffect(() => {
-    if (!clipInfo) {
+    if (!selectedAssetId) {
       setWords([]);
       setError(null);
       return;
@@ -129,7 +134,7 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
     setError(null);
 
     invoke<TranscriptWord[]>('get_transcript_words', {
-      assetId: clipInfo.assetId,
+      assetId: selectedAssetId,
     })
       .then((result) => {
         if (!cancelled && isMountedRef.current) {
@@ -150,7 +155,7 @@ export function useTranscriptEditing(): UseTranscriptEditingReturn {
     return () => {
       cancelled = true;
     };
-  }, [clipInfo?.assetId, loadTrigger]);
+  }, [selectedAssetId, loadTrigger]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
### **User description**
## Description

Adds OpenReelio-native Codex dynamic tools so embedded Codex sessions can read host context, project state, timeline snapshots, asset summaries, command schemas, and execute approved edit commands through the OpenReelio command log. The branch also refreshes legacy Codex session links for the new tool protocol, treats native structured app tools as ready in settings, and keeps related UI/helper modules maintainable.

## Related Issue

Closes #682

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added Codex app-server dynamic tool support for OpenReelio host context, project/timeline/assets reads, command schema reads, and approval-gated command execution.
- Added Codex OpenReelio tool protocol metadata so stale persisted sessions start fresh, and updated settings readiness to prefer native structured app tools when available.
- Split timeline dock, error overlay helpers, and JSX-free provider modules while stabilizing media hook dependencies and simplifying effect count exports.

## Screenshots / Videos

N/A. No screenshot-required visual workflow changes are included.

## Testing

### Test Environment

- OS: WSL2 Linux 6.6.87.2-microsoft-standard-WSL2
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

Targeted Vitest command used locally: `npm run test:run -- src/agents/external/adapters/CodexAppServerClient.test.ts src/agents/external/adapters/CodexNotificationMapper.test.ts src/agents/external/adapters/CodexReferenceAdapter.test.ts src/agents/external/chatRuntime.test.ts src/agents/external/sessionPersistence.test.ts src/components/features/settings/sections/ExternalAgentRuntimeSettings.test.tsx src/components/shared/ErrorOverlay.test.tsx src/hooks/useKeyboardScope.test.tsx`.

Repository hooks also passed during commits: `npm run version:check`, `npm run type-check`, and `npm run lint`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

No dependent branch is required. `cargo test` was not run because this change only touches TypeScript/React source and tests.


___

### **PR Type**
Enhancement, Refactoring, Tests


___

### **Description**
- Adds OpenReelio-native Codex dynamic tools for host context.

- Implements approval-gated command execution for agent edits.

- Refreshes legacy Codex sessions to ensure protocol compatibility.

- Refactors UI components and providers for better maintainability.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph CodexRuntime
    A["CodexAppServerClient"] -- "startThread" --> B["Dynamic Tools"]
    B -- "host_context" --> C["Project State"]
    B -- "command_execute" --> D["Approval Flow"]
  end
  D -- "accept" --> E["Backend Command Log"]
  E -- "refresh" --> F["Project Store"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>openreelioCodexTools.ts</strong><dd><code>Implement OpenReelio-specific dynamic tools for Codex</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-78b40377e0e9fccbf98b98f67b7c52e322184ae79113f5293cc6ad0e085d548d">+510/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CodexReferenceAdapter.ts</strong><dd><code>Integrate dynamic tools and developer instructions into sessions</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-24a34cb421e858c46bdd7ca2827ea3a87dd8fc920e92fbd83134b770ed17ad96">+69/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexAppServerClient.ts</strong><dd><code>Extend client to support experimental capabilities and tools</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-56fc3e9dbc1425f3ef07598b3ecf7e21c4032c8d9ab52bc5b1ca686fe2cdff8b">+50/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExternalAgentRuntimeSettings.tsx</strong><dd><code>Update settings to recognize native app tools readiness</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-e3caa2a28b4e47864c95ce6c1dc9fc1ad2c6c81eb14eb9cd79d3e76b9e1b3241">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>chatRuntime.ts</strong><dd><code>Add protocol versioning to handle legacy Codex sessions</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-f92a170cff36d13bbdb22254f87f676115c20d195016519dd5b5bd43c00606e7">+32/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAudioPlayback.ts</strong><dd><code>Stabilize media hook dependencies for audio playback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>EditorTimelineDockPanel.tsx</strong><dd><code>Extract timeline dock panel into a standalone component</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-a00d72d7bf37830952decfd7b2c9be3ad95f04acefbd3463ae5c2a0e404b90be">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>errorOverlayModel.ts</strong><dd><code>Decouple error overlay logic from React components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-839cbcf6f3945bd2f856db26062ac569542619056ee27a4e1c253a28f2195a43">+106/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CodexReferenceAdapter.test.ts</strong><dd><code>Add tests for dynamic tool calls and approvals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-fdfb6a18bfafa2be87c1e63fd4c5113048bac88026cc6372c364ec3fd683d53a">+237/-17</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>effectCategoryData.tsx</strong><dd><code>Simplify effect count export to a constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-e4c7a7d11017ed8ba5466b2a10a3db933fcdce46cbe3e04e7928310ba988a738">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>CodexAppServerClient.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-7db5424c715334f55f416c92dbb7e71f5cf53d07ff8104fe3ba2cf22121a4ca0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexNotificationMapper.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-1b115289fa309632dcd76c2918024ed7e5c606273c75075a31943c976ce87f4a">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexNotificationMapper.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-a07cd2403272255cb79fd6b29cc557b2bb4db8dc924774ff50b7747e38939e28">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatRuntime.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-672bc6f38ffd376b8a5cef8a466aec15fe47ae89d5bf15c48f0c05377e50d664">+40/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sessionPersistence.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-28cd29c953b2c1f22a87657d6e15d60e793344dec34db2ae18c65b5f9a2628c2">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sessionPersistence.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-b68b278a05f033ef3e191b605d7cb33417a8a140baf5dc83b25a3ff54d195878">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-2d0b9c54feb5fb1a2e861182b442247f5d7ff0698e9582d8771b378fcea5f578">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EditorPanels.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-09c35f0f54628a35f51a56137bc0b05240002f64fdda095117d3a61af500c67f">+3/-93</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EditorView.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-382f457b2b2ae7d56d3a83f74c92b764a355a1f23c23ae7bb103d3ad306a63da">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EffectsBrowser.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-d92d89cbd20c7a0468740ccb4a18a35d63e7bd1de0478e08a52c9dcf8edcdeea">+7/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExternalAgentRuntimeSettings.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-90ac50c0b7ecf48240cc3e9f61d5f3fb34b121735ca5a798bbe18efd0809df5b">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ErrorOverlay.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-31de4a8f00b0308d7edde490de4c0a34de1f6c8b5cecac354718f70cff7092e2">+19/-84</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ErrorOverlay.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-f15c90bfeb4abb49f4d3ee6724fb0ba759877b7c84a0525f3c14a065381ace7e">+8/-203</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-9e3494d8109cd2c182b7f318d6f6763b90109d449036d661a06fa9a1b2aed80f">+5/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useErrorOverlay.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-64fdff8c5fc47419c38653b124b4d164c9f8dec3c5f7343a782dc5a463b9e90d">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimelineOperationsContext.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-cc7b8f07a82737969c1ae193ae9b911e8bc8cf00aefde1476276fbf4d563b15f">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useKeyboardScope.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-1211d5c001bbe7042515f76f7063ddc96fab4b924332032a50403092504fbe11">+23/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useTranscriptEditing.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/683/files#diff-de912b25ad0d8f1b3b71d38b2d1d53e7f71b989c96eb5a29c95868697e87ea7e">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic tool support for Codex integration, enabling command execution, context information, and project asset access with approval workflows.
  * Improved external session persistence with version compatibility tracking.

* **Bug Fixes**
  * Enhanced error categorization and display with improved recovery suggestions.

* **Improvements**
  * Refactored timeline panel UI for better modularity.
  * Optimized effects browser rendering and data handling.
  * Updated error overlay messaging for clearer user feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openreelio/openreelio/pull/683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->