### PR TITLE
feat(ai): harden Codex runtime and approval-gated plans

### DIFF
--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -9,6 +9,7 @@ use openreelio_core::ipc::CommandPayload;
 use serde_json::Value;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 #[derive(Args)]
 pub struct McpAction {
@@ -29,6 +30,11 @@ struct McpServerState {
     approval_token: Option<String>,
     approval_expires_at_ms: Option<i64>,
     approval_expiry_error: Option<String>,
+    approval_plan_id: Option<String>,
+    approval_project_id: Option<String>,
+    approval_runtime_id: Option<String>,
+    approval_session_id: Option<String>,
+    approval_consumed: Arc<Mutex<bool>>,
 }
 
 pub fn execute(action: McpAction) -> anyhow::Result<()> {
@@ -40,6 +46,11 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
         approval_token: std::env::var("OPENREELIO_MCP_APPROVAL_TOKEN").ok(),
         approval_expires_at_ms,
         approval_expiry_error,
+        approval_plan_id: read_trimmed_env("OPENREELIO_MCP_APPROVAL_PLAN_ID"),
+        approval_project_id: read_trimmed_env("OPENREELIO_MCP_APPROVAL_PROJECT_ID"),
+        approval_runtime_id: read_trimmed_env("OPENREELIO_MCP_APPROVAL_RUNTIME_ID"),
+        approval_session_id: read_trimmed_env("OPENREELIO_MCP_APPROVAL_SESSION_ID"),
+        approval_consumed: Arc::new(Mutex::new(false)),
     };
 
     if action.stdio {
@@ -64,10 +75,10 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
 
 impl McpServerState {
     fn has_active_approval_token(&self) -> bool {
-        self.active_approval_token().is_ok()
+        self.active_approval_token(None).is_ok()
     }
 
-    fn active_approval_token(&self) -> Result<&str, ToolError> {
+    fn active_approval_token(&self, plan_id: Option<&str>) -> Result<&str, ToolError> {
         let Some(token) = self.approval_token.as_deref() else {
             return Err(ToolError::PermissionDenied(
                 "openreelio.plan.apply requires an approval token".to_string(),
@@ -88,7 +99,38 @@ impl McpServerState {
             }
         }
 
+        if *self.approval_consumed.lock().map_err(|_| {
+            ToolError::PermissionDenied("approvalToken state is poisoned".to_string())
+        })? {
+            return Err(ToolError::PermissionDenied(
+                "approvalToken has already been consumed".to_string(),
+            ));
+        }
+
+        if let (Some(expected_plan_id), Some(actual_plan_id)) =
+            (self.approval_plan_id.as_deref(), plan_id)
+        {
+            if expected_plan_id != actual_plan_id {
+                return Err(ToolError::PermissionDenied(format!(
+                    "approvalToken is scoped to plan '{expected_plan_id}', not '{actual_plan_id}'"
+                )));
+            }
+        }
+
         Ok(token)
+    }
+
+    fn consume_approval_token(&self) -> Result<(), ToolError> {
+        let mut consumed = self.approval_consumed.lock().map_err(|_| {
+            ToolError::PermissionDenied("approvalToken state is poisoned".to_string())
+        })?;
+        if *consumed {
+            return Err(ToolError::PermissionDenied(
+                "approvalToken has already been consumed".to_string(),
+            ));
+        }
+        *consumed = true;
+        Ok(())
     }
 }
 
@@ -114,6 +156,13 @@ fn read_approval_expiry_from_env() -> (Option<i64>, Option<String>) {
             )),
         ),
     }
+}
+
+fn read_trimmed_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn serve_stdio(state: McpServerState) -> anyhow::Result<()> {
@@ -430,6 +479,7 @@ fn call_tool(state: &McpServerState, name: &str, arguments: Value) -> Result<Val
 
 fn build_host_context(state: &McpServerState) -> Value {
     let project = load_project_summary(state);
+    let approval_grant = build_approval_grant_context(state);
     serde_json::json!({
         "host": {
             "appId": "openreelio",
@@ -466,7 +516,29 @@ fn build_host_context(state: &McpServerState) -> Value {
             "approvalMode": if state.has_active_approval_token() { "approve-mutations" } else { "read-only" },
             "rawMediaAccess": "none",
             "filesystemAccess": if state.project.is_some() { "project-readonly" } else { "none" }
-        }
+        },
+        "approvalGrant": approval_grant
+    })
+}
+
+fn build_approval_grant_context(state: &McpServerState) -> Value {
+    let (consumed, state_error) = match state.approval_consumed.lock() {
+        Ok(consumed) => (*consumed, Value::Null),
+        Err(_) => (true, serde_json::json!("approvalToken state is poisoned")),
+    };
+
+    serde_json::json!({
+        "available": state.has_active_approval_token(),
+        "consumed": consumed,
+        "expiresAtMs": state.approval_expires_at_ms,
+        "expiryError": state.approval_expiry_error,
+        "scopes": {
+            "planId": state.approval_plan_id,
+            "projectId": state.approval_project_id,
+            "runtimeId": state.approval_runtime_id,
+            "sessionId": state.approval_session_id
+        },
+        "stateError": state_error
     })
 }
 
@@ -805,7 +877,17 @@ fn validate_plan(arguments: Value) -> Result<Value, ToolError> {
 }
 
 fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
-    let expected_token = state.active_approval_token()?;
+    state.active_approval_token(None)?;
+
+    let plan_value = arguments
+        .get("plan")
+        .cloned()
+        .ok_or_else(|| ToolError::InvalidArguments("plan is required".to_string()))?;
+    let plan_id = plan_value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::InvalidArguments("plan.id is required".to_string()))?;
+    let expected_token = state.active_approval_token(Some(plan_id))?;
     let actual_token = arguments
         .get("approvalToken")
         .and_then(Value::as_str)
@@ -820,10 +902,6 @@ fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolErr
     let project_path = state.project.as_ref().ok_or_else(|| {
         ToolError::InvalidArguments("A project path is required to apply a plan".to_string())
     })?;
-    let plan_value = arguments
-        .get("plan")
-        .cloned()
-        .ok_or_else(|| ToolError::InvalidArguments("plan is required".to_string()))?;
     let edit_plan: plan::EditPlan = serde_json::from_value(plan_value)
         .map_err(|error| ToolError::InvalidArguments(format!("Invalid plan JSON: {error}")))?;
 
@@ -836,6 +914,8 @@ fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolErr
             "errors": validation_errors,
         }));
     }
+
+    state.consume_approval_token()?;
 
     let mut project = super::load_project(project_path)
         .map_err(|error| ToolError::Execution(error.to_string()))?;
@@ -949,11 +1029,8 @@ mod tests {
 
         let state = McpServerState {
             project: Some(project_path.clone()),
-            client_name: None,
-            client_version: None,
             approval_token: Some("expected-token".to_string()),
-            approval_expires_at_ms: None,
-            approval_expiry_error: None,
+            ..Default::default()
         };
         let plan = serde_json::json!({
             "id": "denied-plan",
@@ -986,6 +1063,57 @@ mod tests {
         assert_eq!(response["error"]["code"], -32001);
         let reopened = openreelio_core::ActiveProject::open(project_path).expect("reopen");
         assert_eq!(reopened.state.op_count, initial_op_count);
+    }
+
+    #[test]
+    fn should_reject_plan_apply_when_approval_token_is_scoped_to_another_plan() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let project_path = temp_dir.path().join("wrong_plan_scope_project");
+        let project =
+            openreelio_core::ActiveProject::create("Wrong Plan Scope", project_path.clone())
+                .expect("project");
+        let sequence_id = project.state.active_sequence_id.clone().expect("sequence");
+        drop(project);
+
+        let state = McpServerState {
+            project: Some(project_path),
+            approval_token: Some("scoped-token".to_string()),
+            approval_plan_id: Some("expected-plan".to_string()),
+            ..Default::default()
+        };
+        let plan = serde_json::json!({
+            "id": "actual-plan",
+            "steps": [{
+                "id": "step-1",
+                "commandType": "AddTrack",
+                "payload": {
+                    "sequenceId": sequence_id,
+                    "name": "Wrong Scope Track",
+                    "kind": "video"
+                },
+                "dependsOn": []
+            }]
+        });
+
+        let response = handle_jsonrpc_request(
+            &state,
+            request(
+                "tools/call",
+                serde_json::json!({
+                    "name": "openreelio.plan.apply",
+                    "arguments": {
+                        "approvalToken": "scoped-token",
+                        "plan": plan
+                    }
+                }),
+            ),
+        );
+
+        assert_eq!(response["error"]["code"], -32001);
+        assert!(response["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("expected-plan"));
     }
 
     #[test]
@@ -1069,11 +1197,9 @@ mod tests {
 
         let state = McpServerState {
             project: Some(project_path.clone()),
-            client_name: None,
-            client_version: None,
             approval_token: Some("expired-token".to_string()),
             approval_expires_at_ms: Some(1),
-            approval_expiry_error: None,
+            ..Default::default()
         };
         let plan = serde_json::json!({
             "id": "expired-plan",
@@ -1130,11 +1256,9 @@ mod tests {
 
         let state = McpServerState {
             project: Some(project_path.clone()),
-            client_name: None,
-            client_version: None,
             approval_token: Some("approved-token".to_string()),
-            approval_expires_at_ms: None,
-            approval_expiry_error: None,
+            approval_plan_id: Some("approved-plan".to_string()),
+            ..Default::default()
         };
         let plan = serde_json::json!({
             "id": "approved-plan",
@@ -1184,6 +1308,37 @@ mod tests {
             .tracks
             .iter()
             .any(|track| track.name == "Approved Track"));
+
+        let replay_response = handle_jsonrpc_request(
+            &state,
+            request(
+                "tools/call",
+                serde_json::json!({
+                    "name": "openreelio.plan.apply",
+                    "arguments": {
+                        "approvalToken": "approved-token",
+                        "plan": {
+                            "id": "approved-plan",
+                            "steps": [{
+                                "id": "step-1",
+                                "commandType": "AddTrack",
+                                "payload": {
+                                    "sequenceId": sequence_id,
+                                    "name": "Replay Track",
+                                    "kind": "video"
+                                },
+                                "dependsOn": []
+                            }]
+                        }
+                    }
+                }),
+            ),
+        );
+        assert_eq!(replay_response["error"]["code"], -32001);
+        assert!(replay_response["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("already been consumed"));
     }
 
     #[test]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,8 +33,8 @@ const e2eBaseUrl = process.env.E2E_BASE_URL ?? `http://${e2eHost}:${e2ePort}`;
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const e2eWebServerCommand =
   e2eServerMode === 'dev'
-    ? `${npmCommand} run dev -- --host ${e2eHost} --port ${e2ePort} --strictPort`
-    : `${npmCommand} run build && ${npmCommand} exec -- vite preview --host ${e2eHost} --port ${e2ePort} --strictPort`;
+    ? `${npmCommand} run dev -- --mode e2e --host ${e2eHost} --port ${e2ePort} --strictPort`
+    : `${npmCommand} run build -- --mode e2e && node scripts/prepare-e2e-fixtures.mjs && ${npmCommand} exec -- vite preview --host ${e2eHost} --port ${e2ePort} --strictPort`;
 
 export default defineConfig({
   testDir: './tests/e2e',

--- a/scripts/prepare-e2e-fixtures.mjs
+++ b/scripts/prepare-e2e-fixtures.mjs
@@ -1,0 +1,8 @@
+import { cp, mkdir } from 'node:fs/promises';
+import { URL } from 'node:url';
+
+const source = new URL('../tests/e2e/fixtures/', import.meta.url);
+const destination = new URL('../dist/tests/e2e/fixtures/', import.meta.url);
+
+await mkdir(destination, { recursive: true });
+await cp(source, destination, { recursive: true });

--- a/src-tauri/src/core/codex.rs
+++ b/src-tauri/src/core/codex.rs
@@ -562,7 +562,7 @@ fn default_codex_models_for_version(version: Option<&str>) -> Vec<CodexModelInfo
     };
 
     entries
-        .into_iter()
+        .iter()
         .map(|(slug, display_name)| CodexModelInfo {
             slug: (*slug).to_string(),
             display_name: (*display_name).to_string(),

--- a/src-tauri/src/core/codex.rs
+++ b/src-tauri/src/core/codex.rs
@@ -5,11 +5,14 @@ use specta::Type;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
-use tokio::time::{timeout, Duration};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout, Duration};
 
 pub const CODEX_CLI_ENV_VAR: &str = "OPENREELIO_CODEX_CLI";
-pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.4";
+pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.5";
 pub const DEFAULT_CODEX_REASONING_EFFORT: &str = "medium";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -34,6 +37,7 @@ pub struct CodexStatusProbeResult {
     pub installed: bool,
     pub version: Option<String>,
     pub auth_status: String,
+    pub app_server_ready: Option<bool>,
     pub reason: Option<String>,
 }
 
@@ -188,6 +192,7 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
                 installed: false,
                 version: None,
                 auth_status: "unknown".to_string(),
+                app_server_ready: None,
                 reason: Some(reason),
             };
         }
@@ -205,6 +210,7 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
                 installed: false,
                 version: None,
                 auth_status: "unknown".to_string(),
+                app_server_ready: None,
                 reason: Some("codex --version timed out".to_string()),
             };
         }
@@ -222,6 +228,7 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
                         installed: true,
                         version,
                         auth_status: "error".to_string(),
+                        app_server_ready: None,
                         reason: Some(reason),
                     };
                 }
@@ -238,6 +245,7 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
                         installed: true,
                         version,
                         auth_status: "error".to_string(),
+                        app_server_ready: None,
                         reason: Some("codex login status timed out".to_string()),
                     };
                 }
@@ -249,18 +257,35 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     let (auth_status, auth_reason) =
                         parse_codex_auth_status(&stdout, &stderr, output.status.success());
+                    let authenticated = auth_status == "signed-in" || auth_status == "api-key";
+                    let app_server_probe = if authenticated {
+                        let app_server_model = default_codex_model_for_version(version.as_deref());
+                        match probe_codex_app_server_initialization(
+                            app_server_model,
+                            DEFAULT_CODEX_REASONING_EFFORT,
+                        )
+                        .await
+                        {
+                            Ok(()) => (Some(true), None),
+                            Err(reason) => (Some(false), Some(reason)),
+                        }
+                    } else {
+                        (None, None)
+                    };
 
                     CodexStatusProbeResult {
                         installed: true,
                         version,
                         auth_status,
-                        reason: auth_reason,
+                        app_server_ready: app_server_probe.0,
+                        reason: app_server_probe.1.or(auth_reason),
                     }
                 }
                 Err(error) => CodexStatusProbeResult {
                     installed: true,
                     version,
                     auth_status: "error".to_string(),
+                    app_server_ready: None,
                     reason: Some(format_codex_io_error(
                         "Failed to run codex login status",
                         &error,
@@ -272,6 +297,7 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
             installed: false,
             version: None,
             auth_status: "unknown".to_string(),
+            app_server_ready: None,
             reason: Some(format!(
                 "codex --version failed with status {}",
                 output.status
@@ -281,6 +307,7 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
             installed: false,
             version: None,
             auth_status: "unknown".to_string(),
+            app_server_ready: None,
             reason: Some(
                 "Codex executable was not found in PATH or common install locations.".to_string(),
             ),
@@ -289,12 +316,89 @@ pub async fn probe_codex_status() -> CodexStatusProbeResult {
             installed: false,
             version: None,
             auth_status: "unknown".to_string(),
+            app_server_ready: None,
             reason: Some(format_codex_io_error(
                 "Failed to run codex --version",
                 &error,
             )),
         },
     }
+}
+
+async fn probe_codex_app_server_initialization(model: &str, effort: &str) -> Result<(), String> {
+    let mut command = create_codex_command()?;
+    command
+        .arg("app-server")
+        .arg("-c")
+        .arg(format!("model={}", quote_toml_string(model)))
+        .arg("-c")
+        .arg(format!(
+            "model_reasoning_effort={}",
+            quote_toml_string(effort)
+        ))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format_codex_io_error("Failed to start codex app-server", &error))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to open Codex app-server stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to open Codex app-server stderr".to_string())?;
+    let stdout_task = tokio::spawn(read_process_stream(stdout));
+    let stderr_task = tokio::spawn(read_process_stream(stderr));
+
+    // The app-server is not an MCP server; requiring an `initialize` response here
+    // incorrectly marks older but usable Codex builds as unavailable. A successful
+    // smoke test means the process starts and stays alive for the readiness window.
+    sleep(Duration::from_millis(1_200)).await;
+
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            let stdout = await_process_output(stdout_task).await;
+            let stderr = await_process_output(stderr_task).await;
+            Err(format!(
+                "codex app-server exited during startup with status {status}: {}",
+                collect_command_output(&stdout, &stderr)
+            ))
+        }
+        Ok(None) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            Err(format_codex_io_error(
+                "Failed to inspect codex app-server startup",
+                &error,
+            ))
+        }
+    }
+}
+
+async fn read_process_stream<R>(mut stream: R) -> Vec<u8>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let mut output = Vec::new();
+    let _ = stream.read_to_end(&mut output).await;
+    output
+}
+
+async fn await_process_output(task: JoinHandle<Vec<u8>>) -> Vec<u8> {
+    timeout(Duration::from_millis(500), task)
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or_default()
 }
 
 pub async fn get_codex_model_catalog() -> CodexModelCatalogResult {
@@ -331,41 +435,69 @@ pub async fn get_codex_model_catalog() -> CodexModelCatalogResult {
             };
         }
         Err(_) => {
-            return CodexModelCatalogResult {
-                installed: true,
-                default_model: DEFAULT_CODEX_MODEL.to_string(),
-                default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
-                models: default_codex_models(),
-                reason: Some("Codex model catalog request timed out.".to_string()),
-            };
+            return fallback_codex_model_catalog(
+                true,
+                Some("Codex model catalog request timed out.".to_string()),
+            )
+            .await;
         }
     };
 
     if !output.status.success() {
-        return CodexModelCatalogResult {
-            installed: true,
-            default_model: DEFAULT_CODEX_MODEL.to_string(),
-            default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
-            models: default_codex_models(),
-            reason: Some(collect_command_output(&output.stdout, &output.stderr)),
-        };
+        return fallback_codex_model_catalog(
+            true,
+            Some(collect_command_output(&output.stdout, &output.stderr)),
+        )
+        .await;
     }
 
     match parse_codex_model_catalog(&String::from_utf8_lossy(&output.stdout)) {
-        Ok(models) => CodexModelCatalogResult {
-            installed: true,
-            default_model: DEFAULT_CODEX_MODEL.to_string(),
-            default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
-            models,
-            reason: None,
-        },
-        Err(reason) => CodexModelCatalogResult {
-            installed: true,
-            default_model: DEFAULT_CODEX_MODEL.to_string(),
-            default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
-            models: default_codex_models(),
-            reason: Some(reason),
-        },
+        Ok(models) => {
+            let (default_model, default_reasoning_effort) = resolve_codex_catalog_default(&models);
+            CodexModelCatalogResult {
+                installed: true,
+                default_model,
+                default_reasoning_effort,
+                models,
+                reason: None,
+            }
+        }
+        Err(reason) => fallback_codex_model_catalog(true, Some(reason)).await,
+    }
+}
+
+async fn fallback_codex_model_catalog(
+    installed: bool,
+    reason: Option<String>,
+) -> CodexModelCatalogResult {
+    let version = if installed {
+        read_codex_version_label().await
+    } else {
+        None
+    };
+    let default_model = default_codex_model_for_version(version.as_deref()).to_string();
+
+    CodexModelCatalogResult {
+        installed,
+        default_model,
+        default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
+        models: default_codex_models_for_version(version.as_deref()),
+        reason,
+    }
+}
+
+fn resolve_codex_catalog_default(models: &[CodexModelInfo]) -> (String, String) {
+    let model = models
+        .iter()
+        .find(|model| model.slug == DEFAULT_CODEX_MODEL)
+        .or_else(|| models.first());
+
+    match model {
+        Some(model) => (model.slug.clone(), model.default_reasoning_effort.clone()),
+        None => (
+            DEFAULT_CODEX_MODEL.to_string(),
+            DEFAULT_CODEX_REASONING_EFFORT.to_string(),
+        ),
     }
 }
 
@@ -376,7 +508,6 @@ fn parse_codex_model_catalog(input: &str) -> Result<Vec<CodexModelInfo>, String>
         .models
         .into_iter()
         .filter(|model| model.visibility.as_deref() != Some("hide"))
-        .filter(|model| model.slug != "gpt-5.5")
         .map(|model| {
             let supported_reasoning_efforts = model
                 .supported_reasoning_levels
@@ -407,21 +538,97 @@ fn parse_codex_model_catalog(input: &str) -> Result<Vec<CodexModelInfo>, String>
 }
 
 fn default_codex_models() -> Vec<CodexModelInfo> {
-    [
-        ("gpt-5.4", "gpt-5.4"),
-        ("gpt-5.4-mini", "GPT-5.4-Mini"),
-        ("gpt-5.3-codex", "gpt-5.3-codex"),
-        ("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),
-        ("gpt-5.2", "gpt-5.2"),
-    ]
-    .into_iter()
-    .map(|(slug, display_name)| CodexModelInfo {
-        slug: slug.to_string(),
-        display_name: display_name.to_string(),
-        default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
-        supported_reasoning_efforts: default_reasoning_efforts(),
+    default_codex_models_for_version(None)
+}
+
+fn default_codex_models_for_version(version: Option<&str>) -> Vec<CodexModelInfo> {
+    let entries: &[(&str, &str)] = if codex_version_supports_gpt_5_5(version) {
+        &[
+            ("gpt-5.5", "gpt-5.5"),
+            ("gpt-5.4", "gpt-5.4"),
+            ("gpt-5.4-mini", "GPT-5.4-Mini"),
+            ("gpt-5.3-codex", "gpt-5.3-codex"),
+            ("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),
+            ("gpt-5.2", "gpt-5.2"),
+        ]
+    } else {
+        &[
+            ("gpt-5.4", "gpt-5.4"),
+            ("gpt-5.4-mini", "GPT-5.4-Mini"),
+            ("gpt-5.3-codex", "gpt-5.3-codex"),
+            ("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),
+            ("gpt-5.2", "gpt-5.2"),
+        ]
+    };
+
+    entries
+        .into_iter()
+        .map(|(slug, display_name)| CodexModelInfo {
+            slug: (*slug).to_string(),
+            display_name: (*display_name).to_string(),
+            default_reasoning_effort: DEFAULT_CODEX_REASONING_EFFORT.to_string(),
+            supported_reasoning_efforts: default_reasoning_efforts(),
+        })
+        .collect()
+}
+
+pub fn normalize_codex_model_for_version(requested_model: String, version: Option<&str>) -> String {
+    if requested_model == DEFAULT_CODEX_MODEL && !codex_version_supports_gpt_5_5(version) {
+        return "gpt-5.4".to_string();
+    }
+
+    requested_model
+}
+
+pub async fn normalize_codex_model_for_installed_cli(requested_model: String) -> String {
+    let version = read_codex_version_label().await;
+    normalize_codex_model_for_version(requested_model, version.as_deref())
+}
+
+fn default_codex_model_for_version(version: Option<&str>) -> &'static str {
+    if codex_version_supports_gpt_5_5(version) {
+        DEFAULT_CODEX_MODEL
+    } else {
+        "gpt-5.4"
+    }
+}
+
+fn codex_version_supports_gpt_5_5(version: Option<&str>) -> bool {
+    let Some((major, minor, _patch)) = version.and_then(parse_codex_version_numbers) else {
+        return true;
+    };
+
+    major > 0 || minor >= 130
+}
+
+pub(crate) fn parse_codex_version_numbers(label: &str) -> Option<(u64, u64, u64)> {
+    label.split_whitespace().find_map(|token| {
+        let token = token.trim_start_matches('v');
+        let numeric = token
+            .split(|ch: char| !(ch.is_ascii_digit() || ch == '.'))
+            .find(|part| part.contains('.'))?;
+        let mut parts = numeric.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next().unwrap_or("0").parse().ok()?;
+        Some((major, minor, patch))
     })
-    .collect()
+}
+
+async fn read_codex_version_label() -> Option<String> {
+    let mut command = create_codex_command().ok()?;
+    let output = timeout(Duration::from_secs(5), command.arg("--version").output())
+        .await
+        .ok()?
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_codex_version(
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
 }
 
 fn default_reasoning_efforts() -> Vec<String> {
@@ -442,10 +649,14 @@ fn collect_command_output(stdout: &[u8], stderr: &[u8]) -> String {
         .collect::<Vec<_>>()
         .join("\n");
     if combined.is_empty() {
-        "Codex model catalog command failed without output.".to_string()
+        "Codex command failed without output.".to_string()
     } else {
         combined
     }
+}
+
+fn quote_toml_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 pub fn format_codex_io_error(action: &str, error: &std::io::Error) -> String {
@@ -651,9 +862,11 @@ fn resolve_first_runnable_candidate(
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_codex_executable_candidates_for_platform, format_codex_io_error,
-        parse_codex_auth_status, parse_codex_model_catalog, parse_codex_version,
-        resolve_first_runnable_candidate, CodexExecutablePlatform,
+        collect_codex_executable_candidates_for_platform, default_reasoning_efforts,
+        format_codex_io_error, normalize_codex_model_for_version, parse_codex_auth_status,
+        parse_codex_model_catalog, parse_codex_version, parse_codex_version_numbers,
+        resolve_codex_catalog_default, resolve_first_runnable_candidate, CodexExecutablePlatform,
+        DEFAULT_CODEX_MODEL,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -819,8 +1032,57 @@ mod tests {
         )
         .expect("models");
 
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].slug, "gpt-5.4");
-        assert_eq!(models[0].supported_reasoning_efforts, vec!["low", "high"]);
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].slug, "gpt-5.5");
+        assert_eq!(
+            models[0].supported_reasoning_efforts,
+            default_reasoning_efforts()
+        );
+        assert_eq!(models[1].slug, "gpt-5.4");
+        assert_eq!(models[1].supported_reasoning_efforts, vec!["low", "high"]);
+    }
+
+    #[test]
+    fn uses_first_catalog_model_as_default_when_latest_model_is_unavailable() {
+        let models = parse_codex_model_catalog(
+            r#"{"models":[{"slug":"gpt-5.4","display_name":"gpt-5.4","default_reasoning_level":"high","visibility":"list"}]}"#,
+        )
+        .expect("models");
+
+        assert_eq!(
+            resolve_codex_catalog_default(&models),
+            ("gpt-5.4".to_string(), "high".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_codex_cli_semver_from_version_labels() {
+        assert_eq!(
+            parse_codex_version_numbers("codex-cli 0.130.0-alpha.5"),
+            Some((0, 130, 0))
+        );
+        assert_eq!(parse_codex_version_numbers("codex 1.2.3"), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn keeps_latest_codex_model_for_newer_cli_versions() {
+        assert_eq!(
+            normalize_codex_model_for_version(
+                DEFAULT_CODEX_MODEL.to_string(),
+                Some("codex-cli 0.130.0-alpha.5"),
+            ),
+            DEFAULT_CODEX_MODEL
+        );
+    }
+
+    #[test]
+    fn downgrades_latest_codex_model_for_older_cli_versions() {
+        assert_eq!(
+            normalize_codex_model_for_version(
+                DEFAULT_CODEX_MODEL.to_string(),
+                Some("codex-cli 0.118.0"),
+            ),
+            "gpt-5.4"
+        );
     }
 }

--- a/src-tauri/src/core/external_agent.rs
+++ b/src-tauri/src/core/external_agent.rs
@@ -238,20 +238,14 @@ pub async fn configure_codex_agent_runtime(
     let plugin_marketplace_configured = plugin_result.is_ok();
     let mcp_configured = mcp_result.is_ok();
     let app_server_ready = status.app_server_ready != Some(false);
-    let ready = authenticated && app_server_ready;
-    let message = if ready {
-        Some("Codex is connected with OpenReelio tools.".to_string())
-    } else if status.app_server_ready == Some(false) {
-        status
-            .reason
-            .or_else(|| Some("Codex app-server could not start.".to_string()))
-    } else if !authenticated {
-        status
-            .reason
-            .or_else(|| Some("Codex needs sign-in.".to_string()))
-    } else {
-        plugin_result.err().or_else(|| mcp_result.err())
-    };
+    let (ready, message) = resolve_codex_configuration_readiness(
+        authenticated,
+        app_server_ready,
+        status.app_server_ready == Some(false),
+        status.reason,
+        plugin_result.err(),
+        mcp_result.err(),
+    );
 
     ConfigureCodexAgentRuntimeResult {
         installed: true,
@@ -263,6 +257,30 @@ pub async fn configure_codex_agent_runtime(
         mcp_configured,
         message,
     }
+}
+
+fn resolve_codex_configuration_readiness(
+    authenticated: bool,
+    app_server_ready: bool,
+    app_server_failed: bool,
+    status_reason: Option<String>,
+    plugin_error: Option<String>,
+    mcp_error: Option<String>,
+) -> (bool, Option<String>) {
+    let ready = authenticated && app_server_ready && mcp_error.is_none();
+    let message = if ready {
+        Some("Codex is connected with OpenReelio tools.".to_string())
+    } else if app_server_failed {
+        status_reason.or_else(|| Some("Codex app-server could not start.".to_string()))
+    } else if !authenticated {
+        status_reason.or_else(|| Some("Codex needs sign-in.".to_string()))
+    } else if let Some(error) = mcp_error {
+        Some(error)
+    } else {
+        plugin_error
+    };
+
+    (ready, message)
 }
 
 pub async fn start_codex_login() -> CodexAgentLoginResult {
@@ -934,6 +952,24 @@ mod tests {
         assert_eq!(
             info.codex_mcp_command_reason,
             Some("Open a project to generate a project-scoped MCP command.".to_string())
+        );
+    }
+
+    #[test]
+    fn does_not_mark_codex_ready_when_mcp_configuration_fails() {
+        let (ready, message) = resolve_codex_configuration_readiness(
+            true,
+            true,
+            false,
+            None,
+            None,
+            Some("Open a project before enabling OpenReelio tools for Codex.".to_string()),
+        );
+
+        assert!(!ready);
+        assert_eq!(
+            message,
+            Some("Open a project before enabling OpenReelio tools for Codex.".to_string())
         );
     }
 

--- a/src-tauri/src/core/external_agent.rs
+++ b/src-tauri/src/core/external_agent.rs
@@ -98,6 +98,25 @@ pub struct CodexAgentLoginResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
+pub struct CodexCliInstallResult {
+    pub success: bool,
+    pub version: Option<String>,
+    pub attempted_command: Option<String>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexCliUpdateResult {
+    pub success: bool,
+    pub before_version: Option<String>,
+    pub after_version: Option<String>,
+    pub attempted_command: Option<String>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
 pub struct ExternalAgentApprovalTokenGrant {
     pub token: String,
     pub token_id: String,
@@ -198,21 +217,34 @@ pub async fn configure_codex_agent_runtime(
     }
 
     let authenticated = is_authenticated(&status.auth_status);
-    let plugin_result = configure_codex_plugin_marketplace().await;
-    let mcp_result = match input
-        .project_path
-        .map(|path| path.trim().to_string())
-        .filter(|path| !path.is_empty())
-    {
-        Some(project_path) => configure_codex_mcp(&project_path).await,
-        None => Err("Open a project before enabling OpenReelio tools for Codex.".to_string()),
+    let (plugin_result, mcp_result) = if authenticated {
+        let plugin_result = configure_codex_plugin_marketplace().await;
+        let mcp_result = match input
+            .project_path
+            .map(|path| path.trim().to_string())
+            .filter(|path| !path.is_empty())
+        {
+            Some(project_path) => configure_codex_mcp(&project_path).await,
+            None => Err("Open a project before enabling OpenReelio tools for Codex.".to_string()),
+        };
+        (plugin_result, mcp_result)
+    } else {
+        (
+            Err("Codex needs sign-in.".to_string()),
+            Err("Codex needs sign-in.".to_string()),
+        )
     };
 
     let plugin_marketplace_configured = plugin_result.is_ok();
     let mcp_configured = mcp_result.is_ok();
-    let ready = authenticated && plugin_marketplace_configured && mcp_configured;
+    let app_server_ready = status.app_server_ready != Some(false);
+    let ready = authenticated && app_server_ready;
     let message = if ready {
         Some("Codex is connected with OpenReelio tools.".to_string())
+    } else if status.app_server_ready == Some(false) {
+        status
+            .reason
+            .or_else(|| Some("Codex app-server could not start.".to_string()))
     } else if !authenticated {
         status
             .reason
@@ -497,8 +529,13 @@ fn is_authenticated(auth_status: &str) -> bool {
 }
 
 async fn configure_codex_plugin_marketplace() -> Result<(), String> {
-    let marketplace_root = find_repo_agents_root()
-        .ok_or_else(|| "OpenReelio plugin marketplace was not found.".to_string())?;
+    let Some(marketplace_root) = find_repo_agents_root() else {
+        return Ok(());
+    };
+    if !codex_plugin_marketplace_supported().await {
+        return Ok(());
+    }
+
     let args = vec![
         "plugin".to_string(),
         "marketplace".to_string(),
@@ -516,6 +553,171 @@ async fn configure_codex_plugin_marketplace() -> Result<(), String> {
                 Err(error)
             }
         })
+}
+
+pub async fn install_codex_cli() -> CodexCliInstallResult {
+    let before = crate::core::codex::probe_codex_status().await;
+    if before.installed {
+        return CodexCliInstallResult {
+            success: true,
+            version: before.version,
+            attempted_command: None,
+            message: Some("Codex CLI is already installed.".to_string()),
+        };
+    }
+
+    let npm = match find_npm_command().await {
+        Some(command) => command,
+        None => {
+            return CodexCliInstallResult {
+                success: false,
+                version: None,
+                attempted_command: Some("npm install -g @openai/codex@latest".to_string()),
+                message: Some(
+                    "npm was not found. Install Node.js with npm, then install Codex from OpenReelio again."
+                        .to_string(),
+                ),
+            };
+        }
+    };
+    let attempted_command = format!("{npm} install -g @openai/codex@latest");
+    let install_result = run_external_command(
+        &npm,
+        &["install", "-g", "@openai/codex@latest"],
+        Duration::from_secs(300),
+    )
+    .await;
+    let after = crate::core::codex::probe_codex_status().await;
+    let success = after.installed;
+
+    CodexCliInstallResult {
+        success,
+        version: after.version,
+        attempted_command: Some(attempted_command),
+        message: if success {
+            Some("Codex CLI installation completed.".to_string())
+        } else {
+            Some(match install_result {
+                Ok(output) if output.is_empty() => {
+                    "Codex CLI installation did not complete.".to_string()
+                }
+                Ok(output) => output,
+                Err(error) => error,
+            })
+        },
+    }
+}
+
+pub async fn update_codex_cli() -> CodexCliUpdateResult {
+    let before = crate::core::codex::probe_codex_status().await;
+    if !before.installed {
+        return CodexCliUpdateResult {
+            success: false,
+            before_version: before.version,
+            after_version: None,
+            attempted_command: None,
+            message: before
+                .reason
+                .or_else(|| Some("Codex CLI is not installed.".to_string())),
+        };
+    }
+
+    let mut attempted_commands = vec!["codex update".to_string()];
+    let mut update_result = run_codex_command(&["update"], &[], Duration::from_secs(300)).await;
+
+    if update_result
+        .as_ref()
+        .err()
+        .is_some_and(|error| is_unsupported_update_command(error))
+    {
+        attempted_commands.push("codex --upgrade".to_string());
+        update_result = run_codex_command(&["--upgrade"], &[], Duration::from_secs(300)).await;
+    }
+
+    let mut after = crate::core::codex::probe_codex_status().await;
+    if update_result.is_err() || detected_codex_version_still_needs_update(&before, &after) {
+        match run_npm_codex_install().await {
+            Some((attempted_command, npm_result)) => {
+                attempted_commands.push(attempted_command);
+                update_result = npm_result;
+                after = crate::core::codex::probe_codex_status().await;
+            }
+            None if update_result.is_err() => {
+                attempted_commands.push("npm install -g @openai/codex@latest".to_string());
+                update_result = Err(
+                    "npm was not found. Install Node.js with npm, then update Codex from OpenReelio again."
+                        .to_string(),
+                );
+            }
+            None => {}
+        }
+    }
+
+    let success =
+        update_result.is_ok() && after.installed && !codex_cli_version_needs_update(&after.version);
+    let before_version = before.version.clone();
+    let after_version = after.version.clone();
+
+    CodexCliUpdateResult {
+        success,
+        before_version,
+        after_version: after_version.clone(),
+        attempted_command: Some(attempted_commands.join(" -> ")),
+        message: if success {
+            Some("Codex CLI update completed.".to_string())
+        } else if update_result.is_ok() && after.installed {
+            Some(format!(
+                "Codex update command completed, but OpenReelio still detects {}. A different Codex launcher may be earlier in OpenReelio's search path.",
+                after_version
+                    .as_deref()
+                    .unwrap_or("the same Codex CLI version")
+            ))
+        } else {
+            Some(match update_result {
+                Ok(output) if output.is_empty() => "Codex CLI update did not complete.".to_string(),
+                Ok(output) => output,
+                Err(error) => error,
+            })
+        },
+    }
+}
+
+async fn run_npm_codex_install() -> Option<(String, Result<String, String>)> {
+    let npm = find_npm_command().await?;
+    let attempted_command = format!("{npm} install -g @openai/codex@latest");
+    let result = run_external_command(
+        &npm,
+        &["install", "-g", "@openai/codex@latest"],
+        Duration::from_secs(300),
+    )
+    .await;
+    Some((attempted_command, result))
+}
+
+fn detected_codex_version_still_needs_update(
+    before: &crate::core::codex::CodexStatusProbeResult,
+    after: &crate::core::codex::CodexStatusProbeResult,
+) -> bool {
+    codex_cli_version_needs_update(&before.version)
+        && codex_cli_version_needs_update(&after.version)
+}
+
+fn codex_cli_version_needs_update(version: &Option<String>) -> bool {
+    let Some((major, minor, _patch)) = version
+        .as_deref()
+        .and_then(crate::core::codex::parse_codex_version_numbers)
+    else {
+        return false;
+    };
+
+    major == 0 && minor < 130
+}
+
+async fn codex_plugin_marketplace_supported() -> bool {
+    run_codex_command(&["plugin", "--help"], &[], Duration::from_secs(10))
+        .await
+        .map(|output| output.to_lowercase().contains("marketplace"))
+        .unwrap_or(false)
 }
 
 async fn configure_codex_mcp(project_path: &str) -> Result<(), String> {
@@ -598,9 +800,80 @@ async fn run_codex_command_owned(
     }
 }
 
+async fn find_npm_command() -> Option<String> {
+    for candidate in npm_command_candidates() {
+        if run_external_command(candidate, &["--version"], Duration::from_secs(10))
+            .await
+            .is_ok()
+        {
+            return Some((*candidate).to_string());
+        }
+    }
+
+    None
+}
+
+fn npm_command_candidates() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &["npm.cmd", "npm"]
+    } else {
+        &["npm"]
+    }
+}
+
+async fn run_external_command(
+    executable: &str,
+    args: &[&str],
+    timeout_duration: Duration,
+) -> Result<String, String> {
+    let output = timeout(
+        timeout_duration,
+        tokio::process::Command::new(executable)
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("{executable} command timed out."))?
+    .map_err(|error| {
+        crate::core::codex::format_codex_io_error(
+            &format!("Failed to run {executable} command"),
+            &error,
+        )
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = stdout
+        .lines()
+        .chain(stderr.lines())
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if output.status.success() {
+        Ok(combined)
+    } else if combined.is_empty() {
+        Err(format!(
+            "{executable} command failed with status {}",
+            output.status
+        ))
+    } else {
+        Err(combined)
+    }
+}
+
 fn is_already_configured_error(output: &str) -> bool {
     let lower = output.to_lowercase();
     lower.contains("already") || lower.contains("exists")
+}
+
+fn is_unsupported_update_command(output: &str) -> bool {
+    let lower = output.to_lowercase();
+    lower.contains("unexpected argument")
+        || lower.contains("unrecognized subcommand")
+        || lower.contains("unknown command")
 }
 
 fn invalid_validation(reason: impl Into<String>) -> ExternalAgentApprovalTokenValidation {

--- a/src-tauri/src/ipc/commands/codex_app_server.rs
+++ b/src-tauri/src/ipc/commands/codex_app_server.rs
@@ -92,7 +92,10 @@ pub async fn start_codex_app_server(
     }
 
     let codex_command = crate::core::codex::codex_command_label();
-    let codex_model = resolve_codex_app_server_model(input.model);
+    let codex_model = crate::core::codex::normalize_codex_model_for_installed_cli(
+        resolve_codex_app_server_model(input.model),
+    )
+    .await;
     let codex_reasoning_effort = resolve_codex_app_server_reasoning_effort(input.reasoning_effort);
     let mut command = crate::core::codex::create_codex_command()?;
     command

--- a/src-tauri/src/ipc/commands/external_agent.rs
+++ b/src-tauri/src/ipc/commands/external_agent.rs
@@ -3,8 +3,9 @@
 use crate::core::external_agent::{
     build_external_agent_setup_info,
     configure_codex_agent_runtime as configure_codex_agent_runtime_core,
-    start_codex_login as start_codex_login_core, CodexAgentLoginResult,
-    ConfigureCodexAgentRuntimeInput, ConfigureCodexAgentRuntimeResult,
+    install_codex_cli as install_codex_cli_core, start_codex_login as start_codex_login_core,
+    update_codex_cli as update_codex_cli_core, CodexAgentLoginResult, CodexCliInstallResult,
+    CodexCliUpdateResult, ConfigureCodexAgentRuntimeInput, ConfigureCodexAgentRuntimeResult,
     ConsumeExternalAgentApprovalTokenInput, CreateExternalAgentApprovalTokenInput,
     ExternalAgentApprovalTokenGrant, ExternalAgentApprovalTokenValidation, ExternalAgentSetupInfo,
     ExternalAgentSetupInfoInput, RevokeExternalAgentApprovalTokenInput,
@@ -44,6 +45,18 @@ pub async fn configure_codex_agent_runtime(
 #[specta::specta]
 pub async fn start_codex_login() -> Result<CodexAgentLoginResult, String> {
     Ok(start_codex_login_core().await)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn install_codex_cli() -> Result<CodexCliInstallResult, String> {
+    Ok(install_codex_cli_core().await)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn update_codex_cli() -> Result<CodexCliUpdateResult, String> {
+    Ok(update_codex_cli_core().await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1286,6 +1286,8 @@ mod tauri_app {
                 $crate::ipc::get_external_agent_setup_info,
                 $crate::ipc::configure_codex_agent_runtime,
                 $crate::ipc::start_codex_login,
+                $crate::ipc::install_codex_cli,
+                $crate::ipc::update_codex_cli,
                 $crate::ipc::consume_external_agent_approval_token,
                 $crate::ipc::revoke_external_agent_approval_token,
                 // AI Conversation persistence commands
@@ -1748,6 +1750,8 @@ mod tauri_app {
             ipc::get_external_agent_setup_info,
             ipc::configure_codex_agent_runtime,
             ipc::start_codex_login,
+            ipc::install_codex_cli,
+            ipc::update_codex_cli,
             ipc::consume_external_agent_approval_token,
             ipc::revoke_external_agent_approval_token,
             // AI Conversation persistence commands

--- a/src/agents/external/adapters/CodexAppServerClient.test.ts
+++ b/src/agents/external/adapters/CodexAppServerClient.test.ts
@@ -14,6 +14,7 @@ class MockCodexTransport implements CodexAppServerTransport {
   });
 
   private handler: ((message: CodexAppServerIncomingMessage) => void) | null = null;
+  private errorHandler: ((error: Error) => void) | null = null;
 
   onMessage(handler: (message: CodexAppServerIncomingMessage) => void): () => void {
     this.handler = handler;
@@ -22,8 +23,19 @@ class MockCodexTransport implements CodexAppServerTransport {
     };
   }
 
+  onError(handler: (error: Error) => void): () => void {
+    this.errorHandler = handler;
+    return () => {
+      this.errorHandler = null;
+    };
+  }
+
   receive(message: CodexAppServerIncomingMessage): void {
     this.handler?.(message);
+  }
+
+  fail(error: Error): void {
+    this.errorHandler?.(error);
   }
 }
 
@@ -231,6 +243,20 @@ describe('CodexAppServerClient', () => {
     });
 
     await expect(threadPromise).rejects.toThrow('Not authenticated');
+  });
+
+  it('rejects pending requests when the app-server transport fails before responding', async () => {
+    const transport = new MockCodexTransport();
+    const client = new CodexAppServerClient(transport);
+    const initPromise = client.initialize();
+
+    await waitForSent(transport, 1);
+    transport.fail(
+      new Error('Codex app-server exited with exit code 1. Last stderr: migration failed'),
+    );
+
+    await expect(initPromise).rejects.toThrow('migration failed');
+    await expect(client.startThread()).rejects.toThrow('migration failed');
   });
 
   it('normalizes JSON-RPC model compatibility errors before surfacing them', async () => {

--- a/src/agents/external/adapters/CodexAppServerClient.ts
+++ b/src/agents/external/adapters/CodexAppServerClient.ts
@@ -160,6 +160,7 @@ export type CodexAppServerIncomingMessage =
 export interface CodexAppServerTransport {
   send(message: CodexAppServerOutgoingMessage): Promise<void> | void;
   onMessage(handler: (message: CodexAppServerIncomingMessage) => void): () => void;
+  onError?(handler: (error: Error) => void): () => void;
 }
 
 interface PendingRequest {
@@ -175,8 +176,10 @@ export class CodexAppServerClient {
   private readonly notificationHandlers = new Set<CodexAppServerNotificationHandler>();
   private readonly requestHandlers = new Set<CodexAppServerRequestHandler>();
   private readonly unsubscribeTransport: () => void;
+  private readonly unsubscribeTransportError: (() => void) | null;
   private readonly clientInfo: CodexAppServerClientInfo;
   private readonly capabilities: CodexInitializeCapabilities;
+  private transportError: Error | null = null;
 
   constructor(
     private readonly transport: CodexAppServerTransport,
@@ -191,6 +194,8 @@ export class CodexAppServerClient {
       experimentalApi: true,
     };
     this.unsubscribeTransport = this.transport.onMessage((message) => this.handleMessage(message));
+    this.unsubscribeTransportError =
+      this.transport.onError?.((error) => this.handleTransportError(error)) ?? null;
   }
 
   async initialize(): Promise<void> {
@@ -304,6 +309,7 @@ export class CodexAppServerClient {
 
   dispose(): void {
     this.unsubscribeTransport();
+    this.unsubscribeTransportError?.();
     for (const [, pending] of this.pendingRequests) {
       pending.reject(new Error('Codex app-server client disposed'));
     }
@@ -313,6 +319,10 @@ export class CodexAppServerClient {
   }
 
   private async request<T = unknown>(method: string, params?: CodexJsonObject): Promise<T> {
+    if (this.transportError) {
+      throw this.transportError;
+    }
+
     const id = this.nextRequestId++;
     const response = new Promise<T>((resolve, reject) => {
       this.pendingRequests.set(id, {
@@ -402,6 +412,17 @@ export class CodexAppServerClient {
         },
       });
     }
+  }
+
+  private handleTransportError(error: Error): void {
+    const normalizedError = new Error(normalizeCodexAppServerErrorMessage(error.message));
+    this.transportError = normalizedError;
+    for (const [, pending] of this.pendingRequests) {
+      pending.reject(normalizedError);
+    }
+    this.pendingRequests.clear();
+    this.initializePromise = Promise.reject(normalizedError);
+    this.initializePromise.catch(() => undefined);
   }
 }
 

--- a/src/agents/external/adapters/CodexReferenceAdapter.test.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.test.ts
@@ -627,9 +627,7 @@ describe('CodexReferenceAdapter', () => {
     })) as CodexDynamicToolCallResponse;
 
     const projectStateResponse = JSON.parse(getFirstTextContent(response));
-    expect(projectStateResponse.contextToken).toMatch(
-      /^orctx:\d+:0000001000000z00000zz0000zzz$/,
-    );
+    expect(projectStateResponse.contextToken).toMatch(/^orctx:\d+:0000001000000z00000zz0000zzz$/);
     expect(getRandomValues).toHaveBeenCalledWith(expect.any(Uint32Array));
   });
 
@@ -782,6 +780,200 @@ describe('CodexReferenceAdapter', () => {
         },
       ],
     });
+  });
+
+  it('should validate, approve, token-gate, and atomically apply OpenReelio dynamic plans', async () => {
+    const requestHandlers: Array<(request: any) => unknown> = [];
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onServerRequest: vi.fn((handler: (request: any) => unknown) => {
+        requestHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    const agentPlanResult = {
+      planId: 'plan_1',
+      success: true,
+      totalSteps: 1,
+      stepsCompleted: 1,
+      stepResults: [],
+      operationIds: ['op_1'],
+      rollbackReport: null,
+      errorMessage: null,
+      executionTimeMs: 12,
+    };
+    vi.mocked(invoke).mockImplementation(async (command, args) => {
+      if (command === 'get_project_state') {
+        return {
+          meta: {
+            name: 'Launch Cut',
+            version: '1',
+            createdAt: '2026-05-13T00:00:00Z',
+            modifiedAt: '2026-05-13T00:00:00Z',
+            description: null,
+            author: null,
+          },
+          assets: [],
+          sequences: [],
+          effects: [],
+          activeSequenceId: 'seq_1',
+          textClips: [],
+          isDirty: false,
+        };
+      }
+      if (command === 'validate_command_payload') {
+        return null;
+      }
+      if (command === 'create_external_agent_approval_token') {
+        return {
+          token: 'grant-token',
+          tokenId: 'grant-1',
+          sessionId: 'thr_123',
+          runId: null,
+          planId: 'plan_1',
+          projectId: 'project-1',
+          runtimeId: 'codex',
+          scopes: ['openreelio.plan.apply'],
+          createdAt: 1,
+          expiresAt: 2,
+        };
+      }
+      if (command === 'consume_external_agent_approval_token') {
+        return {
+          valid: true,
+          reason: null,
+          grant: null,
+        };
+      }
+      if (command === 'execute_agent_plan') {
+        expect(args).toMatchObject({
+          plan: {
+            id: 'plan_1',
+            approvalGranted: true,
+            sessionId: 'thr_123',
+          },
+        });
+        return agentPlanResult;
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    projectStoreMocks.refreshFromBackendMutation.mockResolvedValue(8);
+    const approvalDecisionProvider = vi.fn().mockResolvedValue('accept');
+    const adapter = new CodexReferenceAdapter(undefined, {
+      appServerClient,
+      approvalDecisionProvider,
+    });
+
+    await adapter.startSession({ projectId: 'project-1', cwd: '/project' });
+    const respondToRequest = requestHandlers[0];
+    if (!respondToRequest) {
+      throw new Error('Expected Codex server request handler to be registered');
+    }
+    const contextResponse = (await respondToRequest({
+      id: 30,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_context',
+        namespace: 'openreelio',
+        tool: 'project_state',
+        arguments: {},
+      },
+    })) as any;
+    const contextToken = JSON.parse(getFirstTextContent(contextResponse)).contextToken;
+
+    const plan = {
+      id: 'plan_1',
+      goal: 'Add a B-roll track',
+      approvalGranted: false,
+      steps: [
+        {
+          id: 'step_1',
+          toolName: 'CreateTrack',
+          params: {
+            sequenceId: 'seq_1',
+            name: 'B-roll',
+            kind: 'video',
+          },
+          description: 'Add a B-roll video track',
+          riskLevel: 'medium',
+        },
+      ],
+    };
+    const response = (await respondToRequest({
+      id: 31,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_plan_apply',
+        namespace: 'openreelio',
+        tool: 'plan_apply',
+        arguments: {
+          plan,
+          reason: 'Apply a one-step B-roll track plan',
+          contextToken,
+        },
+      },
+    })) as any;
+
+    expect(approvalDecisionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalType: 'openreelio_plan_apply',
+        tool: 'OpenReelio plan apply',
+        description: 'Apply a one-step B-roll track plan',
+        args: expect.objectContaining({
+          planId: 'plan_1',
+          stepCount: 1,
+          projectId: 'project-1',
+        }),
+      }),
+    );
+    expect(invoke).toHaveBeenCalledWith('validate_command_payload', {
+      commandType: 'CreateTrack',
+      payload: {
+        sequenceId: 'seq_1',
+        name: 'B-roll',
+        kind: 'video',
+      },
+    });
+    expect(invoke).toHaveBeenCalledWith('create_external_agent_approval_token', {
+      input: expect.objectContaining({
+        sessionId: 'thr_123',
+        planId: 'plan_1',
+        projectId: 'project-1',
+        runtimeId: 'codex',
+        scopes: ['openreelio.plan.apply'],
+      }),
+    });
+    expect(invoke).toHaveBeenCalledWith('consume_external_agent_approval_token', {
+      input: expect.objectContaining({
+        token: 'grant-token',
+        sessionId: 'thr_123',
+        planId: 'plan_1',
+        projectId: 'project-1',
+        runtimeId: 'codex',
+        requiredScope: 'openreelio.plan.apply',
+      }),
+    });
+    expect(invoke).toHaveBeenCalledWith(
+      'execute_agent_plan',
+      expect.objectContaining({
+        plan: expect.objectContaining({
+          id: 'plan_1',
+          approvalGranted: true,
+          sessionId: 'thr_123',
+        }),
+      }),
+    );
+    expect(projectStoreMocks.refreshFromBackendMutation).toHaveBeenCalled();
+    expect(response.success).toBe(true);
+    expect(getFirstTextContent(response)).toContain('"status": "ok"');
+    expect(getFirstTextContent(response)).toContain('"tokenId": "grant-1"');
   });
 
   it('should reject OpenReelio dynamic tool calls for unknown Codex sessions', async () => {

--- a/src/agents/external/adapters/CodexReferenceAdapter.test.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.test.ts
@@ -87,6 +87,40 @@ describe('CodexReferenceAdapter', () => {
     expect(appServerClientFactory).not.toHaveBeenCalled();
   });
 
+  it('should not mark signed-in Codex as available when app-server initialization fails', async () => {
+    const adapter = new CodexReferenceAdapter(async () => ({
+      installed: true,
+      version: '0.130.0-alpha.5',
+      authStatus: 'signed-in',
+      appServerReady: false,
+      reason: 'codex app-server exited before initialization: migration failed',
+    }));
+
+    await expect(adapter.detect()).resolves.toEqual({
+      runtimeId: 'codex',
+      displayName: 'Codex',
+      installStatus: 'installed',
+      authStatus: 'signed-in',
+      available: false,
+      version: '0.130.0-alpha.5',
+      reason: 'codex app-server exited before initialization: migration failed',
+    });
+  });
+
+  it('should use a fallback app-server unavailable reason when the probe omits details', async () => {
+    const adapter = new CodexReferenceAdapter(async () => ({
+      installed: true,
+      version: '0.130.0-alpha.5',
+      authStatus: 'signed-in',
+      appServerReady: false,
+    }));
+
+    const status = await adapter.detect();
+
+    expect(status.available).toBe(false);
+    expect(status.reason).toBe('Codex app-server could not initialize');
+  });
+
   it('should start an app-server thread and optional first turn when connected', async () => {
     const appServerClient = {
       startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
@@ -114,7 +148,7 @@ describe('CodexReferenceAdapter', () => {
       expect.objectContaining({
         serviceName: 'openreelio',
         cwd: '/project',
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         approvalPolicy: 'on-request',
         approvalsReviewer: 'user',
         sandbox: 'read-only',
@@ -133,7 +167,7 @@ describe('CodexReferenceAdapter', () => {
     expect(commandExecuteTool.inputSchema.properties.commandType.enum).not.toContain('DeleteFile');
     expect(appServerClient.startTurn).toHaveBeenCalledWith('thr_123', 'Inspect this timeline', {
       cwd: '/project',
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       effort: 'medium',
       approvalPolicy: 'on-request',
       approvalsReviewer: 'user',
@@ -156,7 +190,7 @@ describe('CodexReferenceAdapter', () => {
 
     expect(appServerClient.startTurn).toHaveBeenCalledWith('thr_123', 'Add captions', {
       cwd: '/project',
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       effort: 'medium',
       approvalPolicy: 'on-request',
       approvalsReviewer: 'user',
@@ -188,7 +222,7 @@ describe('CodexReferenceAdapter', () => {
       expect.objectContaining({
         threadId: 'thr_existing',
         cwd: '/project',
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         approvalPolicy: 'on-request',
         approvalsReviewer: 'user',
         sandbox: 'read-only',
@@ -198,7 +232,7 @@ describe('CodexReferenceAdapter', () => {
     expect(appServerClient.startThread).not.toHaveBeenCalled();
     expect(appServerClient.startTurn).toHaveBeenCalledWith('thr_existing', 'Continue', {
       cwd: '/project',
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       effort: 'medium',
       approvalPolicy: 'on-request',
       approvalsReviewer: 'user',
@@ -240,7 +274,7 @@ describe('CodexReferenceAdapter', () => {
       expect.objectContaining({
         serviceName: 'openreelio',
         cwd: '/project',
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         developerInstructions: expect.stringContaining('OpenReelio'),
       }),
     );

--- a/src/agents/external/adapters/CodexReferenceAdapter.test.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.test.ts
@@ -976,6 +976,66 @@ describe('CodexReferenceAdapter', () => {
     expect(getFirstTextContent(response)).toContain('"tokenId": "grant-1"');
   });
 
+  it('should reject OpenReelio dynamic plans with cyclic dependencies', async () => {
+    const requestHandlers: Array<(request: any) => unknown> = [];
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onServerRequest: vi.fn((handler: (request: any) => unknown) => {
+        requestHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    const adapter = new CodexReferenceAdapter(undefined, { appServerClient });
+
+    await adapter.startSession({ projectId: 'project-1', cwd: '/project' });
+    const respondToRequest = requestHandlers[0];
+    if (!respondToRequest) {
+      throw new Error('Expected Codex server request handler to be registered');
+    }
+
+    const response = (await respondToRequest({
+      id: 32,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_plan_validate',
+        namespace: 'openreelio',
+        tool: 'plan_validate',
+        arguments: {
+          plan: {
+            id: 'cyclic-plan',
+            goal: 'Create an invalid dependency graph',
+            steps: [
+              {
+                id: 'step_a',
+                toolName: 'CreateTrack',
+                params: { sequenceId: 'seq_1', name: 'A', kind: 'video' },
+                dependsOn: ['step_b'],
+              },
+              {
+                id: 'step_b',
+                toolName: 'CreateTrack',
+                params: { sequenceId: 'seq_1', name: 'B', kind: 'video' },
+                dependsOn: ['step_a'],
+              },
+            ],
+          },
+        },
+      },
+    })) as any;
+
+    expect(response.success).toBe(false);
+    expect(getFirstTextContent(response)).toContain('"status": "error"');
+    expect(getFirstTextContent(response)).toContain(
+      'Plan contains cyclic dependency: step_a -> step_b -> step_a',
+    );
+    expect(invoke).not.toHaveBeenCalledWith('validate_command_payload', expect.anything());
+  });
+
   it('should reject OpenReelio dynamic tool calls for unknown Codex sessions', async () => {
     const requestHandlers: Array<(request: any) => unknown> = [];
     const appServerClient = {

--- a/src/agents/external/adapters/CodexReferenceAdapter.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.ts
@@ -35,6 +35,7 @@ export interface CodexStatusProbeResult {
   installed: boolean;
   version?: string | null;
   authStatus: ExternalAgentAuthStatus;
+  appServerReady?: boolean | null;
   reason?: string | null;
 }
 
@@ -61,7 +62,7 @@ export interface CodexReferenceAdapterOptions {
   reasoningEffort?: string;
 }
 
-const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.4';
+const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.5';
 const DEFAULT_CODEX_REASONING_EFFORT = 'medium';
 
 const CODEX_CAPABILITIES: ExternalAgentRuntimeCapabilities = {
@@ -92,7 +93,8 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     const probe = await this.probeStatus();
     const installStatus = probe.installed ? 'installed' : 'missing';
     const authenticated = probe.authStatus === 'signed-in' || probe.authStatus === 'api-key';
-    const available = probe.installed && authenticated;
+    const appServerReady = probe.appServerReady !== false;
+    const available = probe.installed && authenticated && appServerReady;
 
     return {
       runtimeId: this.id,
@@ -226,6 +228,10 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
 
     if (probe.authStatus === 'error') {
       return 'Codex authentication status could not be read';
+    }
+
+    if (probe.appServerReady === false) {
+      return 'Codex app-server could not initialize';
     }
 
     return 'Codex is unavailable';

--- a/src/agents/external/adapters/CodexTauriAppServerTransport.test.ts
+++ b/src/agents/external/adapters/CodexTauriAppServerTransport.test.ts
@@ -87,6 +87,69 @@ describe('CodexTauriAppServerTransport', () => {
     expect(handler).toHaveBeenCalledWith({ id: 1, result: {} });
   });
 
+  it('should surface backend stderr and exit events as transport errors', async () => {
+    let listener: (event: { payload: CodexAppServerStreamEvent }) => void = () => undefined;
+    const invokeCommand = vi.fn().mockResolvedValue({
+      serverId: 'server-1',
+      eventName: 'codex:app-server:server-1',
+      command: 'codex',
+      args: ['app-server'],
+      cwd: '/project',
+    });
+    const listenEvent = vi.fn().mockImplementation(async (_eventName, handler) => {
+      listener = handler;
+      return vi.fn();
+    });
+    const transport = await CodexTauriAppServerTransport.start(
+      {},
+      { invoke: invokeCommand, listen: listenEvent },
+    );
+    const errorHandler = vi.fn();
+    transport.onError(errorHandler);
+
+    listener({
+      payload: { type: 'stderr', text: 'failed to initialize sqlite state db' },
+    });
+    listener({
+      payload: { type: 'exit', exitCode: 1 },
+    });
+
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed to initialize sqlite state db'),
+      }),
+    );
+  });
+
+  it('should surface backend stream error events as transport errors', async () => {
+    let listener: (event: { payload: CodexAppServerStreamEvent }) => void = () => undefined;
+    const invokeCommand = vi.fn().mockResolvedValue({
+      serverId: 'server-1',
+      eventName: 'codex:app-server:server-1',
+      command: 'codex',
+      args: ['app-server'],
+      cwd: '/project',
+    });
+    const listenEvent = vi.fn().mockImplementation(async (_eventName, handler) => {
+      listener = handler;
+      return vi.fn();
+    });
+    const transport = await CodexTauriAppServerTransport.start(
+      {},
+      { invoke: invokeCommand, listen: listenEvent },
+    );
+    const errorHandler = vi.fn();
+    transport.onError(errorHandler);
+
+    listener({
+      payload: { type: 'error', message: 'Malformed app-server JSON' },
+    });
+
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Malformed app-server JSON' }),
+    );
+  });
+
   it('should stop the backend process when disposed by default', async () => {
     const unlisten = vi.fn();
     const invokeCommand = vi

--- a/src/agents/external/adapters/CodexTauriAppServerTransport.ts
+++ b/src/agents/external/adapters/CodexTauriAppServerTransport.ts
@@ -45,8 +45,10 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
   private readonly invokeCommand: TauriInvoke;
   private readonly listenEvent: TauriListen;
   private readonly handlers = new Set<(message: CodexAppServerIncomingMessage) => void>();
+  private readonly errorHandlers = new Set<(error: Error) => void>();
   private readonly unlistenPromise: Promise<UnlistenFn>;
   private disposed = false;
+  private lastStderrLine: string | null = null;
 
   private constructor(
     readonly startResult: CodexAppServerStartResult,
@@ -93,6 +95,11 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
     return () => this.handlers.delete(handler);
   }
 
+  onError(handler: (error: Error) => void): () => void {
+    this.errorHandlers.add(handler);
+    return () => this.errorHandlers.delete(handler);
+  }
+
   async dispose(): Promise<void> {
     if (this.disposed) {
       return;
@@ -102,6 +109,7 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
     const unlisten = await this.unlistenPromise;
     unlisten();
     this.handlers.clear();
+    this.errorHandlers.clear();
 
     if (this.options.autoStopOnDispose ?? true) {
       await this.invokeCommand('stop_codex_app_server', {
@@ -111,12 +119,39 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
   }
 
   private handleStreamEvent(event: CodexAppServerStreamEvent): void {
-    if (event.type !== 'message') {
+    if (this.disposed) {
       return;
     }
 
-    for (const handler of this.handlers) {
-      handler(event.message);
+    if (event.type === 'message') {
+      for (const handler of this.handlers) {
+        handler(event.message);
+      }
+      return;
+    }
+
+    if (event.type === 'stderr') {
+      this.lastStderrLine = event.text;
+      return;
+    }
+
+    if (event.type === 'error') {
+      this.emitError(event.message);
+      return;
+    }
+
+    if (event.type === 'exit') {
+      const suffix = this.lastStderrLine ? ` Last stderr: ${this.lastStderrLine}` : '';
+      const exitCode =
+        event.exitCode === null ? 'without an exit code' : `with exit code ${event.exitCode}`;
+      this.emitError(`Codex app-server exited ${exitCode}.${suffix}`);
+    }
+  }
+
+  private emitError(message: string): void {
+    const error = new Error(message);
+    for (const handler of this.errorHandlers) {
+      handler(error);
     }
   }
 }

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1116,11 +1116,13 @@ function validatePlanDependencies(
   plan: AgentPlan,
 ): { valid: true } | { valid: false; message: string } {
   const stepIds = new Set<string>();
+  const dependencyMap = new Map<string, string[]>();
   for (const step of plan.steps) {
     if (stepIds.has(step.id)) {
       return { valid: false, message: `AgentPlan contains duplicate step id '${step.id}'.` };
     }
     stepIds.add(step.id);
+    dependencyMap.set(step.id, step.dependsOn ?? []);
   }
 
   for (const step of plan.steps) {
@@ -1134,6 +1136,46 @@ function validatePlanDependencies(
           message: `Plan step '${step.id}' depends on unknown step '${dependency}'.`,
         };
       }
+    }
+  }
+
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const stack: string[] = [];
+
+  const findCycle = (stepId: string): string[] | null => {
+    const activeIndex = stack.indexOf(stepId);
+    if (activeIndex >= 0) {
+      return [...stack.slice(activeIndex), stepId];
+    }
+    if (visited.has(stepId)) {
+      return null;
+    }
+
+    visiting.add(stepId);
+    stack.push(stepId);
+    for (const dependency of dependencyMap.get(stepId) ?? []) {
+      const cycle = findCycle(dependency);
+      if (cycle) {
+        return cycle;
+      }
+    }
+    stack.pop();
+    visiting.delete(stepId);
+    visited.add(stepId);
+    return null;
+  };
+
+  for (const stepId of stepIds) {
+    if (visiting.has(stepId) || visited.has(stepId)) {
+      continue;
+    }
+    const cycle = findCycle(stepId);
+    if (cycle) {
+      return {
+        valid: false,
+        message: `Plan contains cyclic dependency: ${cycle.join(' -> ')}`,
+      };
     }
   }
 

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1,6 +1,15 @@
 import { invoke } from '@tauri-apps/api/core';
 
-import type { CommandResultDto, ProjectInfo, ProjectStateDto } from '@/bindings';
+import type {
+  AgentPlan,
+  AgentPlanResult,
+  CommandResultDto,
+  ExternalAgentApprovalTokenGrant,
+  ExternalAgentApprovalTokenValidation,
+  PlanRiskLevel,
+  ProjectInfo,
+  ProjectStateDto,
+} from '@/bindings';
 
 import type { ExternalAgentApprovalDecisionProvider, ExternalAgentApprovalRequest } from '../types';
 import type {
@@ -116,7 +125,7 @@ interface ContextTokenRecord {
   projectId: string;
   issuedAt: number;
   activeSequenceId: string | null;
-  source: 'project_state' | 'timeline_snapshot' | 'assets_list';
+  source: 'project_state' | 'timeline_snapshot' | 'assets_list' | 'selection_read';
 }
 
 const contextTokensBySessionId = new Map<string, ContextTokenRecord>();
@@ -157,6 +166,56 @@ const COMMAND_EXECUTE_SCHEMA: CodexJsonObject = {
   additionalProperties: false,
 };
 
+const COMMAND_VALIDATE_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['commandType', 'payload'],
+  properties: {
+    commandType: {
+      type: 'string',
+      enum: OPENREELIO_EXECUTABLE_COMMAND_TYPES,
+      description: 'PascalCase OpenReelio edit command type to validate.',
+    },
+    payload: {
+      type: 'object',
+      description: 'CamelCase JSON payload matching the command type.',
+    },
+  },
+  additionalProperties: false,
+};
+
+const PLAN_OBJECT_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  description:
+    'OpenReelio AgentPlan with id, goal, approvalGranted, and ordered steps using toolName and params.',
+};
+
+const PLAN_VALIDATE_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['plan'],
+  properties: {
+    plan: PLAN_OBJECT_SCHEMA,
+  },
+  additionalProperties: false,
+};
+
+const PLAN_APPLY_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['plan', 'reason', 'contextToken'],
+  properties: {
+    plan: PLAN_OBJECT_SCHEMA,
+    reason: {
+      type: 'string',
+      description: 'Short user-facing reason for the plan approval prompt.',
+    },
+    contextToken: {
+      type: 'string',
+      description:
+        'Fresh mutation context token returned by openreelio.project_state, timeline_snapshot, assets_list, or selection_read in this session.',
+    },
+  },
+  additionalProperties: false,
+};
+
 export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
   {
     namespace: 'openreelio',
@@ -187,10 +246,59 @@ export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
   },
   {
     namespace: 'openreelio',
+    name: 'selection_read',
+    description:
+      'Read current timeline selection, selected project asset, playhead, and active editing tool state.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'diagnostics_read',
+    description:
+      'Read non-mutating project/runtime diagnostics relevant to planning safe OpenReelio edits.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'preview_describe',
+    description:
+      'Read preview/playback state and whether raw frame inspection is available through the OpenReelio bridge.',
+    inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
     name: 'command_schema',
     description:
       'Read the supported OpenReelio event-sourced edit command types and payload conventions.',
     inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'command_validate',
+    description:
+      'Validate one OpenReelio edit command payload without mutating the project or asking for approval.',
+    inputSchema: COMMAND_VALIDATE_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'plan_validate',
+    description:
+      'Validate an OpenReelio AgentPlan and every step payload without mutating the project or asking for approval.',
+    inputSchema: PLAN_VALIDATE_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'diff_preview',
+    description:
+      'Preview a non-mutating structural summary of an OpenReelio AgentPlan after validation.',
+    inputSchema: PLAN_VALIDATE_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'plan_apply',
+    description:
+      'Apply a validated OpenReelio AgentPlan atomically through execute_agent_plan after explicit user approval.',
+    inputSchema: PLAN_APPLY_SCHEMA,
   },
   {
     namespace: 'openreelio',
@@ -228,8 +336,9 @@ export function buildOpenReelioCodexDeveloperInstructions(
     '- Project truth is the OpenReelio command log, not direct JSON state mutation.',
     '- Use OpenReelio dynamic tools before claiming project, timeline, asset, or selection facts.',
     '- Use openreelio.host_context first when the user asks where you are, what you can use, or what environment this is.',
-    '- Use openreelio.timeline_snapshot, openreelio.assets_list, and openreelio.command_schema before proposing concrete edits.',
-    '- Apply edits through openreelio.command_execute with the fresh contextToken returned by openreelio.project_state, openreelio.timeline_snapshot, or openreelio.assets_list so the app can validate, approve, persist, undo, and refresh the UI.',
+    '- Use openreelio.timeline_snapshot, openreelio.assets_list, openreelio.selection_read, and openreelio.command_schema before proposing concrete edits.',
+    '- Prefer openreelio.plan_validate and openreelio.plan_apply for multi-step edits. Use openreelio.command_execute only for a narrow single-command edit.',
+    '- Apply edits with the fresh contextToken returned by openreelio.project_state, openreelio.timeline_snapshot, openreelio.assets_list, or openreelio.selection_read so the app can validate, approve, persist, undo, and refresh the UI.',
     '- Do not manually edit .openreelio state files or invent command payloads without checking the schema and current IDs.',
     '- Do not use shell or filesystem tools to mutate OpenReelio project state; OpenReelio edits must go through the command log.',
     '- Shell and filesystem tools are secondary; prefer OpenReelio tools for video-editing state and mutations.',
@@ -269,8 +378,30 @@ export async function handleOpenReelioCodexDynamicToolCall(
         return toolResponse(buildTimelineSnapshot(await readProjectState(), context));
       case 'assets_list':
         return toolResponse(buildAssetsList(await readProjectState(), context));
+      case 'selection_read':
+        return toolResponse(await buildSelectionResponse(context));
+      case 'diagnostics_read':
+        return toolResponse(await buildDiagnosticsResponse());
+      case 'preview_describe':
+        return toolResponse(await buildPreviewDescription());
       case 'command_schema':
         return toolResponse(buildCommandSchema());
+      case 'command_validate': {
+        const result = await validateCommandToolCall(toolCall.arguments);
+        return toolResponse(result, result.status === 'ok');
+      }
+      case 'plan_validate': {
+        const result = await validatePlanToolCall(toolCall.arguments);
+        return toolResponse(result, result.status === 'ok');
+      }
+      case 'diff_preview': {
+        const result = await previewPlanDiff(toolCall.arguments);
+        return toolResponse(result, result.status === 'ok');
+      }
+      case 'plan_apply': {
+        const result = await applyApprovedPlan(toolCall.arguments, request, context);
+        return toolResponse(result, result.status === 'ok');
+      }
       case 'command_execute': {
         const result = await executeApprovedCommand(toolCall.arguments, request, context);
         return toolResponse(result, result.status === 'ok');
@@ -419,15 +550,27 @@ async function buildHostContext(context: OpenReelioCodexToolContext): Promise<Co
       timelineRead: true,
       assetRead: true,
       commandSchemaRead: true,
+      commandValidate: true,
+      planValidate: true,
+      planApplyWithApproval: true,
+      diffPreview: true,
+      selectionRead: true,
+      diagnosticsRead: true,
+      previewDescribe: true,
       commandExecuteWithApproval: true,
       undoableCommandLog: true,
     },
     policy: {
-      mutationPath: 'openreelio.command_execute',
+      mutationPath: 'openreelio.plan_apply',
       approvalRequiredForMutations: true,
       directStateFileEdits: 'forbidden',
       contextTokenRequiredForMutations: true,
-      mutationContextSources: ['project_state', 'timeline_snapshot', 'assets_list'],
+      mutationContextSources: [
+        'project_state',
+        'timeline_snapshot',
+        'assets_list',
+        'selection_read',
+      ],
     },
   };
 }
@@ -441,6 +584,125 @@ async function buildProjectStateResponse(
     contextToken: contextToken.token,
     contextTokenExpiresAt: contextToken.issuedAt + CONTEXT_TOKEN_TTL_MS,
     projectState: state as unknown as CodexJsonObject,
+  };
+}
+
+async function buildSelectionResponse(
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
+  const [state, timelineModule, playbackModule, projectModule, editorToolModule] =
+    await Promise.all([
+      readProjectState(),
+      import('@/stores/timelineStore'),
+      import('@/stores/playbackStore'),
+      import('@/stores/projectStore'),
+      import('@/stores/editorToolStore'),
+    ]);
+  const timelineState = timelineModule.useTimelineStore.getState();
+  const playbackState = playbackModule.usePlaybackStore.getState();
+  const projectStoreState = projectModule.useProjectStore.getState();
+  const editorToolState = editorToolModule.useEditorToolStore.getState();
+  const selectedClipIds = [...timelineState.selectedClipIds];
+  const selectedTrackIds = [...timelineState.selectedTrackIds];
+  const contextToken = issueContextToken(context, state, 'selection_read');
+
+  return {
+    contextToken: contextToken.token,
+    contextTokenExpiresAt: contextToken.issuedAt + CONTEXT_TOKEN_TTL_MS,
+    activeSequenceId: state.activeSequenceId,
+    selectedClipIds,
+    selectedTrackIds,
+    selectedAssetId: projectStoreState.selectedAssetId,
+    playheadSec: playbackState.currentTime,
+    playback: {
+      isPlaying: playbackState.isPlaying,
+      duration: playbackState.duration,
+      playbackRate: playbackState.playbackRate,
+      muted: playbackState.isMuted,
+    },
+    activeTool: editorToolState.activeTool,
+    selectedClips: selectedClipIds.map((clipId) => findClipSummary(state, clipId)).filter(Boolean),
+    selectedTracks: selectedTrackIds
+      .map((trackId) => findTrackSummary(state, trackId))
+      .filter(Boolean),
+  };
+}
+
+async function buildDiagnosticsResponse(): Promise<CodexJsonObject> {
+  const [projectInfo, projectState] = await Promise.all([
+    readOptionalProjectInfo(),
+    readOptionalProjectState(),
+  ]);
+  let frontendError: string | null = null;
+  try {
+    const projectModule = await import('@/stores/projectStore');
+    frontendError = projectModule.useProjectStore.getState().error;
+  } catch {
+    frontendError = null;
+  }
+
+  const missingAssets =
+    projectState?.assets
+      ?.filter((asset) => asset.missing)
+      .map((asset) => ({
+        id: asset.id,
+        name: asset.name,
+        kind: asset.kind,
+      })) ?? [];
+
+  return {
+    available: Boolean(projectInfo ?? projectState),
+    projectId: projectInfo?.id ?? null,
+    projectName: projectInfo?.name ?? projectState?.meta?.name ?? null,
+    activeSequenceId: projectState?.activeSequenceId ?? null,
+    isDirty: projectState?.isDirty ?? null,
+    assetCount: projectState?.assets?.length ?? 0,
+    sequenceCount: projectState?.sequences?.length ?? 0,
+    missingAssetCount: missingAssets.length,
+    missingAssets,
+    frontendError,
+    policy: {
+      mutationRequiresApproval: true,
+      commandPayloadValidation: true,
+      planApplyPath: 'execute_agent_plan',
+      directStateFileEdits: 'forbidden',
+    },
+  };
+}
+
+async function buildPreviewDescription(): Promise<CodexJsonObject> {
+  const [state, playbackModule, previewModule] = await Promise.all([
+    readOptionalProjectState(),
+    import('@/stores/playbackStore'),
+    import('@/stores/previewStore'),
+  ]);
+  const playbackState = playbackModule.usePlaybackStore.getState();
+  const previewState = previewModule.usePreviewStore.getState();
+  const activeSequence = state?.sequences.find(
+    (sequence) => sequence.id === state.activeSequenceId,
+  );
+
+  return {
+    available: Boolean(state),
+    activeSequenceId: state?.activeSequenceId ?? null,
+    activeSequence: activeSequence ? summarizeSequence(activeSequence) : null,
+    playheadSec: playbackState.currentTime,
+    durationSec: playbackState.duration,
+    isPlaying: playbackState.isPlaying,
+    playbackRate: playbackState.playbackRate,
+    preview: {
+      zoomLevel: previewState.zoomLevel,
+      zoomMode: previewState.zoomMode,
+      panX: previewState.panX,
+      panY: previewState.panY,
+    },
+    mediaInspection: {
+      rawFrameAccess: false,
+      transcriptAccess: false,
+      waveformAccess: false,
+      message:
+        'Raw frame, transcript, and waveform analysis are not exposed through this Codex bridge yet.',
+    },
   };
 }
 
@@ -516,7 +778,8 @@ async function executeApprovedCommand(
     return {
       status: 'denied',
       commandType,
-      message: 'The OpenReelio command was not approved by the user.',
+      message:
+        'The OpenReelio command was not approved. Approve it with the chat approval card; plain chat replies do not grant tool execution.',
     };
   }
 
@@ -530,6 +793,166 @@ async function executeApprovedCommand(
   return {
     status: 'ok',
     commandType,
+    result,
+    refresh,
+  };
+}
+
+async function validateCommandToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
+  if (!args) {
+    throw new Error('OpenReelio command_validate requires object arguments.');
+  }
+
+  const commandType = getString(args, 'commandType')?.trim();
+  if (!commandType) {
+    throw new Error('OpenReelio command_validate requires commandType.');
+  }
+  const unsupported = getUnsupportedExecutableCommandMessage(commandType);
+  if (unsupported) {
+    return {
+      status: 'error',
+      commandType,
+      message: unsupported,
+    };
+  }
+
+  const payload = asObject(args.payload);
+  if (!payload) {
+    throw new Error('OpenReelio command_validate requires an object payload.');
+  }
+
+  const validation = await validateCommandPayload(commandType, payload);
+  if (!validation.valid) {
+    return {
+      status: 'error',
+      commandType,
+      message: validation.message,
+    };
+  }
+
+  return {
+    status: 'ok',
+    commandType,
+    message: 'Command payload is valid.',
+  };
+}
+
+async function validatePlanToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
+  const validation = await validateAgentPlanArgument(args);
+  if (!validation.valid) {
+    return {
+      status: 'error',
+      message: validation.message,
+    };
+  }
+
+  return {
+    status: 'ok',
+    planId: validation.plan.id,
+    goal: validation.plan.goal,
+    totalSteps: validation.plan.steps.length,
+    steps: validation.plan.steps.map((step) => ({
+      id: step.id,
+      toolName: step.toolName,
+      riskLevel: step.riskLevel,
+      optional: step.optional ?? false,
+      dependsOn: step.dependsOn ?? [],
+    })),
+  };
+}
+
+async function previewPlanDiff(args: CodexJsonObject | null): Promise<CodexJsonObject> {
+  const validation = await validateAgentPlanArgument(args);
+  if (!validation.valid) {
+    return {
+      status: 'error',
+      message: validation.message,
+    };
+  }
+
+  return {
+    status: 'ok',
+    previewType: 'structural',
+    renderedVisualDiffAvailable: false,
+    planId: validation.plan.id,
+    goal: validation.plan.goal,
+    totalSteps: validation.plan.steps.length,
+    commands: validation.plan.steps.map((step, index) => ({
+      index,
+      stepId: step.id,
+      commandType: step.toolName,
+      description: step.description,
+      riskLevel: step.riskLevel,
+      params: step.params,
+    })),
+  };
+}
+
+async function applyApprovedPlan(
+  args: CodexJsonObject | null,
+  request: CodexAppServerRequest,
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
+  if (!args) {
+    throw new Error('OpenReelio plan_apply requires object arguments.');
+  }
+
+  const validation = await validateAgentPlanArgument(args);
+  if (!validation.valid) {
+    return {
+      status: 'error',
+      message: validation.message,
+    };
+  }
+
+  const contextToken = getString(args, 'contextToken')?.trim() ?? null;
+  const tokenValidation = validateContextToken(context, contextToken);
+  if (!tokenValidation.valid) {
+    return {
+      status: 'error',
+      planId: validation.plan.id,
+      message: tokenValidation.message.replace(/command_execute/g, 'plan_apply'),
+    };
+  }
+
+  const reason = getString(args, 'reason')?.trim() || `Apply plan ${validation.plan.id}`;
+  const decision = context.approvalDecisionProvider
+    ? await context.approvalDecisionProvider(
+        buildPlanApprovalRequest({
+          request,
+          context,
+          plan: validation.plan,
+          reason,
+        }),
+      )
+    : 'decline';
+
+  if (decision !== 'accept' && decision !== 'acceptForSession') {
+    return {
+      status: 'denied',
+      planId: validation.plan.id,
+      message:
+        'The OpenReelio plan was not approved. Approve it with the chat approval card; plain chat replies do not grant tool execution.',
+    };
+  }
+
+  const approvalGrant = await issueAndConsumePlanApplyApproval(context, validation.plan.id);
+  const plan: AgentPlan = {
+    ...validation.plan,
+    approvalGranted: true,
+    sessionId: validation.plan.sessionId ?? context.sessionId,
+  };
+  const result = await invoke<AgentPlanResult>('execute_agent_plan', { plan });
+  contextTokensBySessionId.delete(context.sessionId);
+  const refresh = await refreshProjectStoreAfterMutation();
+
+  return {
+    status: result.success ? 'ok' : 'error',
+    planId: validation.plan.id,
+    approval: {
+      tokenId: approvalGrant.tokenId,
+      consumed: true,
+    },
     result,
     refresh,
   };
@@ -549,6 +972,172 @@ async function validateCommandPayload(
       message: `OpenReelio command_execute rejected an invalid ${commandType} payload before approval: ${message}`,
     };
   }
+}
+
+function getUnsupportedExecutableCommandMessage(commandType: string): string | null {
+  if (!OPENREELIO_COMMAND_TYPE_SET.has(commandType)) {
+    return `OpenReelio command '${commandType}' is not in the supported command enum.`;
+  }
+
+  if (OPENREELIO_WORKSPACE_COMMAND_TYPES.has(commandType)) {
+    return 'Workspace filesystem commands are not available through Codex timeline editing. Use the dedicated OpenReelio workspace flow instead.';
+  }
+
+  return null;
+}
+
+async function validateAgentPlanArgument(
+  args: CodexJsonObject | null,
+): Promise<{ valid: true; plan: AgentPlan } | { valid: false; message: string }> {
+  if (!args) {
+    return { valid: false, message: 'OpenReelio plan validation requires object arguments.' };
+  }
+  const rawPlan = asObject(args.plan);
+  if (!rawPlan) {
+    return { valid: false, message: 'OpenReelio plan validation requires an object plan.' };
+  }
+
+  const normalized = normalizeAgentPlan(rawPlan);
+  if (!normalized.valid) {
+    return normalized;
+  }
+
+  const dependencyValidation = validatePlanDependencies(normalized.plan);
+  if (!dependencyValidation.valid) {
+    return dependencyValidation;
+  }
+
+  for (const step of normalized.plan.steps) {
+    const unsupported = getUnsupportedExecutableCommandMessage(step.toolName);
+    if (unsupported) {
+      return {
+        valid: false,
+        message: `Plan step '${step.id}' is invalid: ${unsupported}`,
+      };
+    }
+    const params = asObject(step.params);
+    if (!params) {
+      return {
+        valid: false,
+        message: `Plan step '${step.id}' params must be an object.`,
+      };
+    }
+    const payloadValidation = await validateCommandPayload(step.toolName, params);
+    if (!payloadValidation.valid) {
+      return {
+        valid: false,
+        message: `Plan step '${step.id}' rejected invalid ${step.toolName} params: ${payloadValidation.message}`,
+      };
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeAgentPlan(
+  rawPlan: CodexJsonObject,
+): { valid: true; plan: AgentPlan } | { valid: false; message: string } {
+  const id = getString(rawPlan, 'id')?.trim();
+  const goal = getString(rawPlan, 'goal')?.trim();
+  const rawSteps = rawPlan.steps;
+  if (!id) {
+    return { valid: false, message: 'AgentPlan.id is required.' };
+  }
+  if (!goal) {
+    return { valid: false, message: 'AgentPlan.goal is required.' };
+  }
+  if (!Array.isArray(rawSteps) || rawSteps.length === 0) {
+    return { valid: false, message: 'AgentPlan.steps must contain at least one step.' };
+  }
+
+  const steps: AgentPlan['steps'] = [];
+  for (const [index, rawStep] of rawSteps.entries()) {
+    const stepObject = asObject(rawStep);
+    if (!stepObject) {
+      return { valid: false, message: `AgentPlan.steps[${index}] must be an object.` };
+    }
+    const stepId = getString(stepObject, 'id')?.trim();
+    const toolName = getString(stepObject, 'toolName')?.trim();
+    const params = asObject(stepObject.params);
+    const description =
+      getString(stepObject, 'description')?.trim() || (toolName ? `Run ${toolName}` : '');
+    const riskLevel = normalizePlanRiskLevel(getString(stepObject, 'riskLevel'));
+    const dependsOn = normalizeStringArray(stepObject.dependsOn);
+    const optional = typeof stepObject.optional === 'boolean' ? stepObject.optional : false;
+
+    if (!stepId) {
+      return { valid: false, message: `AgentPlan.steps[${index}].id is required.` };
+    }
+    if (!toolName) {
+      return { valid: false, message: `AgentPlan.steps[${index}].toolName is required.` };
+    }
+    if (!params) {
+      return { valid: false, message: `AgentPlan.steps[${index}].params must be an object.` };
+    }
+
+    steps.push({
+      id: stepId,
+      toolName,
+      params: params as AgentPlan['steps'][number]['params'],
+      description,
+      riskLevel,
+      dependsOn,
+      optional,
+    });
+  }
+
+  return {
+    valid: true,
+    plan: {
+      id,
+      goal,
+      steps,
+      approvalGranted: Boolean(rawPlan.approvalGranted),
+      sessionId: getString(rawPlan, 'sessionId'),
+    },
+  };
+}
+
+function normalizePlanRiskLevel(value: string | null): PlanRiskLevel {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'critical'
+    ? value
+    : 'medium';
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+}
+
+function validatePlanDependencies(
+  plan: AgentPlan,
+): { valid: true } | { valid: false; message: string } {
+  const stepIds = new Set<string>();
+  for (const step of plan.steps) {
+    if (stepIds.has(step.id)) {
+      return { valid: false, message: `AgentPlan contains duplicate step id '${step.id}'.` };
+    }
+    stepIds.add(step.id);
+  }
+
+  for (const step of plan.steps) {
+    for (const dependency of step.dependsOn ?? []) {
+      if (dependency === step.id) {
+        return { valid: false, message: `Plan step '${step.id}' cannot depend on itself.` };
+      }
+      if (!stepIds.has(dependency)) {
+        return {
+          valid: false,
+          message: `Plan step '${step.id}' depends on unknown step '${dependency}'.`,
+        };
+      }
+    }
+  }
+
+  return { valid: true };
 }
 
 function buildCommandApprovalRequest(input: {
@@ -578,6 +1167,82 @@ function buildCommandApprovalRequest(input: {
     reason: input.reason,
     requestedAt: Date.now(),
   };
+}
+
+function buildPlanApprovalRequest(input: {
+  request: CodexAppServerRequest;
+  context: OpenReelioCodexToolContext;
+  plan: AgentPlan;
+  reason: string;
+}): ExternalAgentApprovalRequest {
+  const params = input.request.params ?? {};
+  return {
+    id: `codex:openreelio-plan:${input.request.id}:${getString(params, 'callId') ?? input.plan.id}`,
+    runtimeId: input.context.runtimeId,
+    sessionId: input.context.sessionId,
+    turnId: getString(params, 'turnId'),
+    itemId: getString(params, 'callId'),
+    requestId: input.request.id,
+    approvalType: 'openreelio_plan_apply',
+    tool: 'OpenReelio plan apply',
+    description: input.reason,
+    args: {
+      planId: input.plan.id,
+      goal: input.plan.goal,
+      stepCount: input.plan.steps.length,
+      commands: input.plan.steps.map((step) => ({
+        id: step.id,
+        toolName: step.toolName,
+        description: step.description,
+        riskLevel: step.riskLevel,
+      })),
+      projectId: input.context.projectId,
+      cwd: input.context.cwd ?? null,
+    },
+    reason: input.reason,
+    requestedAt: Date.now(),
+  };
+}
+
+async function issueAndConsumePlanApplyApproval(
+  context: OpenReelioCodexToolContext,
+  planId: string,
+): Promise<ExternalAgentApprovalTokenGrant> {
+  const grant = await invoke<ExternalAgentApprovalTokenGrant>(
+    'create_external_agent_approval_token',
+    {
+      input: {
+        sessionId: context.sessionId,
+        runId: null,
+        planId,
+        projectId: context.projectId,
+        runtimeId: context.runtimeId,
+        scopes: ['openreelio.plan.apply'],
+        ttlMs: 10 * 60 * 1000,
+      },
+    },
+  );
+  const validation = await invoke<ExternalAgentApprovalTokenValidation>(
+    'consume_external_agent_approval_token',
+    {
+      input: {
+        token: grant.token,
+        sessionId: context.sessionId,
+        planId,
+        projectId: context.projectId,
+        runtimeId: context.runtimeId,
+        requiredScope: 'openreelio.plan.apply',
+      },
+    },
+  );
+
+  if (!validation.valid) {
+    throw new Error(
+      validation.reason ?? 'OpenReelio plan approval token was rejected before plan execution.',
+    );
+  }
+
+  return grant;
 }
 
 async function readProjectState(): Promise<ProjectStateDto> {
@@ -655,6 +1320,64 @@ function summarizeSequence(sequence: unknown): CodexJsonObject {
   };
 }
 
+function findClipSummary(state: ProjectStateDto, clipId: string): CodexJsonObject | null {
+  for (const sequence of state.sequences) {
+    const sequenceObject = asObject(sequence) ?? {};
+    const tracks = Array.isArray(sequenceObject.tracks) ? sequenceObject.tracks : [];
+    for (const track of tracks) {
+      const trackObject = asObject(track) ?? {};
+      const clips = Array.isArray(trackObject.clips) ? trackObject.clips : [];
+      const clip = clips.find((candidate) => asObject(candidate)?.id === clipId);
+      const clipObject = asObject(clip);
+      if (!clipObject) {
+        continue;
+      }
+      const place = asObject(clipObject.place) ?? {};
+      const range = asObject(clipObject.range) ?? {};
+      return {
+        id: clipObject.id,
+        assetId: clipObject.assetId,
+        sequenceId: sequenceObject.id,
+        trackId: trackObject.id,
+        trackName: trackObject.name,
+        timelineInSec: place.timelineInSec,
+        durationSec: place.durationSec,
+        sourceInSec: range.sourceInSec,
+        sourceOutSec: range.sourceOutSec,
+        speed: clipObject.speed,
+        enabled: clipObject.enabled,
+      };
+    }
+  }
+
+  return null;
+}
+
+function findTrackSummary(state: ProjectStateDto, trackId: string): CodexJsonObject | null {
+  for (const sequence of state.sequences) {
+    const sequenceObject = asObject(sequence) ?? {};
+    const tracks = Array.isArray(sequenceObject.tracks) ? sequenceObject.tracks : [];
+    const track = tracks.find((candidate) => asObject(candidate)?.id === trackId);
+    const trackObject = asObject(track);
+    if (!trackObject) {
+      continue;
+    }
+    const clips = Array.isArray(trackObject.clips) ? trackObject.clips : [];
+    return {
+      id: trackObject.id,
+      sequenceId: sequenceObject.id,
+      name: trackObject.name,
+      kind: trackObject.kind,
+      muted: trackObject.muted,
+      locked: trackObject.locked,
+      visible: trackObject.visible,
+      clipCount: clips.length,
+    };
+  }
+
+  return null;
+}
+
 function buildAssetsList(
   state: ProjectStateDto,
   context: OpenReelioCodexToolContext,
@@ -706,9 +1429,9 @@ function createContextToken(): string {
   if (cryptoApi?.getRandomValues) {
     const randomWords = new Uint32Array(4);
     cryptoApi.getRandomValues(randomWords);
-    const randomPart = Array.from(randomWords, (word) =>
-      word.toString(36).padStart(7, '0'),
-    ).join('');
+    const randomPart = Array.from(randomWords, (word) => word.toString(36).padStart(7, '0')).join(
+      '',
+    );
     return `orctx:${Date.now()}:${randomPart}`;
   }
 

--- a/src/agents/external/approvalGateway.test.ts
+++ b/src/agents/external/approvalGateway.test.ts
@@ -157,6 +157,10 @@ describe('ExternalAgentApprovalGateway', () => {
     expect(gateway.buildMcpApprovalEnvironment(grant())).toEqual({
       OPENREELIO_MCP_APPROVAL_TOKEN: 'or_mcp_test_token',
       OPENREELIO_MCP_APPROVAL_EXPIRES_AT_MS: '601000',
+      OPENREELIO_MCP_APPROVAL_SESSION_ID: 'session-1',
+      OPENREELIO_MCP_APPROVAL_PLAN_ID: 'plan-1',
+      OPENREELIO_MCP_APPROVAL_PROJECT_ID: 'project-1',
+      OPENREELIO_MCP_APPROVAL_RUNTIME_ID: 'codex',
     });
   });
 

--- a/src/agents/external/approvalGateway.ts
+++ b/src/agents/external/approvalGateway.ts
@@ -108,6 +108,10 @@ export class ExternalAgentApprovalGateway {
     return {
       OPENREELIO_MCP_APPROVAL_TOKEN: grant.token,
       OPENREELIO_MCP_APPROVAL_EXPIRES_AT_MS: String(grant.expiresAt),
+      OPENREELIO_MCP_APPROVAL_SESSION_ID: grant.sessionId,
+      OPENREELIO_MCP_APPROVAL_PLAN_ID: grant.planId ?? '',
+      OPENREELIO_MCP_APPROVAL_PROJECT_ID: grant.projectId,
+      OPENREELIO_MCP_APPROVAL_RUNTIME_ID: grant.runtimeId,
     };
   }
 

--- a/src/agents/external/chatRuntime.test.ts
+++ b/src/agents/external/chatRuntime.test.ts
@@ -629,6 +629,61 @@ describe('ExternalAgentChatRuntimeController', () => {
     );
   });
 
+  it('should surface broker-only OpenReelio approval requests as chat cards', async () => {
+    const conversation = new FakeConversationGateway();
+    const adapter = new FakeExternalAgentAdapter();
+    const approvalBroker = new ExternalAgentApprovalBroker({ timeoutMs: 0 });
+    const controller = new ExternalAgentChatRuntimeController({
+      adapter,
+      conversation,
+      projectId: 'project-1',
+      approvalBroker,
+    });
+
+    await controller.sendMessage('Apply the OpenReelio plan');
+    const decisionPromise = approvalBroker.requestDecision({
+      id: 'codex:openreelio-plan:99:shorts-cleanup-v1',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      turnId: 'turn_1',
+      itemId: 'plan_apply_1',
+      requestId: 99,
+      approvalType: 'openreelio_plan_apply',
+      tool: 'OpenReelio plan apply',
+      description: 'Apply approved shorts cleanup plan',
+      args: { planId: 'shorts-cleanup-v1', stepCount: 42 },
+      reason: null,
+      requestedAt: 1000,
+    });
+
+    expect(controller.getState().pendingToolPermissionRequest).toEqual({
+      id: 'codex:openreelio-plan:99:shorts-cleanup-v1',
+      tool: 'OpenReelio plan apply',
+      description: 'Apply approved shorts cleanup plan',
+      args: { planId: 'shorts-cleanup-v1', stepCount: 42 },
+      riskLevel: 'medium',
+    });
+    expect(conversation.getMessageParts('assistant-1')).toEqual([
+      {
+        type: 'tool_approval',
+        stepId: 'codex:openreelio-plan:99:shorts-cleanup-v1',
+        tool: 'OpenReelio plan apply',
+        args: { planId: 'shorts-cleanup-v1', stepCount: 42 },
+        description: 'Apply approved shorts cleanup plan',
+        riskLevel: 'medium',
+        status: 'pending',
+      },
+    ]);
+
+    controller.resolveApproval('accept');
+
+    await expect(decisionPromise).resolves.toBe('accept');
+    expect(controller.getState().pendingToolPermissionRequest).toBeNull();
+    expect(conversation.getMessageParts('assistant-1')?.[0]).toMatchObject({
+      status: 'approved',
+    });
+  });
+
   it('should treat unknown approval types as high risk', async () => {
     const conversation = new FakeConversationGateway();
     const adapter = new FakeExternalAgentAdapter();

--- a/src/agents/external/chatRuntime.ts
+++ b/src/agents/external/chatRuntime.ts
@@ -113,6 +113,9 @@ export class ExternalAgentChatRuntimeController {
     this.unsubscribe = options.adapter.subscribe?.((event) => this.handleEvent(event)) ?? null;
     this.unsubscribeApprovalBroker =
       options.approvalBroker?.subscribe((snapshot) => {
+        if (snapshot.pending) {
+          this.handleBrokerApprovalRequest(snapshot.pending);
+        }
         this.setState({
           pendingToolPermissionRequest: snapshot.pending
             ? mapApprovalRequestToPermissionRequest(snapshot.pending)
@@ -507,6 +510,34 @@ export class ExternalAgentChatRuntimeController {
     this.approvalPartIndex.set(approvalId, { messageId, partIndex });
   }
 
+  private handleBrokerApprovalRequest(request: ExternalAgentApprovalRequest): void {
+    const messageId = this.messageIdByExternalSessionId.get(request.sessionId);
+    if (!messageId) {
+      return;
+    }
+
+    const parts = this.options.conversation.getMessageParts(messageId) ?? [];
+    const existingIndex = parts.findIndex(
+      (part) => part.type === 'tool_approval' && part.stepId === request.id,
+    );
+    if (existingIndex >= 0) {
+      this.approvalPartIndex.set(request.id, { messageId, partIndex: existingIndex });
+      return;
+    }
+
+    const partIndex = parts.length;
+    this.options.conversation.appendPart(messageId, {
+      type: 'tool_approval',
+      stepId: request.id,
+      tool: request.tool,
+      args: request.args,
+      description: request.description || request.reason || 'Approve Codex request',
+      riskLevel: inferApprovalRiskLevel(request.approvalType),
+      status: 'pending',
+    });
+    this.approvalPartIndex.set(request.id, { messageId, partIndex });
+  }
+
   private handleTurnCompleted(
     event: Extract<ExternalAgentRuntimeEvent, { type: 'turn_completed' }>,
   ): void {
@@ -727,7 +758,7 @@ function inferApprovalRiskLevel(
   if (approvalType === 'file_change' || approvalType === 'openreelio_workspace_command') {
     return 'high';
   }
-  if (approvalType === 'openreelio_edit_command') {
+  if (approvalType === 'openreelio_edit_command' || approvalType === 'openreelio_plan_apply') {
     return 'medium';
   }
   return 'high';
@@ -744,6 +775,9 @@ function formatApprovalTool(
   }
   if (approvalType === 'openreelio_edit_command') {
     return 'OpenReelio edit';
+  }
+  if (approvalType === 'openreelio_plan_apply') {
+    return 'OpenReelio plan apply';
   }
   if (approvalType === 'openreelio_workspace_command') {
     return 'OpenReelio workspace change';

--- a/src/agents/external/host.ts
+++ b/src/agents/external/host.ts
@@ -29,6 +29,7 @@ export interface ExternalAgentRuntimeSummary {
   reason: string | null;
   installStatus: ExternalAgentRuntimeStatus['installStatus'];
   authStatus: ExternalAgentAuthStatus;
+  version: string | null;
   capabilities: ExternalAgentRuntimeCapabilities;
 }
 
@@ -103,6 +104,7 @@ export function buildExternalAgentHostSummary(
       reason: readiness.reason,
       installStatus: runtime.status.installStatus,
       authStatus: runtime.status.authStatus,
+      version: runtime.status.version,
       capabilities: runtime.capabilities,
     };
   });

--- a/src/agents/external/types.ts
+++ b/src/agents/external/types.ts
@@ -97,6 +97,10 @@ export interface ConsumeExternalAgentPlanApplyApprovalInput {
 export interface ExternalAgentMcpApprovalEnvironment {
   OPENREELIO_MCP_APPROVAL_TOKEN: string;
   OPENREELIO_MCP_APPROVAL_EXPIRES_AT_MS: string;
+  OPENREELIO_MCP_APPROVAL_SESSION_ID: string;
+  OPENREELIO_MCP_APPROVAL_PLAN_ID: string;
+  OPENREELIO_MCP_APPROVAL_PROJECT_ID: string;
+  OPENREELIO_MCP_APPROVAL_RUNTIME_ID: string;
 }
 
 export interface StartAgentSessionInput {
@@ -191,6 +195,7 @@ export type ExternalAgentRuntimeEvent =
         | 'os_command'
         | 'file_change'
         | 'openreelio_edit_command'
+        | 'openreelio_plan_apply'
         | 'openreelio_workspace_command'
         | 'unknown';
       reason?: string | null;
@@ -220,6 +225,7 @@ export interface ExternalAgentApprovalRequest {
     | 'os_command'
     | 'file_change'
     | 'openreelio_edit_command'
+    | 'openreelio_plan_apply'
     | 'openreelio_workspace_command'
     | 'unknown';
   tool: string;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -905,6 +905,20 @@ async startCodexLogin() : Promise<Result<CodexAgentLoginResult, string>> {
     return { status: "error", error: e  as any };
 }
 },
+async installCodexCli() : Promise<Result<CodexCliInstallResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("install_codex_cli") };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
+async updateCodexCli() : Promise<Result<CodexCliUpdateResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("update_codex_cli") };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
 async consumeExternalAgentApprovalToken(input: ConsumeExternalAgentApprovalTokenInput) : Promise<Result<ExternalAgentApprovalTokenValidation, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("consume_external_agent_approval_token", { input }) };
@@ -3654,10 +3668,12 @@ export type CodexAgentLoginResult = { success: boolean; authStatus: string; mess
 export type CodexAppServerSessionInput = { serverId: string }
 export type CodexAppServerStartResult = { serverId: string; eventName: string; command: string; args: string[]; cwd: string }
 export type CodexAppServerWriteInput = { serverId: string; message: JsonValue }
+export type CodexCliInstallResult = { success: boolean; version: string | null; attemptedCommand: string | null; message: string | null }
+export type CodexCliUpdateResult = { success: boolean; beforeVersion: string | null; afterVersion: string | null; attemptedCommand: string | null; message: string | null }
 export type CodexModelCatalogResult = { installed: boolean; defaultModel: string; defaultReasoningEffort: string; models: CodexModelInfo[]; reason: string | null }
 export type CodexModelInfo = { slug: string; displayName: string; defaultReasoningEffort: string; supportedReasoningEfforts: string[] }
 export type CodexReasoningEffortDto = "low" | "medium" | "high" | "xhigh"
-export type CodexStatusProbeResult = { installed: boolean; version: string | null; authStatus: string; reason: string | null }
+export type CodexStatusProbeResult = { installed: boolean; version: string | null; authStatus: string; appServerReady: boolean | null; reason: string | null }
 /**
  * Color (RGBA)
  */

--- a/src/components/features/agent/AgentRuntimeApprovalOverlay.test.tsx
+++ b/src/components/features/agent/AgentRuntimeApprovalOverlay.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AgentRuntimeApprovalOverlay } from './AgentRuntimeApprovalOverlay';
+
+const noop = vi.fn();
+
+describe('AgentRuntimeApprovalOverlay', () => {
+  it('renders a blocking approval popup for tool permission requests', async () => {
+    const onAllow = vi.fn();
+    render(
+      <AgentRuntimeApprovalOverlay
+        pendingPlan={null}
+        pendingToolPermissionRequest={{
+          id: 'codex:openreelio-plan:1',
+          tool: 'OpenReelio plan apply',
+          args: { planId: 'shorts-cleanup-v1' },
+          description: 'Apply the shorts cleanup edit.',
+          riskLevel: 'medium',
+        }}
+        onApprove={noop}
+        onReject={noop}
+        onToolAllow={onAllow}
+        onToolAllowAlways={noop}
+        onToolDeny={noop}
+      />,
+    );
+
+    expect(screen.getByTestId('agent-runtime-approval-overlay')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Agent approval request' })).toBeInTheDocument();
+    expect(screen.getByTestId('tool-approval-part')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('tool-approval-allow-btn'));
+
+    expect(onAllow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/features/agent/AgentRuntimeApprovalOverlay.tsx
+++ b/src/components/features/agent/AgentRuntimeApprovalOverlay.tsx
@@ -1,0 +1,80 @@
+import type { Plan } from '@/agents/engine';
+import type { AgentRuntimePermissionRequest } from './AgentComposerTray';
+import { ApprovalPartRenderer } from './parts/ApprovalPartRenderer';
+import { ToolApprovalPartRenderer } from './parts/ToolApprovalPartRenderer';
+
+interface AgentRuntimeApprovalOverlayProps {
+  pendingPlan: Plan | null;
+  pendingToolPermissionRequest: AgentRuntimePermissionRequest | null;
+  onApprove: () => void;
+  onReject: (reason?: string) => void;
+  onToolAllow: () => void;
+  onToolAllowAlways: () => void;
+  onToolDeny: () => void;
+}
+
+export function AgentRuntimeApprovalOverlay({
+  pendingPlan,
+  pendingToolPermissionRequest,
+  onApprove,
+  onReject,
+  onToolAllow,
+  onToolAllowAlways,
+  onToolDeny,
+}: AgentRuntimeApprovalOverlayProps) {
+  if (!pendingPlan && !pendingToolPermissionRequest) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-surface-base/35 p-3"
+      data-testid="agent-runtime-approval-overlay"
+      aria-live="assertive"
+    >
+      <div
+        className="pointer-events-auto w-full max-w-md overflow-hidden rounded-xl border border-border-subtle bg-surface-elevated shadow-2xl"
+        role="dialog"
+        aria-modal="false"
+        aria-label="Agent approval request"
+      >
+        <div className="border-b border-border-subtle px-3 py-2">
+          <p className="text-xs font-medium text-text-primary">Approval Required</p>
+          <p className="mt-0.5 text-[11px] text-text-tertiary">
+            Review the request before the agent changes the project.
+          </p>
+        </div>
+        <div className="max-h-[min(70vh,32rem)] space-y-2 overflow-y-auto p-3">
+          {pendingPlan && (
+            <ApprovalPartRenderer
+              part={{
+                type: 'approval',
+                plan: pendingPlan,
+                status: 'pending',
+              }}
+              onApprove={onApprove}
+              onReject={onReject}
+            />
+          )}
+
+          {pendingToolPermissionRequest && (
+            <ToolApprovalPartRenderer
+              part={{
+                type: 'tool_approval',
+                stepId: pendingToolPermissionRequest.id,
+                tool: pendingToolPermissionRequest.tool,
+                args: pendingToolPermissionRequest.args,
+                description: pendingToolPermissionRequest.description,
+                riskLevel: pendingToolPermissionRequest.riskLevel,
+                status: 'pending',
+              }}
+              onAllow={onToolAllow}
+              onAllowAlways={onToolAllowAlways}
+              onDeny={onToolDeny}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/agent/AgentRuntimeChatShell.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.tsx
@@ -22,6 +22,7 @@ import { useProjectStore } from '@/stores';
 import { useAgentArtifactReviewStore } from '@/stores/agentArtifactReviewStore';
 import { ChatMessageList, type ChatMessageListProps } from './ChatMessageList';
 import { ChatInputArea } from './ChatInputArea';
+import { AgentRuntimeApprovalOverlay } from './AgentRuntimeApprovalOverlay';
 import { AgentArtifactFocusBanner } from './AgentArtifactFocusBanner';
 import { AgentArtifactDetailPanel } from './AgentArtifactDetailPanel';
 import { AgentSessionPersistenceBanner } from './AgentSessionPersistenceBanner';
@@ -318,7 +319,7 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
     return (
       <div
         data-testid={chatTestId}
-        className={`flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-surface-base ${className}`}
+        className={`relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-surface-base ${className}`}
       >
         <AgentSessionPersistenceBanner className="shrink-0" />
         <AgentSessionArtifactSummary
@@ -347,6 +348,16 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
           onToolAllowAlways={onToolAllowAlways}
           onToolDeny={onToolDeny}
           artifactFocus={artifactFocus}
+        />
+
+        <AgentRuntimeApprovalOverlay
+          pendingPlan={phase === 'awaiting_approval' ? plan : null}
+          pendingToolPermissionRequest={pendingToolPermissionRequest}
+          onApprove={onApprove}
+          onReject={onReject}
+          onToolAllow={onToolAllow}
+          onToolAllowAlways={onToolAllowAlways}
+          onToolDeny={onToolDeny}
         />
 
         <ChatInputArea

--- a/src/components/features/agent/AgenticSidebarContent.test.tsx
+++ b/src/components/features/agent/AgenticSidebarContent.test.tsx
@@ -343,6 +343,7 @@ describe('AgenticSidebarContent', () => {
             reason: null,
             installStatus: 'installed',
             authStatus: 'signed-in',
+            version: 'codex-cli 0.130.0',
             capabilities: {
               streamingEvents: true,
               interrupt: true,
@@ -405,6 +406,7 @@ describe('AgenticSidebarContent', () => {
             reason: null,
             installStatus: 'installed',
             authStatus: 'signed-in',
+            version: 'codex-cli 0.130.0',
             capabilities: {
               streamingEvents: true,
               interrupt: true,
@@ -477,6 +479,7 @@ describe('AgenticSidebarContent', () => {
             reason: 'Codex is not authenticated',
             installStatus: 'installed',
             authStatus: 'signed-out',
+            version: 'codex-cli 0.130.0',
             capabilities: {
               streamingEvents: true,
               interrupt: true,

--- a/src/components/features/agent/AgenticSidebarWorkspace.tsx
+++ b/src/components/features/agent/AgenticSidebarWorkspace.tsx
@@ -78,7 +78,7 @@ export function AgenticSidebarWorkspace({
   return (
     <div
       data-testid="agentic-sidebar-content"
-      className={`relative flex min-w-0 flex-1 overflow-hidden ${className}`}
+      className={`relative flex min-h-0 min-w-0 flex-1 overflow-hidden ${className}`}
     >
       {showSessionList && (
         <div className="absolute inset-y-0 left-0 z-20 flex w-[82%] max-w-[240px] min-w-0 flex-col border-r border-border-subtle bg-surface-base shadow-xl">
@@ -103,7 +103,7 @@ export function AgenticSidebarWorkspace({
         </div>
       )}
 
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <div className="flex items-center px-2 py-1 border-b border-border-subtle bg-surface-base">
           <button
             onClick={onToggleSessionList}

--- a/src/components/features/agent/ChatInputArea.test.tsx
+++ b/src/components/features/agent/ChatInputArea.test.tsx
@@ -32,7 +32,7 @@ const baseProps = {
 };
 
 describe('ChatInputArea', () => {
-  it('renders a single compact permission decision surface while blocking input', () => {
+  it('keeps the composer compact while blocking input for permission requests', () => {
     render(
       <ChatInputArea
         {...baseProps}
@@ -48,8 +48,8 @@ describe('ChatInputArea', () => {
       />,
     );
 
-    expect(screen.getByTestId('tool-approval-part')).toBeInTheDocument();
+    expect(screen.queryByTestId('tool-approval-part')).not.toBeInTheDocument();
     expect(screen.getByTestId('prompt-input')).toBeDisabled();
-    expect(screen.queryByText(/Permission:/)).not.toBeInTheDocument();
+    expect(screen.getByText('Permission: OpenReelio edit')).toBeInTheDocument();
   });
 });

--- a/src/components/features/agent/ChatInputArea.tsx
+++ b/src/components/features/agent/ChatInputArea.tsx
@@ -17,8 +17,6 @@ import {
   type AgentRuntimeSummary,
 } from './AgentComposerTray';
 import { PromptInput } from './PromptInput';
-import { ApprovalPartRenderer } from './parts/ApprovalPartRenderer';
-import { ToolApprovalPartRenderer } from './parts/ToolApprovalPartRenderer';
 
 // =============================================================================
 // Types
@@ -61,11 +59,6 @@ export function ChatInputArea({
   onInputChange,
   onSubmit,
   onStop,
-  onApprove,
-  onReject,
-  onToolAllow,
-  onToolAllowAlways,
-  onToolDeny,
   placeholder,
   disabled,
   isRunning,
@@ -87,49 +80,17 @@ export function ChatInputArea({
   // desync the agent.
   const hasBlockingDecision =
     (phase === 'awaiting_approval' && !!pendingPlan) || !!pendingToolPermissionRequest;
-  const hasDecisionSurface =
-    !!pendingClarificationQuestion ||
-    (phase === 'awaiting_approval' && !!pendingPlan) ||
-    !!pendingToolPermissionRequest;
-  const trayPendingToolPermissionRequest = pendingToolPermissionRequest ? null : undefined;
+  const hasDecisionSurface = !!pendingClarificationQuestion;
+  const trayPendingToolPermissionRequest = pendingToolPermissionRequest ?? undefined;
 
   return (
-    <div className="max-h-[45%] min-w-0 shrink-0 overflow-visible border-t border-border-subtle bg-surface-base px-3 py-2">
+    <div className="relative z-10 min-w-0 shrink-0 border-t border-border-subtle bg-surface-base px-3 py-2">
       <div className="flex max-h-full min-h-0 flex-col gap-2 overflow-visible">
         {hasDecisionSurface && (
           <div className="min-h-0 shrink overflow-y-auto pr-1">
             <div className="space-y-2">
               {pendingClarificationQuestion && (
                 <AgentClarificationDock question={pendingClarificationQuestion} />
-              )}
-
-              {phase === 'awaiting_approval' && pendingPlan && (
-                <ApprovalPartRenderer
-                  part={{
-                    type: 'approval',
-                    plan: pendingPlan,
-                    status: 'pending',
-                  }}
-                  onApprove={onApprove}
-                  onReject={onReject}
-                />
-              )}
-
-              {pendingToolPermissionRequest && (
-                <ToolApprovalPartRenderer
-                  part={{
-                    type: 'tool_approval',
-                    stepId: pendingToolPermissionRequest.id,
-                    tool: pendingToolPermissionRequest.tool,
-                    args: pendingToolPermissionRequest.args,
-                    description: pendingToolPermissionRequest.description,
-                    riskLevel: pendingToolPermissionRequest.riskLevel,
-                    status: 'pending',
-                  }}
-                  onAllow={onToolAllow}
-                  onAllowAlways={onToolAllowAlways}
-                  onDeny={onToolDeny}
-                />
               )}
             </div>
           </div>

--- a/src/components/features/settings/sections/CostControlPanel.test.tsx
+++ b/src/components/features/settings/sections/CostControlPanel.test.tsx
@@ -12,7 +12,7 @@ import type { AISettings } from '@/stores/settingsStore';
 
 const defaultAISettings: AISettings = {
   assistantRuntime: 'api',
-  codexModel: 'gpt-5.4',
+  codexModel: 'gpt-5.5',
   codexReasoningEffort: 'medium',
   primaryProvider: 'anthropic',
   primaryModel: 'claude-sonnet-4-5-20251015',

--- a/src/components/features/settings/sections/ExternalAgentRuntimeSettings.test.tsx
+++ b/src/components/features/settings/sections/ExternalAgentRuntimeSettings.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 const defaultSettings: AISettings = {
   assistantRuntime: 'api',
-  codexModel: 'gpt-5.4',
+  codexModel: 'gpt-5.5',
   codexReasoningEffort: 'medium',
   primaryProvider: 'anthropic',
   primaryModel: 'claude-sonnet-4-5-20251015',
@@ -69,12 +69,12 @@ describe('ExternalAgentRuntimeSettings', () => {
       if (command === 'get_codex_model_catalog') {
         return Promise.resolve({
           installed: true,
-          defaultModel: 'gpt-5.4',
+          defaultModel: 'gpt-5.5',
           defaultReasoningEffort: 'medium',
           models: [
             {
-              slug: 'gpt-5.4',
-              displayName: 'gpt-5.4',
+              slug: 'gpt-5.5',
+              displayName: 'gpt-5.5',
               defaultReasoningEffort: 'medium',
               supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
             },
@@ -93,6 +93,23 @@ describe('ExternalAgentRuntimeSettings', () => {
           success: true,
           authStatus: 'signed-in',
           message: 'Codex sign-in completed.',
+        });
+      }
+      if (command === 'install_codex_cli') {
+        return Promise.resolve({
+          success: true,
+          version: 'codex-cli 0.130.0',
+          attemptedCommand: null,
+          message: 'Codex CLI is already installed.',
+        });
+      }
+      if (command === 'update_codex_cli') {
+        return Promise.resolve({
+          success: true,
+          beforeVersion: 'codex-cli 0.130.0',
+          afterVersion: 'codex-cli 0.130.0',
+          attemptedCommand: 'codex update',
+          message: 'Codex CLI update completed.',
         });
       }
       return Promise.reject(new Error(`Unexpected command: ${command}`));
@@ -166,7 +183,7 @@ describe('ExternalAgentRuntimeSettings', () => {
       if (command === 'get_codex_model_catalog') {
         return Promise.resolve({
           installed: true,
-          defaultModel: 'gpt-5.4',
+          defaultModel: 'gpt-5.5',
           defaultReasoningEffort: 'medium',
           models: [],
           reason: null,
@@ -214,7 +231,7 @@ describe('ExternalAgentRuntimeSettings', () => {
       if (command === 'get_codex_model_catalog') {
         return Promise.resolve({
           installed: true,
-          defaultModel: 'gpt-5.4',
+          defaultModel: 'gpt-5.5',
           defaultReasoningEffort: 'medium',
           models: [],
           reason: null,
@@ -244,6 +261,126 @@ describe('ExternalAgentRuntimeSettings', () => {
     expect(vi.mocked(invoke)).toHaveBeenCalledWith('start_codex_login');
   });
 
+  it('should install Codex CLI from the settings panel when it is missing', async () => {
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === 'get_codex_status') {
+        return Promise.resolve({
+          installed: false,
+          version: null,
+          authStatus: 'unknown',
+          reason: 'Codex CLI was not found.',
+        });
+      }
+      if (command === 'configure_codex_agent_runtime') {
+        return Promise.resolve({
+          installed: false,
+          version: null,
+          authStatus: 'unknown',
+          ready: false,
+          requiresLogin: false,
+          pluginMarketplaceConfigured: false,
+          mcpConfigured: false,
+          message: 'Codex CLI was not found.',
+        });
+      }
+      if (command === 'get_codex_model_catalog') {
+        return Promise.resolve({
+          installed: false,
+          defaultModel: 'gpt-5.5',
+          defaultReasoningEffort: 'medium',
+          models: [],
+          reason: 'Codex CLI was not found.',
+        });
+      }
+      if (command === 'install_codex_cli') {
+        return Promise.resolve({
+          success: true,
+          version: 'codex-cli 0.130.0',
+          attemptedCommand: 'npm install -g @openai/codex',
+          message: 'Codex CLI installation completed.',
+        });
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    render(
+      <ExternalAgentRuntimeSettings
+        settings={{ ...defaultSettings, assistantRuntime: 'codex' }}
+        onUpdate={vi.fn()}
+        disabled={false}
+      />,
+    );
+
+    const installButton = await screen.findByRole('button', { name: /install codex/i });
+    await userEvent.click(installButton);
+
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith('install_codex_cli');
+  });
+
+  it('should update an old Codex CLI from the settings panel', async () => {
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === 'get_codex_status') {
+        return Promise.resolve({
+          installed: true,
+          version: 'codex-cli 0.118.0',
+          authStatus: 'signed-in',
+          reason: null,
+        });
+      }
+      if (command === 'configure_codex_agent_runtime') {
+        return Promise.resolve({
+          installed: true,
+          version: 'codex-cli 0.118.0',
+          authStatus: 'signed-in',
+          ready: true,
+          requiresLogin: false,
+          pluginMarketplaceConfigured: true,
+          mcpConfigured: true,
+          message: 'Codex is connected with OpenReelio tools.',
+        });
+      }
+      if (command === 'get_codex_model_catalog') {
+        return Promise.resolve({
+          installed: true,
+          defaultModel: 'gpt-5.4',
+          defaultReasoningEffort: 'medium',
+          models: [
+            {
+              slug: 'gpt-5.4',
+              displayName: 'gpt-5.4',
+              defaultReasoningEffort: 'medium',
+              supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
+            },
+          ],
+          reason: null,
+        });
+      }
+      if (command === 'update_codex_cli') {
+        return Promise.resolve({
+          success: true,
+          beforeVersion: 'codex-cli 0.118.0',
+          afterVersion: 'codex-cli 0.130.0',
+          attemptedCommand: 'codex update',
+          message: 'Codex CLI update completed.',
+        });
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    render(
+      <ExternalAgentRuntimeSettings
+        settings={{ ...defaultSettings, assistantRuntime: 'codex' }}
+        onUpdate={vi.fn()}
+        disabled={false}
+      />,
+    );
+
+    const updateButton = await screen.findByRole('button', { name: /update codex/i });
+    await userEvent.click(updateButton);
+
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith('update_codex_cli');
+  });
+
   it('should not show sign-in when Codex cannot be launched on this OS', async () => {
     vi.mocked(invoke).mockImplementation((command) => {
       if (command === 'get_codex_status') {
@@ -271,7 +408,7 @@ describe('ExternalAgentRuntimeSettings', () => {
       if (command === 'get_codex_model_catalog') {
         return Promise.resolve({
           installed: false,
-          defaultModel: 'gpt-5.4',
+          defaultModel: 'gpt-5.5',
           defaultReasoningEffort: 'medium',
           models: [],
           reason: 'Codex is unavailable',
@@ -327,5 +464,63 @@ describe('ExternalAgentRuntimeSettings', () => {
     await userEvent.selectOptions(effortSelect, 'medium');
 
     expect(onUpdate).toHaveBeenCalledWith({ codexReasoningEffort: 'medium' });
+  });
+
+  it('should replace an unavailable saved Codex model with the catalog default', async () => {
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === 'get_codex_status') {
+        return Promise.resolve({
+          installed: true,
+          version: 'codex-cli 0.129.0',
+          authStatus: 'signed-in',
+          reason: null,
+        });
+      }
+      if (command === 'configure_codex_agent_runtime') {
+        return Promise.resolve({
+          installed: true,
+          version: 'codex-cli 0.129.0',
+          authStatus: 'signed-in',
+          ready: true,
+          requiresLogin: false,
+          pluginMarketplaceConfigured: true,
+          mcpConfigured: true,
+          message: 'Codex is connected with OpenReelio tools.',
+        });
+      }
+      if (command === 'get_codex_model_catalog') {
+        return Promise.resolve({
+          installed: true,
+          defaultModel: 'gpt-5.4',
+          defaultReasoningEffort: 'medium',
+          models: [
+            {
+              slug: 'gpt-5.4',
+              displayName: 'gpt-5.4',
+              defaultReasoningEffort: 'medium',
+              supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
+            },
+          ],
+          reason: null,
+        });
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+    const onUpdate = vi.fn();
+
+    render(
+      <ExternalAgentRuntimeSettings
+        settings={{ ...defaultSettings, assistantRuntime: 'codex', codexModel: 'gpt-5.5' }}
+        onUpdate={onUpdate}
+        disabled={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith({
+        codexModel: 'gpt-5.4',
+        codexReasoningEffort: 'medium',
+      }),
+    );
   });
 });

--- a/src/components/features/settings/sections/ExternalAgentRuntimeSettings.tsx
+++ b/src/components/features/settings/sections/ExternalAgentRuntimeSettings.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Download, Loader2, RefreshCw, UploadCloud } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 
 import { useExternalAgentHostStatus, EXTERNAL_AGENT_STATUS_REFRESH_EVENT } from '@/agents/external';
@@ -29,6 +29,21 @@ interface CodexAgentLoginResult {
   message: string | null;
 }
 
+interface CodexCliInstallResult {
+  success: boolean;
+  version: string | null;
+  attemptedCommand: string | null;
+  message: string | null;
+}
+
+interface CodexCliUpdateResult {
+  success: boolean;
+  beforeVersion: string | null;
+  afterVersion: string | null;
+  attemptedCommand: string | null;
+  message: string | null;
+}
+
 interface CodexModelInfo {
   slug: string;
   displayName: string;
@@ -45,6 +60,12 @@ interface CodexModelCatalogResult {
 }
 
 const FALLBACK_CODEX_MODELS: CodexModelInfo[] = [
+  {
+    slug: 'gpt-5.5',
+    displayName: 'gpt-5.5',
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh'],
+  },
   {
     slug: 'gpt-5.4',
     displayName: 'gpt-5.4',
@@ -88,10 +109,32 @@ function formatAuthStatus(authStatus?: string | null): string {
 
 function formatActionError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  if (message.includes('Win32') || message.includes('os error 193') || message.includes('%1')) {
+  if (isLauncherExecutableError(message)) {
     return 'The selected Codex launcher is not executable on this OS. OpenReelio needs a native Codex CLI launcher such as codex.cmd or codex.exe.';
   }
   return message;
+}
+
+function isLauncherExecutableError(message?: string | null): boolean {
+  const normalized = message?.toLowerCase() ?? '';
+  return (
+    normalized.includes('win32') ||
+    normalized.includes('os error 193') ||
+    normalized.includes('%1') ||
+    normalized.includes('not executable on this os')
+  );
+}
+
+function parseCodexCliVersion(label?: string | null): { major: number; minor: number } | null {
+  const match = label?.match(/\b(\d+)\.(\d+)(?:\.\d+)?/);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+function shouldOfferCodexUpdate(version?: string | null): boolean {
+  const parsed = parseCodexCliVersion(version);
+  if (!parsed) return false;
+  return parsed.major === 0 && parsed.minor < 130;
 }
 
 function SetupPill({
@@ -134,6 +177,8 @@ export function ExternalAgentRuntimeSettings({
   const [modelCatalog, setModelCatalog] = useState<CodexModelCatalogResult | null>(null);
   const [isConfiguring, setIsConfiguring] = useState(false);
   const [isSigningIn, setIsSigningIn] = useState(false);
+  const [isInstalling, setIsInstalling] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const lastAutoConfigureKeyRef = useRef<string | null>(null);
   const codexSelected = settings.assistantRuntime === 'codex';
   const codexStatus = useExternalAgentHostStatus({
@@ -152,10 +197,10 @@ export function ExternalAgentRuntimeSettings({
   const nativeToolsReady = Boolean(
     codexRuntime?.ready && codexRuntime.capabilities?.structuredToolCalls,
   );
-  const toolsReady = Boolean(
-    nativeToolsReady || (setupResult?.pluginMarketplaceConfigured && setupResult?.mcpConfigured),
-  );
   const runtimeReady = Boolean(setupResult?.ready || nativeToolsReady);
+  const toolsReady = Boolean(
+    runtimeReady || (setupResult?.pluginMarketplaceConfigured && setupResult?.mcpConfigured),
+  );
   const requiresLogin = Boolean(
     codexInstalled &&
     (setupResult?.requiresLogin ||
@@ -168,10 +213,45 @@ export function ExternalAgentRuntimeSettings({
   const reasoningEfforts = selectedCodexModel?.supportedReasoningEfforts.length
     ? selectedCodexModel.supportedReasoningEfforts
     : ['low', 'medium', 'high', 'xhigh'];
+  const codexVersion = setupResult?.version ?? codexRuntime?.version ?? null;
+  const codexNeedsUpdate = Boolean(codexInstalled && shouldOfferCodexUpdate(codexVersion));
+  const launcherExecutableError = isLauncherExecutableError(
+    setupResult?.message ?? codexRuntime?.reason,
+  );
+  const codexStatusKnown = Boolean(setupResult || codexRuntime) && !codexStatus.loading;
+  const canInstallCodex = Boolean(
+    codexSelected && codexStatusKnown && !codexInstalled && !launcherExecutableError,
+  );
+  const isRuntimeActionPending = isConfiguring || isSigningIn || isInstalling || isUpdating;
 
   const refreshExternalAgentStatus = useCallback(() => {
     window.dispatchEvent(new Event(EXTERNAL_AGENT_STATUS_REFRESH_EVENT));
   }, []);
+
+  const applyModelCatalogResult = useCallback(
+    (result: CodexModelCatalogResult) => {
+      setModelCatalog(result);
+      const configuredModel = settings.codexModel?.trim();
+      const configuredModelAvailable = Boolean(
+        configuredModel && result.models.some((model) => model.slug === configuredModel),
+      );
+      const defaultModel =
+        result.models.find((model) => model.slug === result.defaultModel) ?? result.models[0];
+      if (!configuredModelAvailable && defaultModel) {
+        onUpdate({
+          codexModel: defaultModel.slug,
+          codexReasoningEffort:
+            defaultModel.defaultReasoningEffort as AISettings['codexReasoningEffort'],
+        });
+      }
+    },
+    [onUpdate, settings.codexModel],
+  );
+
+  const loadCodexModels = useCallback(async () => {
+    const result = await invoke<CodexModelCatalogResult>('get_codex_model_catalog');
+    applyModelCatalogResult(result);
+  }, [applyModelCatalogResult]);
 
   const configureCodex = useCallback(async () => {
     if (!codexSelected) return;
@@ -222,20 +302,13 @@ export function ExternalAgentRuntimeSettings({
     }
 
     let cancelled = false;
-    async function loadCodexModels(): Promise<void> {
+    async function loadCodexModelsForSelection(): Promise<void> {
       try {
         const result = await invoke<CodexModelCatalogResult>('get_codex_model_catalog');
         if (cancelled) {
           return;
         }
-        setModelCatalog(result);
-        if (!settings.codexModel && result.defaultModel) {
-          onUpdate({
-            codexModel: result.defaultModel,
-            codexReasoningEffort:
-              result.defaultReasoningEffort as AISettings['codexReasoningEffort'],
-          });
-        }
+        applyModelCatalogResult(result);
       } catch {
         if (!cancelled) {
           setModelCatalog(null);
@@ -243,11 +316,11 @@ export function ExternalAgentRuntimeSettings({
       }
     }
 
-    void loadCodexModels();
+    void loadCodexModelsForSelection();
     return () => {
       cancelled = true;
     };
-  }, [codexSelected, onUpdate, settings.codexModel]);
+  }, [applyModelCatalogResult, codexSelected]);
 
   const handleRuntimeSelect = useCallback(
     (runtime: AssistantRuntime) => {
@@ -296,9 +369,47 @@ export function ExternalAgentRuntimeSettings({
     }
   }, [configureCodex, refreshExternalAgentStatus]);
 
+  const handleInstall = useCallback(async () => {
+    setIsInstalling(true);
+    setActionError(null);
+    try {
+      const result = await invoke<CodexCliInstallResult>('install_codex_cli');
+      if (!result.success) {
+        setActionError(result.message ?? 'Codex CLI installation did not complete.');
+      }
+      await loadCodexModels().catch(() => setModelCatalog(null));
+      await configureCodex();
+      refreshExternalAgentStatus();
+    } catch (error) {
+      setActionError(formatActionError(error));
+    } finally {
+      setIsInstalling(false);
+    }
+  }, [configureCodex, loadCodexModels, refreshExternalAgentStatus]);
+
+  const handleUpdate = useCallback(async () => {
+    setIsUpdating(true);
+    setActionError(null);
+    try {
+      const result = await invoke<CodexCliUpdateResult>('update_codex_cli');
+      if (!result.success) {
+        setActionError(result.message ?? 'Codex CLI update did not complete.');
+      }
+      await loadCodexModels().catch(() => setModelCatalog(null));
+      await configureCodex();
+      refreshExternalAgentStatus();
+    } catch (error) {
+      setActionError(formatActionError(error));
+    } finally {
+      setIsUpdating(false);
+    }
+  }, [configureCodex, loadCodexModels, refreshExternalAgentStatus]);
+
   const statusLine = useMemo(() => {
     if (!codexSelected) return 'OpenReelio will use the API provider and model below.';
     if (isSigningIn) return 'Opening the Codex sign-in flow...';
+    if (isInstalling) return 'Installing Codex CLI...';
+    if (isUpdating) return 'Updating Codex CLI...';
     if (isConfiguring) return 'Connecting Codex to OpenReelio tools...';
     if (!hasProject) return 'Open a project to attach OpenReelio tools.';
     if (!codexInstalled) {
@@ -319,7 +430,9 @@ export function ExternalAgentRuntimeSettings({
     effectiveAuthStatus,
     hasProject,
     isConfiguring,
+    isInstalling,
     isSigningIn,
+    isUpdating,
     requiresLogin,
     runtimeReady,
     setupResult?.message,
@@ -367,9 +480,9 @@ export function ExternalAgentRuntimeSettings({
                 Codex Model
               </span>
               <select
-                value={settings.codexModel || selectedCodexModel?.slug || 'gpt-5.4'}
+                value={selectedCodexModel?.slug || settings.codexModel || 'gpt-5.5'}
                 onChange={(event) => handleCodexModelChange(event.target.value)}
-                disabled={disabled || isSigningIn || isConfiguring}
+                disabled={disabled || isRuntimeActionPending}
                 className="h-8 w-full rounded border border-editor-border bg-editor-bg px-2 text-xs text-editor-text outline-none focus:border-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {codexModels.map((model) => (
@@ -386,7 +499,7 @@ export function ExternalAgentRuntimeSettings({
               <select
                 value={settings.codexReasoningEffort || selectedCodexModel?.defaultReasoningEffort}
                 onChange={(event) => handleCodexReasoningEffortChange(event.target.value)}
-                disabled={disabled || isSigningIn || isConfiguring}
+                disabled={disabled || isRuntimeActionPending}
                 className="h-8 w-full rounded border border-editor-border bg-editor-bg px-2 text-xs capitalize text-editor-text outline-none focus:border-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {reasoningEfforts.map((effort) => (
@@ -410,19 +523,47 @@ export function ExternalAgentRuntimeSettings({
                 <SetupPill label="OpenReelio tools" ready={toolsReady} pending={isConfiguring} />
               </div>
               <p className="mt-2 text-xs leading-5 text-editor-text-muted">{statusLine}</p>
-              {setupResult?.version && (
-                <p className="mt-1 truncate text-[11px] text-editor-text-muted">
-                  {setupResult.version}
-                </p>
+              {codexVersion && (
+                <p className="mt-1 truncate text-[11px] text-editor-text-muted">{codexVersion}</p>
               )}
             </div>
 
             <div className="flex shrink-0 items-center gap-2">
+              {canInstallCodex && (
+                <button
+                  type="button"
+                  onClick={handleInstall}
+                  disabled={disabled || isRuntimeActionPending}
+                  className="inline-flex h-8 items-center gap-1.5 rounded bg-primary-500 px-3 text-xs font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isInstalling ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Download className="h-3.5 w-3.5" />
+                  )}
+                  Install Codex
+                </button>
+              )}
+              {codexNeedsUpdate && (
+                <button
+                  type="button"
+                  onClick={handleUpdate}
+                  disabled={disabled || isRuntimeActionPending}
+                  className="inline-flex h-8 items-center gap-1.5 rounded border border-editor-border px-2 text-xs text-editor-text hover:bg-editor-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isUpdating ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <UploadCloud className="h-3.5 w-3.5" />
+                  )}
+                  Update Codex
+                </button>
+              )}
               {requiresLogin && (
                 <button
                   type="button"
                   onClick={handleSignIn}
-                  disabled={disabled || isSigningIn || isConfiguring}
+                  disabled={disabled || isRuntimeActionPending}
                   className="inline-flex h-8 items-center gap-1.5 rounded bg-primary-500 px-3 text-xs font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {isSigningIn && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
@@ -432,7 +573,7 @@ export function ExternalAgentRuntimeSettings({
               <button
                 type="button"
                 onClick={configureCodex}
-                disabled={disabled || isSigningIn || isConfiguring}
+                disabled={disabled || isRuntimeActionPending}
                 className="inline-flex h-8 items-center gap-1.5 rounded border border-editor-border px-2 text-xs text-editor-text hover:bg-editor-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
                 aria-label="Reconnect Codex"
                 title="Reconnect Codex"
@@ -447,7 +588,7 @@ export function ExternalAgentRuntimeSettings({
             </div>
           </div>
 
-          {actionError && !runtimeReady && (
+          {actionError && (!runtimeReady || codexNeedsUpdate || !codexInstalled) && (
             <p className="mt-2 rounded border border-yellow-600/20 bg-yellow-600/10 px-2 py-1.5 text-xs leading-5 text-yellow-200">
               {actionError}
             </p>

--- a/src/e2e/openreelioE2eHooks.ts
+++ b/src/e2e/openreelioE2eHooks.ts
@@ -1,0 +1,89 @@
+import type { Asset, Sequence } from '@/types';
+import { usePlaybackStore } from '@/stores/playbackStore';
+import { useProjectStore } from '@/stores/projectStore';
+import { useWorkspaceLayoutStore, type PanelId } from '@/stores/workspaceLayoutStore';
+
+interface ProjectMetaFixture {
+  id: string;
+  name: string;
+  path: string;
+  createdAt: string;
+  modifiedAt: string;
+}
+
+interface ProxyPreviewFixtureState {
+  project: ProjectMetaFixture;
+  assets: Asset[];
+  sequences: Sequence[];
+  activeSequenceId: string;
+  selectedAssetId: string | null;
+  playback: {
+    currentTime: number;
+    duration: number;
+    isPlaying: boolean;
+    playbackRate: number;
+    volume: number;
+    isMuted: boolean;
+    loop: boolean;
+    syncWithTimeline: boolean;
+  };
+  activePanel?: {
+    zoneId: 'left' | 'center-top' | 'center-bottom' | 'right' | 'bottom';
+    panelId: PanelId;
+  };
+}
+
+interface PlaybackSnapshot {
+  currentTime: number;
+  isPlaying: boolean;
+}
+
+declare global {
+  interface Window {
+    __OPENREELIO_E2E__?: {
+      seedProxyPreviewState: (state: ProxyPreviewFixtureState) => void;
+      seekPlayback: (time: number, source?: string) => void;
+      readPlaybackSnapshot: () => PlaybackSnapshot;
+    };
+  }
+}
+
+window.__OPENREELIO_E2E__ = {
+  seedProxyPreviewState: (state) => {
+    useProjectStore.setState({
+      isLoaded: true,
+      isLoading: false,
+      isDirty: false,
+      meta: state.project,
+      assets: new Map(state.assets.map((asset) => [asset.id, asset])),
+      sequences: new Map(state.sequences.map((sequence) => [sequence.id, sequence])),
+      activeSequenceId: state.activeSequenceId,
+      selectedAssetId: state.selectedAssetId,
+      error: null,
+    });
+
+    usePlaybackStore.setState({
+      currentTime: state.playback.currentTime,
+      duration: state.playback.duration,
+      isPlaying: state.playback.isPlaying,
+      playbackRate: state.playback.playbackRate,
+      volume: state.playback.volume,
+      isMuted: state.playback.isMuted,
+      loop: state.playback.loop,
+      syncWithTimeline: state.playback.syncWithTimeline,
+    });
+
+    if (state.activePanel) {
+      useWorkspaceLayoutStore
+        .getState()
+        .setActivePanel(state.activePanel.zoneId, state.activePanel.panelId);
+    }
+  },
+  seekPlayback: (time, source = 'e2e-seek') => {
+    usePlaybackStore.getState().seek(time, source);
+  },
+  readPlaybackSnapshot: () => {
+    const state = usePlaybackStore.getState();
+    return { currentTime: state.currentTime, isPlaying: state.isPlaying };
+  },
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,10 @@ try {
   logger.error('Agent system initialization failed — AI features may be unavailable', { err });
 }
 
+if (import.meta.env.MODE === 'e2e') {
+  void import('./e2e/openreelioE2eHooks');
+}
+
 /**
  * Root error fallback for catastrophic failures.
  * Shows a basic UI that allows the user to reload the application.

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -309,7 +309,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   ai: {
     assistantRuntime: 'api',
-    codexModel: 'gpt-5.4',
+    codexModel: 'gpt-5.5',
     codexReasoningEffort: 'medium',
     primaryProvider: 'anthropic',
     primaryModel: 'claude-sonnet-4-5-20251015',

--- a/tests/e2e/proxy-preview.spec.ts
+++ b/tests/e2e/proxy-preview.spec.ts
@@ -23,11 +23,7 @@ async function dismissBlockingFFmpegWarning(page: Page): Promise<void> {
 
 async function seedProxyPreviewState(page: Page): Promise<void> {
   const origin = new URL(page.url()).origin;
-  await page.evaluate(async (baseUrl) => {
-    const { useProjectStore } = await import('../../src/stores/projectStore.ts');
-    const { usePlaybackStore } = await import('../../src/stores/playbackStore.ts');
-    const { useWorkspaceLayoutStore } = await import('../../src/stores/workspaceLayoutStore.ts');
-
+  await page.evaluate((baseUrl) => {
     const now = new Date().toISOString();
     const fixtureBase = `${baseUrl}/tests/e2e/fixtures`;
 
@@ -110,36 +106,35 @@ async function seedProxyPreviewState(page: Page): Promise<void> {
       markers: [],
     };
 
-    useProjectStore.setState({
-      isLoaded: true,
-      isLoading: false,
-      isDirty: false,
-      meta: {
+    const hooks = window.__OPENREELIO_E2E__;
+    if (!hooks) {
+      throw new Error('OpenReelio E2E hooks are not available in this build.');
+    }
+
+    hooks.seedProxyPreviewState({
+      project: {
         id: 'project_proxy_qa_1',
         name: 'Proxy QA Project',
         path: '/tmp/proxy-qa',
         createdAt: now,
         modifiedAt: now,
       },
-      assets: new Map([[asset.id, asset]]),
-      sequences: new Map([[sequence.id, sequence]]),
+      assets: [asset],
+      sequences: [sequence],
       activeSequenceId: sequence.id,
       selectedAssetId: asset.id,
-      error: null,
+      playback: {
+        currentTime: 0,
+        duration: 8,
+        isPlaying: false,
+        playbackRate: 1,
+        volume: 1,
+        isMuted: false,
+        loop: false,
+        syncWithTimeline: true,
+      },
+      activePanel: { zoneId: 'center-top', panelId: 'program-monitor' },
     });
-
-    usePlaybackStore.setState({
-      currentTime: 0,
-      duration: 8,
-      isPlaying: false,
-      playbackRate: 1,
-      volume: 1,
-      isMuted: false,
-      loop: false,
-      syncWithTimeline: true,
-    });
-
-    useWorkspaceLayoutStore.getState().setActivePanel('center-top', 'program-monitor');
   }, origin);
 }
 
@@ -176,9 +171,8 @@ test.describe('Proxy Preview QA', () => {
     const source = await proxyVideo.getAttribute('src');
     expect(source).toContain('sample-video.mp4');
 
-    await page.evaluate(async () => {
-      const { usePlaybackStore } = await import('../../src/stores/playbackStore.ts');
-      usePlaybackStore.getState().seek(2.5, 'proxy-qa-seek');
+    await page.evaluate(() => {
+      window.__OPENREELIO_E2E__?.seekPlayback(2.5, 'proxy-qa-seek');
     });
 
     await page.waitForTimeout(200);
@@ -188,10 +182,12 @@ test.describe('Proxy Preview QA', () => {
     expect(Math.abs(videoTimeAfterSeek - 2.5)).toBeLessThanOrEqual(0.2);
 
     const readPlaybackSnapshot = async () =>
-      page.evaluate(async () => {
-        const { usePlaybackStore } = await import('../../src/stores/playbackStore.ts');
-        const state = usePlaybackStore.getState();
-        return { currentTime: state.currentTime, isPlaying: state.isPlaying };
+      page.evaluate(() => {
+        const hooks = window.__OPENREELIO_E2E__;
+        if (!hooks) {
+          throw new Error('OpenReelio E2E hooks are not available in this build.');
+        }
+        return hooks.readPlaybackSnapshot();
       });
 
     const beforePlay = await readPlaybackSnapshot();

--- a/tests/e2e/proxy-preview.spec.ts
+++ b/tests/e2e/proxy-preview.spec.ts
@@ -172,7 +172,11 @@ test.describe('Proxy Preview QA', () => {
     expect(source).toContain('sample-video.mp4');
 
     await page.evaluate(() => {
-      window.__OPENREELIO_E2E__?.seekPlayback(2.5, 'proxy-qa-seek');
+      const hooks = window.__OPENREELIO_E2E__;
+      if (!hooks || typeof hooks.seekPlayback !== 'function') {
+        throw new Error('OpenReelio E2E seek hook is not available in this build.');
+      }
+      hooks.seekPlayback(2.5, 'proxy-qa-seek');
     });
 
     await page.waitForTimeout(200);


### PR DESCRIPTION
### **User description**
## Description

Hardens the Codex external runtime setup path and adds approval-gated OpenReelio plan execution for Codex. The PR improves app-server startup detection and transport error propagation, adds in-app Codex CLI install/update actions, introduces dynamic planning tools with explicit user approval, and keeps approval prompts visible without expanding the composer.

## Related Issue

Closes #685
Closes #686

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Hardened Codex runtime setup and app-server failure handling, including app-server readiness probing, transport error propagation, model compatibility fallback, detected version display, and Codex CLI install/update actions.
- Added OpenReelio Codex planning tools for selection, diagnostics, preview state, command validation, plan validation, structural diff preview, and approval-gated atomic `plan_apply` with scoped one-time MCP approval tokens.
- Moved pending agent approval decisions into an overlay while keeping the composer compact, and added e2e-only hooks plus fixture preparation for proxy preview testing.

## Screenshots / Videos

Not included; this change is primarily runtime, approval-flow, settings, and test infrastructure behavior.

## Testing

Validated with the pre-commit hook on each commit and targeted Rust/TypeScript test suites after the split commits were created.

### Test Environment

- OS: Linux jun 6.6.87.2-microsoft-standard-WSL2 x86_64
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Commands run:

- `npm run type-check`
- `cargo fmt --all --check`
- `cargo test -p openreelio-cli mcp`
- `cargo test -p openreelio codex`
- `npm run test:run -- src/agents/external/adapters/CodexAppServerClient.test.ts src/agents/external/adapters/CodexTauriAppServerTransport.test.ts src/agents/external/adapters/CodexReferenceAdapter.test.ts src/agents/external/chatRuntime.test.ts src/agents/external/approvalGateway.test.ts src/components/features/agent/AgentRuntimeApprovalOverlay.test.tsx src/components/features/agent/ChatInputArea.test.tsx src/components/features/settings/sections/ExternalAgentRuntimeSettings.test.tsx`


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Hardens Codex runtime with improved startup detection and transport error propagation.

- Adds in-app Codex CLI installation and update actions in settings.

- Implements approval-gated multi-step editing plans with scoped MCP tokens.

- Introduces a non-blocking approval overlay UI for agent decisions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Codex Runtime"
    A["App Server"] -- "Transport Errors" --> B["Client"]
    B -- "Status Probe" --> C["Settings UI"]
  end
  subgraph "Planning Flow"
    D["AgentPlan"] -- "plan_validate" --> E["User Approval"]
    E -- "Grant Token" --> F["plan_apply"]
    F -- "Atomic Execution" --> G["Project State"]
  end
  C -- "Install/Update" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>openreelioCodexTools.ts</strong><dd><code>Add dynamic planning tools and selection/diagnostic read capabilities</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-78b40377e0e9fccbf98b98f67b7c52e322184ae79113f5293cc6ad0e085d548d">+733/-10</a></td>

</tr>

<tr>
  <td><strong>ExternalAgentRuntimeSettings.tsx</strong><dd><code>Add Codex CLI install/update actions and version detection</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-e3caa2a28b4e47864c95ce6c1dc9fc1ad2c6c81eb14eb9cd79d3e76b9e1b3241">+166/-25</a></td>

</tr>

<tr>
  <td><strong>AgentRuntimeApprovalOverlay.tsx</strong><dd><code>Create new overlay component for agent approval requests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-ca11162b1bf42dda9fd081ff5f4e2f03cf4bb29162f52c4619d42feecfda3269">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatRuntime.ts</strong><dd><code>Surface broker-only approval requests as chat cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-f92a170cff36d13bbdb22254f87f676115c20d195016519dd5b5bd43c00606e7">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChatInputArea.tsx</strong><dd><code>Refactor composer to move approvals into overlay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-445b9c485b7782b1f482d4388bb3c241e70483ae4915df52de12fae646d0e14c">+3/-42</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CodexAppServerClient.ts</strong><dd><code>Improve transport error handling and request rejection on failure</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-56fc3e9dbc1425f3ef07598b3ecf7e21c4032c8d9ab52bc5b1ca686fe2cdff8b">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CodexTauriAppServerTransport.ts</strong><dd><code>Capture stderr and exit codes to emit transport errors</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-5d69fa45229518b6792761a24c6b398e8cef485b7d305f9910f8df247dd8b8e4">+38/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>openreelioE2eHooks.ts</strong><dd><code>Add global hooks for seeding state in E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-63f646d821f18f9a729c91f01614b8e466fd0fc4a5b41b6f9dc065109a52d26a">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexReferenceAdapter.test.ts</strong><dd><code>Add tests for plan validation and atomic application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-fdfb6a18bfafa2be87c1e63fd4c5113048bac88026cc6372c364ec3fd683d53a">+235/-9</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>external_agent.rs</strong><dd><code>Expose CLI install and update commands to frontend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-ad960acf57e592269b5c3bdf99fb1c5b5993ec425db7897e15cbbdda5f29c274">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>26 files</summary><table>
<tr>
  <td><strong>mcp.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+174/-19</a></td>

</tr>

<tr>
  <td><strong>playwright.config.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prepare-e2e-fixtures.mjs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-80f1322c9f05968c8f3a052f552a53450ad4c1e9afae6329018dd49b933fc1ca">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codex.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-b9767a9867fa11cc89b76d832d15e87578b4a63077680239ae5f215c936832b1">+315/-53</a></td>

</tr>

<tr>
  <td><strong>external_agent.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-3c964d567329e9003849b750744ee99173b6fcdee276cbd63653a9cb81bc18b4">+284/-11</a></td>

</tr>

<tr>
  <td><strong>codex_app_server.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-0d9fc5a202deaf36d7d89e74fc64e486bf317a5e71574a1f1fd363a5cc5b7467">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexAppServerClient.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-7db5424c715334f55f416c92dbb7e71f5cf53d07ff8104fe3ba2cf22121a4ca0">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexReferenceAdapter.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-24a34cb421e858c46bdd7ca2827ea3a87dd8fc920e92fbd83134b770ed17ad96">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexTauriAppServerTransport.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-c1550c147627ef036c504162f469f60a635fac4ba09f57a2fe9a4db807fe92ce">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>approvalGateway.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-7909c8a1b39c8904a0d2985b5bbf10771001367a4e830fb64a0e279c2d7702d4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>approvalGateway.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-b809cf3579bf66392c3695a1593f4198170123e56332ab89a6b89d0bf39b8d8c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatRuntime.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-672bc6f38ffd376b8a5cef8a466aec15fe47ae89d5bf15c48f0c05377e50d664">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>host.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-ad8d07ab2366821b65f285b465c8f51f980487a1c52da102ebf3d3af9a1e21fa">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-2d0b9c54feb5fb1a2e861182b442247f5d7ff0698e9582d8771b378fcea5f578">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bindings.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeApprovalOverlay.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-61539e99777bf96f3d4ad0a36aa9ca4f83c3b265d8ff19f890fa80890d9160f9">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-cfbd011a7c5d0d30bcefdf80916bd1a897e3da724bc64d6bf16e4fc2430c9233">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgenticSidebarContent.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-77f56605bd10cfd30db19f8998584f0d71dd041b76724a023c5886a946699cc0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgenticSidebarWorkspace.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-f3f064581f5ee0b3b405ca40a5bba32666e7886a07e59c352123632911b72f41">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChatInputArea.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-a97c5ecda4d5dfcfd01d6bec926ad3dc8ec6ede01fbf41aafee65fc40c4d9c8f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CostControlPanel.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-604ce3ff6a4ee074d06086ef2163df3b0e4d5ebcfb75b05b7f425bb12d48e446">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExternalAgentRuntimeSettings.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-90ac50c0b7ecf48240cc3e9f61d5f3fb34b121735ca5a798bbe18efd0809df5b">+202/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settingsStore.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-ce49e0cdebbd35f82e7bd42214719d77cac39a9afef79f7e67b2c35489380d9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proxy-preview.spec.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/687/files#diff-30561fe56f77d23df3c5589f9ad56d41c3b568ef7554c6e93672b6448326dcc5">+29/-33</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval workflow for OpenReelio agent plans (validate, scoped approval, consume-once)
  * Codex CLI install/update actions from settings
  * New dynamic Codex tools for plan preview/validation/apply and read-only helpers

* **Bug Fixes**
  * Ensure E2E fixture preparation in preview mode
  * Improved error propagation from Codex transport and backend app-server

* **Refactor**
  * Default Codex model bumped to gpt-5.5 with version-aware selection
  * Approval UI moved to a dedicated overlay; input area simplified

* **Tests**
  * Expanded coverage for approvals, transport errors, model catalog, and E2E helpers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openreelio/openreelio/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->