### PR TITLE
feat: add caption styling, text placement, and generative media tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
     name: Rust Tests
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    env:
+      SKIP_FFMPEG_DOWNLOAD: '1'
 
     steps:
       - name: Checkout repository

--- a/crates/openreelio-cli/src/commands/caption.rs
+++ b/crates/openreelio-cli/src/commands/caption.rs
@@ -227,13 +227,12 @@ fn parse_position_json(position_json: Option<String>) -> anyhow::Result<Option<s
     let value: serde_json::Value = serde_json::from_str(&position_json)
         .map_err(|e| anyhow::anyhow!("Invalid --position-json payload: {}", e))?;
 
-    if !value.is_object() {
+    let Some(object) = value.as_object() else {
         return Err(anyhow::anyhow!(
             "--position-json must be a JSON object, for example '{{\"type\":\"custom\",\"xPercent\":50,\"yPercent\":88}}'"
         ));
-    }
+    };
 
-    let object = value.as_object().expect("checked above");
     let position_type = object
         .get("type")
         .and_then(|kind| kind.as_str())
@@ -251,13 +250,15 @@ fn parse_position_json(position_json: Option<String>) -> anyhow::Result<Option<s
             }
         }
         "custom" => {
-            let has_x = object.get("xPercent").or_else(|| object.get("x")).is_some();
-            let has_y = object.get("yPercent").or_else(|| object.get("y")).is_some();
-            if !has_x || !has_y {
+            let x = object.get("xPercent").or_else(|| object.get("x"));
+            let y = object.get("yPercent").or_else(|| object.get("y"));
+            let (Some(x), Some(y)) = (x, y) else {
                 return Err(anyhow::anyhow!(
                     "--position-json custom position requires xPercent and yPercent"
                 ));
-            }
+            };
+            validate_custom_position_coordinate("xPercent", x)?;
+            validate_custom_position_coordinate("yPercent", y)?;
         }
         other => {
             return Err(anyhow::anyhow!(
@@ -268,6 +269,27 @@ fn parse_position_json(position_json: Option<String>) -> anyhow::Result<Option<s
     }
 
     Ok(Some(value))
+}
+
+fn validate_custom_position_coordinate(
+    field: &str,
+    value: &serde_json::Value,
+) -> anyhow::Result<()> {
+    let Some(number) = value.as_f64() else {
+        return Err(anyhow::anyhow!(
+            "--position-json custom {} must be a number between 0 and 100",
+            field
+        ));
+    };
+
+    if !(0.0..=100.0).contains(&number) {
+        return Err(anyhow::anyhow!(
+            "--position-json custom {} must be between 0 and 100",
+            field
+        ));
+    }
+
+    Ok(())
 }
 
 fn parse_caption_position(
@@ -779,5 +801,48 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
                 "captionCount": caption_data.len(),
             }))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_position_json_accepts_custom_coordinate_aliases() {
+        let parsed = parse_position_json(Some(r#"{"type":"custom","x":25,"y":75}"#.to_string()))
+            .expect("position json should parse")
+            .expect("position json should be present");
+
+        assert_eq!(parsed["x"], 25);
+        assert_eq!(parsed["y"], 75);
+    }
+
+    #[test]
+    fn parse_position_json_rejects_non_numeric_custom_coordinates() {
+        let error = parse_position_json(Some(
+            r#"{"type":"custom","xPercent":"50","yPercent":75}"#.to_string(),
+        ))
+        .expect_err("non-numeric xPercent should fail");
+
+        assert!(
+            error.to_string().contains("xPercent must be a number"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_position_json_rejects_out_of_range_custom_coordinates() {
+        let error = parse_position_json(Some(
+            r#"{"type":"custom","xPercent":101,"yPercent":75}"#.to_string(),
+        ))
+        .expect_err("out-of-range xPercent should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("xPercent must be between 0 and 100"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/openreelio-cli/src/commands/caption.rs
+++ b/crates/openreelio-cli/src/commands/caption.rs
@@ -41,6 +41,10 @@ pub enum CaptionAction {
         #[arg(long)]
         position: Option<String>,
 
+        /// Optional caption position JSON object
+        #[arg(long = "position-json")]
+        position_json: Option<String>,
+
         /// Sequence ID (defaults to active)
         #[arg(long)]
         sequence: Option<String>,
@@ -79,6 +83,10 @@ pub enum CaptionAction {
         /// Optional position preset: top, center, bottom
         #[arg(long)]
         position: Option<String>,
+
+        /// Optional caption position JSON object
+        #[arg(long = "position-json")]
+        position_json: Option<String>,
 
         /// Sequence ID (defaults to active)
         #[arg(long)]
@@ -140,6 +148,10 @@ pub enum CaptionAction {
         /// Optional position preset: top, center, bottom
         #[arg(long)]
         position: Option<String>,
+
+        /// Optional caption position JSON object applied to every imported caption
+        #[arg(long = "position-json")]
+        position_json: Option<String>,
 
         /// Sequence ID (defaults to active)
         #[arg(long)]
@@ -205,6 +217,75 @@ fn parse_position_preset(position: Option<String>) -> anyhow::Result<Option<serd
         "vertical": vertical,
         "marginPercent": 5,
     })))
+}
+
+fn parse_position_json(position_json: Option<String>) -> anyhow::Result<Option<serde_json::Value>> {
+    let Some(position_json) = position_json else {
+        return Ok(None);
+    };
+
+    let value: serde_json::Value = serde_json::from_str(&position_json)
+        .map_err(|e| anyhow::anyhow!("Invalid --position-json payload: {}", e))?;
+
+    if !value.is_object() {
+        return Err(anyhow::anyhow!(
+            "--position-json must be a JSON object, for example '{{\"type\":\"custom\",\"xPercent\":50,\"yPercent\":88}}'"
+        ));
+    }
+
+    let object = value.as_object().expect("checked above");
+    let position_type = object
+        .get("type")
+        .and_then(|kind| kind.as_str())
+        .unwrap_or("custom");
+    match position_type {
+        "preset" => {
+            let vertical = object
+                .get("vertical")
+                .and_then(|vertical| vertical.as_str())
+                .ok_or_else(|| anyhow::anyhow!("--position-json preset requires vertical"))?;
+            if !matches!(vertical, "top" | "center" | "bottom") {
+                return Err(anyhow::anyhow!(
+                    "--position-json preset vertical must be top, center, or bottom"
+                ));
+            }
+        }
+        "custom" => {
+            let has_x = object.get("xPercent").or_else(|| object.get("x")).is_some();
+            let has_y = object.get("yPercent").or_else(|| object.get("y")).is_some();
+            if !has_x || !has_y {
+                return Err(anyhow::anyhow!(
+                    "--position-json custom position requires xPercent and yPercent"
+                ));
+            }
+        }
+        other => {
+            return Err(anyhow::anyhow!(
+                "--position-json type '{}' is unsupported. Use preset or custom.",
+                other
+            ));
+        }
+    }
+
+    Ok(Some(value))
+}
+
+fn parse_caption_position(
+    position: Option<String>,
+    position_json: Option<String>,
+) -> anyhow::Result<Option<serde_json::Value>> {
+    if position.is_some() && position_json.is_some() {
+        return Err(anyhow::anyhow!(
+            "Use either --position or --position-json, not both."
+        ));
+    }
+
+    let parsed_json = parse_position_json(position_json)?;
+    if parsed_json.is_some() {
+        return Ok(parsed_json);
+    }
+
+    parse_position_preset(position)
 }
 
 fn get_sequence<'a>(project: &'a ActiveProject, sequence_id: &str) -> anyhow::Result<&'a Sequence> {
@@ -411,13 +492,14 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             end,
             style_json,
             position,
+            position_json,
             sequence,
         } => {
             validate::non_empty(&text, "text")?;
             validate::time_range_ordered(start, end, "start", "end")?;
 
             let style = parse_style_json(style_json)?;
-            let position = parse_position_preset(position)?;
+            let position = parse_caption_position(position, position_json)?;
 
             let mut project = super::load_project(&path)?;
             let seq_id = super::resolve_sequence_id(&project, sequence)?;
@@ -451,6 +533,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             end,
             style_json,
             position,
+            position_json,
             sequence,
         } => {
             validate::non_empty(&id, "id")?;
@@ -463,7 +546,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             }
 
             let style = parse_style_json(style_json)?;
-            let position = parse_position_preset(position)?;
+            let position = parse_caption_position(position, position_json)?;
 
             if text.is_none()
                 && start.is_none()
@@ -472,7 +555,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
                 && position.is_none()
             {
                 return Err(anyhow::anyhow!(
-                    "No update requested. Provide one of --text, --start, --end, --style-json, or --position."
+                    "No update requested. Provide one of --text, --start, --end, --style-json, --position, or --position-json."
                 ));
             }
 
@@ -548,7 +631,10 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
                         "trackId": track.id,
                         "text": clip.label,
                         "startSec": clip.place.timeline_in_sec,
+                        "endSec": clip.place.timeline_in_sec + clip.place.duration_sec,
                         "durationSec": clip.place.duration_sec,
+                        "style": clip.caption_style,
+                        "position": clip.caption_position,
                     }));
                 }
             }
@@ -567,6 +653,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             format,
             style_json,
             position,
+            position_json,
             sequence,
         } => {
             let subtitle_path = std::fs::canonicalize(&file).map_err(|e| {
@@ -575,7 +662,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             let format = detect_caption_file_format(&subtitle_path, format.as_deref())?;
             let captions = load_caption_file(&subtitle_path, format)?;
             let style = parse_style_json(style_json)?;
-            let position = parse_position_preset(position)?;
+            let position = parse_caption_position(position, position_json)?;
 
             if captions.is_empty() {
                 return Err(anyhow::anyhow!(

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -264,6 +264,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "end": { "type": "number", "required": true, "desc": "End time in seconds" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object" },
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
+                    "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },
                 "example": "openreelio-cli caption add --path ./project --text \"Hello\" --start 0.0 --end 3.0"
@@ -295,6 +296,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "format": { "type": "string", "required": false, "desc": "Subtitle format: srt or vtt (auto-detected when omitted)" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object applied to all cues" },
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
+                    "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object applied to all cues" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },
                 "example": "openreelio-cli caption import --path ./project --file captions.srt"
@@ -310,6 +312,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "end": { "type": "number", "required": false, "desc": "New caption end time in seconds" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object" },
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
+                    "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },
                 "example": "openreelio-cli caption update --path ./project --id cap_001 --text \"Updated text\""
@@ -474,6 +477,7 @@ mod tests {
         assert!(commands.contains_key("caption.import"));
         assert!(commands["caption.update"]["params"]["start"].is_object());
         assert!(commands["caption.update"]["params"]["style-json"].is_object());
+        assert!(commands["caption.update"]["params"]["position-json"].is_object());
         assert!(commands["caption.add"]["params"]["track"]["required"] == false);
         assert!(commands.contains_key("analysis.report"));
         assert!(commands.contains_key("analysis.search"));

--- a/docs/ASSET_DISCOVERY.md
+++ b/docs/ASSET_DISCOVERY.md
@@ -1,11 +1,13 @@
 # Asset Discovery
 
-OpenReelio uses an English-first asset discovery surface for agent workflows. External provider search returns candidate references and policy metadata only; it does not import, download, or place external assets automatically.
+OpenReelio uses an English-first asset discovery surface for agent workflows. External provider search returns candidate references and policy metadata first; import and timeline placement are separate approval-gated actions.
 
 ## Implemented Foundation
 
 - `search_stock_media` searches configured stock providers through backend adapters.
 - `find_assets_for_script` is the agent-facing high-level wrapper for scene/script-based discovery.
+- `search_sound_for_scene` is the agent-facing high-level wrapper for SFX and ambient audio discovery.
+- `import_asset_candidate` imports an approved candidate through `import_stock_media_asset` with a license snapshot.
 - Openverse image/audio search works without a user API key and is the built-in zero-config fallback.
 - Pexels and Pixabay visual search require configured API keys.
 - Freesound audio search requires a configured API key.
@@ -35,13 +37,12 @@ Every external candidate should flow through this chain:
 provider result
   -> normalized LicenseInfo
   -> LicensePolicyDecision
-  -> import preflight
+  -> import_asset_candidate/import_stock_media_asset preflight
   -> timeline placement preflight
   -> export/QC manifest preflight
 ```
 
-The current implementation covers the first three steps. Future import and placement tools must reject blocked candidates and must require a license snapshot before downloading external media.
-`import_stock_media_asset` now enforces the download/import preflight for selected candidates by requiring `licenseAck`, rejecting blocked policies, and persisting the license snapshot before the asset is registered.
+The current implementation covers provider search, normalized policy decisions, and explicit import with license snapshots. `import_stock_media_asset` enforces the download/import preflight for selected candidates by requiring `licenseAck`, rejecting blocked policies, and persisting the license snapshot before the asset is registered. Timeline placement still must reject unsafe external candidates and export/QC should continue checking attribution and provider terms.
 
 ## Local Search Status
 

--- a/src-tauri/src/core/commands/caption.rs
+++ b/src-tauri/src/core/commands/caption.rs
@@ -112,8 +112,8 @@ impl Command for CreateCaptionCommand {
         clip.place = ClipPlace::new(self.start_sec, duration);
         clip.range = ClipRange::new(0.0, duration);
         clip.label = normalize_caption_text(std::mem::take(&mut self.text));
-        clip.caption_style = self.style.clone();
-        clip.caption_position = self.position.clone();
+        clip.caption_style = self.style.clone().filter(|style| !style.is_null());
+        clip.caption_position = self.position.clone().filter(|position| !position.is_null());
 
         let caption_id = clip.id.clone();
         self.created_caption_id = Some(caption_id.clone());
@@ -376,11 +376,15 @@ impl Command for UpdateCaptionCommand {
         }
 
         if let Some(style) = self.style.clone() {
-            clip.caption_style = Some(style);
+            clip.caption_style = if style.is_null() { None } else { Some(style) };
         }
 
         if let Some(position) = self.position.clone() {
-            clip.caption_position = Some(position);
+            clip.caption_position = if position.is_null() {
+                None
+            } else {
+                Some(position)
+            };
         }
 
         let op_id = ulid::Ulid::new().to_string();

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2776,6 +2776,16 @@ fn build_caption_drawtext_with_enable(clip: &Clip) -> Option<String> {
             }
         }
 
+        if let Some(background_padding) =
+            get_json_field(style, &["backgroundPadding", "background_padding"])
+                .and_then(parse_json_number)
+        {
+            effect.set_param(
+                "background_padding",
+                ParamValue::Int(background_padding.clamp(0.0, 500.0).round() as i64),
+            );
+        }
+
         if let Some(shadow_value) = get_json_field(style, &["shadowColor", "shadow_color"]) {
             if let Some((hex, _)) = parse_caption_color(shadow_value) {
                 effect.set_param("shadow_color", ParamValue::String(hex));
@@ -2788,12 +2798,33 @@ fn build_caption_drawtext_with_enable(clip: &Clip) -> Option<String> {
             }
         }
 
-        if let Some(shadow_offset) =
-            get_json_field(style, &["shadowOffset", "shadow_offset"]).and_then(parse_json_number)
-        {
-            let clamped = shadow_offset.clamp(-500.0, 500.0).round() as i64;
-            effect.set_param("shadow_x", ParamValue::Int(clamped));
-            effect.set_param("shadow_y", ParamValue::Int(clamped));
+        let shadow_offset =
+            get_json_field(style, &["shadowOffset", "shadow_offset"]).and_then(parse_json_number);
+        let shadow_offset_x = get_json_field(
+            style,
+            &["shadowOffsetX", "shadow_offset_x", "shadowX", "shadow_x"],
+        )
+        .and_then(parse_json_number)
+        .or(shadow_offset);
+        let shadow_offset_y = get_json_field(
+            style,
+            &["shadowOffsetY", "shadow_offset_y", "shadowY", "shadow_y"],
+        )
+        .and_then(parse_json_number)
+        .or(shadow_offset);
+
+        if let Some(shadow_offset_x) = shadow_offset_x {
+            effect.set_param(
+                "shadow_x",
+                ParamValue::Int(shadow_offset_x.clamp(-500.0, 500.0).round() as i64),
+            );
+        }
+
+        if let Some(shadow_offset_y) = shadow_offset_y {
+            effect.set_param(
+                "shadow_y",
+                ParamValue::Int(shadow_offset_y.clamp(-500.0, 500.0).round() as i64),
+            );
         }
 
         if let Some(outline_width) =
@@ -2824,7 +2855,10 @@ fn build_caption_drawtext_with_enable(clip: &Clip) -> Option<String> {
                 get_json_field(style, &["fontWeight", "font_weight"]).and_then(|value| {
                     if let Some(raw) = value.as_str() {
                         let normalized = raw.to_ascii_lowercase();
-                        Some(normalized == "bold" || normalized == "700" || normalized == "800")
+                        Some(matches!(
+                            normalized.as_str(),
+                            "bold" | "semibold" | "black" | "heavy" | "700" | "800" | "900"
+                        ))
                     } else {
                         parse_json_number(value).map(|weight| weight >= 600.0)
                     }
@@ -3198,9 +3232,11 @@ impl ExportEngine {
 
         // Add inputs and build filter graph
         for (clip, track) in &all_clips {
-            if matches!(track.kind, TrackKind::Caption | TrackKind::Overlay) {
-                // Caption/overlay tracks are not rendered by the current export pipeline.
-                // Skip them so virtual caption clips are not treated as file inputs.
+            if track.kind == TrackKind::Caption
+                || (track.kind == TrackKind::Overlay && !is_text_clip(clip))
+            {
+                // Caption tracks are burned in later; non-text overlay tracks are not
+                // rendered by the current export pipeline.
                 continue;
             }
 
@@ -4781,9 +4817,11 @@ pub fn build_complex_filter_args_with_audio_info(
 
     // Add inputs and build filter graph
     for (clip, track) in &all_clips {
-        if matches!(track.kind, TrackKind::Caption | TrackKind::Overlay) {
-            // Caption/overlay tracks are not rendered by the current export pipeline.
-            // Skip them so virtual caption clips are not treated as file inputs.
+        if track.kind == TrackKind::Caption
+            || (track.kind == TrackKind::Overlay && !is_text_clip(clip))
+        {
+            // Caption tracks are burned in later; non-text overlay tracks are not
+            // rendered by the current export pipeline.
             continue;
         }
 
@@ -7269,10 +7307,17 @@ mod tests {
         caption_clip.label = Some("Styled caption".to_string());
         caption_clip.caption_style = Some(serde_json::json!({
             "fontSize": 64,
+            "fontWeight": 700,
             "alignment": "left",
             "color": { "r": 255, "g": 0, "b": 0, "a": 128 },
+            "backgroundColor": "#00000080",
+            "backgroundPadding": 18,
             "outlineColor": "#000000",
-            "outlineWidth": 3
+            "outlineWidth": 3,
+            "shadowColor": "#112233",
+            "shadowOffsetX": 4,
+            "shadowOffsetY": 6,
+            "lineHeight": 1.5
         }));
         caption_clip.caption_position = Some(serde_json::json!({
             "type": "preset",
@@ -7324,6 +7369,26 @@ mod tests {
         assert!(
             args_str.contains("x=(w*0.5000)"),
             "Expected left alignment x expression. Got: {}",
+            args_str
+        );
+        assert!(
+            args_str.contains("font='Arial\\:style=Bold'") || args_str.contains("style=Bold"),
+            "Expected numeric font weight to request bold font style. Got: {}",
+            args_str
+        );
+        assert!(
+            args_str.contains("boxborderw=18"),
+            "Expected caption background padding to map to boxborderw. Got: {}",
+            args_str
+        );
+        assert!(
+            args_str.contains("shadowx=4") && args_str.contains("shadowy=6"),
+            "Expected caption shadow offsets to map independently. Got: {}",
+            args_str
+        );
+        assert!(
+            args_str.contains("line_spacing=32"),
+            "Expected caption line height to map to drawtext line spacing. Got: {}",
             args_str
         );
     }

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2722,6 +2722,23 @@ fn resolve_caption_anchor(position: Option<&Value>, style: Option<&Value>) -> (f
     (x, y)
 }
 
+fn font_weight_implies_bold(value: &Value) -> Option<bool> {
+    if let Some(raw) = value.as_str() {
+        let normalized = raw.trim().to_ascii_lowercase();
+        if matches!(normalized.as_str(), "bold" | "semibold" | "black" | "heavy") {
+            return Some(true);
+        }
+
+        return normalized
+            .parse::<f64>()
+            .ok()
+            .map(|weight| weight >= 600.0)
+            .or(Some(false));
+    }
+
+    parse_json_number(value).map(|weight| weight >= 600.0)
+}
+
 fn find_transition_effect<'a>(
     clip: &Clip,
     effects: &'a HashMap<String, Effect>,
@@ -2852,17 +2869,8 @@ fn build_caption_drawtext_with_enable(clip: &Clip) -> Option<String> {
         let bold = get_json_field(style, &["bold"])
             .and_then(parse_json_bool)
             .or_else(|| {
-                get_json_field(style, &["fontWeight", "font_weight"]).and_then(|value| {
-                    if let Some(raw) = value.as_str() {
-                        let normalized = raw.to_ascii_lowercase();
-                        Some(matches!(
-                            normalized.as_str(),
-                            "bold" | "semibold" | "black" | "heavy" | "700" | "800" | "900"
-                        ))
-                    } else {
-                        parse_json_number(value).map(|weight| weight >= 600.0)
-                    }
-                })
+                get_json_field(style, &["fontWeight", "font_weight"])
+                    .and_then(font_weight_implies_bold)
             });
         if let Some(bold) = bold {
             effect.set_param("bold", ParamValue::Bool(bold));
@@ -4603,29 +4611,37 @@ pub fn validate_export_settings(
         return validation;
     }
 
-    let has_enabled_overlay_clips = sequence.tracks.iter().any(|track| {
+    let has_enabled_unsupported_overlay_clips = sequence.tracks.iter().any(|track| {
         track.kind == TrackKind::Overlay
             && track_included_in_export(track)
-            && track.clips.iter().any(|clip| clip.enabled)
+            && track
+                .clips
+                .iter()
+                .any(|clip| clip.enabled && !is_text_clip(clip))
     });
-    if has_enabled_overlay_clips {
+    if has_enabled_unsupported_overlay_clips {
         validation.add_error("Overlay tracks are not supported in final render export yet");
     }
 
     let visual_clip_count: usize = sequence
         .tracks
         .iter()
-        .filter(|track| track.kind == TrackKind::Video && track_included_in_export(track))
+        .filter(|track| track_included_in_export(track))
         .map(|track| {
             track
                 .clips
                 .iter()
-                .filter(|clip| clip.enabled && !clip.is_adjustment_layer())
+                .filter(|clip| {
+                    clip.enabled
+                        && !clip.is_adjustment_layer()
+                        && (track.kind == TrackKind::Video
+                            || (track.kind == TrackKind::Overlay && is_text_clip(clip)))
+                })
                 .count()
         })
         .sum();
     if visual_clip_count == 0 {
-        if !has_enabled_overlay_clips {
+        if !has_enabled_unsupported_overlay_clips {
             validation.add_error("Sequence has no visual clips to export");
         }
         return validation;
@@ -4637,14 +4653,17 @@ pub fn validate_export_settings(
             continue;
         }
 
-        if matches!(track.kind, TrackKind::Caption | TrackKind::Overlay) {
-            // Caption/overlay tracks are currently excluded from final render composition.
-            // Skip file-based asset validation for these tracks.
+        if track.kind == TrackKind::Caption {
+            // Caption tracks are burned in separately and do not use file-backed assets.
             continue;
         }
 
         for clip in &track.clips {
             if !clip.enabled {
+                continue;
+            }
+
+            if track.kind == TrackKind::Overlay && !is_text_clip(clip) {
                 continue;
             }
 
@@ -5691,6 +5710,43 @@ mod tests {
             .errors
             .iter()
             .any(|error| error.to_lowercase().contains("overlay tracks")));
+    }
+
+    #[test]
+    fn test_validation_allows_overlay_text_clips() {
+        use crate::core::commands::TEXT_ASSET_PREFIX;
+        use crate::core::effects::{Effect, EffectType, ParamValue};
+        use crate::core::timeline::{Clip, SequenceFormat, Track, TrackKind};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut overlay_track = Track::new("Overlay Text", TrackKind::Overlay);
+
+        let effect_id = "overlay_text_effect".to_string();
+        let mut text_clip = Clip::new(&format!("{}overlay", TEXT_ASSET_PREFIX))
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        text_clip.effects.push(effect_id.clone());
+        overlay_track.add_clip(text_clip);
+        sequence.add_track(overlay_track);
+
+        let mut effect = Effect::new(EffectType::TextOverlay);
+        effect.id = effect_id.clone();
+        effect.set_param("text", ParamValue::String("Overlay title".to_string()));
+
+        let mut effects = HashMap::new();
+        effects.insert(effect_id, effect);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &HashMap::new(),
+            &effects,
+            &ExportSettings::default(),
+        );
+
+        assert!(
+            validation.is_valid,
+            "Expected overlay text clips to pass export validation. Got: {validation:?}"
+        );
     }
 
     #[test]
@@ -7390,6 +7446,26 @@ mod tests {
             args_str.contains("line_spacing=32"),
             "Expected caption line height to map to drawtext line spacing. Got: {}",
             args_str
+        );
+    }
+
+    #[test]
+    fn test_font_weight_implies_bold_accepts_numeric_strings() {
+        assert_eq!(
+            font_weight_implies_bold(&serde_json::json!("600")),
+            Some(true)
+        );
+        assert_eq!(
+            font_weight_implies_bold(&serde_json::json!("700.0")),
+            Some(true)
+        );
+        assert_eq!(
+            font_weight_implies_bold(&serde_json::json!("500")),
+            Some(false)
+        );
+        assert_eq!(
+            font_weight_implies_bold(&serde_json::json!(700)),
+            Some(true)
         );
     }
 

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2957,15 +2957,16 @@ fn collect_caption_drawtext_filters(all_clips: &[(&Clip, &Track)]) -> Vec<String
         .collect()
 }
 
-fn append_caption_overlays(
+fn append_drawtext_overlays(
     filter_complex: &mut String,
     base_video_label: &str,
-    caption_filters: &[String],
+    drawtext_filters: &[String],
+    label_prefix: &str,
 ) -> String {
     let mut current_video_label = base_video_label.to_string();
 
-    for (index, filter) in caption_filters.iter().enumerate() {
-        let next_video_label = format!("[capv{}]", index);
+    for (index, filter) in drawtext_filters.iter().enumerate() {
+        let next_video_label = format!("[{}{}]", label_prefix, index);
         filter_complex.push(';');
         filter_complex.push_str(&format!(
             "{}{}{}",
@@ -2975,6 +2976,81 @@ fn append_caption_overlays(
     }
 
     current_video_label
+}
+
+fn append_caption_overlays(
+    filter_complex: &mut String,
+    base_video_label: &str,
+    caption_filters: &[String],
+) -> String {
+    append_drawtext_overlays(filter_complex, base_video_label, caption_filters, "capv")
+}
+
+fn append_text_clip_overlays(
+    filter_complex: &mut String,
+    base_video_label: &str,
+    overlay_text_filters: &[String],
+) -> String {
+    append_drawtext_overlays(
+        filter_complex,
+        base_video_label,
+        overlay_text_filters,
+        "txtv",
+    )
+}
+
+fn build_text_clip_drawtext_with_enable(
+    clip: &Clip,
+    effects: &HashMap<String, Effect>,
+) -> Result<String, ExportError> {
+    let text_effect = clip
+        .effects
+        .iter()
+        .find_map(|effect_id| {
+            effects
+                .get(effect_id)
+                .filter(|effect| effect.effect_type == EffectType::TextOverlay && effect.enabled)
+        })
+        .ok_or_else(|| {
+            ExportError::InvalidSettings(format!(
+                "Text clip '{}' is missing an enabled TextOverlay effect",
+                clip.id
+            ))
+        })?;
+
+    let start = clip.place.timeline_in_sec;
+    let end = clip.place.timeline_out_sec();
+    if !start.is_finite() || !end.is_finite() || end <= start {
+        return Err(ExportError::InvalidSettings(format!(
+            "Text clip '{}' has invalid timing",
+            clip.id
+        )));
+    }
+
+    let mut resolved_text_effect = text_effect.clone();
+    apply_text_transform_overrides(&mut resolved_text_effect, clip);
+
+    Ok(format!(
+        "{}:enable='between(t,{:.6},{:.6})'",
+        resolved_text_effect.to_filter_body(),
+        start.max(0.0),
+        end.max(0.0)
+    ))
+}
+
+fn collect_overlay_text_drawtext_filters(
+    all_clips: &[(&Clip, &Track)],
+    effects: &HashMap<String, Effect>,
+) -> Result<Vec<String>, ExportError> {
+    let mut filters = Vec::new();
+
+    for (clip, track) in all_clips {
+        if track.kind == TrackKind::Overlay && is_text_clip(clip) {
+            filters.push(build_text_clip_drawtext_with_enable(clip, effects)?);
+        }
+    }
+
+    Ok(filters)
 }
 
 // =============================================================================
@@ -3213,6 +3289,7 @@ impl ExportEngine {
         }
 
         let caption_filters = collect_caption_drawtext_filters(&all_clips);
+        let overlay_text_filters = collect_overlay_text_drawtext_filters(&all_clips, effects)?;
 
         let (output_width, output_height) = output_video_dimensions(sequence, settings);
         let output_fps = output_video_fps(sequence, settings);
@@ -3240,11 +3317,9 @@ impl ExportEngine {
 
         // Add inputs and build filter graph
         for (clip, track) in &all_clips {
-            if track.kind == TrackKind::Caption
-                || (track.kind == TrackKind::Overlay && !is_text_clip(clip))
-            {
-                // Caption tracks are burned in later; non-text overlay tracks are not
-                // rendered by the current export pipeline.
+            if matches!(track.kind, TrackKind::Caption | TrackKind::Overlay) {
+                // Caption tracks and overlay text clips are burned in after the base
+                // video concat. Non-text overlay tracks are rejected during validation.
                 continue;
             }
 
@@ -3526,8 +3601,13 @@ impl ExportEngine {
             filter_complex.push_str(&format!("[{}]null[outv]", adj_video_label));
         }
 
-        let final_video_label =
-            append_caption_overlays(&mut filter_complex, "[outv]", &caption_filters);
+        let text_overlay_video_label =
+            append_text_clip_overlays(&mut filter_complex, "[outv]", &overlay_text_filters);
+        let final_video_label = append_caption_overlays(
+            &mut filter_complex,
+            &text_overlay_video_label,
+            &caption_filters,
+        );
 
         let final_audio_label = append_master_audio_output(
             &mut filter_complex,
@@ -4632,10 +4712,7 @@ pub fn validate_export_settings(
                 .clips
                 .iter()
                 .filter(|clip| {
-                    clip.enabled
-                        && !clip.is_adjustment_layer()
-                        && (track.kind == TrackKind::Video
-                            || (track.kind == TrackKind::Overlay && is_text_clip(clip)))
+                    clip.enabled && !clip.is_adjustment_layer() && track.kind == TrackKind::Video
                 })
                 .count()
         })
@@ -4776,6 +4853,7 @@ pub fn build_complex_filter_args_with_audio_info(
     }
 
     let caption_filters = collect_caption_drawtext_filters(&all_clips);
+    let overlay_text_filters = collect_overlay_text_drawtext_filters(&all_clips, effects)?;
 
     // Build FilterGraph helper (inline version without engine)
     // If effects have keyframes, they are resolved at the midpoint of the clip
@@ -4836,11 +4914,9 @@ pub fn build_complex_filter_args_with_audio_info(
 
     // Add inputs and build filter graph
     for (clip, track) in &all_clips {
-        if track.kind == TrackKind::Caption
-            || (track.kind == TrackKind::Overlay && !is_text_clip(clip))
-        {
-            // Caption tracks are burned in later; non-text overlay tracks are not
-            // rendered by the current export pipeline.
+        if matches!(track.kind, TrackKind::Caption | TrackKind::Overlay) {
+            // Caption tracks and overlay text clips are burned in after the base
+            // video concat. Non-text overlay tracks are rejected during validation.
             continue;
         }
 
@@ -5097,8 +5173,13 @@ pub fn build_complex_filter_args_with_audio_info(
         filter_complex.push_str(&format!("[{}]null[outv]", adj_video_label));
     }
 
-    let final_video_label =
-        append_caption_overlays(&mut filter_complex, "[outv]", &caption_filters);
+    let text_overlay_video_label =
+        append_text_clip_overlays(&mut filter_complex, "[outv]", &overlay_text_filters);
+    let final_video_label = append_caption_overlays(
+        &mut filter_complex,
+        &text_overlay_video_label,
+        &caption_filters,
+    );
 
     let final_audio_label = append_master_audio_output(
         &mut filter_complex,
@@ -5713,7 +5794,61 @@ mod tests {
     }
 
     #[test]
-    fn test_validation_allows_overlay_text_clips() {
+    fn test_validation_allows_overlay_text_clips_over_base_video() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::commands::TEXT_ASSET_PREFIX;
+        use crate::core::effects::{Effect, EffectType, ParamValue};
+        use crate::core::timeline::{Clip, SequenceFormat, Track, TrackKind};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut video_track = Track::new_video("Video 1");
+        video_track.add_clip(
+            Clip::new("video_asset")
+                .with_source_range(0.0, 3.0)
+                .place_at(0.0),
+        );
+        sequence.add_track(video_track);
+
+        let mut overlay_track = Track::new("Overlay Text", TrackKind::Overlay);
+
+        let effect_id = "overlay_text_effect".to_string();
+        let mut text_clip = Clip::new(&format!("{}overlay", TEXT_ASSET_PREFIX))
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        text_clip.effects.push(effect_id.clone());
+        overlay_track.add_clip(text_clip);
+        sequence.add_track(overlay_track);
+
+        let mut effect = Effect::new(EffectType::TextOverlay);
+        effect.id = effect_id.clone();
+        effect.set_param("text", ParamValue::String("Overlay title".to_string()));
+
+        let mut effects = HashMap::new();
+        effects.insert(effect_id, effect);
+
+        let video_path = create_temp_media_file("validation_overlay_text_base.mp4");
+        let mut assets = HashMap::new();
+        let mut video_asset = Asset::new_video(
+            "validation_overlay_text_base.mp4",
+            &video_path,
+            VideoInfo::default(),
+        )
+        .with_duration(3.0)
+        .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let validation =
+            validate_export_settings(&sequence, &assets, &effects, &ExportSettings::default());
+
+        assert!(
+            validation.is_valid,
+            "Expected overlay text clips to pass export validation. Got: {validation:?}"
+        );
+    }
+
+    #[test]
+    fn test_validation_does_not_count_overlay_text_as_base_visual() {
         use crate::core::commands::TEXT_ASSET_PREFIX;
         use crate::core::effects::{Effect, EffectType, ParamValue};
         use crate::core::timeline::{Clip, SequenceFormat, Track, TrackKind};
@@ -5743,9 +5878,13 @@ mod tests {
             &ExportSettings::default(),
         );
 
+        assert!(!validation.is_valid);
         assert!(
-            validation.is_valid,
-            "Expected overlay text clips to pass export validation. Got: {validation:?}"
+            validation
+                .errors
+                .iter()
+                .any(|error| error.to_lowercase().contains("no visual clips")),
+            "Expected overlay text without base video to fail as no visual clips. Got: {validation:?}"
         );
     }
 
@@ -6979,6 +7118,95 @@ mod tests {
             args.get(first_map_index + 1).map(String::as_str),
             Some("[capv0]"),
             "Expected video map label to use caption-composited stream"
+        );
+    }
+
+    #[test]
+    fn test_build_filter_composites_overlay_text_after_video_concat() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::commands::TEXT_ASSET_PREFIX;
+        use crate::core::effects::{Effect, EffectType, ParamValue};
+        use crate::core::timeline::{Clip, SequenceFormat, Track, TrackKind};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+
+        let mut video_track = Track::new_video("Video 1");
+        video_track.add_clip(
+            Clip::new("video_asset")
+                .with_source_range(0.0, 3.0)
+                .place_at(0.0),
+        );
+        sequence.add_track(video_track);
+
+        let mut overlay_track = Track::new("Overlay Text", TrackKind::Overlay);
+        let effect_id = "overlay_text_effect".to_string();
+        let mut text_clip = Clip::new(&format!("{}overlay", TEXT_ASSET_PREFIX))
+            .with_source_range(0.0, 2.0)
+            .place_at(0.5);
+        text_clip.effects.push(effect_id.clone());
+        overlay_track.add_clip(text_clip);
+        sequence.add_track(overlay_track);
+
+        let video_path = create_temp_media_file("video_overlay_text.mp4");
+        let mut video_asset =
+            Asset::new_video("video_overlay_text.mp4", &video_path, VideoInfo::default())
+                .with_duration(3.0)
+                .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+
+        let mut assets = std::collections::HashMap::new();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let mut audio_info_map = std::collections::HashMap::new();
+        audio_info_map.insert(
+            "video_asset".to_string(),
+            AssetAudioInfo { has_audio: false },
+        );
+
+        let mut text_effect = Effect::new(EffectType::TextOverlay);
+        text_effect.id = effect_id.clone();
+        text_effect.set_param("text", ParamValue::String("Overlay title".to_string()));
+        text_effect.set_param("x", ParamValue::Float(0.5));
+        text_effect.set_param("y", ParamValue::Float(0.2));
+
+        let mut effects = std::collections::HashMap::new();
+        effects.insert(effect_id, text_effect);
+
+        let args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &effects,
+            &audio_info_map,
+            &ExportSettings::default(),
+        )
+        .expect("overlay text filter generation should succeed");
+        let args_str = args.join(" ");
+
+        assert!(
+            args_str.contains("[outv]drawtext="),
+            "Expected overlay text to be drawn over the concatenated video output. Got: {}",
+            args_str
+        );
+        assert!(
+            args_str.contains("between(t,0.500000,2.500000)"),
+            "Expected overlay text time window in drawtext enable expression. Got: {}",
+            args_str
+        );
+
+        let input_count = args.iter().filter(|arg| arg.as_str() == "-i").count();
+        assert_eq!(
+            input_count, 1,
+            "Overlay text should not add a color-source video segment"
+        );
+
+        let first_map_index = args
+            .iter()
+            .position(|arg| arg.as_str() == "-map")
+            .expect("Expected at least one -map argument");
+        assert_eq!(
+            args.get(first_map_index + 1).map(String::as_str),
+            Some("[txtv0]"),
+            "Expected video map label to use overlay-text-composited stream"
         );
     }
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -288,13 +288,13 @@ export class BackendToolExecutor implements IToolExecutor {
     return BACKEND_DIRECT_TOOLS.has(toolName);
   }
 
-  private isUnsafeMutatingFallback(toolName: string): boolean {
+  private isUnsafeMutatingFallback(toolName: string, args: Record<string, unknown>): boolean {
     const toolDefinition = this.frontendExecutor.getToolDefinition(toolName);
     if (!toolDefinition) {
       return false;
     }
 
-    return requiresProjectMutationPreflight(toolName, toolDefinition.category);
+    return requiresProjectMutationPreflight(toolName, toolDefinition.category, args);
   }
 
   private buildUnsupportedMutationFailure(toolName: string): ToolExecutionResult {
@@ -665,7 +665,7 @@ export class BackendToolExecutor implements IToolExecutor {
     }
 
     if (!executionTarget) {
-      if (this.isUnsafeMutatingFallback(toolName)) {
+      if (this.isUnsafeMutatingFallback(toolName, args)) {
         const preflightFailure = this.getMutationPreflightFailure(toolName, args, context);
         if (preflightFailure) {
           return createFailureResult(preflightFailure, 0);

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.test.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.test.ts
@@ -675,6 +675,52 @@ describe('ToolRegistryAdapter', () => {
       expect(invalid.valid).toBe(false);
       expect(invalid.errors.some((error) => error.includes('splitTime'))).toBe(true);
     });
+
+    it('should validate generate meta-tool calls against the underlying action schema', () => {
+      const metaRegistry = new ToolRegistry();
+      metaRegistry.registerMany([
+        {
+          name: 'generate',
+          description: 'Generation meta-tool',
+          category: 'generation',
+          parameters: {
+            type: 'object',
+            properties: {
+              action: { type: 'string', description: 'Generate action' },
+            },
+            required: ['action'],
+          },
+          handler: vi.fn().mockResolvedValue({ success: true }),
+        },
+        {
+          name: 'generate_video',
+          description: 'Generate video',
+          category: 'generation',
+          parameters: {
+            type: 'object',
+            properties: {
+              prompt: { type: 'string', description: 'Prompt' },
+            },
+            required: ['prompt'],
+          },
+          handler: vi.fn().mockResolvedValue({ success: true }),
+        },
+      ]);
+
+      const metaAdapter = createToolRegistryAdapter(metaRegistry);
+
+      const valid = metaAdapter.validateArgs('generate', {
+        action: 'generate_video',
+        prompt: 'Generate a skyline shot',
+      });
+      expect(valid.valid).toBe(true);
+
+      const invalid = metaAdapter.validateArgs('generate', {
+        action: 'generate_video',
+      });
+      expect(invalid.valid).toBe(false);
+      expect(invalid.errors.some((error) => error.includes('prompt'))).toBe(true);
+    });
   });
 
   describe('hasTool', () => {
@@ -785,6 +831,7 @@ describe('ToolRegistryAdapter', () => {
       await adapter.execute('context_capture', {}, ctx);
 
       expect(capturedContext).not.toBeNull();
+      expect(capturedContext!.selectedClipIds).toEqual(['C1', 'C2']);
       expect(capturedContext!.selectedClips).toEqual(['C1', 'C2']);
     });
 
@@ -806,6 +853,7 @@ describe('ToolRegistryAdapter', () => {
       await adapter.execute('context_capture_tracks', {}, ctx);
 
       expect(capturedContext).not.toBeNull();
+      expect(capturedContext!.selectedTrackIds).toEqual(['V1']);
       expect(capturedContext!.selectedTracks).toEqual(['V1']);
     });
 
@@ -849,6 +897,8 @@ describe('ToolRegistryAdapter', () => {
       await adapter.execute('context_capture_mismatch', {}, ctx);
 
       expect(capturedContext).not.toBeNull();
+      expect(capturedContext!.selectedClipIds).toEqual([]);
+      expect(capturedContext!.selectedTrackIds).toEqual([]);
       expect(capturedContext!.selectedClips).toEqual([]);
       expect(capturedContext!.selectedTracks).toEqual([]);
       expect(capturedContext!.playheadPosition).toBe(0);

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.test.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.test.ts
@@ -721,6 +721,47 @@ describe('ToolRegistryAdapter', () => {
       expect(invalid.valid).toBe(false);
       expect(invalid.errors.some((error) => error.includes('prompt'))).toBe(true);
     });
+
+    it('should validate canonical meta-tool names resolved from aliases', () => {
+      const metaRegistry = new ToolRegistry();
+      metaRegistry.registerMany([
+        {
+          name: 'generate',
+          description: 'Generation meta-tool',
+          category: 'generation',
+          parameters: {
+            type: 'object',
+            properties: {
+              action: { type: 'string', description: 'Generate action' },
+            },
+            required: ['action'],
+          },
+          handler: vi.fn().mockResolvedValue({ success: true }),
+        },
+        {
+          name: 'generate_video',
+          description: 'Generate video',
+          category: 'generation',
+          parameters: {
+            type: 'object',
+            properties: {
+              prompt: { type: 'string', description: 'Prompt' },
+            },
+            required: ['prompt'],
+          },
+          handler: vi.fn().mockResolvedValue({ success: true }),
+        },
+      ]);
+
+      const metaAdapter = createToolRegistryAdapter(metaRegistry);
+
+      const invalid = metaAdapter.validateArgs('Generate', {
+        action: 'generate_video',
+      });
+
+      expect(invalid.valid).toBe(false);
+      expect(invalid.errors.some((error) => error.includes('prompt'))).toBe(true);
+    });
   });
 
   describe('hasTool', () => {

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
@@ -141,11 +141,15 @@ export class ToolRegistryAdapter implements IToolExecutor {
     const selection = getSelectionContext();
     const isActiveSequence = context.sequenceId === selection.sequenceId;
 
+    const selectedClipIds = isActiveSequence ? selection.selectedClipIds : [];
+    const selectedTrackIds = isActiveSequence ? selection.selectedTrackIds : [];
     const legacyContext = {
       projectId: context.projectId,
       sequenceId: context.sequenceId,
-      selectedClips: isActiveSequence ? selection.selectedClipIds : [],
-      selectedTracks: isActiveSequence ? selection.selectedTrackIds : [],
+      selectedClipIds,
+      selectedTrackIds,
+      selectedClips: selectedClipIds,
+      selectedTracks: selectedTrackIds,
       playheadPosition: isActiveSequence ? selection.playheadPosition : 0,
     };
 
@@ -316,7 +320,7 @@ export class ToolRegistryAdapter implements IToolExecutor {
     const errors = this.collectSchemaErrors(tool.parameters, args);
 
     const action = typeof args.action === 'string' ? args.action.trim() : '';
-    if (action && ['query', 'edit', 'audio', 'effects', 'text'].includes(toolName)) {
+    if (action && ['query', 'edit', 'audio', 'effects', 'text', 'generate'].includes(toolName)) {
       const actionTool = this.registry.get(action);
       if (actionTool) {
         const toolArgs = { ...args };

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
@@ -108,7 +108,11 @@ export class ToolRegistryAdapter implements IToolExecutor {
   ): Promise<ToolExecutionResult> {
     const startTime = performance.now();
     const tool = this.registry.get(toolName);
-    const requiresMutationPreflight = requiresProjectMutationPreflight(toolName, tool?.category);
+    const requiresMutationPreflight = requiresProjectMutationPreflight(
+      toolName,
+      tool?.category,
+      args,
+    );
 
     if (requiresMutationPreflight) {
       const { error: revisionError, currentVersion } = validateMutationStateRevision(
@@ -320,12 +324,20 @@ export class ToolRegistryAdapter implements IToolExecutor {
     const errors = this.collectSchemaErrors(tool.parameters, args);
 
     const action = typeof args.action === 'string' ? args.action.trim() : '';
-    if (action && ['query', 'edit', 'audio', 'effects', 'text', 'generate'].includes(toolName)) {
+    const normalizedToolName = tool.name;
+    if (
+      action &&
+      ['query', 'edit', 'audio', 'effects', 'text', 'generate'].includes(normalizedToolName)
+    ) {
       const actionTool = this.registry.get(action);
       if (actionTool) {
         const toolArgs = { ...args };
         delete toolArgs.action;
-        const normalizedArgs = normalizeMetaToolArgsForValidation(toolName, action, toolArgs);
+        const normalizedArgs = normalizeMetaToolArgsForValidation(
+          normalizedToolName,
+          actionTool.name,
+          toolArgs,
+        );
         errors.push(...this.collectSchemaErrors(actionTool.parameters, normalizedArgs));
       }
     }

--- a/src/agents/engine/adapters/tools/mutationPreflight.ts
+++ b/src/agents/engine/adapters/tools/mutationPreflight.ts
@@ -79,7 +79,7 @@ export function validateMutationPreconditions(
     }
   }
 
-  if (!requiresProjectMutationPreflight(toolName, category)) {
+  if (!requiresProjectMutationPreflight(toolName, category, args)) {
     return errors;
   }
 
@@ -181,9 +181,7 @@ function validateClipTrackPair(
     return;
   }
 
-  errors.push(
-    `${clipKey} '${clipId}' is on track '${clip.trackId}', not ${trackKey} '${trackId}'`,
-  );
+  errors.push(`${clipKey} '${clipId}' is on track '${clip.trackId}', not ${trackKey} '${trackId}'`);
 }
 
 function validateTimelineNumberArgs(args: Record<string, unknown>, errors: string[]): void {

--- a/src/agents/engine/core/orchestrationPlaybooks.test.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.test.ts
@@ -389,6 +389,24 @@ describe('buildOrchestrationPlaybook', () => {
     expect(match?.plan.rollbackStrategy).toContain('No timeline changes');
   });
 
+  it('creates a sound-effect search playbook for SFX discovery', () => {
+    const thought: Thought = {
+      understanding: 'Find a whoosh sound effect for the transition',
+      requirements: ['sound effect search'],
+      uncertainties: [],
+      approach: 'Search SFX candidates',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['search_sound_for_scene']);
+    const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
+
+    expect(match?.id).toBe('sound_effect_search');
+    expect(match?.plan.steps).toHaveLength(1);
+    expect(match?.plan.steps[0].tool).toBe('search_sound_for_scene');
+    expect(match?.plan.rollbackStrategy).toContain('No timeline changes');
+  });
+
   it('should not match stock media playbook when search_stock_media tool is missing', () => {
     const thought: Thought = {
       understanding: 'Find stock footage of nature',
@@ -467,6 +485,30 @@ describe('buildOrchestrationPlaybook', () => {
     const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
 
     expect(match?.id).toBe('generate_and_place');
+  });
+
+  it('prefers provider-neutral timeline generation when orchestration tools are available', () => {
+    const thought: Thought = {
+      understanding: 'Create an AI-generated video clip and place it on the timeline',
+      requirements: ['ai video generation', 'timeline insertion'],
+      uncertainties: [],
+      approach: 'Generate then place',
+      needsMoreInfo: false,
+    };
+
+    const toolExecutor = createToolExecutor(['generate_timeline_media', 'generate_video']);
+    const match = buildOrchestrationPlaybook(thought, createContext(), toolExecutor);
+
+    expect(match?.id).toBe('generate_and_place');
+    expect(match?.plan.steps).toHaveLength(1);
+    expect(match?.plan.steps[0]).toMatchObject({
+      tool: 'generate_timeline_media',
+      args: {
+        mediaType: 'video',
+        placementMode: 'pending',
+        autoPlaceWhenReady: true,
+      },
+    });
   });
 
   it('should match auto-caption playbook for "add captions"', () => {

--- a/src/agents/engine/core/orchestrationPlaybooks.ts
+++ b/src/agents/engine/core/orchestrationPlaybooks.ts
@@ -9,6 +9,7 @@ export type OrchestrationPlaybookId =
   | 'timeline_interval_split'
   | 'insert_and_segment'
   | 'stock_media_search'
+  | 'sound_effect_search'
   | 'auto_caption'
   | 'music_bed'
   | 'reference_style_transfer';
@@ -128,6 +129,18 @@ const MUSIC_BED_KEYWORDS = [
   /\badd\s+bgm\b/i,
   /배경\s*음악\s*(?:추가|삽입)/i,
   /음악\s*(?:추가|넣|삽입)/i,
+];
+
+const SOUND_EFFECT_KEYWORDS = [
+  /\bsound\s+effects?\b/i,
+  /\bsfx\b/i,
+  /\bfoley\b/i,
+  /\bwhoosh\b/i,
+  /\bimpact\b/i,
+  /\bambien(?:t|ce)\b/i,
+  /효과음/i,
+  /폴리/i,
+  /소리\s*효과/i,
 ];
 
 const AUTO_CAPTION_KEYWORDS = [
@@ -294,6 +307,11 @@ export function buildOrchestrationPlaybook(
   const musicBed = buildMusicBedPlaybook(playbookContext);
   if (musicBed) {
     return musicBed;
+  }
+
+  const soundEffectSearch = buildSoundEffectSearchPlaybook(playbookContext);
+  if (soundEffectSearch) {
+    return soundEffectSearch;
   }
 
   const referenceStyleTransfer = buildReferenceStyleTransferPlaybook(playbookContext);
@@ -599,6 +617,48 @@ function buildMusicBedPlaybook(
       estimatedTotalDuration: estimateTotalDuration(steps),
       requiresApproval: false,
       rollbackStrategy: 'Remove inserted music clip and restore previous volume level.',
+    },
+  };
+}
+
+function buildSoundEffectSearchPlaybook(
+  playbookContext: PlaybookContext,
+): OrchestrationPlaybookMatch | null {
+  const { text, thought, toolExecutor } = playbookContext;
+
+  if (!matchesAny(text, SOUND_EFFECT_KEYWORDS) || !matchesAny(text, SEARCH_KEYWORDS)) {
+    return null;
+  }
+
+  if (!hasTools(toolExecutor, ['search_sound_for_scene'])) {
+    return null;
+  }
+
+  const sceneDescription =
+    extractSearchQuery(thought) || sanitizePrompt(thought.understanding) || 'cinematic sound effect';
+  const steps: PlanStep[] = [
+    {
+      id: 'playbook_search_sound_effect',
+      tool: 'search_sound_for_scene',
+      args: {
+        sceneDescription,
+        count: 8,
+      },
+      description: `Search licensed sound-effect candidates for "${sceneDescription}"`,
+      riskLevel: 'low',
+      estimatedDuration: 250,
+    },
+  ];
+
+  return {
+    id: 'sound_effect_search',
+    confidence: 0.86,
+    plan: {
+      goal: `Find sound-effect candidates matching "${sceneDescription}"`,
+      steps,
+      estimatedTotalDuration: estimateTotalDuration(steps),
+      requiresApproval: false,
+      rollbackStrategy: 'No timeline changes are applied during sound-effect search.',
     },
   };
 }
@@ -967,10 +1027,19 @@ function buildGenerateAndPlacePlaybook(
   playbookContext: PlaybookContext,
 ): OrchestrationPlaybookMatch | null {
   const { text, context, thought, toolExecutor } = playbookContext;
+  const hasGenerativeTimelineTools = hasTools(toolExecutor, [
+    'generate_timeline_media',
+    'generate_video',
+  ]);
+  const hasLegacyGenerateTools = hasTools(toolExecutor, [
+    'generate_video',
+    'check_generation_status',
+    'insert_clip',
+  ]);
 
   if (
     !matchesAll(text, [GENERATE_KEYWORDS, VIDEO_KEYWORDS, PLACE_KEYWORDS]) ||
-    !hasTools(toolExecutor, ['generate_video', 'check_generation_status', 'insert_clip'])
+    (!hasGenerativeTimelineTools && !hasLegacyGenerateTools)
   ) {
     return null;
   }
@@ -991,6 +1060,43 @@ function buildGenerateAndPlacePlaybook(
 
   const generationPrompt = sanitizePrompt(thought.understanding) || 'Create a cinematic short clip';
   const durationSec = parseDurationSeconds(text) ?? 6;
+
+  if (hasGenerativeTimelineTools) {
+    const steps: PlanStep[] = [
+      {
+        id: 'playbook_generate_timeline_media',
+        tool: 'generate_timeline_media',
+        args: {
+          prompt: generationPrompt,
+          mediaType: 'video',
+          provider: 'auto',
+          quality: 'pro',
+          durationSec,
+          sequenceId,
+          trackId: targetTrackId,
+          timelineStart: clampTimelineStart(context.playheadPosition, context.timelineDuration),
+          placementMode: 'pending',
+          autoPlaceWhenReady: true,
+        },
+        description: 'Submit provider-neutral video generation and visualize pending placement',
+        riskLevel: 'high',
+        estimatedDuration: 700,
+      },
+    ];
+
+    return {
+      id: 'generate_and_place',
+      confidence: 0.91,
+      plan: {
+        goal: 'Generate a new video asset, show pending timeline state, and place it when ready',
+        steps,
+        estimatedTotalDuration: estimateTotalDuration(steps),
+        requiresApproval: true,
+        rollbackStrategy:
+          'Cancel generation if still running; remove pending marker or inserted generated clip if already placed.',
+      },
+    };
+  }
 
   const steps: PlanStep[] = [
     {

--- a/src/agents/engine/core/permissionSubject.test.ts
+++ b/src/agents/engine/core/permissionSubject.test.ts
@@ -176,4 +176,20 @@ describe('permissionSubject', () => {
     expect(generationSubject.subject).toBe('external_provider.cancel#job:job-42');
     expect(generationSubject.subjectType).toBe('resource');
   });
+
+  it('treats generation resolution placement as a timeline mutation subject', () => {
+    const readSubject = buildPermissionSubject('resolve_generation_job', {
+      jobId: 'job-42',
+    });
+    const placementSubject = buildPermissionSubject('resolve_generation_job', {
+      jobId: 'job-42',
+      sequenceId: 'seq-1',
+      trackId: 'track-1',
+      placeWhenComplete: true,
+    });
+
+    expect(readSubject.subject).toBe('external_provider.status.read#job:job-42');
+    expect(placementSubject.subject).toBe('timeline.clip.create#job:job-42');
+    expect(placementSubject.subjectType).toBe('resource');
+  });
 });

--- a/src/agents/engine/core/permissionSubject.ts
+++ b/src/agents/engine/core/permissionSubject.ts
@@ -137,6 +137,20 @@ const EXACT_SUBJECTS: Record<string, { subjectType: PermissionSubjectType; subje
 
 const READ_PREFIXES = ['get_', 'list_', 'find_', 'search_', 'inspect_', 'query_', 'read_'];
 
+function resolveExactSubject(
+  normalizedToolName: string,
+  args: Record<string, unknown>,
+): { subjectType: PermissionSubjectType; subject: string } | undefined {
+  if (normalizedToolName === 'resolve_generation_job' && args.placeWhenComplete === true) {
+    return {
+      subjectType: 'capability',
+      subject: 'timeline.clip.create',
+    };
+  }
+
+  return EXACT_SUBJECTS[normalizedToolName];
+}
+
 function matchLegacyPermissionPattern(pattern: string, value: string): boolean {
   if (pattern === '*') {
     return true;
@@ -518,7 +532,7 @@ export function buildPermissionSubject(
 ): PermissionSubject {
   const rawToolName = toolName.trim().toLowerCase();
   const normalizedToolName = normalizeToolName(toolName, args);
-  const exact = EXACT_SUBJECTS[normalizedToolName];
+  const exact = resolveExactSubject(normalizedToolName, args);
   const resourceBinding = extractResourceBinding(args);
 
   if (exact) {

--- a/src/agents/engine/core/permissionSubject.ts
+++ b/src/agents/engine/core/permissionSubject.ts
@@ -26,7 +26,7 @@ export interface PermissionSubject {
   aliases: string[];
 }
 
-const META_TOOL_NAMES = new Set(['query', 'edit', 'audio', 'effects', 'text']);
+const META_TOOL_NAMES = new Set(['query', 'edit', 'audio', 'effects', 'text', 'generate']);
 
 const EXACT_SUBJECTS: Record<string, { subjectType: PermissionSubjectType; subject: string }> = {
   analyze_asset: {
@@ -97,9 +97,25 @@ const EXACT_SUBJECTS: Record<string, { subjectType: PermissionSubjectType; subje
     subjectType: 'external_provider',
     subject: 'external_provider.search',
   },
+  search_sound_for_scene: {
+    subjectType: 'external_provider',
+    subject: 'external_provider.search',
+  },
+  import_asset_candidate: {
+    subjectType: 'external_provider',
+    subject: 'external_provider.import',
+  },
+  generate_timeline_media: {
+    subjectType: 'external_provider',
+    subject: 'external_provider.generate',
+  },
   generate_video: {
     subjectType: 'external_provider',
     subject: 'external_provider.generate',
+  },
+  resolve_generation_job: {
+    subjectType: 'external_provider',
+    subject: 'external_provider.status.read',
   },
   check_generation_status: {
     subjectType: 'external_provider',

--- a/src/agents/engine/core/toolSemantics.test.ts
+++ b/src/agents/engine/core/toolSemantics.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { requiresProjectMutationPreflight } from './toolSemantics';
+
+describe('toolSemantics', () => {
+  it('requires project mutation preflight for timeline-changing generation actions', () => {
+    expect(
+      requiresProjectMutationPreflight('generate', 'generation', {
+        action: 'generate_timeline_media',
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+      }),
+    ).toBe(true);
+
+    expect(
+      requiresProjectMutationPreflight('generate', 'generation', {
+        action: 'resolve_generation_job',
+        jobId: 'job-1',
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        placeWhenComplete: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      requiresProjectMutationPreflight('generate_video', 'generation', {
+        prompt: 'Create a skyline shot',
+        placement: { sequenceId: 'seq-1', trackId: 'track-1', timelineStart: 0 },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not require project mutation preflight for read-only or import-only generation actions', () => {
+    expect(
+      requiresProjectMutationPreflight('generate', 'generation', {
+        action: 'generate_timeline_media',
+        placementMode: 'import_only',
+      }),
+    ).toBe(false);
+
+    expect(
+      requiresProjectMutationPreflight('generate', 'generation', {
+        action: 'resolve_generation_job',
+        jobId: 'job-1',
+      }),
+    ).toBe(false);
+
+    expect(
+      requiresProjectMutationPreflight('generate', 'generation', {
+        action: 'search_sound_for_scene',
+        sceneDescription: 'door slam',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/agents/engine/core/toolSemantics.ts
+++ b/src/agents/engine/core/toolSemantics.ts
@@ -60,6 +60,45 @@ const MUTATING_UTILITY_TOOLS = new Set([
   'execute_plan',
 ]);
 
+function normalizeActionArg(args?: Record<string, unknown>): string {
+  if (typeof args?.action !== 'string') {
+    return '';
+  }
+
+  return args.action
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .replace(/__+/g, '_')
+    .toLowerCase();
+}
+
+function generationActionRequiresProjectMutationPreflight(
+  toolName: string,
+  args?: Record<string, unknown>,
+): boolean {
+  const action = toolName === 'generate' ? normalizeActionArg(args) : toolName;
+
+  if (action === 'resolve_generation_job') {
+    return args?.placeWhenComplete === true;
+  }
+
+  if (action === 'generate_video') {
+    return args?.placement !== undefined && args.placement !== null;
+  }
+
+  if (action !== 'generate_timeline_media') {
+    return false;
+  }
+
+  const mediaType =
+    typeof args?.mediaType === 'string' ? args.mediaType.trim().toLowerCase() : 'video';
+  const placementMode =
+    typeof args?.placementMode === 'string' ? args.placementMode.trim().toLowerCase() : 'pending';
+
+  return mediaType !== 'sfx' && placementMode !== 'import_only';
+}
+
 export const MUTATION_INTENT_PATTERN = new RegExp(
   [
     '\\b(split|cut|trim|move|shift|delete|remove|insert|add|place|put|edit|update|change|replace|reorder|caption|subtitle|transcribe|mute|unmute|fade|normalize|speed|rename|create|write|apply)\\b',
@@ -103,6 +142,7 @@ export function isReadOnlyToolName(toolName: string, category?: string | null): 
 export function requiresProjectMutationPreflight(
   toolName: string,
   category?: string | null,
+  args?: Record<string, unknown>,
 ): boolean {
   const normalizedToolName = toolName.trim().toLowerCase();
   const normalizedCategory = category?.trim().toLowerCase() ?? null;
@@ -112,6 +152,10 @@ export function requiresProjectMutationPreflight(
   }
 
   if (PROJECT_MUTATION_UTILITY_TOOLS.has(normalizedToolName)) {
+    return true;
+  }
+
+  if (generationActionRequiresProjectMutationPreflight(normalizedToolName, args)) {
     return true;
   }
 

--- a/src/agents/engine/core/toolSemantics.ts
+++ b/src/agents/engine/core/toolSemantics.ts
@@ -56,6 +56,7 @@ const MUTATING_UTILITY_TOOLS = new Set([
   'audio',
   'effects',
   'text',
+  'generate',
   'execute_plan',
 ]);
 

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -117,6 +117,13 @@ const TEXT_ACTIONS = `## Text Actions (meta-tool: text, require sequenceId)
 - add_captions_from_transcription(segments, trackId?) → create captions from timed transcript segments
 - import_captions_from_file(relativePath, format?, trackId?) → import SRT/VTT subtitle files from the workspace`;
 
+const GENERATE_ACTIONS = `## Generate Actions (meta-tool: generate)
+- generate_timeline_media(prompt, mediaType?, provider?, sequenceId?, trackId?, timelineStart?) → submit provider-neutral generation or SFX discovery; video jobs can create a pending marker and auto-place when ready
+- resolve_generation_job(jobId, placeWhenComplete?) → sync long-running generation status; pending states are successful and completed jobs expose assetId
+- search_sound_for_scene(sceneDescription, mood?, durationSec?, tags?) → search audio/SFX candidates with license policy; does not import
+- import_asset_candidate(candidate, licenseAck=true) → import an approved stock candidate with license snapshot; rejects blocked policy candidates
+- generate_video/check_generation_status/estimate_generation_cost/cancel_generation → provider job primitives used by orchestration when video generation is enabled`;
+
 const WORKSPACE_READ_TOOLS = `## Workspace Document Tools (read-only)
 - list_workspace_documents / read_workspace_document`;
 
@@ -135,6 +142,8 @@ const TOOL_OUTPUT_CONTRACTS = buildToolOutputContractSection([
   'insert_clip',
   'insert_clip_from_file',
   'split_clip',
+  'generate_timeline_media',
+  'resolve_generation_job',
 ]);
 
 const EDITING_CONCEPTS = `## Editing Concepts
@@ -155,7 +164,9 @@ const COMMON_WORKFLOWS = `## Common Workflows
 7. Track-specific clip lookup: get_track_clips(trackId) → reference clip IDs via data.clips[n].id
 8. Time-based clip lookup across tracks: get_clips_at_time(time) → reference clip IDs via data[n].id (never data[n].clipId)
 9. Deep source inspection/editing: find_workspace_file or get_asset_catalog → read_source_analysis_report (this already writes the default ".analysis.md" report beside the asset) → check data.quality.status and do not silently edit from an insufficient/partial report; refresh or use build_source_selects with analyzeMissing=true when source selection depends on transcript or frame semantics → search_source_analysis_report / search_source_library → build_source_selects or edit actions
-10. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
+10. Generative edit: generate_timeline_media with sequenceId/trackId/timelineStart creates a pending timeline marker and stores placement intent; the generation store imports and places the asset when the provider job completes. Use resolve_generation_job for explicit status checks.
+11. SFX discovery/import: search_sound_for_scene → present usable candidates and license policy → import_asset_candidate only with licenseAck=true → insert_clip on an audio track.
+12. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
 
 const CLI_REFERENCE = `## CLI (headless alternative)
 openreelio-cli <group> <command> --path <dir> [--args]
@@ -178,6 +189,7 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
         AUDIO_ACTIONS,
         EFFECTS_ACTIONS,
         TEXT_ACTIONS,
+        GENERATE_ACTIONS,
         WORKSPACE_TOOLS,
         EDITING_CONCEPTS,
         COMMON_WORKFLOWS,
@@ -191,6 +203,7 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
         AUDIO_ACTIONS,
         EFFECTS_ACTIONS,
         TEXT_ACTIONS,
+        GENERATE_ACTIONS,
         WORKSPACE_READ_TOOLS,
         EDITING_CONCEPTS,
         COMMON_WORKFLOWS,
@@ -210,7 +223,14 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
         CLI_REFERENCE,
       ];
     case 'audio':
-      return [QUERY_ACTIONS, TOOL_OUTPUT_CONTRACTS, AUDIO_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
+      return [
+        QUERY_ACTIONS,
+        TOOL_OUTPUT_CONTRACTS,
+        AUDIO_ACTIONS,
+        GENERATE_ACTIONS,
+        WORKSPACE_TOOLS,
+        CLI_REFERENCE,
+      ];
     case 'captioner':
       return [QUERY_ACTIONS, TOOL_OUTPUT_CONTRACTS, TEXT_ACTIONS, WORKSPACE_TOOLS, CLI_REFERENCE];
   }

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -139,6 +139,34 @@ function matchesGenerateSourceAnalysisReportPath(path: string): boolean {
   );
 }
 
+function matchesGenerateTimelineMediaPath(path: string): boolean {
+  return (
+    path === 'data' ||
+    path === 'data.jobId' ||
+    path === 'data.status' ||
+    path === 'data.mediaType' ||
+    path === 'data.provider' ||
+    path === 'data.estimatedCostCents' ||
+    path === 'data.autoPlaceWhenReady' ||
+    path === 'data.nextAction' ||
+    path === 'data.pendingTimeline' ||
+    path.startsWith('data.pendingTimeline.')
+  );
+}
+
+function matchesResolveGenerationJobPath(path: string): boolean {
+  return (
+    path === 'data' ||
+    path === 'data.status' ||
+    path === 'data.pending' ||
+    path === 'data.progress' ||
+    path === 'data.assetId' ||
+    path === 'data.message' ||
+    path === 'data.placement' ||
+    path.startsWith('data.placement.')
+  );
+}
+
 export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
   get_timeline_info: {
     summary:
@@ -191,6 +219,18 @@ export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
       'returns structured report fields plus semantic overview/timeline fields and the persisted Markdown report under data.content/data.markdown with its saved workspace path under data.relativePath/data.reportPath',
     examples: ['data.content', 'data.reportPath', 'data.semantic.sceneTimeline[0].summary'],
     validatePath: matchesGenerateSourceAnalysisReportPath,
+  },
+  generate_timeline_media: {
+    summary:
+      'returns submitted generation metadata under data.* including data.jobId, data.pendingTimeline.*, and data.nextAction',
+    examples: ['data.jobId', 'data.pendingTimeline.markerId', 'data.nextAction'],
+    validatePath: matchesGenerateTimelineMediaPath,
+  },
+  resolve_generation_job: {
+    summary:
+      'returns generation sync state under data.* including data.status, data.pending, data.assetId, and optional data.placement',
+    examples: ['data.status', 'data.assetId', 'data.placement.clipId'],
+    validatePath: matchesResolveGenerationJobPath,
   },
 };
 

--- a/src/agents/tools/captionTools.test.ts
+++ b/src/agents/tools/captionTools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import { globalToolRegistry, type AgentContext } from '@/agents';
 import { registerCaptionTools, unregisterCaptionTools } from './captionTools';
@@ -93,15 +93,9 @@ function createSequence(overrides: Partial<Sequence> = {}): Sequence {
 describe('captionTools', () => {
   const executeCommandMock = vi.fn();
 
-  beforeAll(() => {
-    registerCaptionTools();
-  });
-
-  afterAll(() => {
-    unregisterCaptionTools();
-  });
-
   beforeEach(() => {
+    globalToolRegistry.clear();
+    registerCaptionTools();
     vi.clearAllMocks();
     vi.mocked(readWorkspaceDocumentFromBackend).mockResolvedValue({
       relativePath: 'captions/example.srt',
@@ -147,6 +141,11 @@ describe('captionTools', () => {
     } as unknown as ReturnType<typeof useProjectStore.getState>);
   });
 
+  afterEach(() => {
+    unregisterCaptionTools();
+    globalToolRegistry.clear();
+  });
+
   it('should send parsed color and top-level position in style_caption', async () => {
     const tool = globalToolRegistry.get('style_caption');
     expect(tool).toBeDefined();
@@ -159,6 +158,14 @@ describe('captionTools', () => {
         backgroundColor: '#00000066',
         position: 'top',
         fontSize: 42,
+        fontWeight: 700,
+        italic: true,
+        outlineColor: '#445566',
+        outlineWidth: 3,
+        shadowColor: '#00000099',
+        shadowOffsetX: 4,
+        shadowOffsetY: 6,
+        lineHeight: 1.4,
       },
       CTX,
     );
@@ -178,8 +185,16 @@ describe('captionTools', () => {
       captionId: 'cap-001',
       style: {
         fontSize: 42,
+        fontWeight: 700,
+        italic: true,
         color: { r: 17, g: 34, b: 51, a: 204 },
         backgroundColor: { r: 0, g: 0, b: 0, a: 102 },
+        outlineColor: { r: 68, g: 85, b: 102, a: 255 },
+        outlineWidth: 3,
+        shadowColor: { r: 0, g: 0, b: 0, a: 153 },
+        shadowOffsetX: 4,
+        shadowOffsetY: 6,
+        lineHeight: 1.4,
       },
       position: {
         type: 'preset',
@@ -189,6 +204,34 @@ describe('captionTools', () => {
     });
 
     expect((command.payload.style as Record<string, unknown>).position).toBeUndefined();
+  });
+
+  it('should send custom position objects in style_caption', async () => {
+    const tool = globalToolRegistry.get('style_caption');
+    expect(tool).toBeDefined();
+
+    const result = await tool!.handler(
+      {
+        sequenceId: 'seq-1',
+        captionId: 'cap-001',
+        xPercent: 42,
+        yPercent: 84,
+      },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+
+    const command = executeCommandMock.mock.calls[0][0] as {
+      type: string;
+      payload: Record<string, unknown>;
+    };
+
+    expect(command.payload.position).toEqual({
+      type: 'custom',
+      xPercent: 42,
+      yPercent: 84,
+    });
   });
 
   it('should reject invalid caption color in style_caption', async () => {

--- a/src/agents/tools/captionTools.ts
+++ b/src/agents/tools/captionTools.ts
@@ -121,7 +121,73 @@ function parseAgentCaptionPosition(value: unknown): CaptionPosition | undefined 
     };
   }
 
+  if (value && typeof value === 'object') {
+    const candidate = value as Record<string, unknown>;
+    if (candidate.type === 'preset') {
+      const vertical =
+        candidate.vertical === 'top' ||
+        candidate.vertical === 'center' ||
+        candidate.vertical === 'bottom'
+          ? candidate.vertical
+          : undefined;
+      if (!vertical) {
+        return undefined;
+      }
+      const marginPercent = Number(candidate.marginPercent ?? 5);
+      return {
+        type: 'preset',
+        vertical,
+        marginPercent: Number.isFinite(marginPercent)
+          ? Math.max(0, Math.min(50, marginPercent))
+          : 5,
+      };
+    }
+
+    const xPercent = Number(candidate.xPercent ?? candidate.x);
+    const yPercent = Number(candidate.yPercent ?? candidate.y);
+    if (Number.isFinite(xPercent) && Number.isFinite(yPercent)) {
+      return {
+        type: 'custom',
+        xPercent: Math.max(0, Math.min(100, xPercent)),
+        yPercent: Math.max(0, Math.min(100, yPercent)),
+      };
+    }
+  }
+
   return undefined;
+}
+
+function parseOptionalNumber(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): { ok: true; value?: number } | { ok: false; error: string } {
+  if (value === undefined) {
+    return { ok: true };
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return { ok: false, error: `${field} must be a number between ${min} and ${max}.` };
+  }
+
+  return { ok: true, value: parsed };
+}
+
+function parseOptionalBoolean(
+  value: unknown,
+  field: string,
+): { ok: true; value?: boolean } | { ok: false; error: string } {
+  if (value === undefined) {
+    return { ok: true };
+  }
+
+  if (typeof value === 'boolean') {
+    return { ok: true, value };
+  }
+
+  return { ok: false, error: `${field} must be a boolean.` };
 }
 
 function isTranscriptCapableProvider(provider: ProviderCapabilities): boolean {
@@ -210,10 +276,7 @@ async function transcribeWithAnalysisProvider(
   return {
     provider,
     segments: normalized.segments,
-    duration: normalized.segments.reduce(
-      (maxEnd, segment) => Math.max(maxEnd, segment.endTime),
-      0,
-    ),
+    duration: normalized.segments.reduce((maxEnd, segment) => Math.max(maxEnd, segment.endTime), 0),
     fullText: normalized.segments.map((segment) => segment.text).join(' '),
   };
 }
@@ -654,18 +717,88 @@ const CAPTION_TOOLS: ToolDefinition[] = [
           type: 'string',
           description: 'Font family name',
         },
+        fontWeight: {
+          type: 'number',
+          description: 'Font weight from 100 to 900',
+        },
+        bold: {
+          type: 'boolean',
+          description: 'Enable bold styling',
+        },
+        italic: {
+          type: 'boolean',
+          description: 'Enable italic styling',
+        },
+        underline: {
+          type: 'boolean',
+          description: 'Enable underline styling',
+        },
         color: {
           type: 'string',
           description: 'Text color in hex format',
+        },
+        opacity: {
+          type: 'number',
+          description: 'Text opacity from 0 to 1',
         },
         backgroundColor: {
           type: 'string',
           description: 'Background color in hex format with optional alpha',
         },
+        backgroundPadding: {
+          type: 'number',
+          description: 'Background padding in pixels',
+        },
+        outlineColor: {
+          type: 'string',
+          description: 'Outline color in hex format with optional alpha',
+        },
+        outlineWidth: {
+          type: 'number',
+          description: 'Outline width in pixels',
+        },
+        shadowColor: {
+          type: 'string',
+          description: 'Shadow color in hex format with optional alpha',
+        },
+        shadowOffsetX: {
+          type: 'number',
+          description: 'Shadow horizontal offset in pixels',
+        },
+        shadowOffsetY: {
+          type: 'number',
+          description: 'Shadow vertical offset in pixels',
+        },
+        shadowBlur: {
+          type: 'number',
+          description: 'Shadow blur radius metadata in pixels',
+        },
+        alignment: {
+          type: 'string',
+          description: 'Caption text alignment',
+          enum: ['left', 'center', 'right'],
+        },
+        lineHeight: {
+          type: 'number',
+          description: 'Line height multiplier',
+        },
+        letterSpacing: {
+          type: 'number',
+          description: 'Letter spacing in pixels',
+        },
         position: {
           type: 'string',
-          description: 'Caption position (top, center, bottom)',
+          description:
+            'Caption position preset (top, center, bottom). Use xPercent and yPercent for custom placement.',
           enum: ['top', 'center', 'bottom'],
+        },
+        xPercent: {
+          type: 'number',
+          description: 'Custom caption X position as percent from the left',
+        },
+        yPercent: {
+          type: 'number',
+          description: 'Custom caption Y position as percent from the top',
         },
       },
       required: ['sequenceId', 'captionId'],
@@ -696,6 +829,52 @@ const CAPTION_TOOLS: ToolDefinition[] = [
         if (args.fontSize !== undefined) style.fontSize = args.fontSize;
         if (args.fontFamily !== undefined) style.fontFamily = args.fontFamily;
 
+        const numericFields: Array<[string, number, number]> = [
+          ['fontWeight', 100, 900],
+          ['opacity', 0, 1],
+          ['backgroundPadding', 0, 500],
+          ['outlineWidth', 0, 100],
+          ['shadowOffsetX', -500, 500],
+          ['shadowOffsetY', -500, 500],
+          ['shadowBlur', 0, 500],
+          ['lineHeight', 0.5, 5],
+          ['letterSpacing', -100, 200],
+        ];
+
+        for (const [field, min, max] of numericFields) {
+          const parsed = parseOptionalNumber(args[field], field, min, max);
+          if (!parsed.ok) {
+            return { success: false, error: parsed.error };
+          }
+          if (parsed.value !== undefined) {
+            style[field] = parsed.value;
+          }
+        }
+
+        for (const field of ['bold', 'italic', 'underline']) {
+          const parsed = parseOptionalBoolean(args[field], field);
+          if (!parsed.ok) {
+            return { success: false, error: parsed.error };
+          }
+          if (parsed.value !== undefined) {
+            style[field] = parsed.value;
+          }
+        }
+
+        if (args.alignment !== undefined) {
+          if (
+            args.alignment !== 'left' &&
+            args.alignment !== 'center' &&
+            args.alignment !== 'right'
+          ) {
+            return {
+              success: false,
+              error: `Invalid caption alignment '${String(args.alignment)}'. Use left, center, or right.`,
+            };
+          }
+          style.alignment = args.alignment;
+        }
+
         if (args.color !== undefined) {
           const parsedTextColor = parseHexColorToRgba(String(args.color));
           if (!parsedTextColor) {
@@ -718,11 +897,38 @@ const CAPTION_TOOLS: ToolDefinition[] = [
           style.backgroundColor = parsedBackgroundColor;
         }
 
-        const position = parseAgentCaptionPosition(args.position);
-        if (args.position !== undefined && !position) {
+        if (args.outlineColor !== undefined) {
+          const parsedOutlineColor = parseHexColorToRgba(String(args.outlineColor));
+          if (!parsedOutlineColor) {
+            return {
+              success: false,
+              error: `Invalid caption outlineColor '${String(args.outlineColor)}'. Use #RRGGBB or #RRGGBBAA.`,
+            };
+          }
+          style.outlineColor = parsedOutlineColor;
+        }
+
+        if (args.shadowColor !== undefined) {
+          const parsedShadowColor = parseHexColorToRgba(String(args.shadowColor));
+          if (!parsedShadowColor) {
+            return {
+              success: false,
+              error: `Invalid caption shadowColor '${String(args.shadowColor)}'. Use #RRGGBB or #RRGGBBAA.`,
+            };
+          }
+          style.shadowColor = parsedShadowColor;
+        }
+
+        const positionInput =
+          args.position ??
+          (args.xPercent !== undefined || args.yPercent !== undefined
+            ? { xPercent: args.xPercent, yPercent: args.yPercent }
+            : undefined);
+        const position = parseAgentCaptionPosition(positionInput);
+        if (positionInput !== undefined && !position) {
           return {
             success: false,
-            error: `Invalid caption position '${String(args.position)}'. Use top, center, or bottom.`,
+            error: `Invalid caption position '${String(positionInput)}'. Use top, center, bottom, or numeric xPercent and yPercent.`,
           };
         }
 

--- a/src/agents/tools/generationTools.ts
+++ b/src/agents/tools/generationTools.ts
@@ -9,6 +9,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { globalToolRegistry, type ToolDefinition } from '../ToolRegistry';
 import { useVideoGenStore } from '@/stores/videoGenStore';
+import type { VideoGenPlacementRequest } from '@/stores/videoGenStore';
 import { useProjectStore } from '@/stores/projectStore';
 import { createLogger } from '@/services/logger';
 
@@ -56,6 +57,11 @@ const GENERATION_TOOLS: ToolDefinition[] = [
           type: 'string',
           description: 'Aspect ratio (16:9, 9:16, 1:1, default: 16:9)',
         },
+        placement: {
+          type: 'object',
+          description:
+            'Optional pending timeline placement intent with sequenceId, trackId, timelineStart, markerId, and removeMarkerOnPlace.',
+        },
       },
       required: ['prompt'],
     },
@@ -68,9 +74,9 @@ const GENERATION_TOOLS: ToolDefinition[] = [
         }
 
         const referenceAssetIds = Array.isArray(args.referenceAssetIds)
-          ? args.referenceAssetIds.filter(
-              (id): id is string => typeof id === 'string' && id.trim().length > 0,
-            )
+          ? args.referenceAssetIds
+              .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+              .map((id) => id.trim())
           : [];
 
         // Resolve asset IDs to provider-ready URI lists by media type.
@@ -121,8 +127,9 @@ const GENERATION_TOOLS: ToolDefinition[] = [
         }
 
         // Estimate cost first
-        const quality = (args.quality as string) ?? 'pro';
-        const durationSec = (args.durationSec as number) ?? 10;
+        const quality = normalizeQualityArg(args.quality);
+        const durationSec = normalizeDurationArg(args.durationSec);
+        const placement = normalizePlacementArg(args.placement);
 
         const estimate = await invoke<{
           estimatedCents: number;
@@ -140,13 +147,14 @@ const GENERATION_TOOLS: ToolDefinition[] = [
         const store = useVideoGenStore.getState();
         const jobId = await store.submitGeneration({
           prompt,
-          mode: (args.mode as 'text_to_video' | 'image_to_video' | 'multimodal') ?? undefined,
-          quality: (args.quality as 'basic' | 'pro' | 'cinema') ?? undefined,
-          durationSec: (args.durationSec as number) ?? undefined,
+          mode: normalizeModeArg(args.mode),
+          quality,
+          durationSec,
           aspectRatio: (args.aspectRatio as string) ?? undefined,
           referenceImages: referenceImages.length > 0 ? referenceImages : undefined,
           referenceVideos: referenceVideos.length > 0 ? referenceVideos : undefined,
           referenceAudio: referenceAudio.length > 0 ? referenceAudio : undefined,
+          placement,
         });
 
         return {
@@ -154,6 +162,7 @@ const GENERATION_TOOLS: ToolDefinition[] = [
           result: {
             jobId,
             estimatedCostCents: estimate.estimatedCents,
+            placement,
             message: `Video generation submitted (est. $${(estimate.estimatedCents / 100).toFixed(2)}). Use check_generation_status with jobId "${jobId}" to monitor progress.`,
           },
         };
@@ -299,6 +308,48 @@ const GENERATION_TOOLS: ToolDefinition[] = [
     },
   },
 ];
+
+function normalizePlacementArg(value: unknown): VideoGenPlacementRequest | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const raw = value as Record<string, unknown>;
+  const sequenceId = typeof raw.sequenceId === 'string' ? raw.sequenceId.trim() : '';
+  const trackId = typeof raw.trackId === 'string' ? raw.trackId.trim() : '';
+  if (!sequenceId || !trackId) {
+    return null;
+  }
+
+  const timelineStart =
+    typeof raw.timelineStart === 'number' && Number.isFinite(raw.timelineStart)
+      ? Math.max(0, raw.timelineStart)
+      : 0;
+
+  return {
+    sequenceId,
+    trackId,
+    timelineStart,
+    markerId: typeof raw.markerId === 'string' && raw.markerId.trim() ? raw.markerId.trim() : null,
+    removeMarkerOnPlace: raw.removeMarkerOnPlace !== false,
+  };
+}
+
+function normalizeModeArg(value: unknown): 'text_to_video' | 'image_to_video' | 'multimodal' {
+  return value === 'image_to_video' || value === 'multimodal' || value === 'text_to_video'
+    ? value
+    : 'text_to_video';
+}
+
+function normalizeQualityArg(value: unknown): 'basic' | 'pro' | 'cinema' {
+  return value === 'basic' || value === 'cinema' || value === 'pro' ? value : 'pro';
+}
+
+function normalizeDurationArg(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(120, Math.max(5, value))
+    : 10;
+}
 
 // =============================================================================
 // Registration Functions

--- a/src/agents/tools/generativeTimelineTools.test.ts
+++ b/src/agents/tools/generativeTimelineTools.test.ts
@@ -154,6 +154,46 @@ describe('generativeTimelineTools', () => {
     );
   });
 
+  it('does not attach timeline placement for import-only generation', async () => {
+    const generateVideo = vi.fn().mockResolvedValue({
+      success: true,
+      result: { jobId: 'job-import-only', estimatedCostCents: 18 },
+    });
+
+    registerStubTool({
+      name: 'generate_video',
+      description: 'generate video',
+      category: 'generation',
+      parameters: { type: 'object' },
+      handler: generateVideo,
+    });
+
+    const result = await globalToolRegistry.execute(
+      'generate_timeline_media',
+      {
+        prompt: 'Wide establishing shot',
+        mediaType: 'video',
+        placementMode: 'import_only',
+        sequenceId: 'seq-1',
+        trackId: 'video-1',
+        timelineStart: 4,
+      },
+      {},
+    );
+
+    expect(result.success).toBe(true);
+    expect(generateVideo).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        placement: expect.anything(),
+      }),
+      expect.anything(),
+    );
+    expect(result.result).toMatchObject({
+      pendingTimeline: null,
+      autoPlaceWhenReady: false,
+    });
+  });
+
   it('rejects pending generation when no placement target is available', async () => {
     registerStubTool({
       name: 'generate_video',
@@ -205,7 +245,12 @@ describe('generativeTimelineTools', () => {
       parameters: { type: 'object' },
       handler: vi.fn().mockResolvedValue({
         success: true,
-        result: { status: 'failed', progress: 100, assetId: null, error: 'provider quota exceeded' },
+        result: {
+          status: 'failed',
+          progress: 100,
+          assetId: null,
+          error: 'provider quota exceeded',
+        },
       }),
     });
 

--- a/src/agents/tools/generativeTimelineTools.test.ts
+++ b/src/agents/tools/generativeTimelineTools.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { globalToolRegistry, type ToolDefinition } from '@/agents/ToolRegistry';
+import {
+  registerGenerativeTimelineTools,
+  unregisterGenerativeTimelineTools,
+} from './generativeTimelineTools';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+
+function registerStubTool(tool: ToolDefinition): void {
+  globalToolRegistry.register(tool);
+}
+
+describe('generativeTimelineTools', () => {
+  beforeEach(() => {
+    globalToolRegistry.clear();
+    mockedInvoke.mockReset();
+    registerGenerativeTimelineTools();
+  });
+
+  afterEach(() => {
+    unregisterGenerativeTimelineTools();
+    globalToolRegistry.clear();
+  });
+
+  it('submits video generation with pending timeline placement metadata', async () => {
+    const addMarker = vi.fn().mockResolvedValue({
+      success: true,
+      result: { createdIds: ['marker-1'] },
+    });
+    const generateVideo = vi.fn().mockResolvedValue({
+      success: true,
+      result: { jobId: 'job-1', estimatedCostCents: 12 },
+    });
+
+    registerStubTool({
+      name: 'add_marker',
+      description: 'add marker',
+      category: 'timeline',
+      parameters: { type: 'object' },
+      handler: addMarker,
+    });
+    registerStubTool({
+      name: 'generate_video',
+      description: 'generate video',
+      category: 'generation',
+      parameters: { type: 'object' },
+      handler: generateVideo,
+    });
+
+    const result = await globalToolRegistry.execute(
+      'generate_timeline_media',
+      {
+        prompt: 'Cinematic neon street shot',
+        mediaType: 'video',
+        sequenceId: 'seq-1',
+        trackId: 'video-1',
+        timelineStart: 4,
+      },
+      {},
+    );
+
+    expect(result.success).toBe(true);
+    expect(addMarker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sequenceId: 'seq-1',
+        time: 4,
+      }),
+      expect.anything(),
+    );
+    expect(generateVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'Cinematic neon street shot',
+        placement: expect.objectContaining({
+          sequenceId: 'seq-1',
+          trackId: 'video-1',
+          timelineStart: 4,
+          markerId: 'marker-1',
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(result.result).toMatchObject({
+      status: 'submitted',
+      jobId: 'job-1',
+      pendingTimeline: {
+        markerId: 'marker-1',
+      },
+      nextAction: 'resolve_generation_job',
+    });
+  });
+
+  it('uses active timeline context for pending placement when explicit args are omitted', async () => {
+    const addMarker = vi.fn().mockResolvedValue({
+      success: true,
+      result: { createdIds: ['marker-from-context'] },
+    });
+    const generateVideo = vi.fn().mockResolvedValue({
+      success: true,
+      result: { jobId: 'job-context', estimatedCostCents: 18 },
+    });
+
+    registerStubTool({
+      name: 'add_marker',
+      description: 'add marker',
+      category: 'timeline',
+      parameters: { type: 'object' },
+      handler: addMarker,
+    });
+    registerStubTool({
+      name: 'generate_video',
+      description: 'generate video',
+      category: 'generation',
+      parameters: { type: 'object' },
+      handler: generateVideo,
+    });
+
+    const result = await globalToolRegistry.execute(
+      'generate_timeline_media',
+      {
+        prompt: 'Wide establishing shot',
+        mediaType: 'video',
+      },
+      {
+        sequenceId: 'seq-active',
+        selectedTrackIds: ['video-active'],
+        playheadPosition: 12.5,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(addMarker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sequenceId: 'seq-active',
+        time: 12.5,
+      }),
+      expect.anything(),
+    );
+    expect(generateVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: expect.objectContaining({
+          sequenceId: 'seq-active',
+          trackId: 'video-active',
+          timelineStart: 12.5,
+          markerId: 'marker-from-context',
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects pending generation when no placement target is available', async () => {
+    registerStubTool({
+      name: 'generate_video',
+      description: 'generate video',
+      category: 'generation',
+      parameters: { type: 'object' },
+      handler: vi.fn().mockResolvedValue({
+        success: true,
+        result: { jobId: 'job-1', estimatedCostCents: 12 },
+      }),
+    });
+
+    const result = await globalToolRegistry.execute('generate_timeline_media', {
+      prompt: 'Shot without target track',
+      mediaType: 'video',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('requires sequenceId and trackId');
+  });
+
+  it('treats unresolved generation status as a successful pending sync', async () => {
+    registerStubTool({
+      name: 'check_generation_status',
+      description: 'check',
+      category: 'generation',
+      parameters: { type: 'object' },
+      handler: vi.fn().mockResolvedValue({
+        success: true,
+        result: { status: 'processing', progress: 45, assetId: null },
+      }),
+    });
+
+    const result = await globalToolRegistry.execute('resolve_generation_job', { jobId: 'job-1' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({
+      status: 'processing',
+      pending: true,
+      progress: 45,
+    });
+  });
+
+  it('returns failure for failed generation jobs instead of treating them as pending', async () => {
+    registerStubTool({
+      name: 'check_generation_status',
+      description: 'check',
+      category: 'generation',
+      parameters: { type: 'object' },
+      handler: vi.fn().mockResolvedValue({
+        success: true,
+        result: { status: 'failed', progress: 100, assetId: null, error: 'provider quota exceeded' },
+      }),
+    });
+
+    const result = await globalToolRegistry.execute('resolve_generation_job', { jobId: 'job-1' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('provider quota exceeded');
+    expect(result.result).toMatchObject({
+      status: 'failed',
+      pending: false,
+    });
+  });
+
+  it('ranks usable sound candidates before blocked candidates', async () => {
+    registerStubTool({
+      name: 'search_stock_media',
+      description: 'search stock',
+      category: 'analysis',
+      parameters: { type: 'object' },
+      handler: vi.fn().mockResolvedValue({
+        success: true,
+        result: {
+          assets: [
+            {
+              id: 'blocked',
+              durationSec: 1,
+              licensePolicy: { status: 'blocked', reasons: ['No commercial use'] },
+            },
+            {
+              id: 'usable',
+              durationSec: 2,
+              licensePolicy: { status: 'allowed', reasons: [] },
+            },
+          ],
+          policySummary: { allowed: 1, blocked: 1 },
+        },
+      }),
+    });
+
+    const result = await globalToolRegistry.execute('search_sound_for_scene', {
+      sceneDescription: 'fast transition whoosh',
+      durationSec: 2,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({
+      recommendedCandidates: [expect.objectContaining({ id: 'usable' })],
+      blockedCandidates: [expect.objectContaining({ id: 'blocked' })],
+      nextAction: 'import_asset_candidate',
+    });
+  });
+
+  it('imports approved stock candidates through the backend license gate', async () => {
+    mockedInvoke.mockResolvedValue({
+      assetId: 'asset-1',
+      name: 'whoosh',
+      localPath: '/project/.openreelio/imports/stock/whoosh.mp3',
+      opId: 'op-1',
+      licenseSnapshotPath: '/project/.openreelio/licenses/whoosh.json',
+    });
+
+    const result = await globalToolRegistry.execute('import_asset_candidate', {
+      licenseAck: true,
+      candidate: {
+        name: 'whoosh',
+        assetType: 'audio',
+        provider: 'openverse',
+        durationSec: 1.3,
+        tags: ['whoosh'],
+        license: {
+          source: 'stock_provider',
+          provider: 'Openverse',
+          licenseType: 'cc0',
+          allowedUse: ['commercial'],
+        },
+        licensePolicy: { status: 'allowed', reasons: [] },
+        metadata: {
+          downloadUrl: 'https://cdn.example/whoosh.mp3',
+          providerUrl: 'https://openverse.org/audio/1',
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockedInvoke).toHaveBeenCalledWith('import_stock_media_asset', {
+      sourceUrl: 'https://cdn.example/whoosh.mp3',
+      name: 'whoosh',
+      assetType: 'audio',
+      provider: 'openverse',
+      license: expect.objectContaining({ provider: 'Openverse' }),
+      licenseAck: true,
+      durationSec: 1.3,
+      tags: ['whoosh'],
+      providerUrl: 'https://openverse.org/audio/1',
+    });
+  });
+
+  it('rejects stock candidate import without license acknowledgement', async () => {
+    const result = await globalToolRegistry.execute('import_asset_candidate', {
+      licenseAck: false,
+      candidate: {
+        name: 'whoosh',
+        metadata: { downloadUrl: 'https://cdn.example/whoosh.mp3' },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('licenseAck=true');
+  });
+});

--- a/src/agents/tools/generativeTimelineTools.ts
+++ b/src/agents/tools/generativeTimelineTools.ts
@@ -267,21 +267,24 @@ async function generateTimelineMedia(args: Record<string, unknown>, context: Age
     };
   }
 
-  const generation = await globalToolRegistry.execute('generate_video', {
+  const shouldAttachPlacement =
+    placementMode !== 'import_only' && args.autoPlaceWhenReady !== false && Boolean(placement);
+  const generationArgs: Record<string, unknown> = {
     prompt,
     mode: 'text_to_video',
     quality: normalizeQuality(args.quality),
     durationSec: normalizeDuration(args.durationSec),
     referenceAssetIds: Array.isArray(args.referenceAssetIds) ? args.referenceAssetIds : undefined,
     aspectRatio: normalizeString(args.aspectRatio) || undefined,
-    placement:
-      args.autoPlaceWhenReady === false || !placement
-        ? undefined
-        : {
-            ...placement,
-            removeMarkerOnPlace: true,
-          },
-  });
+  };
+  if (shouldAttachPlacement && placement) {
+    generationArgs.placement = {
+      ...placement,
+      removeMarkerOnPlace: true,
+    };
+  }
+
+  const generation = await globalToolRegistry.execute('generate_video', generationArgs);
 
   if (!generation.success) {
     await removePendingMarkerBestEffort(pendingTimeline);
@@ -298,7 +301,7 @@ async function generateTimelineMedia(args: Record<string, unknown>, context: Age
       jobId: getString(generationResult, 'jobId'),
       estimatedCostCents: getNumber(generationResult, 'estimatedCostCents'),
       pendingTimeline,
-      autoPlaceWhenReady: args.autoPlaceWhenReady !== false && Boolean(placement),
+      autoPlaceWhenReady: shouldAttachPlacement,
       nextAction: 'resolve_generation_job',
     },
   };

--- a/src/agents/tools/generativeTimelineTools.ts
+++ b/src/agents/tools/generativeTimelineTools.ts
@@ -1,0 +1,684 @@
+/**
+ * Generative Timeline Tools
+ *
+ * Provider-neutral orchestration tools that make generative work visible and
+ * recoverable through OpenReelio's timeline and job lifecycle.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { globalToolRegistry, type AgentContext, type ToolDefinition } from '../ToolRegistry';
+import { createLogger } from '@/services/logger';
+
+const logger = createLogger('GenerativeTimelineTools');
+
+type MediaType = 'video' | 'image' | 'music' | 'sfx';
+type PlacementMode = 'pending' | 'import_only';
+type LicensePolicyStatus = 'allowed' | 'warning' | 'blocked';
+
+interface CandidateLike {
+  id?: string;
+  name?: string;
+  assetType?: string;
+  asset_type?: string;
+  provider?: string;
+  durationSec?: number | null;
+  duration_sec?: number | null;
+  tags?: string[];
+  license?: Record<string, unknown>;
+  licensePolicy?: {
+    status?: LicensePolicyStatus;
+    requiredActions?: string[];
+    reasons?: string[];
+  };
+  metadata?: Record<string, unknown>;
+}
+
+interface PendingTimelinePlacement {
+  sequenceId: string;
+  trackId: string;
+  timelineStart: number;
+  markerId: string | null;
+  markerLabel: string | null;
+}
+
+const SUPPORTED_VIDEO_PROVIDERS = new Set(['auto', 'seedance']);
+
+const GENERATIVE_TIMELINE_TOOLS: ToolDefinition[] = [
+  {
+    name: 'generate_timeline_media',
+    description:
+      'Provider-neutral generative media orchestration. Submits generation, optionally creates a pending timeline marker, and stores placement intent so completed generated video can auto-place on the timeline.',
+    category: 'generation',
+    parameters: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', description: 'Generation or search prompt.' },
+        mediaType: {
+          type: 'string',
+          enum: ['video', 'image', 'music', 'sfx'],
+          description: 'Media type to create or discover. Defaults to video.',
+        },
+        provider: {
+          type: 'string',
+          enum: ['auto', 'seedance', 'google', 'runway', 'pika', 'luma', 'openai', 'local'],
+          description: 'Preferred provider. Unsupported providers return an explicit error.',
+        },
+        quality: {
+          type: 'string',
+          enum: ['basic', 'pro', 'cinema'],
+          description: 'Video generation quality tier.',
+        },
+        durationSec: { type: 'number', description: 'Requested duration in seconds.' },
+        referenceAssetIds: {
+          type: 'array',
+          description: 'Reference image/video/audio asset IDs.',
+          items: { type: 'string' },
+        },
+        aspectRatio: { type: 'string', description: 'Video aspect ratio such as 16:9 or 9:16.' },
+        sequenceId: { type: 'string', description: 'Target sequence for pending placement.' },
+        trackId: { type: 'string', description: 'Target track for completed placement.' },
+        timelineStart: { type: 'number', description: 'Timeline start in seconds.' },
+        placementMode: {
+          type: 'string',
+          enum: ['pending', 'import_only'],
+          description: 'pending creates timeline visualization; import_only only creates the job.',
+        },
+        autoPlaceWhenReady: {
+          type: 'boolean',
+          description: 'Whether the imported generated asset should be inserted automatically.',
+        },
+        markerLabel: { type: 'string', description: 'Optional label for the pending marker.' },
+        mood: { type: 'string', description: 'Mood/style hint for sfx discovery.' },
+        tags: {
+          type: 'array',
+          description: 'Optional search tags for sfx discovery.',
+          items: { type: 'string' },
+        },
+      },
+      required: ['prompt'],
+    },
+    handler: async (args, context) => generateTimelineMedia(args, context),
+  },
+  {
+    name: 'resolve_generation_job',
+    description:
+      'Synchronize a generation job with the timeline. Pending provider states return success with pending status; completed jobs can place the imported asset when requested.',
+    category: 'generation',
+    parameters: {
+      type: 'object',
+      properties: {
+        jobId: { type: 'string', description: 'Local generation job ID.' },
+        sequenceId: { type: 'string', description: 'Target sequence for manual placement.' },
+        trackId: { type: 'string', description: 'Target track for manual placement.' },
+        timelineStart: { type: 'number', description: 'Timeline start for manual placement.' },
+        placeWhenComplete: {
+          type: 'boolean',
+          description: 'Insert the completed asset if the job has an assetId.',
+        },
+      },
+      required: ['jobId'],
+    },
+    handler: async (args) => resolveGenerationJob(args),
+  },
+  {
+    name: 'search_sound_for_scene',
+    description:
+      'Find sound-effect or ambient audio candidates for a scene through configured stock providers. Returns references and license policy only; it does not import or place media.',
+    category: 'analysis',
+    parameters: {
+      type: 'object',
+      properties: {
+        sceneDescription: {
+          type: 'string',
+          description: 'Scene/action description to search sound effects for.',
+        },
+        mood: { type: 'string', description: 'Optional mood, e.g. tense, playful, cinematic.' },
+        durationSec: { type: 'number', description: 'Preferred duration in seconds.' },
+        count: { type: 'number', description: 'Maximum result count, 1-50.' },
+        tags: {
+          type: 'array',
+          description: 'Additional audio tags such as whoosh, impact, ambience, foley.',
+          items: { type: 'string' },
+        },
+      },
+      required: ['sceneDescription'],
+    },
+    handler: async (args) => searchSoundForScene(args),
+  },
+  {
+    name: 'import_asset_candidate',
+    description:
+      'Import an approved stock media candidate after license acknowledgement. Requires licenseAck=true and rejects blocked license-policy candidates.',
+    category: 'generation',
+    parameters: {
+      type: 'object',
+      properties: {
+        candidate: { type: 'object', description: 'Candidate object returned by stock search.' },
+        sourceUrl: { type: 'string', description: 'Direct media URL override.' },
+        name: { type: 'string', description: 'Imported asset name.' },
+        assetType: {
+          type: 'string',
+          enum: ['video', 'image', 'audio'],
+          description: 'Candidate media type.',
+        },
+        provider: { type: 'string', description: 'Provider name.' },
+        license: { type: 'object', description: 'Normalized LicenseInfo object.' },
+        licenseAck: {
+          type: 'boolean',
+          description: 'Must be true after user/provider/license acknowledgement.',
+        },
+        durationSec: { type: 'number', description: 'Optional media duration.' },
+        tags: {
+          type: 'array',
+          description: 'Optional imported asset tags.',
+          items: { type: 'string' },
+        },
+        providerUrl: { type: 'string', description: 'Provider landing page URL.' },
+      },
+      required: ['licenseAck'],
+    },
+    handler: async (args) => importAssetCandidate(args),
+  },
+];
+
+async function generateTimelineMedia(args: Record<string, unknown>, context: AgentContext) {
+  const prompt = normalizeString(args.prompt);
+  if (!prompt) {
+    return { success: false, error: 'prompt cannot be empty' };
+  }
+
+  const mediaType = normalizeMediaType(args.mediaType);
+  if (mediaType === 'sfx') {
+    return searchSoundForScene({
+      sceneDescription: prompt,
+      mood: args.mood,
+      durationSec: args.durationSec,
+      count: args.count,
+      tags: args.tags,
+    });
+  }
+
+  if (mediaType !== 'video') {
+    return {
+      success: false,
+      error: `Generative timeline ${mediaType} creation is not implemented yet. Use search_sound_for_scene for SFX or add a provider adapter for this media type.`,
+    };
+  }
+
+  const provider = normalizeProvider(args.provider);
+  if (!SUPPORTED_VIDEO_PROVIDERS.has(provider)) {
+    return {
+      success: false,
+      error: `Video provider '${provider}' is not implemented for OpenReelio timeline orchestration yet. Configure a provider adapter or use provider 'auto'.`,
+    };
+  }
+
+  if (!globalToolRegistry.has('generate_video')) {
+    return {
+      success: false,
+      error:
+        'Video generation tools are not registered. Enable USE_VIDEO_GENERATION and configure a supported provider.',
+    };
+  }
+
+  const placementMode = normalizePlacementMode(args.placementMode);
+  const placement = buildPlacement(args, context);
+  let pendingTimeline: PendingTimelinePlacement | null = null;
+
+  if (placementMode === 'pending' && !placement) {
+    return {
+      success: false,
+      error:
+        'Pending timeline generation requires sequenceId and trackId, either as arguments or active timeline context. Use placementMode="import_only" to submit without timeline visualization.',
+    };
+  }
+
+  if (placementMode === 'pending' && placement) {
+    if (!globalToolRegistry.has('add_marker')) {
+      return {
+        success: false,
+        error: 'add_marker is not registered; pending timeline visualization is unavailable.',
+      };
+    }
+
+    const label = normalizeString(args.markerLabel) || `Generating: ${truncateLabel(prompt)}`;
+    const marker = await globalToolRegistry.execute('add_marker', {
+      sequenceId: placement.sequenceId,
+      time: placement.timelineStart,
+      label,
+      color: '#8B5CF6',
+    });
+
+    if (!marker.success) {
+      return {
+        success: false,
+        error: `Failed to create pending generation marker: ${marker.error}`,
+      };
+    }
+
+    const markerId = extractCreatedId(marker.result);
+    placement.markerId = markerId;
+    pendingTimeline = {
+      sequenceId: placement.sequenceId,
+      trackId: placement.trackId,
+      timelineStart: placement.timelineStart,
+      markerId,
+      markerLabel: label,
+    };
+  }
+
+  const generation = await globalToolRegistry.execute('generate_video', {
+    prompt,
+    mode: 'text_to_video',
+    quality: normalizeQuality(args.quality),
+    durationSec: normalizeDuration(args.durationSec),
+    referenceAssetIds: Array.isArray(args.referenceAssetIds) ? args.referenceAssetIds : undefined,
+    aspectRatio: normalizeString(args.aspectRatio) || undefined,
+    placement:
+      args.autoPlaceWhenReady === false || !placement
+        ? undefined
+        : {
+            ...placement,
+            removeMarkerOnPlace: true,
+          },
+  });
+
+  if (!generation.success) {
+    await removePendingMarkerBestEffort(pendingTimeline);
+    return generation;
+  }
+
+  const generationResult = asRecord(generation.result);
+  return {
+    success: true,
+    result: {
+      status: 'submitted',
+      mediaType,
+      provider: provider === 'auto' ? 'seedance' : provider,
+      jobId: getString(generationResult, 'jobId'),
+      estimatedCostCents: getNumber(generationResult, 'estimatedCostCents'),
+      pendingTimeline,
+      autoPlaceWhenReady: args.autoPlaceWhenReady !== false && Boolean(placement),
+      nextAction: 'resolve_generation_job',
+    },
+  };
+}
+
+async function resolveGenerationJob(args: Record<string, unknown>) {
+  const jobId = normalizeString(args.jobId);
+  if (!jobId) {
+    return { success: false, error: 'jobId cannot be empty' };
+  }
+
+  const status = await globalToolRegistry.execute('check_generation_status', { jobId });
+  if (!status.success) {
+    return status;
+  }
+
+  const statusResult = asRecord(status.result);
+  const jobStatus = getString(statusResult, 'status') ?? 'unknown';
+  const assetId = getString(statusResult, 'assetId');
+  const shouldPlace = args.placeWhenComplete === true;
+  const statusError = getString(statusResult, 'error');
+
+  if (jobStatus === 'failed' || jobStatus === 'cancelled') {
+    return {
+      success: false,
+      error:
+        jobStatus === 'failed'
+          ? `Generation failed${statusError ? `: ${statusError}` : ''}`
+          : 'Generation was cancelled',
+      result: {
+        status: jobStatus,
+        pending: false,
+        assetId,
+        error: statusError,
+      },
+    };
+  }
+
+  if (jobStatus === 'completed' && !assetId) {
+    return {
+      success: false,
+      error: 'Generation completed but no imported assetId is available.',
+      result: {
+        status: jobStatus,
+        pending: false,
+        assetId: null,
+      },
+    };
+  }
+
+  if (!assetId || jobStatus !== 'completed') {
+    return {
+      success: true,
+      result: {
+        status: jobStatus,
+        pending: true,
+        progress: getNumber(statusResult, 'progress'),
+        assetId,
+        message: 'Generation is not ready for final timeline placement yet.',
+      },
+    };
+  }
+
+  if (!shouldPlace) {
+    return {
+      success: true,
+      result: {
+        status: jobStatus,
+        pending: false,
+        assetId,
+        message: 'Generation completed and asset is imported.',
+      },
+    };
+  }
+
+  const sequenceId = normalizeString(args.sequenceId);
+  const trackId = normalizeString(args.trackId);
+  if (!sequenceId || !trackId) {
+    return {
+      success: false,
+      error: 'sequenceId and trackId are required when placeWhenComplete=true',
+    };
+  }
+
+  const insert = await globalToolRegistry.execute('insert_clip', {
+    sequenceId,
+    trackId,
+    assetId,
+    timelineStart: normalizeTimelineStart(args.timelineStart),
+  });
+
+  if (!insert.success) {
+    return insert;
+  }
+
+  return {
+    success: true,
+    result: {
+      status: jobStatus,
+      pending: false,
+      assetId,
+      placement: insert.result,
+    },
+  };
+}
+
+async function searchSoundForScene(args: Record<string, unknown>) {
+  const sceneDescription = normalizeString(args.sceneDescription);
+  if (!sceneDescription) {
+    return { success: false, error: 'sceneDescription cannot be empty' };
+  }
+
+  if (!globalToolRegistry.has('search_stock_media')) {
+    return {
+      success: false,
+      error: 'search_stock_media is not registered; configure asset discovery tools first.',
+    };
+  }
+
+  const query = buildSoundQuery(sceneDescription, args.mood, args.tags);
+  const result = await globalToolRegistry.execute('search_stock_media', {
+    query,
+    type: 'audio',
+    count: normalizeCount(args.count),
+  });
+
+  if (!result.success) {
+    return result;
+  }
+
+  const payload = asRecord(result.result) ?? {};
+  const assets = Array.isArray(payload.assets) ? payload.assets.map(toCandidateLike) : [];
+  const ranked = rankAudioCandidates(assets, getNumber(args, 'durationSec'));
+  const usable = ranked.filter((candidate) => candidate.licensePolicy?.status !== 'blocked');
+  const blocked = ranked.filter((candidate) => candidate.licensePolicy?.status === 'blocked');
+
+  return {
+    success: true,
+    result: {
+      query,
+      count: ranked.length,
+      recommendedCandidates: usable,
+      blockedCandidates: blocked,
+      policySummary: payload.policySummary ?? {},
+      requiresImportApproval: true,
+      nextAction: 'import_asset_candidate',
+    },
+  };
+}
+
+async function importAssetCandidate(args: Record<string, unknown>) {
+  const candidate = toCandidateLike(args.candidate);
+  const licensePolicy = candidate.licensePolicy;
+  if (licensePolicy?.status === 'blocked') {
+    return {
+      success: false,
+      error: `Candidate is blocked by license policy: ${(licensePolicy.reasons ?? []).join('; ')}`,
+    };
+  }
+
+  if (args.licenseAck !== true) {
+    return {
+      success: false,
+      error: 'import_asset_candidate requires licenseAck=true after provider/license review.',
+    };
+  }
+
+  const sourceUrl =
+    normalizeString(args.sourceUrl) ||
+    getString(candidate.metadata, 'downloadUrl') ||
+    getString(candidate.metadata, 'previewUrl') ||
+    getString(candidate.metadata, 'sourceUrl');
+  const name = normalizeString(args.name) || candidate.name || candidate.id || 'stock-media';
+  const assetType = normalizeAssetType(args.assetType ?? candidate.assetType ?? candidate.asset_type);
+  const provider =
+    normalizeString(args.provider) || candidate.provider || getString(candidate.metadata, 'provider');
+  const license = asRecord(args.license) ?? candidate.license;
+
+  if (!sourceUrl) {
+    return { success: false, error: 'Candidate does not include a downloadable media URL.' };
+  }
+  if (!provider) {
+    return { success: false, error: 'Candidate provider is required.' };
+  }
+  if (!license) {
+    return { success: false, error: 'Candidate license is required.' };
+  }
+
+  try {
+    const result = await invoke('import_stock_media_asset', {
+      sourceUrl,
+      name,
+      assetType,
+      provider,
+      license,
+      licenseAck: true,
+      durationSec: getNumber(args, 'durationSec') ?? candidate.durationSec ?? candidate.duration_sec ?? null,
+      tags: Array.isArray(args.tags) ? args.tags : candidate.tags ?? null,
+      providerUrl: normalizeString(args.providerUrl) || getString(candidate.metadata, 'providerUrl') || null,
+    });
+
+    return {
+      success: true,
+      result: {
+        import: result,
+        nextAction: 'insert_clip',
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('import_asset_candidate failed', { error: message });
+    return { success: false, error: message };
+  }
+}
+
+function normalizeMediaType(value: unknown): MediaType {
+  return value === 'image' || value === 'music' || value === 'sfx' || value === 'video'
+    ? value
+    : 'video';
+}
+
+function normalizeProvider(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim().toLowerCase() : 'auto';
+}
+
+function normalizePlacementMode(value: unknown): PlacementMode {
+  return value === 'import_only' ? 'import_only' : 'pending';
+}
+
+function normalizeQuality(value: unknown): string {
+  return value === 'basic' || value === 'cinema' || value === 'pro' ? value : 'pro';
+}
+
+function normalizeDuration(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(120, Math.max(5, value))
+    : 6;
+}
+
+function normalizeTimelineStart(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function normalizeCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(50, Math.max(1, Math.trunc(value)))
+    : 8;
+}
+
+function normalizeAssetType(value: unknown): 'video' | 'image' | 'audio' {
+  return value === 'video' || value === 'image' || value === 'audio' ? value : 'audio';
+}
+
+function buildPlacement(
+  args: Record<string, unknown>,
+  context: AgentContext,
+): PendingTimelinePlacement | null {
+  const sequenceId = normalizeString(args.sequenceId) || context.sequenceId || '';
+  const trackId =
+    normalizeString(args.trackId) ||
+    (Array.isArray(context.selectedTrackIds) ? context.selectedTrackIds[0] : '') ||
+    '';
+
+  if (!sequenceId || !trackId) {
+    return null;
+  }
+
+  return {
+    sequenceId,
+    trackId,
+    timelineStart:
+      typeof args.timelineStart === 'number' && Number.isFinite(args.timelineStart)
+        ? Math.max(0, args.timelineStart)
+        : Math.max(0, context.playheadPosition ?? 0),
+    markerId: null,
+    markerLabel: null,
+  };
+}
+
+function buildSoundQuery(sceneDescription: string, mood: unknown, tags: unknown): string {
+  const parts = [sceneDescription, normalizeString(mood), 'sound effect'];
+  if (Array.isArray(tags)) {
+    parts.push(...tags.filter((tag): tag is string => typeof tag === 'string'));
+  }
+  return parts
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+function rankAudioCandidates(candidates: CandidateLike[], preferredDuration?: number | null) {
+  return [...candidates].sort((left, right) => {
+    const leftBlocked = left.licensePolicy?.status === 'blocked' ? 1 : 0;
+    const rightBlocked = right.licensePolicy?.status === 'blocked' ? 1 : 0;
+    if (leftBlocked !== rightBlocked) return leftBlocked - rightBlocked;
+
+    if (typeof preferredDuration === 'number' && Number.isFinite(preferredDuration)) {
+      const leftDuration = left.durationSec ?? left.duration_sec;
+      const rightDuration = right.durationSec ?? right.duration_sec;
+      const leftDelta = typeof leftDuration === 'number' ? Math.abs(leftDuration - preferredDuration) : Infinity;
+      const rightDelta =
+        typeof rightDuration === 'number' ? Math.abs(rightDuration - preferredDuration) : Infinity;
+      return leftDelta - rightDelta;
+    }
+
+    return 0;
+  });
+}
+
+function toCandidateLike(value: unknown): CandidateLike {
+  return (asRecord(value) ?? {}) as CandidateLike;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getString(value: unknown, key: string): string | null {
+  const record = asRecord(value);
+  const raw = record?.[key];
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+}
+
+function getNumber(value: unknown, key?: string): number | null {
+  const raw = key ? asRecord(value)?.[key] : value;
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function truncateLabel(value: string): string {
+  return value.length > 48 ? `${value.slice(0, 45)}...` : value;
+}
+
+function extractCreatedId(value: unknown): string | null {
+  const record = asRecord(value);
+  const createdIds = record?.createdIds;
+  if (Array.isArray(createdIds)) {
+    const id = createdIds.find((candidate): candidate is string => typeof candidate === 'string');
+    if (id) return id;
+  }
+
+  const marker = asRecord(record?.marker);
+  return getString(record, 'markerId') ?? getString(marker, 'id');
+}
+
+async function removePendingMarkerBestEffort(pendingTimeline: PendingTimelinePlacement | null) {
+  if (!pendingTimeline?.markerId) return;
+  try {
+    await globalToolRegistry.execute('remove_marker', {
+      sequenceId: pendingTimeline.sequenceId,
+      markerId: pendingTimeline.markerId,
+    });
+  } catch (error) {
+    logger.warn('Failed to remove pending marker after generation submission failure', {
+      error: String(error),
+    });
+  }
+}
+
+export function registerGenerativeTimelineTools(): void {
+  globalToolRegistry.registerMany(GENERATIVE_TIMELINE_TOOLS);
+  logger.info('Generative timeline tools registered', {
+    count: GENERATIVE_TIMELINE_TOOLS.length,
+  });
+}
+
+export function unregisterGenerativeTimelineTools(): void {
+  for (const tool of GENERATIVE_TIMELINE_TOOLS) {
+    globalToolRegistry.unregister(tool.name);
+  }
+  logger.info('Generative timeline tools unregistered', {
+    count: GENERATIVE_TIMELINE_TOOLS.length,
+  });
+}
+
+export function getGenerativeTimelineToolNames(): string[] {
+  return GENERATIVE_TIMELINE_TOOLS.map((tool) => tool.name);
+}

--- a/src/agents/tools/index.ts
+++ b/src/agents/tools/index.ts
@@ -3,7 +3,7 @@
  *
  * Exports all tool modules for the agent system.
  *
- * When USE_META_TOOLS is enabled, the 6 consolidated meta-tools are
+ * When USE_META_TOOLS is enabled, consolidated meta-tools are
  * registered ON TOP of individual tools. The LLM sees only the meta-tools,
  * and each meta-tool dispatches to the underlying individual tool handler.
  */
@@ -15,6 +15,10 @@ import { registerCaptionTools, unregisterCaptionTools } from './captionTools';
 import { registerEffectTools, unregisterEffectTools } from './effectTools';
 import { registerTransitionTools, unregisterTransitionTools } from './transitionTools';
 import { registerGenerationTools, unregisterGenerationTools } from './generationTools';
+import {
+  registerGenerativeTimelineTools,
+  unregisterGenerativeTimelineTools,
+} from './generativeTimelineTools';
 import { registerAssetDiscoveryTools, unregisterAssetDiscoveryTools } from './assetDiscoveryTools';
 import { registerWorkspaceTools, unregisterWorkspaceTools } from './workspaceTools';
 import { registerMediaAnalysisTools, unregisterMediaAnalysisTools } from './mediaAnalysisTools';
@@ -52,6 +56,12 @@ export {
 } from './generationTools';
 
 export {
+  registerGenerativeTimelineTools,
+  unregisterGenerativeTimelineTools,
+  getGenerativeTimelineToolNames,
+} from './generativeTimelineTools';
+
+export {
   registerAssetDiscoveryTools,
   unregisterAssetDiscoveryTools,
   getAssetDiscoveryToolNames,
@@ -81,7 +91,7 @@ let metaToolsRegistered = false;
  * Register all agent tools with the global registry.
  *
  * Individual tools are always registered (they serve as the execution layer).
- * When USE_META_TOOLS is enabled, the 6 meta-tools are additionally registered
+ * When USE_META_TOOLS is enabled, the meta-tools are additionally registered
  * and the Planner will expose only the meta-tools to the LLM.
  *
  * Each registration is isolated so a single module failure
@@ -97,6 +107,7 @@ export function registerAllTools(): void {
     ['effect', registerEffectTools],
     ['transition', registerTransitionTools],
     ['assetDiscovery', registerAssetDiscoveryTools],
+    ['generativeTimeline', registerGenerativeTimelineTools],
     ['workspace', registerWorkspaceTools],
     ['mediaAnalysis', registerMediaAnalysisTools],
   ];
@@ -127,7 +138,7 @@ export function registerAllTools(): void {
     try {
       registerMetaTools();
       metaToolsRegistered = true;
-      logger.info('Meta-tools enabled: LLM will see 6 consolidated tools');
+      logger.info('Meta-tools enabled: LLM will see consolidated tools');
     } catch (error) {
       logger.error('Failed to register meta-tools', {
         error: error instanceof Error ? error.message : String(error),
@@ -160,6 +171,7 @@ export function unregisterAllTools(): void {
     ['effect', unregisterEffectTools],
     ['transition', unregisterTransitionTools],
     ['assetDiscovery', unregisterAssetDiscoveryTools],
+    ['generativeTimeline', unregisterGenerativeTimelineTools],
     ['workspace', unregisterWorkspaceTools],
     ['mediaAnalysis', unregisterMediaAnalysisTools],
   ];

--- a/src/agents/tools/metaTools.test.ts
+++ b/src/agents/tools/metaTools.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { globalToolRegistry } from '@/agents';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { globalToolRegistry, type ToolDefinition } from '@/agents';
 import { createToolRegistryAdapter } from '@/agents/engine/adapters/tools/ToolRegistryAdapter';
 import { registerCaptionTools, unregisterCaptionTools } from './captionTools';
 import {
@@ -83,5 +83,49 @@ describe('metaTools', () => {
       type: 'audio',
       count: 4,
     });
+  });
+
+  it('forwards execution context from generate meta-tool to the underlying action', async () => {
+    const captureContext = vi.fn().mockResolvedValue({
+      success: true,
+      result: { ok: true },
+    });
+    const timelineTool: ToolDefinition = {
+      name: 'generate_timeline_media',
+      description: 'Capture context',
+      category: 'generation',
+      parameters: {
+        type: 'object',
+        properties: {
+          prompt: { type: 'string', description: 'Prompt' },
+        },
+        required: ['prompt'],
+      },
+      handler: captureContext,
+    };
+    globalToolRegistry.register(timelineTool);
+
+    const result = await globalToolRegistry.execute(
+      'generate',
+      {
+        action: 'generate_timeline_media',
+        prompt: 'Context-sensitive shot',
+      },
+      {
+        sequenceId: 'seq-1',
+        selectedTrackIds: ['track-1'],
+        playheadPosition: 7,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(captureContext).toHaveBeenCalledWith(
+      { prompt: 'Context-sensitive shot' },
+      expect.objectContaining({
+        sequenceId: 'seq-1',
+        selectedTrackIds: ['track-1'],
+        playheadPosition: 7,
+      }),
+    );
   });
 });

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -11,13 +11,14 @@
  * 3. audio    - audio tools (6 tools)
  * 4. effects  - effect + transition tools (8 tools)
  * 5. text     - caption tools
+ * 6. generate - provider-neutral generation orchestration + provider job tools
  *
  * Legacy compatibility:
  * - execute_plan remains registered for transitional callers, but should not
  *   be part of the default tool surface shown to the model.
  */
 
-import { globalToolRegistry, type ToolDefinition } from '../ToolRegistry';
+import { globalToolRegistry, type AgentContext, type ToolDefinition } from '../ToolRegistry';
 import { createLogger } from '@/services/logger';
 import { getAnalysisToolNames } from './analysisTools';
 import { getMediaAnalysisToolNames } from './mediaAnalysisTools';
@@ -27,6 +28,8 @@ import { getAudioToolNames } from './audioTools';
 import { getEffectToolNames } from './effectTools';
 import { getTransitionToolNames } from './transitionTools';
 import { getCaptionToolNames } from './captionTools';
+import { getGenerationToolNames } from './generationTools';
+import { getGenerativeTimelineToolNames } from './generativeTimelineTools';
 import { canonicalizeToolNameCandidate } from '../toolNameNormalization';
 
 const logger = createLogger('MetaTools');
@@ -43,6 +46,7 @@ async function dispatchToTool(
   metaToolName: string,
   args: Record<string, unknown>,
   validActions: readonly string[],
+  context: AgentContext,
 ) {
   const rawAction = args.action as string | undefined;
   const action =
@@ -75,7 +79,7 @@ async function dispatchToTool(
   }
 
   try {
-    return await globalToolRegistry.execute(action, normalizedArgs, {});
+    return await globalToolRegistry.execute(action, normalizedArgs, context);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error(`Meta-tool ${metaToolName} dispatch failed`, { action, error: msg });
@@ -202,6 +206,7 @@ const EDIT_ACTIONS = getEditingToolNames();
 const AUDIO_ACTIONS = getAudioToolNames();
 const EFFECTS_ACTIONS = [...getEffectToolNames(), ...getTransitionToolNames()];
 const TEXT_ACTIONS = getCaptionToolNames();
+const GENERATE_ACTIONS = [...getGenerativeTimelineToolNames(), ...getGenerationToolNames()];
 
 // =============================================================================
 // 6. Execute Plan Meta-Tool (batch execution)
@@ -327,7 +332,7 @@ const META_TOOLS: ToolDefinition[] = [
       },
       required: ['action'],
     },
-    handler: async (args) => dispatchToTool('query', args, QUERY_ACTIONS),
+    handler: async (args, context) => dispatchToTool('query', args, QUERY_ACTIONS, context),
   },
 
   // ---------------------------------------------------------------------------
@@ -395,7 +400,7 @@ const META_TOOLS: ToolDefinition[] = [
       },
       required: ['action'],
     },
-    handler: async (args) => dispatchToTool('edit', args, EDIT_ACTIONS),
+    handler: async (args, context) => dispatchToTool('edit', args, EDIT_ACTIONS, context),
   },
 
   // ---------------------------------------------------------------------------
@@ -427,7 +432,7 @@ const META_TOOLS: ToolDefinition[] = [
       },
       required: ['action', 'sequenceId', 'trackId'],
     },
-    handler: async (args) => dispatchToTool('audio', args, AUDIO_ACTIONS),
+    handler: async (args, context) => dispatchToTool('audio', args, AUDIO_ACTIONS, context),
   },
 
   // ---------------------------------------------------------------------------
@@ -463,7 +468,7 @@ const META_TOOLS: ToolDefinition[] = [
       },
       required: ['action'],
     },
-    handler: async (args) => dispatchToTool('effects', args, EFFECTS_ACTIONS),
+    handler: async (args, context) => dispatchToTool('effects', args, EFFECTS_ACTIONS, context),
   },
 
   // ---------------------------------------------------------------------------
@@ -518,11 +523,75 @@ const META_TOOLS: ToolDefinition[] = [
       },
       required: ['action'],
     },
-    handler: async (args) => dispatchToTool('text', args, TEXT_ACTIONS),
+    handler: async (args, context) => dispatchToTool('text', args, TEXT_ACTIONS, context),
   },
 
   // ---------------------------------------------------------------------------
-  // 6. execute_plan
+  // 6. generate
+  // ---------------------------------------------------------------------------
+  {
+    name: 'generate',
+    description: `Create or discover generated media, synchronize long-running generation jobs, search SFX candidates, and import approved stock candidates. Actions: ${GENERATE_ACTIONS.join(', ')}`,
+    category: 'generation',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          description: 'The generation orchestration action to perform',
+          enum: [...GENERATE_ACTIONS],
+        },
+        prompt: { type: 'string', description: 'Generation or discovery prompt' },
+        mediaType: { type: 'string', description: 'Media type: video, image, music, or sfx' },
+        provider: { type: 'string', description: 'Preferred provider or auto' },
+        quality: { type: 'string', description: 'Generation quality tier' },
+        durationSec: { type: 'number', description: 'Preferred duration in seconds' },
+        referenceAssetIds: {
+          type: 'array',
+          description: 'Reference asset IDs',
+          items: { type: 'string' },
+        },
+        aspectRatio: { type: 'string', description: 'Generated video aspect ratio' },
+        sequenceId: { type: 'string', description: 'Target sequence ID' },
+        trackId: { type: 'string', description: 'Target track ID' },
+        timelineStart: { type: 'number', description: 'Timeline start in seconds' },
+        placementMode: {
+          type: 'string',
+          description: 'pending creates a marker; import_only submits/imports without placement',
+        },
+        autoPlaceWhenReady: {
+          type: 'boolean',
+          description: 'Automatically place completed generated video when imported',
+        },
+        markerLabel: { type: 'string', description: 'Pending timeline marker label' },
+        jobId: { type: 'string', description: 'Generation job ID' },
+        placeWhenComplete: {
+          type: 'boolean',
+          description: 'Place the completed generation result immediately when assetId exists',
+        },
+        sceneDescription: { type: 'string', description: 'Scene description for SFX search' },
+        mood: { type: 'string', description: 'Mood/style hint for SFX search' },
+        tags: {
+          type: 'array',
+          description: 'Tags for search/import',
+          items: { type: 'string' },
+        },
+        count: { type: 'number', description: 'Search result count' },
+        candidate: { type: 'object', description: 'Stock candidate object returned by search' },
+        sourceUrl: { type: 'string', description: 'Direct stock media URL override' },
+        name: { type: 'string', description: 'Imported asset name' },
+        assetType: { type: 'string', description: 'Asset type: video, image, or audio' },
+        license: { type: 'object', description: 'Normalized LicenseInfo object' },
+        licenseAck: { type: 'boolean', description: 'Required approval acknowledgement for import' },
+        providerUrl: { type: 'string', description: 'Provider landing page URL' },
+      },
+      required: ['action'],
+    },
+    handler: async (args, context) => dispatchToTool('generate', args, GENERATE_ACTIONS, context),
+  },
+
+  // ---------------------------------------------------------------------------
+  // 7. execute_plan
   // ---------------------------------------------------------------------------
   {
     name: 'execute_plan',
@@ -641,7 +710,7 @@ const META_TOOLS: ToolDefinition[] = [
 // =============================================================================
 
 /**
- * Register the 6 consolidated meta-tools with the global registry.
+ * Register the consolidated meta-tools with the global registry.
  * Individual tools must already be registered (meta-tools dispatch to them).
  */
 export function registerMetaTools(): void {
@@ -650,7 +719,7 @@ export function registerMetaTools(): void {
 }
 
 /**
- * Unregister the 6 meta-tools from the global registry.
+ * Unregister the consolidated meta-tools from the global registry.
  */
 export function unregisterMetaTools(): void {
   for (const tool of META_TOOLS) {

--- a/src/components/features/editor/EditorPanels.tsx
+++ b/src/components/features/editor/EditorPanels.tsx
@@ -5,6 +5,7 @@ import type { AudioMixerPanelProps } from '@/components/features/mixer';
 import { Inspector, type InspectorProps } from '@/components/features/inspector';
 import { ProjectExplorer } from '@/components/explorer';
 import { UnifiedPreviewPlayer } from '@/components/preview';
+import type { TextPlacementCommitPayload } from '@/components/preview/TextPlacementOverlay';
 import { SourceMonitor } from '@/components/features/preview/SourceMonitor';
 import type { TimelineProps } from '@/components/timeline';
 import {
@@ -70,6 +71,8 @@ export interface EditorPanelContentOptions {
   previewContainerRef: RefObject<HTMLDivElement>;
   isFullscreen: boolean;
   onCaptureSnapshot: () => void | Promise<void>;
+  textPlacementModeActive?: boolean;
+  onTextPlacementCommit?: (payload: TextPlacementCommitPayload) => void | Promise<void>;
   showMixer: boolean;
   onToggleMixer: () => void;
   sequenceNavigationStack: string[];
@@ -89,6 +92,8 @@ export function createEditorPanelContent({
   previewContainerRef,
   isFullscreen,
   onCaptureSnapshot,
+  textPlacementModeActive = false,
+  onTextPlacementCommit,
   showMixer,
   onToggleMixer,
   sequenceNavigationStack,
@@ -129,6 +134,8 @@ export function createEditorPanelContent({
             showControls
             showTimecode
             showStats={import.meta.env.DEV}
+            textPlacementModeActive={textPlacementModeActive}
+            onTextPlacementCommit={onTextPlacementCommit}
           />
         </PreviewErrorBoundary>
         <button

--- a/src/components/features/editor/EditorView.tsx
+++ b/src/components/features/editor/EditorView.tsx
@@ -16,7 +16,13 @@ import {
 } from '@/components/features/inspector';
 import { type AISidebarProps } from '@/components/features/ai';
 import { type TimelineProps } from '@/components/timeline';
-import { useProjectStore, usePlaybackStore, useTimelineStore, useAudioMixerStore } from '@/stores';
+import {
+  useProjectStore,
+  usePlaybackStore,
+  useTimelineStore,
+  useAudioMixerStore,
+  useEditorToolStore,
+} from '@/stores';
 // Direct imports instead of barrel to avoid bundling all 100+ hooks
 import { useTimelineActions } from '@/hooks/useTimelineActions';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
@@ -38,6 +44,11 @@ import { dbToLinear, linearToDb } from '@/utils/audioMeter';
 import { resolveAutoDuckTargets } from '@/utils/audioDucking';
 import { extractTextDataFromClipWithMap } from '@/utils/textRenderer';
 import { getClipTimelineDurationSec, getClipTimelineEndSec } from '@/utils/clipTiming';
+import {
+  getDefaultTrackInsertPosition,
+  getNextTrackName,
+  trackHasOverlap,
+} from '@/hooks/timelineActions/helpers';
 import { commands } from '@/bindings';
 import { createLogger } from '@/services/logger';
 import { startPlayheadBackendSync } from '@/services/playheadBackendSync';
@@ -45,7 +56,6 @@ import { isVideoGenerationEnabled } from '@/config/featureFlags';
 import { getSplitTargetsAtTime } from '@/utils/clipLinking';
 import type {
   BlendMode,
-  CaptionPosition,
   ClipId,
   Effect,
   EffectId,
@@ -56,17 +66,20 @@ import type {
   Track,
 } from '@/types';
 import type { AddTextPayload } from '@/components/features/text';
+import type { TextPlacementCommitPayload } from '@/components/preview/TextPlacementOverlay';
 import type { AudioMixerPanelProps, ChannelLevels } from '@/components/features/mixer';
 import type { MulticamGroup } from '@/utils/multicam';
-import { isTextClip, hasActiveTimeRemap } from '@/types';
+import { createTextClipData, isTextClip, hasActiveTimeRemap } from '@/types';
 import { createEditorPanelContent } from './EditorPanels';
 import { BottomTerminalControls } from './BottomTerminalControls';
+import { normalizeCaptionStyle, parseCaptionPositionValue } from '@/utils/captionStyle';
 
 const logger = createLogger('EditorView');
 const AI_AUTO_COLLAPSE_BREAKPOINT = 1440;
 /** FFmpeg JPEG quality (1=best, 31=worst). Default: 2 for high quality frame export. */
 const JPEG_EXPORT_QUALITY = 2;
 const AUTO_TIMELINE_INSERT_TRACK_ID = '__openreelio_auto_timeline_track__';
+const DEFAULT_PREVIEW_TEXT_DURATION_SEC = 5;
 
 const ExportDialog = lazy(async () => {
   const module = await import('@/components/features/export');
@@ -87,46 +100,6 @@ export interface EditorViewProps {
   sequence: Sequence | null;
   /** App version string displayed in header */
   appVersion?: string;
-}
-
-function normalizeCaptionPositionValue(value: unknown): CaptionPosition | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  const candidate = value as Partial<CaptionPosition> & Record<string, unknown>;
-  if (candidate.type === 'custom') {
-    const xPercent = Number(candidate.xPercent);
-    const yPercent = Number(candidate.yPercent);
-    if (!Number.isFinite(xPercent) || !Number.isFinite(yPercent)) {
-      return null;
-    }
-
-    return {
-      type: 'custom',
-      xPercent: Math.max(0, Math.min(100, xPercent)),
-      yPercent: Math.max(0, Math.min(100, yPercent)),
-    };
-  }
-
-  if (candidate.type === 'preset') {
-    const vertical =
-      candidate.vertical === 'top' || candidate.vertical === 'center'
-        ? candidate.vertical
-        : 'bottom';
-    const marginPercent = Number(candidate.marginPercent);
-    if (!Number.isFinite(marginPercent)) {
-      return null;
-    }
-
-    return {
-      type: 'preset',
-      vertical,
-      marginPercent: Math.max(0, Math.min(50, marginPercent)),
-    };
-  }
-
-  return null;
 }
 
 function isTimelineInsertableAssetKind(
@@ -153,10 +126,25 @@ function resolveExplorerInsertTrackId(
   return preferredTrack?.id ?? AUTO_TIMELINE_INSERT_TRACK_ID;
 }
 
+function resolveAvailablePreviewTextTrack(
+  sequence: Sequence,
+  timelineInSec: number,
+  durationSec: number,
+): Track | undefined {
+  return sequence.tracks.find(
+    (track) =>
+      track.kind === 'video' &&
+      !track.locked &&
+      !trackHasOverlap(track, timelineInSec, durationSec),
+  );
+}
+
 export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps): JSX.Element {
   const { selectedAssetId, assets, effects, executeCommand } = useProjectStore();
   const currentTime = usePlaybackStore((state) => state.currentTime);
-  const { selectedClipIds, linkedSelectionEnabled } = useTimelineStore();
+  const { selectedClipIds, linkedSelectionEnabled, selectClip } = useTimelineStore();
+  const activeTool = useEditorToolStore((state) => state.activeTool);
+  const setActiveTool = useEditorToolStore((state) => state.setActiveTool);
   const sanitizeSelection = useTimelineStore((state) => state.sanitizeSelection);
   const sequenceNavigationStack = useProjectStore((s) => s.sequenceNavigationStack);
   const sequences = useProjectStore((s) => s.sequences);
@@ -633,7 +621,7 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
     onPasteEffects: handlePasteEffectsToSelection,
     onToggleClipEnabled: handleToggleClipEnabledForPalette,
     onToggleMixer: handleToggleMixer,
-    onAddText: () => setShowAddTextDialog(true),
+    onAddText: () => setActiveTool('text'),
     onAutoDuck: handleAutoDuck,
   });
 
@@ -900,8 +888,15 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
           captionId,
           text: value,
         });
+      } else if (property === 'style' && value && typeof value === 'object') {
+        handleUpdateCaption({
+          sequenceId: sequence.id,
+          trackId,
+          captionId,
+          style: normalizeCaptionStyle(value as Record<string, unknown>),
+        });
       } else if (property === 'position') {
-        const normalizedPosition = normalizeCaptionPositionValue(value);
+        const normalizedPosition = parseCaptionPositionValue(value);
         if (!normalizedPosition) {
           return;
         }
@@ -984,8 +979,8 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
 
   // Add Text handlers
   const handleOpenAddText = useCallback(() => {
-    setShowAddTextDialog(true);
-  }, []);
+    setActiveTool('text');
+  }, [setActiveTool]);
 
   const handleCloseAddText = useCallback(() => {
     setShowAddTextDialog(false);
@@ -1003,6 +998,77 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
       });
     },
     [sequence, addTextClip],
+  );
+
+  const handlePreviewTextPlacementCommit = useCallback(
+    async ({ content, position }: TextPlacementCommitPayload) => {
+      if (!sequence) {
+        return;
+      }
+
+      const trimmedContent = content.trim();
+      if (!trimmedContent) {
+        return;
+      }
+
+      const timelineIn = Math.max(0, currentTime);
+      const duration = DEFAULT_PREVIEW_TEXT_DURATION_SEC;
+      let trackId = resolveAvailablePreviewTextTrack(sequence, timelineIn, duration)?.id;
+
+      try {
+        if (!trackId) {
+          const sequenceSnapshot =
+            useProjectStore.getState().sequences.get(sequence.id) ?? sequence;
+          const createTrackResult = await executeCommand({
+            type: 'CreateTrack',
+            payload: {
+              sequenceId: sequence.id,
+              kind: 'video',
+              name: getNextTrackName(sequenceSnapshot, 'video'),
+              position: getDefaultTrackInsertPosition(sequenceSnapshot, 'video'),
+            },
+          });
+
+          trackId = createTrackResult.createdIds[0];
+        }
+
+        if (!trackId) {
+          throw new Error('Text track could not be created');
+        }
+
+        const textData = createTextClipData(trimmedContent);
+        textData.position = position;
+        textData.style = {
+          ...textData.style,
+          backgroundPadding: 0,
+        };
+        textData.outline = { color: '#000000', width: 2 };
+        textData.shadow = { color: '#000000', offsetX: 2, offsetY: 2, blur: 3 };
+
+        const createdClipId = await addTextClip({
+          trackId,
+          timelineIn,
+          duration,
+          textData,
+        });
+
+        if (createdClipId) {
+          selectClip(createdClipId);
+          setActiveTool('select');
+        }
+      } catch (error) {
+        logger.error('Failed to create preview text clip', {
+          error,
+          sequenceId: sequence.id,
+          timelineIn,
+        });
+        useToastStore.getState().addToast({
+          variant: 'error',
+          message: 'Text clip could not be created.',
+        });
+      }
+    },
+    [addTextClip, currentTime, executeCommand, selectClip, sequence, setActiveTool],
   );
 
   // Audio Mixer handlers - connected to store and Web Audio
@@ -1267,6 +1333,8 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
         previewContainerRef,
         isFullscreen,
         onCaptureSnapshot: captureSnapshot,
+        textPlacementModeActive: activeTool === 'text',
+        onTextPlacementCommit: handlePreviewTextPlacementCommit,
         showMixer,
         onToggleMixer: handleToggleMixer,
         sequenceNavigationStack,
@@ -1283,6 +1351,8 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
       sequence,
       isFullscreen,
       captureSnapshot,
+      activeTool,
+      handlePreviewTextPlacementCommit,
       showMixer,
       handleToggleMixer,
       sequenceNavigationStack,

--- a/src/components/features/inspector/Inspector.test.tsx
+++ b/src/components/features/inspector/Inspector.test.tsx
@@ -353,6 +353,53 @@ describe('Inspector', () => {
     );
   });
 
+  it('allows custom caption font names and numeric bold toggles', () => {
+    const selectedCaption = {
+      id: 'cap-1',
+      text: 'Hello',
+      startSec: 0,
+      endSec: 5,
+      style: {
+        fontFamily: 'Arial',
+        fontSize: 24,
+        fontWeight: 'normal' as const,
+        color: { r: 255, g: 255, b: 255, a: 255 },
+        outlineColor: { r: 0, g: 0, b: 0, a: 255 },
+        outlineWidth: 2,
+        shadowColor: { r: 0, g: 0, b: 0, a: 128 },
+        shadowOffset: 2,
+        alignment: 'center' as const,
+        italic: false,
+        underline: false,
+      },
+    };
+
+    const handleCaptionChange = vi.fn();
+
+    render(<Inspector selectedCaption={selectedCaption} onCaptionChange={handleCaptionChange} />);
+
+    fireEvent.change(screen.getByTestId('caption-font-family-input'), {
+      target: { value: 'Brand Caption' },
+    });
+    expect(handleCaptionChange).toHaveBeenLastCalledWith(
+      'cap-1',
+      'style',
+      expect.objectContaining({
+        fontFamily: 'Brand Caption',
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('caption-bold-toggle'));
+    expect(handleCaptionChange).toHaveBeenLastCalledWith(
+      'cap-1',
+      'style',
+      expect.objectContaining({
+        fontWeight: 700,
+        bold: true,
+      }),
+    );
+  });
+
   it('disables caption editing controls when readOnly is true', () => {
     const selectedCaption = {
       id: 'cap-1',

--- a/src/components/features/inspector/Inspector.test.tsx
+++ b/src/components/features/inspector/Inspector.test.tsx
@@ -314,6 +314,45 @@ describe('Inspector', () => {
     expect(handleCaptionChange).toHaveBeenCalledWith('cap-1', 'text', 'Hello World');
   });
 
+  it('calls onCaptionChange when caption style is updated', () => {
+    const selectedCaption = {
+      id: 'cap-1',
+      text: 'Hello',
+      startSec: 0,
+      endSec: 5,
+      style: {
+        fontFamily: 'Arial',
+        fontSize: 24,
+        fontWeight: 'normal' as const,
+        color: { r: 255, g: 255, b: 255, a: 255 },
+        outlineColor: { r: 0, g: 0, b: 0, a: 255 },
+        outlineWidth: 2,
+        shadowColor: { r: 0, g: 0, b: 0, a: 128 },
+        shadowOffset: 2,
+        alignment: 'center' as const,
+        italic: false,
+        underline: false,
+      },
+    };
+
+    const handleCaptionChange = vi.fn();
+
+    render(<Inspector selectedCaption={selectedCaption} onCaptionChange={handleCaptionChange} />);
+
+    fireEvent.change(screen.getByTestId('caption-font-size'), { target: { value: '48' } });
+
+    expect(handleCaptionChange).toHaveBeenCalledWith(
+      'cap-1',
+      'style',
+      expect.objectContaining({
+        fontFamily: 'Arial',
+        fontSize: 48,
+        color: { r: 255, g: 255, b: 255, a: 255 },
+        outlineWidth: 2,
+      }),
+    );
+  });
+
   it('disables caption editing controls when readOnly is true', () => {
     const selectedCaption = {
       id: 'cap-1',
@@ -347,6 +386,8 @@ describe('Inspector', () => {
     expect(screen.getByDisplayValue('Hello')).toBeDisabled();
     expect(screen.getByTestId('caption-position-mode')).toBeDisabled();
     expect(screen.getByTestId('caption-position-margin')).toBeDisabled();
+    expect(screen.getByTestId('caption-font-size')).toBeDisabled();
+    expect(screen.getByTestId('caption-bold-toggle')).toBeDisabled();
   });
 
   it('hides effect actions when clip inspector is readOnly', () => {

--- a/src/components/features/inspector/Inspector.tsx
+++ b/src/components/features/inspector/Inspector.tsx
@@ -311,6 +311,20 @@ export function Inspector({
   }
 
   // ===========================================================================
+  // Render Caption Properties
+  // ===========================================================================
+
+  if (selectedCaption) {
+    return (
+      <CaptionInspectorPanel
+        selectedCaption={selectedCaption}
+        onCaptionChange={onCaptionChange}
+        readOnly={readOnly}
+      />
+    );
+  }
+
+  // ===========================================================================
   // Render Clip Properties
   // ===========================================================================
 
@@ -350,20 +364,6 @@ export function Inspector({
 
   if (selectedAsset) {
     return <AssetInspectorPanel selectedAsset={selectedAsset} />;
-  }
-
-  // ===========================================================================
-  // Render Caption Properties
-  // ===========================================================================
-
-  if (selectedCaption) {
-    return (
-      <CaptionInspectorPanel
-        selectedCaption={selectedCaption}
-        onCaptionChange={onCaptionChange}
-        readOnly={readOnly}
-      />
-    );
   }
 
   return <></>;

--- a/src/components/features/inspector/InspectorPanels.tsx
+++ b/src/components/features/inspector/InspectorPanels.tsx
@@ -1,26 +1,43 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  Bold,
   Clock,
   FileText,
   Film,
   Gauge,
   Image as ImageIcon,
   Info,
+  Italic,
   Maximize,
   Music,
+  Palette,
+  Square,
   Type,
+  Underline,
 } from 'lucide-react';
 import { formatDuration } from '@/utils/formatters';
+import {
+  captionColorToHex,
+  normalizeCaptionPosition,
+  normalizeCaptionStyle,
+  parseCaptionHexColor,
+} from '@/utils/captionStyle';
 import { EffectsList, SaveEffectPresetDialog } from '../effects';
 import { BlendModePicker } from '../effects/BlendModePicker';
 import { EffectInspector } from '../effects/EffectInspector';
 import type {
   BlendMode,
+  CaptionColor,
   CaptionPosition,
+  CaptionStyle,
   Effect,
   EffectId,
   ParamDef,
   SimpleParamValue,
+  TextAlignment,
 } from '@/types';
 import type { SelectedAsset, SelectedCaption, SelectedClip } from './Inspector';
 
@@ -37,33 +54,6 @@ function getAssetIcon(kind: SelectedAsset['kind']): JSX.Element {
     default:
       return <FileText className="w-4 h-4" />;
   }
-}
-
-function normalizeCaptionPosition(position: CaptionPosition | undefined): CaptionPosition {
-  if (!position) {
-    return {
-      type: 'preset',
-      vertical: 'bottom',
-      marginPercent: 5,
-    };
-  }
-
-  if (position.type === 'custom') {
-    const xPercent = Number.isFinite(position.xPercent) ? position.xPercent : 50;
-    const yPercent = Number.isFinite(position.yPercent) ? position.yPercent : 90;
-    return {
-      type: 'custom',
-      xPercent: Math.max(0, Math.min(100, xPercent)),
-      yPercent: Math.max(0, Math.min(100, yPercent)),
-    };
-  }
-
-  const marginPercent = Number.isFinite(position.marginPercent) ? position.marginPercent : 5;
-  return {
-    type: 'preset',
-    vertical: position.vertical,
-    marginPercent: Math.max(0, Math.min(50, marginPercent)),
-  };
 }
 
 function SpeedInput({
@@ -420,6 +410,152 @@ export function AssetInspectorPanel({ selectedAsset }: AssetInspectorPanelProps)
   );
 }
 
+type CaptionStyleField = keyof Pick<
+  CaptionStyle,
+  'color' | 'backgroundColor' | 'outlineColor' | 'shadowColor'
+>;
+
+const CAPTION_FONT_FAMILIES = [
+  'Arial',
+  'Helvetica',
+  'Verdana',
+  'Inter',
+  'Georgia',
+  'Times New Roman',
+  'Courier New',
+  'Impact',
+  'Noto Sans',
+  'Noto Sans KR',
+];
+
+function InspectorSection({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon?: JSX.Element;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <section className="pt-4 border-t border-editor-border first:border-t-0 first:pt-0">
+      <h4 className="mb-3 flex items-center gap-2 text-xs font-semibold text-editor-text-muted">
+        {icon}
+        {title}
+      </h4>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  unit,
+  disabled,
+  testId,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  unit?: string;
+  disabled?: boolean;
+  testId?: string;
+}): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <label className="text-xs text-editor-text-muted">{label}</label>
+      <div className="flex items-center gap-1">
+        <input
+          data-testid={testId}
+          type="number"
+          min={min}
+          max={max}
+          step={step}
+          className="w-20 rounded border border-editor-border bg-editor-input px-2 py-1 text-right text-xs text-editor-text focus:border-primary-500 focus:outline-none disabled:opacity-50"
+          value={Number.isFinite(value) ? value : min}
+          onChange={(event) => onChange(Number(event.target.value))}
+          disabled={disabled}
+        />
+        {unit && <span className="w-5 text-[11px] text-editor-text-muted">{unit}</span>}
+      </div>
+    </div>
+  );
+}
+
+function ColorField({
+  label,
+  color,
+  onChange,
+  disabled,
+  testId,
+}: {
+  label: string;
+  color: CaptionColor;
+  onChange: (color: CaptionColor) => void;
+  disabled?: boolean;
+  testId?: string;
+}): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <label className="text-xs text-editor-text-muted">{label}</label>
+      <input
+        data-testid={testId}
+        type="color"
+        className="h-8 w-12 cursor-pointer rounded border border-editor-border bg-editor-input disabled:cursor-not-allowed disabled:opacity-50"
+        value={captionColorToHex(color)}
+        onChange={(event) => {
+          const parsed = parseCaptionHexColor(event.target.value);
+          if (parsed) {
+            onChange({ ...parsed, a: color.a });
+          }
+        }}
+        disabled={disabled}
+      />
+    </div>
+  );
+}
+
+function StyleToggle({
+  title,
+  active,
+  onClick,
+  disabled,
+  children,
+  testId,
+}: {
+  title: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+  testId?: string;
+}): JSX.Element {
+  return (
+    <button
+      data-testid={testId}
+      type="button"
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={`rounded border p-1.5 transition-colors ${
+        active
+          ? 'border-primary-500 bg-primary-500 text-white'
+          : 'border-editor-border bg-editor-input text-editor-text-muted hover:border-primary-500'
+      } disabled:opacity-50`}
+    >
+      {children}
+    </button>
+  );
+}
+
 export interface CaptionInspectorPanelProps {
   selectedCaption: SelectedCaption;
   onCaptionChange?: (captionId: string, property: string, value: unknown) => void;
@@ -432,7 +568,23 @@ export function CaptionInspectorPanel({
   readOnly = false,
 }: CaptionInspectorPanelProps): JSX.Element {
   const captionPosition = normalizeCaptionPosition(selectedCaption.position);
+  const captionStyle = normalizeCaptionStyle(selectedCaption.style);
   const isReadOnly = readOnly || !onCaptionChange;
+
+  const commitCaptionStyle = (updates: Partial<CaptionStyle>): void => {
+    onCaptionChange?.(
+      selectedCaption.id,
+      'style',
+      normalizeCaptionStyle({
+        ...captionStyle,
+        ...updates,
+      }),
+    );
+  };
+
+  const updateCaptionColor = (field: CaptionStyleField, color: CaptionColor | undefined): void => {
+    commitCaptionStyle({ [field]: color } as Partial<CaptionStyle>);
+  };
 
   const commitCaptionPosition = (position: CaptionPosition): void => {
     onCaptionChange?.(selectedCaption.id, 'position', position);
@@ -464,6 +616,18 @@ export function CaptionInspectorPanel({
     });
   };
 
+  const fontWeightValue =
+    typeof captionStyle.fontWeight === 'number'
+      ? captionStyle.fontWeight
+      : captionStyle.bold || captionStyle.fontWeight === 'bold'
+        ? 700
+        : captionStyle.fontWeight === 'light'
+          ? 300
+          : 400;
+  const hasBackground = Boolean(captionStyle.backgroundColor);
+  const hasOutline = Boolean(captionStyle.outlineColor && captionStyle.outlineWidth > 0);
+  const hasShadow = Boolean(captionStyle.shadowColor);
+
   return (
     <div
       data-testid="inspector"
@@ -476,19 +640,20 @@ export function CaptionInspectorPanel({
         Caption Properties
       </h3>
 
-      <div className="space-y-4">
-        <div className="space-y-2">
+      <div className="space-y-5">
+        <InspectorSection title="Content" icon={<Type className="w-3 h-3" />}>
           <label className="text-xs font-medium text-editor-text-muted">Content</label>
           <textarea
+            data-testid="caption-content-input"
             className="w-full h-24 bg-editor-input bg-opacity-50 border border-editor-border rounded p-2 text-sm text-editor-text focus:border-primary-500 focus:ring-1 focus:ring-primary-500 focus:outline-none resize-none"
             value={selectedCaption.text}
             onChange={(e) => onCaptionChange?.(selectedCaption.id, 'text', e.target.value)}
             placeholder="Enter caption text..."
             disabled={isReadOnly}
           />
-        </div>
+        </InspectorSection>
 
-        <div className="space-y-1">
+        <InspectorSection title="Timing" icon={<Clock className="w-3 h-3" />}>
           <PropertyRow
             label="Start Time"
             value={formatDuration(selectedCaption.startSec)}
@@ -506,9 +671,301 @@ export function CaptionInspectorPanel({
             value={`${(selectedCaption.endSec - selectedCaption.startSec).toFixed(2)}s`}
             testId="caption-duration"
           />
-        </div>
+        </InspectorSection>
 
-        <div className="space-y-2">
+        <InspectorSection title="Font" icon={<Type className="w-3 h-3" />}>
+          <div className="flex items-center justify-between gap-3">
+            <label className="text-xs text-editor-text-muted">Family</label>
+            <select
+              data-testid="caption-font-family"
+              value={captionStyle.fontFamily}
+              className="w-36 rounded border border-editor-border bg-editor-input px-2 py-1 text-xs text-editor-text focus:border-primary-500 focus:outline-none disabled:opacity-50"
+              onChange={(event) => commitCaptionStyle({ fontFamily: event.target.value })}
+              disabled={isReadOnly}
+            >
+              {CAPTION_FONT_FAMILIES.map((family) => (
+                <option key={family} value={family}>
+                  {family}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <NumberField
+            label="Size"
+            value={captionStyle.fontSize}
+            min={1}
+            max={500}
+            unit="pt"
+            testId="caption-font-size"
+            onChange={(fontSize) => commitCaptionStyle({ fontSize })}
+            disabled={isReadOnly}
+          />
+
+          <NumberField
+            label="Weight"
+            value={fontWeightValue}
+            min={100}
+            max={900}
+            step={100}
+            testId="caption-font-weight"
+            onChange={(fontWeight) => commitCaptionStyle({ fontWeight, bold: fontWeight >= 600 })}
+            disabled={isReadOnly}
+          />
+
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-editor-text-muted">Style</label>
+            <div className="flex gap-1">
+              <StyleToggle
+                title="Bold"
+                active={fontWeightValue >= 600}
+                onClick={() =>
+                  commitCaptionStyle({
+                    fontWeight: fontWeightValue >= 600 ? 'normal' : 'bold',
+                    bold: fontWeightValue < 600,
+                  })
+                }
+                disabled={isReadOnly}
+                testId="caption-bold-toggle"
+              >
+                <Bold className="h-4 w-4" />
+              </StyleToggle>
+              <StyleToggle
+                title="Italic"
+                active={captionStyle.italic}
+                onClick={() => commitCaptionStyle({ italic: !captionStyle.italic })}
+                disabled={isReadOnly}
+                testId="caption-italic-toggle"
+              >
+                <Italic className="h-4 w-4" />
+              </StyleToggle>
+              <StyleToggle
+                title="Underline"
+                active={captionStyle.underline}
+                onClick={() => commitCaptionStyle({ underline: !captionStyle.underline })}
+                disabled={isReadOnly}
+                testId="caption-underline-toggle"
+              >
+                <Underline className="h-4 w-4" />
+              </StyleToggle>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-editor-text-muted">Alignment</label>
+            <div className="flex gap-1">
+              {(['left', 'center', 'right'] as TextAlignment[]).map((alignment) => (
+                <StyleToggle
+                  key={alignment}
+                  title={`Align ${alignment}`}
+                  active={captionStyle.alignment === alignment}
+                  onClick={() => commitCaptionStyle({ alignment })}
+                  disabled={isReadOnly}
+                  testId={`caption-align-${alignment}`}
+                >
+                  {alignment === 'left' && <AlignLeft className="h-4 w-4" />}
+                  {alignment === 'center' && <AlignCenter className="h-4 w-4" />}
+                  {alignment === 'right' && <AlignRight className="h-4 w-4" />}
+                </StyleToggle>
+              ))}
+            </div>
+          </div>
+
+          <NumberField
+            label="Line Height"
+            value={captionStyle.lineHeight ?? 1.2}
+            min={0.5}
+            max={5}
+            step={0.1}
+            testId="caption-line-height"
+            onChange={(lineHeight) => commitCaptionStyle({ lineHeight })}
+            disabled={isReadOnly}
+          />
+
+          <NumberField
+            label="Letter Spacing"
+            value={captionStyle.letterSpacing ?? 0}
+            min={-100}
+            max={200}
+            unit="px"
+            testId="caption-letter-spacing"
+            onChange={(letterSpacing) => commitCaptionStyle({ letterSpacing })}
+            disabled={isReadOnly}
+          />
+        </InspectorSection>
+
+        <InspectorSection title="Fill" icon={<Palette className="w-3 h-3" />}>
+          <ColorField
+            label="Text Color"
+            color={captionStyle.color}
+            onChange={(color) => updateCaptionColor('color', color)}
+            disabled={isReadOnly}
+            testId="caption-text-color"
+          />
+
+          <NumberField
+            label="Opacity"
+            value={Math.round((captionStyle.opacity ?? 1) * 100)}
+            min={0}
+            max={100}
+            unit="%"
+            testId="caption-opacity"
+            onChange={(opacityPercent) =>
+              commitCaptionStyle({ opacity: Math.max(0, Math.min(100, opacityPercent)) / 100 })
+            }
+            disabled={isReadOnly}
+          />
+
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-editor-text-muted">Background</label>
+            <StyleToggle
+              title={hasBackground ? 'Remove background' : 'Add background'}
+              active={hasBackground}
+              onClick={() =>
+                updateCaptionColor(
+                  'backgroundColor',
+                  hasBackground ? undefined : { r: 0, g: 0, b: 0, a: 180 },
+                )
+              }
+              disabled={isReadOnly}
+              testId="caption-background-toggle"
+            >
+              <Square className="h-4 w-4" />
+            </StyleToggle>
+          </div>
+
+          {captionStyle.backgroundColor && (
+            <>
+              <ColorField
+                label="Background Color"
+                color={captionStyle.backgroundColor}
+                onChange={(color) => updateCaptionColor('backgroundColor', color)}
+                disabled={isReadOnly}
+                testId="caption-background-color"
+              />
+              <NumberField
+                label="Padding"
+                value={captionStyle.backgroundPadding ?? 10}
+                min={0}
+                max={500}
+                unit="px"
+                testId="caption-background-padding"
+                onChange={(backgroundPadding) => commitCaptionStyle({ backgroundPadding })}
+                disabled={isReadOnly}
+              />
+            </>
+          )}
+        </InspectorSection>
+
+        <InspectorSection title="Outline" icon={<Square className="w-3 h-3" />}>
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-editor-text-muted">Enabled</label>
+            <StyleToggle
+              title={hasOutline ? 'Remove outline' : 'Add outline'}
+              active={hasOutline}
+              onClick={() =>
+                hasOutline
+                  ? commitCaptionStyle({ outlineColor: undefined, outlineWidth: 0 })
+                  : commitCaptionStyle({
+                      outlineColor: { r: 0, g: 0, b: 0, a: 255 },
+                      outlineWidth: 2,
+                    })
+              }
+              disabled={isReadOnly}
+              testId="caption-outline-toggle"
+            >
+              <Square className="h-4 w-4" />
+            </StyleToggle>
+          </div>
+
+          {captionStyle.outlineColor && (
+            <>
+              <ColorField
+                label="Outline Color"
+                color={captionStyle.outlineColor}
+                onChange={(color) => updateCaptionColor('outlineColor', color)}
+                disabled={isReadOnly}
+                testId="caption-outline-color"
+              />
+              <NumberField
+                label="Width"
+                value={captionStyle.outlineWidth}
+                min={0}
+                max={100}
+                unit="px"
+                testId="caption-outline-width"
+                onChange={(outlineWidth) => commitCaptionStyle({ outlineWidth })}
+                disabled={isReadOnly}
+              />
+            </>
+          )}
+        </InspectorSection>
+
+        <InspectorSection title="Shadow" icon={<Square className="w-3 h-3" />}>
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-editor-text-muted">Enabled</label>
+            <StyleToggle
+              title={hasShadow ? 'Remove shadow' : 'Add shadow'}
+              active={hasShadow}
+              onClick={() =>
+                updateCaptionColor(
+                  'shadowColor',
+                  hasShadow ? undefined : { r: 0, g: 0, b: 0, a: 160 },
+                )
+              }
+              disabled={isReadOnly}
+              testId="caption-shadow-toggle"
+            >
+              <Square className="h-4 w-4" />
+            </StyleToggle>
+          </div>
+
+          {captionStyle.shadowColor && (
+            <>
+              <ColorField
+                label="Shadow Color"
+                color={captionStyle.shadowColor}
+                onChange={(color) => updateCaptionColor('shadowColor', color)}
+                disabled={isReadOnly}
+                testId="caption-shadow-color"
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <NumberField
+                  label="X"
+                  value={captionStyle.shadowOffsetX ?? captionStyle.shadowOffset}
+                  min={-500}
+                  max={500}
+                  unit="px"
+                  testId="caption-shadow-x"
+                  onChange={(shadowOffsetX) => commitCaptionStyle({ shadowOffsetX })}
+                  disabled={isReadOnly}
+                />
+                <NumberField
+                  label="Y"
+                  value={captionStyle.shadowOffsetY ?? captionStyle.shadowOffset}
+                  min={-500}
+                  max={500}
+                  unit="px"
+                  testId="caption-shadow-y"
+                  onChange={(shadowOffsetY) => commitCaptionStyle({ shadowOffsetY })}
+                  disabled={isReadOnly}
+                />
+              </div>
+              <NumberField
+                label="Blur"
+                value={captionStyle.shadowBlur ?? 0}
+                min={0}
+                max={500}
+                unit="px"
+                testId="caption-shadow-blur"
+                onChange={(shadowBlur) => commitCaptionStyle({ shadowBlur })}
+                disabled={isReadOnly}
+              />
+            </>
+          )}
+        </InspectorSection>
+
+        <InspectorSection title="Position" icon={<Maximize className="w-3 h-3" />}>
           <label className="text-xs font-medium text-editor-text-muted">Position</label>
           <select
             data-testid="caption-position-mode"
@@ -585,7 +1042,7 @@ export function CaptionInspectorPanel({
               </div>
             </div>
           )}
-        </div>
+        </InspectorSection>
       </div>
     </div>
   );

--- a/src/components/features/inspector/InspectorPanels.tsx
+++ b/src/components/features/inspector/InspectorPanels.tsx
@@ -21,6 +21,7 @@ import {
 import { formatDuration } from '@/utils/formatters';
 import {
   captionColorToHex,
+  getCaptionFontWeightNumber,
   normalizeCaptionPosition,
   normalizeCaptionStyle,
   parseCaptionHexColor,
@@ -616,14 +617,7 @@ export function CaptionInspectorPanel({
     });
   };
 
-  const fontWeightValue =
-    typeof captionStyle.fontWeight === 'number'
-      ? captionStyle.fontWeight
-      : captionStyle.bold || captionStyle.fontWeight === 'bold'
-        ? 700
-        : captionStyle.fontWeight === 'light'
-          ? 300
-          : 400;
+  const fontWeightValue = getCaptionFontWeightNumber(captionStyle);
   const hasBackground = Boolean(captionStyle.backgroundColor);
   const hasOutline = Boolean(captionStyle.outlineColor && captionStyle.outlineWidth > 0);
   const hasShadow = Boolean(captionStyle.shadowColor);
@@ -676,19 +670,20 @@ export function CaptionInspectorPanel({
         <InspectorSection title="Font" icon={<Type className="w-3 h-3" />}>
           <div className="flex items-center justify-between gap-3">
             <label className="text-xs text-editor-text-muted">Family</label>
-            <select
-              data-testid="caption-font-family"
+            <input
+              data-testid="caption-font-family-input"
+              type="text"
+              list="caption-font-families"
               value={captionStyle.fontFamily}
               className="w-36 rounded border border-editor-border bg-editor-input px-2 py-1 text-xs text-editor-text focus:border-primary-500 focus:outline-none disabled:opacity-50"
               onChange={(event) => commitCaptionStyle({ fontFamily: event.target.value })}
               disabled={isReadOnly}
-            >
+            />
+            <datalist id="caption-font-families">
               {CAPTION_FONT_FAMILIES.map((family) => (
-                <option key={family} value={family}>
-                  {family}
-                </option>
+                <option key={family} value={family} />
               ))}
-            </select>
+            </datalist>
           </div>
 
           <NumberField
@@ -721,7 +716,7 @@ export function CaptionInspectorPanel({
                 active={fontWeightValue >= 600}
                 onClick={() =>
                   commitCaptionStyle({
-                    fontWeight: fontWeightValue >= 600 ? 'normal' : 'bold',
+                    fontWeight: fontWeightValue >= 600 ? 400 : 700,
                     bold: fontWeightValue < 600,
                   })
                 }

--- a/src/components/features/inspector/TextInspector.test.tsx
+++ b/src/components/features/inspector/TextInspector.test.tsx
@@ -28,7 +28,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       expect(screen.getByTestId('text-inspector')).toBeInTheDocument();
@@ -41,7 +41,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       expect(screen.getByText('Content')).toBeInTheDocument();
@@ -57,7 +57,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const fontSelector = screen.getByRole('combobox');
@@ -73,10 +73,7 @@ describe('TextInspector', () => {
       };
 
       render(
-        <TextInspector
-          selectedTextClip={titleClip}
-          onTextDataChange={mockOnTextDataChange}
-        />
+        <TextInspector selectedTextClip={titleClip} onTextDataChange={mockOnTextDataChange} />,
       );
 
       expect(screen.getByTestId('text-content-input')).toHaveValue('Title Text');
@@ -91,7 +88,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const textarea = screen.getByTestId('text-content-input');
@@ -114,7 +111,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const boldButton = screen.getByTitle('Bold');
@@ -124,7 +121,7 @@ describe('TextInspector', () => {
         'clip-1',
         expect.objectContaining({
           style: expect.objectContaining({ bold: true }),
-        })
+        }),
       );
     });
 
@@ -135,7 +132,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const italicButton = screen.getByTitle('Italic');
@@ -145,7 +142,7 @@ describe('TextInspector', () => {
         'clip-1',
         expect.objectContaining({
           style: expect.objectContaining({ italic: true }),
-        })
+        }),
       );
     });
 
@@ -156,7 +153,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const underlineButton = screen.getByTitle('Underline');
@@ -166,7 +163,7 @@ describe('TextInspector', () => {
         'clip-1',
         expect.objectContaining({
           style: expect.objectContaining({ underline: true }),
-        })
+        }),
       );
     });
 
@@ -177,7 +174,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const leftAlignButton = screen.getByTitle('Align left');
@@ -187,7 +184,7 @@ describe('TextInspector', () => {
         'clip-1',
         expect.objectContaining({
           style: expect.objectContaining({ alignment: 'left' }),
-        })
+        }),
       );
     });
 
@@ -198,7 +195,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const fontSelector = screen.getByRole('combobox');
@@ -208,8 +205,26 @@ describe('TextInspector', () => {
         'clip-1',
         expect.objectContaining({
           style: expect.objectContaining({ fontFamily: 'Helvetica' }),
-        })
+        }),
       );
+    });
+
+    it('should allow custom installed font family names', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TextInspector
+          selectedTextClip={defaultTextClip}
+          onTextDataChange={mockOnTextDataChange}
+        />,
+      );
+
+      const fontInput = screen.getByTestId('text-font-family-input');
+      await user.clear(fontInput);
+      await user.type(fontInput, 'Brand Display');
+
+      const lastCall = mockOnTextDataChange.mock.calls[mockOnTextDataChange.mock.calls.length - 1];
+      expect(lastCall[1].style.fontFamily).toBe('Brand Display');
     });
   });
 
@@ -221,16 +236,14 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       await user.click(screen.getByTitle('Enable shadow'));
 
       // Should have been called with shadow data
       const calls = mockOnTextDataChange.mock.calls;
-      const shadowCall = calls.find(
-        (call) => call[1].shadow !== undefined
-      );
+      const shadowCall = calls.find((call) => call[1].shadow !== undefined);
       expect(shadowCall).toBeDefined();
     });
   });
@@ -243,16 +256,14 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       await user.click(screen.getByTitle('Enable outline'));
 
       // Should have been called with outline data
       const calls = mockOnTextDataChange.mock.calls;
-      const outlineCall = calls.find(
-        (call) => call[1].outline !== undefined
-      );
+      const outlineCall = calls.find((call) => call[1].outline !== undefined);
       expect(outlineCall).toBeDefined();
     });
   });
@@ -263,7 +274,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       const sliders = screen.getAllByRole('slider');
@@ -277,7 +288,7 @@ describe('TextInspector', () => {
         'clip-1',
         expect.objectContaining({
           position: expect.objectContaining({ x: 0.25 }),
-        })
+        }),
       );
     });
   });
@@ -314,10 +325,7 @@ describe('TextInspector', () => {
       };
 
       render(
-        <TextInspector
-          selectedTextClip={customTextClip}
-          onTextDataChange={mockOnTextDataChange}
-        />
+        <TextInspector selectedTextClip={customTextClip} onTextDataChange={mockOnTextDataChange} />,
       );
 
       const resetButton = screen.getByTitle('Reset to defaults');
@@ -335,7 +343,7 @@ describe('TextInspector', () => {
           }),
           rotation: 0,
           opacity: 1.0,
-        })
+        }),
       );
     });
   });
@@ -347,7 +355,7 @@ describe('TextInspector', () => {
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
           readOnly={true}
-        />
+        />,
       );
 
       const textarea = screen.getByTestId('text-content-input');
@@ -367,7 +375,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={defaultTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       // Verify initial content
@@ -385,7 +393,7 @@ describe('TextInspector', () => {
         <TextInspector
           selectedTextClip={updatedTextClip}
           onTextDataChange={mockOnTextDataChange}
-        />
+        />,
       );
 
       // Verify content updated

--- a/src/components/features/inspector/TextInspector.tsx
+++ b/src/components/features/inspector/TextInspector.tsx
@@ -71,6 +71,27 @@ export interface TextInspectorProps {
 // Sub-components
 // =============================================================================
 
+const TEXT_FONT_FAMILIES = [
+  'Arial',
+  'Helvetica',
+  'Verdana',
+  'Inter',
+  'Roboto',
+  'Noto Sans',
+  'Noto Sans KR',
+  'Pretendard',
+  'Apple SD Gothic Neo',
+  'Malgun Gothic',
+  'Nanum Gothic',
+  'Georgia',
+  'Times New Roman',
+  'Courier New',
+  'Impact',
+  'Montserrat',
+  'Poppins',
+  'Oswald',
+];
+
 interface SectionProps {
   title: string;
   children: React.ReactNode;
@@ -101,9 +122,7 @@ function Section({
           {title}
         </span>
         {collapsible && (
-          <span className="text-editor-text-muted text-xs">
-            {isExpanded ? '-' : '+'}
-          </span>
+          <span className="text-editor-text-muted text-xs">{isExpanded ? '-' : '+'}</span>
         )}
       </button>
       {isExpanded && <div className="pb-4 space-y-3">{children}</div>}
@@ -119,12 +138,7 @@ interface ColorInputProps {
   disabled?: boolean;
 }
 
-function ColorInput({
-  label,
-  value,
-  onChange,
-  disabled = false,
-}: ColorInputProps): JSX.Element {
+function ColorInput({ label, value, onChange, disabled = false }: ColorInputProps): JSX.Element {
   const [localValue, setLocalValue] = useState(value);
 
   useEffect(() => {
@@ -138,7 +152,7 @@ function ColorInput({
         onChange(newValue);
       }
     },
-    [onChange]
+    [onChange],
   );
 
   return (
@@ -200,7 +214,7 @@ function NumberInput({
         onChange(parsed);
       }
     },
-    [onChange]
+    [onChange],
   );
 
   return (
@@ -275,9 +289,7 @@ export function TextInspector({
   // Local State
   // ===========================================================================
 
-  const [localTextData, setLocalTextData] = useState<TextClipData>(
-    selectedTextClip.textData
-  );
+  const [localTextData, setLocalTextData] = useState<TextClipData>(selectedTextClip.textData);
 
   // Sync local state with prop changes
   useEffect(() => {
@@ -292,8 +304,13 @@ export function TextInspector({
   const hasOutline = useMemo(() => !!localTextData.outline, [localTextData.outline]);
   const hasBackground = useMemo(
     () => !!localTextData.style.backgroundColor,
-    [localTextData.style.backgroundColor]
+    [localTextData.style.backgroundColor],
   );
+  const fontFamilyOptions = useMemo(() => {
+    return TEXT_FONT_FAMILIES.includes(localTextData.style.fontFamily)
+      ? TEXT_FONT_FAMILIES
+      : [localTextData.style.fontFamily, ...TEXT_FONT_FAMILIES];
+  }, [localTextData.style.fontFamily]);
 
   // ===========================================================================
   // Update Handlers
@@ -305,7 +322,7 @@ export function TextInspector({
       setLocalTextData(newTextData);
       onTextDataChange(selectedTextClip.id, newTextData);
     },
-    [localTextData, selectedTextClip.id, onTextDataChange]
+    [localTextData, selectedTextClip.id, onTextDataChange],
   );
 
   const updateStyle = useCallback(
@@ -314,7 +331,7 @@ export function TextInspector({
         style: { ...localTextData.style, ...updates },
       });
     },
-    [localTextData.style, updateTextData]
+    [localTextData.style, updateTextData],
   );
 
   const updatePosition = useCallback(
@@ -323,7 +340,7 @@ export function TextInspector({
         position: { ...localTextData.position, ...updates },
       });
     },
-    [localTextData.position, updateTextData]
+    [localTextData.position, updateTextData],
   );
 
   const updateShadow = useCallback(
@@ -333,7 +350,7 @@ export function TextInspector({
         shadow: { ...currentShadow, ...updates },
       });
     },
-    [localTextData.shadow, updateTextData]
+    [localTextData.shadow, updateTextData],
   );
 
   const updateOutline = useCallback(
@@ -343,7 +360,7 @@ export function TextInspector({
         outline: { ...currentOutline, ...updates },
       });
     },
-    [localTextData.outline, updateTextData]
+    [localTextData.outline, updateTextData],
   );
 
   // ===========================================================================
@@ -408,7 +425,7 @@ export function TextInspector({
       setLocalTextData(newTextData);
       onTextDataChange(selectedTextClip.id, newTextData);
     },
-    [localTextData.content, selectedTextClip.id, onTextDataChange]
+    [localTextData.content, selectedTextClip.id, onTextDataChange],
   );
 
   // ===========================================================================
@@ -453,11 +470,7 @@ export function TextInspector({
 
       {/* Presets Section */}
       <Section title="Style Presets" icon={<Palette className="w-4 h-4" />} defaultExpanded={false}>
-        <TextPresetPicker
-          onSelect={handlePresetSelect}
-          disabled={readOnly}
-          compact
-        />
+        <TextPresetPicker onSelect={handlePresetSelect} disabled={readOnly} compact />
       </Section>
 
       {/* Font Section */}
@@ -472,14 +485,24 @@ export function TextInspector({
               disabled={readOnly}
               className="w-32 px-2 py-1 text-xs bg-editor-input border border-editor-border rounded text-editor-text focus:border-primary-500 focus:outline-none disabled:opacity-50"
             >
-              <option value="Arial">Arial</option>
-              <option value="Helvetica">Helvetica</option>
-              <option value="Verdana">Verdana</option>
-              <option value="Georgia">Georgia</option>
-              <option value="Times New Roman">Times New Roman</option>
-              <option value="Courier New">Courier New</option>
-              <option value="Impact">Impact</option>
+              {fontFamilyOptions.map((fontFamily) => (
+                <option key={fontFamily} value={fontFamily}>
+                  {fontFamily}
+                </option>
+              ))}
             </select>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-editor-text-muted">Custom</label>
+            <input
+              type="text"
+              value={localTextData.style.fontFamily}
+              onChange={(e) => updateStyle({ fontFamily: e.target.value })}
+              disabled={readOnly}
+              className="w-32 px-2 py-1 text-xs bg-editor-input border border-editor-border rounded text-editor-text focus:border-primary-500 focus:outline-none disabled:opacity-50"
+              data-testid="text-font-family-input"
+            />
           </div>
 
           {/* Font Size */}

--- a/src/components/features/preview/TimecodeInput.tsx
+++ b/src/components/features/preview/TimecodeInput.tsx
@@ -3,7 +3,7 @@
  * Click to enter edit mode, type SMPTE timecode (HH:MM:SS:FF), press Enter to jump.
  */
 
-import { type FC, useState, useCallback, useRef, useEffect } from 'react';
+import { type FC, useState, useCallback, useRef, useEffect, useLayoutEffect } from 'react';
 import { formatTimecode, parseTimecode, isValidTimecode } from '@/utils/formatters';
 import { PLAYBACK } from '@/constants/preview';
 
@@ -61,10 +61,13 @@ export const TimecodeInput: FC<TimecodeInputProps> = ({
     setEditValue(formatTimecode(currentTime, fps));
     setHasError(false);
     setIsEditing(true);
-    requestAnimationFrame(() => {
-      inputRef.current?.select();
-    });
   }, [currentTime, disabled, fps]);
+
+  useLayoutEffect(() => {
+    if (isEditing) {
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
 
   const cancelEdit = useCallback(() => {
     setIsEditing(false);
@@ -78,12 +81,12 @@ export const TimecodeInput: FC<TimecodeInputProps> = ({
     }
   }, [cancelEdit, disabled, isEditing]);
 
-  const confirmEdit = useCallback(() => {
+  const confirmEdit = useCallback((inputValue = inputRef.current?.value ?? editValue) => {
     if (disabled) {
       return;
     }
 
-    const trimmed = editValue.trim();
+    const trimmed = inputValue.trim();
 
     if (!isValidTimecode(trimmed, fps)) {
       showError();
@@ -104,13 +107,13 @@ export const TimecodeInput: FC<TimecodeInputProps> = ({
   }, [disabled, editValue, fps, duration, onSeek, showError]);
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
       // Prevent parent keyboard handlers (JKL shuttle, transport, etc.)
       e.stopPropagation();
 
       if (e.key === 'Enter') {
         e.preventDefault();
-        confirmEdit();
+        confirmEdit(e.currentTarget.value);
       } else if (e.key === 'Escape') {
         e.preventDefault();
         cancelEdit();

--- a/src/components/preview/ProxyPreviewPlayer.test.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ProxyPreviewPlayer } from './ProxyPreviewPlayer';
 import { usePlaybackStore } from '@/stores/playbackStore';
 import { useTimelineStore } from '@/stores/timelineStore';
@@ -138,5 +138,52 @@ describe('ProxyPreviewPlayer', () => {
 
     expect(screen.queryByTestId('proxy-video-clip-top')).not.toBeInTheDocument();
     expect(screen.getByTestId('proxy-video-clip-bottom')).toBeInTheDocument();
+  });
+
+  it('commits text placement from an inline preview input', async () => {
+    const sequence = createSequence();
+    const onTextPlacementCommit = vi.fn();
+    const assets = new Map<string, Asset>([
+      ['asset-top', createVideoAsset('asset-top', 'https://example.com/top.mp4')],
+      ['asset-bottom', createVideoAsset('asset-bottom', 'https://example.com/bottom.mp4')],
+    ]);
+
+    render(
+      <ProxyPreviewPlayer
+        sequence={sequence}
+        assets={assets}
+        showControls
+        textPlacementModeActive
+        onTextPlacementCommit={onTextPlacementCommit}
+      />,
+    );
+
+    const overlay = screen.getByTestId('text-placement-overlay');
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 300,
+        right: 400,
+        bottom: 300,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    fireEvent.pointerDown(overlay, { clientX: 200, clientY: 150, button: 0 });
+    const input = screen.getByTestId('text-placement-input');
+    fireEvent.change(input, { target: { value: 'Placed title' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onTextPlacementCommit).toHaveBeenCalledWith({
+        content: 'Placed title',
+        position: { x: 0.5, y: 0.5 },
+      });
+    });
   });
 });

--- a/src/components/preview/ProxyPreviewPlayer.test.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.test.tsx
@@ -186,4 +186,98 @@ describe('ProxyPreviewPlayer', () => {
       });
     });
   });
+
+  it('keeps the current text placement draft when the overlay is clicked again', () => {
+    const sequence = createSequence();
+    const assets = new Map<string, Asset>([
+      ['asset-top', createVideoAsset('asset-top', 'https://example.com/top.mp4')],
+      ['asset-bottom', createVideoAsset('asset-bottom', 'https://example.com/bottom.mp4')],
+    ]);
+
+    render(
+      <ProxyPreviewPlayer
+        sequence={sequence}
+        assets={assets}
+        showControls
+        textPlacementModeActive
+        onTextPlacementCommit={vi.fn()}
+      />,
+    );
+
+    const overlay = screen.getByTestId('text-placement-overlay');
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 300,
+        right: 400,
+        bottom: 300,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    fireEvent.pointerDown(overlay, { clientX: 200, clientY: 150, button: 0 });
+    const input = screen.getByTestId('text-placement-input');
+    fireEvent.change(input, { target: { value: 'Draft title' } });
+
+    fireEvent.pointerDown(overlay, { clientX: 20, clientY: 20, button: 0 });
+
+    expect(screen.getByTestId('text-placement-input')).toHaveValue('Draft title');
+  });
+
+  it('does not commit text placement while IME composition is active', async () => {
+    const sequence = createSequence();
+    const onTextPlacementCommit = vi.fn();
+    const assets = new Map<string, Asset>([
+      ['asset-top', createVideoAsset('asset-top', 'https://example.com/top.mp4')],
+      ['asset-bottom', createVideoAsset('asset-bottom', 'https://example.com/bottom.mp4')],
+    ]);
+
+    render(
+      <ProxyPreviewPlayer
+        sequence={sequence}
+        assets={assets}
+        showControls
+        textPlacementModeActive
+        onTextPlacementCommit={onTextPlacementCommit}
+      />,
+    );
+
+    const overlay = screen.getByTestId('text-placement-overlay');
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 300,
+        right: 400,
+        bottom: 300,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    fireEvent.pointerDown(overlay, { clientX: 200, clientY: 150, button: 0 });
+    const input = screen.getByTestId('text-placement-input');
+    fireEvent.change(input, { target: { value: 'Composing title' } });
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+
+    expect(onTextPlacementCommit).not.toHaveBeenCalled();
+    expect(screen.getByTestId('text-placement-input')).toHaveValue('Composing title');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onTextPlacementCommit).toHaveBeenCalledWith({
+        content: 'Composing title',
+        position: { x: 0.5, y: 0.5 },
+      });
+    });
+  });
 });

--- a/src/components/preview/ProxyPreviewPlayer.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.tsx
@@ -20,11 +20,21 @@ import { normalizeFileUriToPath } from '@/utils/uri';
 import { useSequenceTextClipData } from '@/hooks/useSequenceTextClipData';
 import { extractTextDataFromClipWithMap } from '@/utils/textRenderer';
 import {
+  buildCaptionCssTextShadow,
+  captionColorToRgba as captionColorToCssRgba,
+  getCaptionFontWeightNumber,
+  normalizeCaptionPosition as normalizeCaptionPositionValue,
+  normalizeCaptionStyle as normalizeCaptionStyleValue,
+  resolveCaptionAnchor as resolveCaptionAnchorValue,
+} from '@/utils/captionStyle';
+import {
   getClipSourceTimeAtTimelineTime,
   getSafeClipSpeed,
   isClipActiveAtTime,
 } from '@/utils/clipTiming';
 import { isCaptionLikeClip } from '@/utils/captionClip';
+import { TextPlacementOverlay, type TextPlacementCommitPayload } from './TextPlacementOverlay';
+import { TransformOverlay } from './TransformOverlay';
 import {
   isTextClip,
   type Sequence,
@@ -32,7 +42,6 @@ import {
   type Clip,
   type CaptionStyle,
   type CaptionPosition,
-  type CaptionColor,
   type TextClipData,
 } from '@/types';
 
@@ -49,6 +58,10 @@ export interface ProxyPreviewPlayerProps {
   className?: string;
   /** Whether to show controls */
   showControls?: boolean;
+  /** Whether the preview should accept click-to-place text input */
+  textPlacementModeActive?: boolean;
+  /** Commit handler for text entered directly on the preview */
+  onTextPlacementCommit?: (payload: TextPlacementCommitPayload) => void | Promise<void>;
 }
 
 interface ActiveClip {
@@ -119,20 +132,6 @@ function clampTimelineTime(time: number, duration: number): number {
   return Math.max(0, Math.min(duration, time));
 }
 
-const DEFAULT_CAPTION_STYLE: CaptionStyle = {
-  fontFamily: 'Arial',
-  fontSize: 48,
-  fontWeight: 'normal',
-  color: { r: 255, g: 255, b: 255, a: 255 },
-  outlineColor: { r: 0, g: 0, b: 0, a: 255 },
-  outlineWidth: 2,
-  shadowColor: { r: 0, g: 0, b: 0, a: 160 },
-  shadowOffset: 2,
-  alignment: 'center',
-  italic: false,
-  underline: false,
-};
-
 const DEFAULT_CAPTION_POSITION: CaptionPosition = {
   type: 'preset',
   vertical: 'bottom',
@@ -148,62 +147,11 @@ function clampPercent(value: number, fallback: number): number {
 }
 
 function normalizeCaptionStyle(style: CaptionStyle | undefined): CaptionStyle {
-  if (!style) {
-    return DEFAULT_CAPTION_STYLE;
-  }
-
-  return {
-    ...DEFAULT_CAPTION_STYLE,
-    ...style,
-    color: {
-      ...DEFAULT_CAPTION_STYLE.color,
-      ...style.color,
-    },
-    backgroundColor: style.backgroundColor
-      ? {
-          r: style.backgroundColor.r,
-          g: style.backgroundColor.g,
-          b: style.backgroundColor.b,
-          a: style.backgroundColor.a,
-        }
-      : undefined,
-    outlineColor: style.outlineColor
-      ? {
-          r: style.outlineColor.r,
-          g: style.outlineColor.g,
-          b: style.outlineColor.b,
-          a: style.outlineColor.a,
-        }
-      : undefined,
-    shadowColor: style.shadowColor
-      ? {
-          r: style.shadowColor.r,
-          g: style.shadowColor.g,
-          b: style.shadowColor.b,
-          a: style.shadowColor.a,
-        }
-      : undefined,
-  };
+  return normalizeCaptionStyleValue(style);
 }
 
 function normalizeCaptionPosition(position: CaptionPosition | undefined): CaptionPosition {
-  if (!position) {
-    return DEFAULT_CAPTION_POSITION;
-  }
-
-  if (position.type === 'custom') {
-    return {
-      type: 'custom',
-      xPercent: clampPercent(position.xPercent, 50),
-      yPercent: clampPercent(position.yPercent, 90),
-    };
-  }
-
-  return {
-    type: 'preset',
-    vertical: position.vertical,
-    marginPercent: clampPercent(position.marginPercent, 5),
-  };
+  return normalizeCaptionPositionValue(position);
 }
 
 function resolveCaptionAnchor(
@@ -213,59 +161,15 @@ function resolveCaptionAnchor(
   xPercent: number;
   yPercent: number;
 } {
-  let xPercent = 50;
-  if (style.alignment === 'left') {
-    xPercent = 10;
-  } else if (style.alignment === 'right') {
-    xPercent = 90;
-  }
-
-  let yPercent = 90;
-  if (position.type === 'custom') {
-    xPercent = position.xPercent;
-    yPercent = position.yPercent;
-  } else if (position.vertical === 'top') {
-    yPercent = position.marginPercent;
-  } else if (position.vertical === 'center') {
-    yPercent = 50;
-  } else {
-    yPercent = 100 - position.marginPercent;
-  }
-
-  return {
-    xPercent: clampPercent(xPercent, 50),
-    yPercent: clampPercent(yPercent, 90),
-  };
+  return resolveCaptionAnchorValue(style, position);
 }
 
-function toRgba(color: CaptionColor): string {
-  return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a / 255})`;
+function toRgba(color: CaptionStyle['color']): string {
+  return captionColorToCssRgba(color);
 }
 
 function buildCaptionTextShadow(style: CaptionStyle): string | undefined {
-  const parts: string[] = [];
-
-  if (style.outlineColor && style.outlineWidth > 0) {
-    const width = Math.max(1, Math.round(style.outlineWidth));
-    const outline = toRgba(style.outlineColor);
-    parts.push(
-      `${-width}px 0 ${outline}`,
-      `${width}px 0 ${outline}`,
-      `0 ${-width}px ${outline}`,
-      `0 ${width}px ${outline}`,
-      `${-width}px ${-width}px ${outline}`,
-      `${width}px ${-width}px ${outline}`,
-      `${-width}px ${width}px ${outline}`,
-      `${width}px ${width}px ${outline}`,
-    );
-  }
-
-  if (style.shadowColor && style.shadowOffset > 0) {
-    const offset = style.shadowOffset;
-    parts.push(`${offset}px ${offset}px ${offset}px ${toRgba(style.shadowColor)}`);
-  }
-
-  return parts.length > 0 ? parts.join(', ') : undefined;
+  return buildCaptionCssTextShadow(style);
 }
 
 function resolveCaptionPositionForClip(
@@ -432,6 +336,8 @@ export function ProxyPreviewPlayer({
   assets,
   className = '',
   showControls = true,
+  textPlacementModeActive = false,
+  onTextPlacementCommit,
 }: ProxyPreviewPlayerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const videoRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
@@ -467,6 +373,7 @@ export function ProxyPreviewPlayer({
   const [videoErrors, setVideoErrors] = useState<Map<string, string>>(new Map());
   const [captionDragState, setCaptionDragState] = useState<CaptionDragState | null>(null);
   const [captionDraftPosition, setCaptionDraftPosition] = useState<CaptionPosition | null>(null);
+  const [containerSize, setContainerSize] = useState({ width: 1920, height: 1080 });
 
   // NOTE: Playback duration is managed by useTimelineEngine (Timeline component).
   // Do NOT compute or set it here - competing setDuration calls cause the SeekBar
@@ -1271,6 +1178,40 @@ export function ProxyPreviewPlayer({
     };
   }, []);
 
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const updateSize = (): void => {
+      const rect = container.getBoundingClientRect();
+      setContainerSize((prev) => {
+        const nextWidth = rect.width > 0 ? rect.width : prev.width;
+        const nextHeight = rect.height > 0 ? rect.height : prev.height;
+
+        if (Math.abs(prev.width - nextWidth) < 0.5 && Math.abs(prev.height - nextHeight) < 0.5) {
+          return prev;
+        }
+
+        return { width: nextWidth, height: nextHeight };
+      });
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [sequence?.format?.canvas?.height, sequence?.format?.canvas?.width]);
+
   // Handle playback end
   useEffect(() => {
     if (!syncWithTimeline && isPlaying && currentTime >= duration && duration > 0) {
@@ -1299,16 +1240,31 @@ export function ProxyPreviewPlayer({
     [togglePlayback, handleFullscreenToggle],
   );
 
-  // Calculate aspect ratio from sequence format (guard against zero height)
-  const aspectRatio =
+  const previewCanvasWidth =
+    sequence?.format?.canvas && sequence.format.canvas.width > 0
+      ? sequence.format.canvas.width
+      : 1920;
+  const previewCanvasHeight =
     sequence?.format?.canvas && sequence.format.canvas.height > 0
-      ? sequence.format.canvas.width / sequence.format.canvas.height
-      : 16 / 9;
+      ? sequence.format.canvas.height
+      : 1080;
+
+  // Calculate aspect ratio from sequence format (guard against zero height)
+  const aspectRatio = previewCanvasWidth / previewCanvasHeight;
 
   const controlsZIndex =
     sequence !== null
       ? sequence.tracks.length * TRACK_LAYER_Z_INDEX_STEP + CONTROLS_Z_INDEX_OFFSET
       : CONTROLS_Z_INDEX_OFFSET;
+  const transformOverlayZIndex = Math.max(1, controlsZIndex - 2);
+  const textPlacementOverlayZIndex = Math.max(1, controlsZIndex - 1);
+  const overlayDisplayScale =
+    containerSize.width <= 0 || containerSize.height <= 0
+      ? 1
+      : Math.min(
+          containerSize.width / previewCanvasWidth,
+          containerSize.height / previewCanvasHeight,
+        );
 
   // Empty state
   if (!sequence) {
@@ -1351,7 +1307,7 @@ export function ProxyPreviewPlayer({
       ref={containerRef}
       data-testid="proxy-preview-player"
       className={`relative isolate bg-black overflow-hidden ${className}`}
-      style={{ aspectRatio }}
+      style={{ aspectRatio, cursor: textPlacementModeActive ? 'text' : undefined }}
       tabIndex={0}
       role="region"
       aria-label="Video preview"
@@ -1441,10 +1397,10 @@ export function ProxyPreviewPlayer({
             const isDraggingSelected =
               captionDragState?.captionId === caption.clip.id && captionDragState.pointerId != null;
 
-            const fontWeight =
-              style.fontWeight === 'bold' ? 700 : style.fontWeight === 'light' ? 300 : 400;
+            const fontWeight = getCaptionFontWeightNumber(style);
             const textShadow = buildCaptionTextShadow(style);
             const textDecoration = style.underline ? 'underline' : 'none';
+            const backgroundPadding = Math.max(0, style.backgroundPadding ?? 0);
 
             return (
               <div
@@ -1463,14 +1419,19 @@ export function ProxyPreviewPlayer({
                   textAlign: style.alignment,
                   textDecoration,
                   whiteSpace: 'pre-line',
-                  lineHeight: 1.2,
+                  lineHeight: style.lineHeight ?? 1.2,
+                  letterSpacing: `${style.letterSpacing ?? 0}px`,
+                  opacity: (style.opacity ?? 1) * caption.clip.opacity,
                   backgroundColor: style.backgroundColor
                     ? toRgba(style.backgroundColor)
                     : 'transparent',
                   textShadow,
                   border: isEditableSelected ? '1px dashed rgba(59, 130, 246, 0.9)' : 'none',
                   borderRadius: isEditableSelected ? '4px' : '0',
-                  padding: isEditableSelected || style.backgroundColor ? '2px 6px' : '0',
+                  padding:
+                    isEditableSelected || style.backgroundColor
+                      ? `${Math.max(2, backgroundPadding * 0.2)}px ${Math.max(6, backgroundPadding * 0.6)}px`
+                      : '0',
                   cursor: isEditableSelected
                     ? isDraggingSelected
                       ? 'grabbing'
@@ -1556,6 +1517,26 @@ export function ProxyPreviewPlayer({
           })}
         </div>
       )}
+
+      <TransformOverlay
+        sequence={sequence}
+        assets={assets}
+        canvasWidth={previewCanvasWidth}
+        canvasHeight={previewCanvasHeight}
+        containerWidth={containerSize.width}
+        containerHeight={containerSize.height}
+        displayScale={overlayDisplayScale}
+        panX={0}
+        panY={0}
+        zIndex={transformOverlayZIndex}
+      />
+
+      <TextPlacementOverlay
+        active={textPlacementModeActive}
+        aspectRatio={aspectRatio}
+        onCommit={onTextPlacementCommit}
+        zIndex={textPlacementOverlayZIndex}
+      />
 
       {/* Controls Overlay */}
       {showControls && (

--- a/src/components/preview/TextPlacementOverlay.tsx
+++ b/src/components/preview/TextPlacementOverlay.tsx
@@ -156,6 +156,10 @@ export function TextPlacementOverlay({
       event.preventDefault();
       event.stopPropagation();
 
+      if (draftRef.current) {
+        return;
+      }
+
       const rect = event.currentTarget.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) {
         return;
@@ -178,6 +182,10 @@ export function TextPlacementOverlay({
       if (event.key === 'Escape') {
         event.preventDefault();
         cancelDraft();
+        return;
+      }
+
+      if (event.nativeEvent.isComposing) {
         return;
       }
 

--- a/src/components/preview/TextPlacementOverlay.tsx
+++ b/src/components/preview/TextPlacementOverlay.tsx
@@ -1,0 +1,226 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react';
+
+export interface TextPlacementCommitPayload {
+  content: string;
+  position: {
+    x: number;
+    y: number;
+  };
+}
+
+export interface TextPlacementOverlayProps {
+  active: boolean;
+  aspectRatio: number;
+  onCommit?: (payload: TextPlacementCommitPayload) => void | Promise<void>;
+  zIndex?: number;
+}
+
+interface DraftTextPlacement {
+  value: string;
+  leftPx: number;
+  topPx: number;
+  position: TextPlacementCommitPayload['position'];
+}
+
+const INPUT_WIDTH_PX = 280;
+const MIN_CONTENT_SIZE_PX = 1;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0.5;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return Boolean(
+    target.closest(
+      'button, input, textarea, select, a, [role="button"], [data-text-placement-control]',
+    ),
+  );
+}
+
+function resolveContainedPosition(
+  rect: DOMRect,
+  clientX: number,
+  clientY: number,
+  aspectRatio: number,
+): DraftTextPlacement {
+  const safeAspectRatio = Number.isFinite(aspectRatio) && aspectRatio > 0 ? aspectRatio : 16 / 9;
+  const containerRatio =
+    rect.width > 0 && rect.height > 0 ? rect.width / rect.height : safeAspectRatio;
+
+  let contentWidth = Math.max(MIN_CONTENT_SIZE_PX, rect.width);
+  let contentHeight = Math.max(MIN_CONTENT_SIZE_PX, rect.height);
+  let contentLeft = 0;
+  let contentTop = 0;
+
+  if (containerRatio > safeAspectRatio) {
+    contentHeight = Math.max(MIN_CONTENT_SIZE_PX, rect.height);
+    contentWidth = Math.max(MIN_CONTENT_SIZE_PX, contentHeight * safeAspectRatio);
+    contentLeft = (rect.width - contentWidth) / 2;
+  } else {
+    contentWidth = Math.max(MIN_CONTENT_SIZE_PX, rect.width);
+    contentHeight = Math.max(MIN_CONTENT_SIZE_PX, contentWidth / safeAspectRatio);
+    contentTop = (rect.height - contentHeight) / 2;
+  }
+
+  const relativeX = clientX - rect.left - contentLeft;
+  const relativeY = clientY - rect.top - contentTop;
+  const x = clamp01(relativeX / contentWidth);
+  const y = clamp01(relativeY / contentHeight);
+
+  return {
+    value: '',
+    leftPx: contentLeft + x * contentWidth,
+    topPx: contentTop + y * contentHeight,
+    position: { x, y },
+  };
+}
+
+export function TextPlacementOverlay({
+  active,
+  aspectRatio,
+  onCommit,
+  zIndex,
+}: TextPlacementOverlayProps): JSX.Element | null {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const draftRef = useRef<DraftTextPlacement | null>(null);
+  const [draft, setDraft] = useState<DraftTextPlacement | null>(null);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  useEffect(() => {
+    if (!active) {
+      draftRef.current = null;
+      setDraft(null);
+    }
+  }, [active]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [draft?.leftPx, draft?.topPx]);
+
+  const commitDraft = useCallback(() => {
+    const current = draftRef.current;
+    if (!current) {
+      return;
+    }
+
+    draftRef.current = null;
+    setDraft(null);
+
+    const content = current.value.trim();
+    if (!content || !onCommit) {
+      return;
+    }
+
+    try {
+      const result = onCommit({
+        content,
+        position: current.position,
+      });
+      void Promise.resolve(result).catch(() => undefined);
+    } catch {
+      // The editor owns user-facing command errors; keep the overlay disposable.
+    }
+  }, [onCommit]);
+
+  const cancelDraft = useCallback(() => {
+    draftRef.current = null;
+    setDraft(null);
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!active || event.button !== 0 || isInteractiveTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const rect = event.currentTarget.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) {
+        return;
+      }
+
+      setDraft(resolveContainedPosition(rect, event.clientX, event.clientY, aspectRatio));
+    },
+    [active, aspectRatio],
+  );
+
+  const handleDraftChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    setDraft((current) => (current ? { ...current, value } : current));
+  }, []);
+
+  const handleDraftKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      event.stopPropagation();
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelDraft();
+        return;
+      }
+
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        commitDraft();
+      }
+    },
+    [cancelDraft, commitDraft],
+  );
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="text-placement-overlay"
+      className="absolute inset-0"
+      style={{ cursor: 'text', zIndex }}
+      onPointerDown={handlePointerDown}
+    >
+      {draft && (
+        <textarea
+          ref={inputRef}
+          data-testid="text-placement-input"
+          value={draft.value}
+          rows={1}
+          className="absolute resize-none rounded border border-teal-300 bg-black/55 px-2 py-1 text-center text-3xl font-semibold text-white shadow-lg outline-none ring-2 ring-teal-400/40 backdrop-blur-sm"
+          style={{
+            left: draft.leftPx,
+            top: draft.topPx,
+            width: INPUT_WIDTH_PX,
+            minHeight: 48,
+            transform: 'translate(-50%, -50%)',
+          }}
+          onChange={handleDraftChange}
+          onKeyDown={handleDraftKeyDown}
+          onBlur={commitDraft}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/preview/TimelinePreviewPlayer.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.tsx
@@ -27,7 +27,14 @@ import { extractTextDataFromClipWithMap, renderTextToCanvas } from '@/utils/text
 import { getClipSourceTimeAtTimelineTime, isClipActiveAtTime } from '@/utils/clipTiming';
 import { isCaptionLikeClip } from '@/utils/captionClip';
 import { getEffectiveBlendMode } from '@/utils/blendModes';
+import {
+  captionColorToRgba,
+  getCaptionFontWeightNumber,
+  normalizeCaptionPosition as normalizeCaptionPositionValue,
+  normalizeCaptionStyle as normalizeCaptionStyleValue,
+} from '@/utils/captionStyle';
 import { SeekBar } from './SeekBar';
+import { TextPlacementOverlay, type TextPlacementCommitPayload } from './TextPlacementOverlay';
 import { TransformOverlay } from './TransformOverlay';
 import { isTextClip } from '@/types';
 import type {
@@ -65,6 +72,10 @@ export interface TimelinePreviewPlayerProps {
   onEnded?: () => void;
   /** Callback when frame is rendered */
   onFrameRender?: (time: number) => void;
+  /** Whether the preview should accept click-to-place text input */
+  textPlacementModeActive?: boolean;
+  /** Commit handler for text entered directly on the preview */
+  onTextPlacementCommit?: (payload: TextPlacementCommitPayload) => void | Promise<void>;
 }
 
 /** Clip info with resolved data for rendering */
@@ -225,6 +236,8 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
   height = DEFAULT_HEIGHT,
   onEnded,
   onFrameRender,
+  textPlacementModeActive = false,
+  onTextPlacementCommit,
 }: TimelinePreviewPlayerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -432,10 +445,13 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         depth: number,
       ): Promise<boolean> => {
         if (depth > MAX_COMPOUND_RENDER_DEPTH) {
-          console.warn('[TimelinePreviewPlayer] Skipped nested compound render beyond depth limit', {
-            sequenceId: sequence.id,
-            depth,
-          });
+          console.warn(
+            '[TimelinePreviewPlayer] Skipped nested compound render beyond depth limit',
+            {
+              sequenceId: sequence.id,
+              depth,
+            },
+          );
           return true;
         }
 
@@ -667,7 +683,14 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 
       onFrameRender?.(time);
     },
-    [activeSequence, getActiveClipsAtTime, extractFrameForAsset, onFrameRender, sequences, textClipDataById],
+    [
+      activeSequence,
+      getActiveClipsAtTime,
+      extractFrameForAsset,
+      onFrameRender,
+      sequences,
+      textClipDataById,
+    ],
   );
 
   // Playback loop integration
@@ -874,7 +897,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
       ref={containerRef}
       data-testid="timeline-preview-player"
       className={`relative isolate bg-black overflow-hidden ${className}`}
-      style={{ aspectRatio }}
+      style={{ aspectRatio, cursor: textPlacementModeActive ? 'text' : undefined }}
       tabIndex={0}
       role="region"
       aria-label="Timeline preview"
@@ -899,6 +922,14 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         displayScale={overlayDisplayScale}
         panX={0}
         panY={0}
+        zIndex={30}
+      />
+
+      <TextPlacementOverlay
+        active={textPlacementModeActive}
+        aspectRatio={aspectRatio}
+        onCommit={onTextPlacementCommit}
+        zIndex={40}
       />
 
       {/* Loading Indicator */}
@@ -938,7 +969,10 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 
       {/* Controls */}
       {showControls && (
-        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-2">
+        <div
+          className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-2"
+          style={{ zIndex: 50 }}
+        >
           {/* Seek Bar */}
           <div className="mb-2">
             <SeekBar
@@ -1013,20 +1047,6 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 // Helpers
 // =============================================================================
 
-const DEFAULT_CAPTION_STYLE: CaptionStyle = {
-  fontFamily: 'Arial',
-  fontSize: 48,
-  fontWeight: 'normal',
-  color: { r: 255, g: 255, b: 255, a: 255 },
-  outlineColor: { r: 0, g: 0, b: 0, a: 255 },
-  outlineWidth: 2,
-  shadowColor: { r: 0, g: 0, b: 0, a: 160 },
-  shadowOffset: 2,
-  alignment: 'center',
-  italic: false,
-  underline: false,
-};
-
 const DEFAULT_CAPTION_POSITION: CaptionPosition = {
   type: 'preset',
   vertical: 'bottom',
@@ -1042,66 +1062,71 @@ function clampPercent(value: number, fallback: number): number {
 }
 
 function normalizeCaptionStyle(style: CaptionStyle | undefined): CaptionStyle {
-  if (!style) {
-    return DEFAULT_CAPTION_STYLE;
-  }
-
-  return {
-    ...DEFAULT_CAPTION_STYLE,
-    ...style,
-    color: {
-      ...DEFAULT_CAPTION_STYLE.color,
-      ...style.color,
-    },
-    backgroundColor: style.backgroundColor
-      ? {
-          r: style.backgroundColor.r,
-          g: style.backgroundColor.g,
-          b: style.backgroundColor.b,
-          a: style.backgroundColor.a,
-        }
-      : undefined,
-    outlineColor: style.outlineColor
-      ? {
-          r: style.outlineColor.r,
-          g: style.outlineColor.g,
-          b: style.outlineColor.b,
-          a: style.outlineColor.a,
-        }
-      : undefined,
-    shadowColor: style.shadowColor
-      ? {
-          r: style.shadowColor.r,
-          g: style.shadowColor.g,
-          b: style.shadowColor.b,
-          a: style.shadowColor.a,
-        }
-      : undefined,
-  };
+  return normalizeCaptionStyleValue(style);
 }
 
 function normalizeCaptionPosition(position: CaptionPosition | undefined): CaptionPosition {
-  if (!position) {
-    return DEFAULT_CAPTION_POSITION;
-  }
-
-  if (position.type === 'custom') {
-    return {
-      type: 'custom',
-      xPercent: clampPercent(position.xPercent, 50),
-      yPercent: clampPercent(position.yPercent, 90),
-    };
-  }
-
-  return {
-    type: 'preset',
-    vertical: position.vertical,
-    marginPercent: clampPercent(position.marginPercent, 5),
-  };
+  return normalizeCaptionPositionValue(position);
 }
 
 function toRgba(color: { r: number; g: number; b: number; a: number }): string {
-  return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a / 255})`;
+  return captionColorToRgba(color);
+}
+
+function measureCaptionLineWidth(
+  ctx: CanvasRenderingContext2D,
+  line: string,
+  letterSpacing: number,
+): number {
+  const characters = Array.from(line);
+  if (characters.length <= 1 || letterSpacing === 0) {
+    return ctx.measureText(line).width;
+  }
+
+  return (
+    characters.reduce((width, character) => width + ctx.measureText(character).width, 0) +
+    letterSpacing * (characters.length - 1)
+  );
+}
+
+function drawCaptionLine(
+  ctx: CanvasRenderingContext2D,
+  line: string,
+  x: number,
+  y: number,
+  alignment: CanvasTextAlign,
+  letterSpacing: number,
+  mode: 'fill' | 'stroke',
+): void {
+  const characters = Array.from(line);
+  if (characters.length <= 1 || letterSpacing === 0) {
+    if (mode === 'stroke') {
+      ctx.strokeText(line, x, y);
+    } else {
+      ctx.fillText(line, x, y);
+    }
+    return;
+  }
+
+  const originalAlign = ctx.textAlign;
+  const totalWidth = measureCaptionLineWidth(ctx, line, letterSpacing);
+  let currentX = x;
+  if (alignment === 'center') {
+    currentX = x - totalWidth / 2;
+  } else if (alignment === 'right') {
+    currentX = x - totalWidth;
+  }
+
+  ctx.textAlign = 'left';
+  for (const character of characters) {
+    if (mode === 'stroke') {
+      ctx.strokeText(character, currentX, y);
+    } else {
+      ctx.fillText(character, currentX, y);
+    }
+    currentX += ctx.measureText(character).width + letterSpacing;
+  }
+  ctx.textAlign = originalAlign;
 }
 
 function renderCaptionClipToCanvas(
@@ -1123,10 +1148,10 @@ function renderCaptionClipToCanvas(
   }
 
   const fontSizePx = Math.max(12, (style.fontSize * canvasHeight) / 1080);
-  const fontWeight =
-    style.fontWeight === 'bold' ? '700' : style.fontWeight === 'light' ? '300' : '400';
+  const fontWeight = String(getCaptionFontWeightNumber(style));
   const fontStyle = style.italic ? 'italic ' : '';
-  const lineHeight = fontSizePx * 1.2;
+  const lineHeight = fontSizePx * (style.lineHeight ?? 1.2);
+  const letterSpacing = style.letterSpacing ?? 0;
 
   let xPercent = 50;
   if (style.alignment === 'left') {
@@ -1153,15 +1178,15 @@ function renderCaptionClipToCanvas(
   const firstLineY = textY - totalHeight / 2 + lineHeight / 2;
 
   ctx.save();
-  ctx.globalAlpha = clip.opacity;
+  ctx.globalAlpha = clip.opacity * (style.opacity ?? 1);
   ctx.font = `${fontStyle}${fontWeight} ${fontSizePx}px ${style.fontFamily}`;
   ctx.textAlign = style.alignment;
   ctx.textBaseline = 'middle';
 
   if (style.backgroundColor) {
-    const padding = fontSizePx * 0.25;
+    const padding = Math.max(0, style.backgroundPadding ?? fontSizePx * 0.25);
     const maxLineWidth = lines.reduce((maxWidth, line) => {
-      return Math.max(maxWidth, ctx.measureText(line).width);
+      return Math.max(maxWidth, measureCaptionLineWidth(ctx, line, letterSpacing));
     }, 0);
 
     let bgX = textX - maxLineWidth / 2 - padding;
@@ -1180,11 +1205,11 @@ function renderCaptionClipToCanvas(
     );
   }
 
-  if (style.shadowColor && style.shadowOffset > 0) {
+  if (style.shadowColor) {
     ctx.shadowColor = toRgba(style.shadowColor);
-    ctx.shadowOffsetX = style.shadowOffset;
-    ctx.shadowOffsetY = style.shadowOffset;
-    ctx.shadowBlur = style.shadowOffset;
+    ctx.shadowOffsetX = style.shadowOffsetX ?? style.shadowOffset;
+    ctx.shadowOffsetY = style.shadowOffsetY ?? style.shadowOffset;
+    ctx.shadowBlur = style.shadowBlur ?? 0;
   }
 
   if (style.outlineColor && style.outlineWidth > 0) {
@@ -1192,7 +1217,15 @@ function renderCaptionClipToCanvas(
     ctx.lineWidth = Math.max(1, style.outlineWidth);
     ctx.lineJoin = 'round';
     lines.forEach((line, index) => {
-      ctx.strokeText(line, textX, firstLineY + index * lineHeight);
+      drawCaptionLine(
+        ctx,
+        line,
+        textX,
+        firstLineY + index * lineHeight,
+        style.alignment,
+        letterSpacing,
+        'stroke',
+      );
     });
     ctx.shadowColor = 'transparent';
     ctx.shadowOffsetX = 0;
@@ -1203,20 +1236,22 @@ function renderCaptionClipToCanvas(
   ctx.fillStyle = toRgba(style.color);
   lines.forEach((line, index) => {
     const lineY = firstLineY + index * lineHeight;
-    ctx.fillText(line, textX, lineY);
+    drawCaptionLine(ctx, line, textX, lineY, style.alignment, letterSpacing, 'fill');
 
     if (style.underline) {
-      const metrics = ctx.measureText(line);
-      let underlineStartX = textX - metrics.width / 2;
+      const lineWidth = measureCaptionLineWidth(ctx, line, letterSpacing);
+      let underlineStartX = textX - lineWidth / 2;
       if (style.alignment === 'left') {
         underlineStartX = textX;
       } else if (style.alignment === 'right') {
-        underlineStartX = textX - metrics.width;
+        underlineStartX = textX - lineWidth;
+      } else {
+        underlineStartX = textX - lineWidth / 2;
       }
       const underlineY = lineY + fontSizePx * 0.35;
       ctx.beginPath();
       ctx.moveTo(underlineStartX, underlineY);
-      ctx.lineTo(underlineStartX + metrics.width, underlineY);
+      ctx.lineTo(underlineStartX + lineWidth, underlineY);
       ctx.lineWidth = Math.max(1, fontSizePx * 0.06);
       ctx.strokeStyle = toRgba(style.color);
       ctx.stroke();

--- a/src/components/preview/TransformOverlay.tsx
+++ b/src/components/preview/TransformOverlay.tsx
@@ -39,6 +39,8 @@ export interface TransformOverlayProps {
   panY: number;
   /** Additional CSS classes */
   className?: string;
+  /** Optional stacking order override for layered preview modes */
+  zIndex?: number;
 }
 
 type HandlePosition =
@@ -179,6 +181,7 @@ export const TransformOverlay = memo(function TransformOverlay({
   panX,
   panY,
   className = '',
+  zIndex,
 }: TransformOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const [dragState, setDragState] = useState<DragState | null>(null);
@@ -491,6 +494,7 @@ export const TransformOverlay = memo(function TransformOverlay({
       ref={overlayRef}
       className={`absolute inset-0 pointer-events-none ${className}`}
       data-testid="transform-overlay"
+      style={{ zIndex }}
     >
       {/* Bounding box */}
       <div

--- a/src/components/preview/UnifiedPreviewPlayer.tsx
+++ b/src/components/preview/UnifiedPreviewPlayer.tsx
@@ -12,6 +12,7 @@ import { memo, useMemo } from 'react';
 import { Music } from 'lucide-react';
 import { TimelinePreviewPlayer } from './TimelinePreviewPlayer';
 import { ProxyPreviewPlayer } from './ProxyPreviewPlayer';
+import type { TextPlacementCommitPayload } from './TextPlacementOverlay';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
 import { useProjectStore } from '@/stores/projectStore';
 import { usePlaybackStore } from '@/stores/playbackStore';
@@ -36,6 +37,10 @@ export interface UnifiedPreviewPlayerProps {
   onEnded?: () => void;
   /** Callback when frame is rendered (canvas mode only) */
   onFrameRender?: (time: number) => void;
+  /** Whether the preview should accept click-to-place text input */
+  textPlacementModeActive?: boolean;
+  /** Commit handler for text entered directly on the preview */
+  onTextPlacementCommit?: (payload: TextPlacementCommitPayload) => void | Promise<void>;
 }
 
 // =============================================================================
@@ -50,6 +55,8 @@ export const UnifiedPreviewPlayer = memo(function UnifiedPreviewPlayer({
   showStats = false,
   onEnded,
   onFrameRender,
+  textPlacementModeActive = false,
+  onTextPlacementCommit,
 }: UnifiedPreviewPlayerProps) {
   // Get sequence from prop or store
   const activeSequenceId = useProjectStore((state) => state.activeSequenceId);
@@ -113,6 +120,8 @@ export const UnifiedPreviewPlayer = memo(function UnifiedPreviewPlayer({
           assets={assets}
           className="w-full h-full"
           showControls={showControls}
+          textPlacementModeActive={textPlacementModeActive}
+          onTextPlacementCommit={onTextPlacementCommit}
         />
 
         {/* Mode indicator (dev only) */}
@@ -142,6 +151,8 @@ export const UnifiedPreviewPlayer = memo(function UnifiedPreviewPlayer({
         height={sequenceCanvas?.height}
         onEnded={onEnded}
         onFrameRender={onFrameRender}
+        textPlacementModeActive={textPlacementModeActive}
+        onTextPlacementCommit={onTextPlacementCommit}
       />
 
       {isAudioOnlySequence && (

--- a/src/components/timeline/EnhancedTimelineToolbar.tsx
+++ b/src/components/timeline/EnhancedTimelineToolbar.tsx
@@ -36,7 +36,12 @@ import {
 } from 'lucide-react';
 import { useTimelineStore } from '@/stores/timelineStore';
 import { usePlaybackStore } from '@/stores/playbackStore';
-import { useEditorToolStore, TOOL_CONFIGS, type EditorTool, type EditMode } from '@/stores/editorToolStore';
+import {
+  useEditorToolStore,
+  TOOL_CONFIGS,
+  type EditorTool,
+  type EditMode,
+} from '@/stores/editorToolStore';
 import { formatTimecode } from '@/utils/formatters';
 import { MIN_ZOOM, MAX_ZOOM } from './constants';
 
@@ -95,6 +100,8 @@ const ToolButton = memo(function ToolButton({
     switch (tool) {
       case 'select':
         return <MousePointer className="w-4 h-4" />;
+      case 'text':
+        return <Type className="w-4 h-4" />;
       case 'razor':
         return <Scissors className="w-4 h-4" />;
       case 'hand':
@@ -219,8 +226,9 @@ function EnhancedTimelineToolbarComponent({
   }, [toggleLinkedSelection]);
 
   const handleAddText = useCallback(() => {
+    setActiveTool('text');
     onAddText?.();
-  }, [onAddText]);
+  }, [onAddText, setActiveTool]);
 
   const handleAddVideoTrack = useCallback(() => {
     onAddVideoTrack?.();
@@ -422,10 +430,15 @@ function EnhancedTimelineToolbarComponent({
         <button
           data-testid="add-text-button"
           type="button"
-          className="p-1.5 rounded text-teal-400 hover:bg-teal-600/20 hover:text-teal-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          aria-pressed={activeTool === 'text'}
+          className={`p-1.5 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+            activeTool === 'text'
+              ? 'bg-teal-500/30 text-teal-300'
+              : 'text-teal-400 hover:bg-teal-600/20 hover:text-teal-300'
+          }`}
           onClick={handleAddText}
           disabled={!hasActiveSequence}
-          title="Add text (T)"
+          title="Text Tool (T)"
         >
           <Type className="w-4 h-4" />
         </button>

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -593,12 +593,14 @@ export function Timeline({
   });
 
   const applyAdvancedTrimChange = useCallback(
-    (change: {
-      clipId: string;
-      sourceIn?: number;
-      sourceOut?: number;
-      timelineIn?: number;
-    } | null) => {
+    (
+      change: {
+        clipId: string;
+        sourceIn?: number;
+        sourceOut?: number;
+        timelineIn?: number;
+      } | null,
+    ) => {
       if (
         !sequence ||
         !onClipTrim ||
@@ -1923,6 +1925,7 @@ export function Timeline({
     const toolCursor = getToolCursorStyle();
     if (toolCursor === 'crosshair') return 'cursor-crosshair';
     if (toolCursor === 'grab') return 'cursor-grab';
+    if (toolCursor === 'text') return 'cursor-text';
     if (toolCursor === 'ew-resize') return 'cursor-ew-resize';
     return '';
   };

--- a/src/hooks/useCaption.test.ts
+++ b/src/hooks/useCaption.test.ts
@@ -61,6 +61,46 @@ describe('useCaption', () => {
     });
   });
 
+  it('should preserve explicit null caption override updates', async () => {
+    const executeCommandMock = vi.fn(
+      async (): Promise<CommandResult> => ({
+        opId: 'op_update_caption',
+        changes: [],
+        createdIds: [],
+        deletedIds: [],
+      }),
+    );
+
+    useProjectStore.setState({
+      activeSequenceId: 'seq_001',
+      executeCommand: executeCommandMock,
+    });
+
+    const { result } = renderHook(() => useCaption());
+
+    await act(async () => {
+      await result.current.updateCaption('track_caption_1', {
+        ...sampleCaption,
+        styleOverride: null,
+        positionOverride: null,
+      } as unknown as Caption);
+    });
+
+    expect(executeCommandMock).toHaveBeenCalledWith({
+      type: 'UpdateCaption',
+      payload: {
+        sequenceId: 'seq_001',
+        trackId: 'track_caption_1',
+        captionId: 'cap_001',
+        text: 'Hello world',
+        startSec: 2,
+        endSec: 4,
+        style: null,
+        position: null,
+      },
+    });
+  });
+
   it('should execute CreateCaption and return created caption id', async () => {
     const executeCommandMock = vi.fn(
       async (): Promise<CommandResult> => ({

--- a/src/hooks/useCaption.ts
+++ b/src/hooks/useCaption.ts
@@ -94,8 +94,10 @@ export function useCaption(): UseCaptionResult {
             text: caption.text,
             startSec: caption.startSec,
             endSec: caption.endSec,
-            ...(caption.styleOverride ? { style: caption.styleOverride } : {}),
-            ...(caption.positionOverride ? { position: caption.positionOverride } : {}),
+            ...(caption.styleOverride !== undefined ? { style: caption.styleOverride } : {}),
+            ...(caption.positionOverride !== undefined
+              ? { position: caption.positionOverride }
+              : {}),
           },
         });
 
@@ -141,8 +143,8 @@ export function useCaption(): UseCaptionResult {
             text: params.text,
             startSec: params.startSec,
             endSec: params.endSec,
-            ...(params.style ? { style: params.style } : {}),
-            ...(params.position ? { position: params.position } : {}),
+            ...(params.style !== undefined ? { style: params.style } : {}),
+            ...(params.position !== undefined ? { position: params.position } : {}),
           },
         });
 

--- a/src/hooks/useCaption.ts
+++ b/src/hooks/useCaption.ts
@@ -7,7 +7,7 @@
 
 import { useState, useCallback } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
-import type { Caption } from '@/types';
+import type { Caption, CaptionPosition, CaptionStyle } from '@/types';
 import { createLogger } from '@/services/logger';
 
 const logger = createLogger('useCaption');
@@ -25,6 +25,10 @@ export interface CreateCaptionParams {
   endSec: number;
   /** Optional speaker name */
   speaker?: string;
+  /** Optional caption style override */
+  style?: CaptionStyle;
+  /** Optional caption position override */
+  position?: CaptionPosition;
 }
 
 export interface UseCaptionResult {
@@ -90,6 +94,8 @@ export function useCaption(): UseCaptionResult {
             text: caption.text,
             startSec: caption.startSec,
             endSec: caption.endSec,
+            ...(caption.styleOverride ? { style: caption.styleOverride } : {}),
+            ...(caption.positionOverride ? { position: caption.positionOverride } : {}),
           },
         });
 
@@ -135,6 +141,8 @@ export function useCaption(): UseCaptionResult {
             text: params.text,
             startSec: params.startSec,
             endSec: params.endSec,
+            ...(params.style ? { style: params.style } : {}),
+            ...(params.position ? { position: params.position } : {}),
           },
         });
 

--- a/src/hooks/useEnhancedKeyboardShortcuts.ts
+++ b/src/hooks/useEnhancedKeyboardShortcuts.ts
@@ -723,6 +723,7 @@ export const ENHANCED_KEYBOARD_SHORTCUTS = [
     category: 'Tools',
     shortcuts: [
       { key: 'V', description: 'Selection Tool' },
+      { key: 'T', description: 'Text Tool' },
       { key: 'C', description: 'Razor/Cut Tool' },
       { key: 'B', description: 'Ripple Edit Tool' },
       { key: 'Y', description: 'Slip Tool' },

--- a/src/hooks/useEnhancedKeyboardShortcuts.ts
+++ b/src/hooks/useEnhancedKeyboardShortcuts.ts
@@ -83,6 +83,7 @@ const SEEK_AMOUNT_LARGE = 5;
 /** Tool keyboard mappings */
 const TOOL_KEYS: Record<string, EditorTool> = {
   v: 'select',
+  t: 'text',
   c: 'razor',
   b: 'ripple',
   y: 'slip',

--- a/src/hooks/useRazorTool.ts
+++ b/src/hooks/useRazorTool.ts
@@ -272,6 +272,8 @@ export function useRazorTool(options: UseRazorToolOptions): UseRazorToolReturn {
     switch (activeTool) {
       case 'razor':
         return RAZOR_CURSOR;
+      case 'text':
+        return 'text';
       case 'hand':
         return 'grab';
       case 'slip':

--- a/src/stores/editorToolStore.test.ts
+++ b/src/stores/editorToolStore.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { act } from '@testing-library/react';
-import { useEditorToolStore } from './editorToolStore';
+import { TOOL_CONFIGS, getToolCursor, useEditorToolStore } from './editorToolStore';
 
 describe('editorToolStore — editMode', () => {
   beforeEach(() => {
@@ -66,6 +66,24 @@ describe('editorToolStore — editMode', () => {
     });
 
     expect(useEditorToolStore.getState().editMode).toBe('overwrite');
+  });
+});
+
+describe('editorToolStore — text tool', () => {
+  beforeEach(() => {
+    act(() => {
+      useEditorToolStore.getState().reset();
+    });
+  });
+
+  it('exposes the text placement tool with a text cursor', () => {
+    act(() => {
+      useEditorToolStore.getState().setActiveTool('text');
+    });
+
+    expect(useEditorToolStore.getState().activeTool).toBe('text');
+    expect(TOOL_CONFIGS.text.shortcut).toBe('T');
+    expect(getToolCursor('text')).toBe('text');
   });
 });
 

--- a/src/stores/editorToolStore.ts
+++ b/src/stores/editorToolStore.ts
@@ -33,6 +33,7 @@ export const RAZOR_CURSOR =
  */
 export type EditorTool =
   | 'select' // Default selection tool (V)
+  | 'text' // Place text directly on the program monitor (T)
   | 'razor' // Split/cut clips at click position (C)
   | 'slip' // Slip edit - adjust source range without moving clip
   | 'slide' // Slide edit - move clip while adjusting neighbors
@@ -173,6 +174,13 @@ export const TOOL_CONFIGS: Record<EditorTool, ToolConfig> = {
     shortcut: 'C',
     cursor: RAZOR_CURSOR,
     description: 'Split clips at click position',
+  },
+  text: {
+    id: 'text',
+    label: 'Text Tool',
+    shortcut: 'T',
+    cursor: 'text',
+    description: 'Place text in the program monitor',
   },
   slip: {
     id: 'slip',

--- a/src/stores/videoGenStore.test.ts
+++ b/src/stores/videoGenStore.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import { executeAgentCommand } from '@/agents/tools/commandExecutor';
-import { useVideoGenStore, type VideoGenJob } from './videoGenStore';
+import { useVideoGenStore, type VideoGenJob, type VideoGenPlacementRequest } from './videoGenStore';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
@@ -101,6 +101,27 @@ describe('videoGenStore placement sync', () => {
       sequenceId: 'seq-1',
       markerId: 'marker-1',
     });
+  });
+
+  it('ignores malformed placement input during generation submission', async () => {
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === 'submit_video_generation') {
+        return {
+          jobId: 'backend-job-1',
+          providerJobId: 'provider-job-1',
+          estimatedCostCents: 10,
+        };
+      }
+      throw new Error(`Unhandled invoke: ${command}`);
+    });
+
+    const jobId = await useVideoGenStore.getState().submitGeneration({
+      prompt: 'Generate a shot',
+      placement: 'invalid-placement' as unknown as VideoGenPlacementRequest,
+    });
+
+    const job = useVideoGenStore.getState().getJob(jobId);
+    expect(job?.placement).toBeNull();
   });
 
   it('keeps the imported asset when automatic placement fails', async () => {

--- a/src/stores/videoGenStore.test.ts
+++ b/src/stores/videoGenStore.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { executeAgentCommand } from '@/agents/tools/commandExecutor';
+import { useVideoGenStore, type VideoGenJob } from './videoGenStore';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@/agents/tools/commandExecutor', () => ({
+  executeAgentCommand: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedExecuteAgentCommand = vi.mocked(executeAgentCommand);
+
+function createJob(overrides: Partial<VideoGenJob> = {}): VideoGenJob {
+  return {
+    id: 'job-1',
+    providerJobId: 'provider-job-1',
+    prompt: 'Generate a shot',
+    mode: 'text_to_video',
+    quality: 'pro',
+    durationSec: 6,
+    status: 'downloading',
+    progress: 100,
+    estimatedCostCents: 10,
+    actualCostCents: null,
+    assetId: null,
+    placement: null,
+    placedClipId: null,
+    placementError: null,
+    error: null,
+    createdAt: '2026-05-23T00:00:00.000Z',
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe('videoGenStore placement sync', () => {
+  beforeEach(() => {
+    mockedInvoke.mockReset();
+    mockedExecuteAgentCommand.mockReset();
+    useVideoGenStore.getState().stopPolling();
+    useVideoGenStore.setState({
+      jobs: new Map(),
+      isPolling: false,
+      pollingIntervalId: null,
+      isPollInFlight: false,
+      completionInFlight: new Set(),
+    });
+  });
+
+  it('places generated assets on the timeline when placement metadata is present', async () => {
+    useVideoGenStore.setState({
+      jobs: new Map([
+        [
+          'job-1',
+          createJob({
+            placement: {
+              sequenceId: 'seq-1',
+              trackId: 'video-1',
+              timelineStart: 3,
+              markerId: 'marker-1',
+              removeMarkerOnPlace: true,
+            },
+          }),
+        ],
+      ]),
+    });
+
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === 'download_generated_video') return { outputPath: '/project/generated.mp4' };
+      if (command === 'import_asset') return { id: 'asset-generated' };
+      if (command === 'generate_asset_thumbnail') return null;
+      throw new Error(`Unhandled invoke: ${command}`);
+    });
+    mockedExecuteAgentCommand.mockImplementation(async (commandType) => ({
+      opId: commandType === 'InsertClip' ? 'op-insert' : 'op-marker',
+      changes: [],
+      createdIds: commandType === 'InsertClip' ? ['clip-generated'] : [],
+      deletedIds: commandType === 'RemoveMarker' ? ['marker-1'] : [],
+    }));
+
+    await useVideoGenStore.getState().onJobCompleted('job-1');
+
+    const job = useVideoGenStore.getState().getJob('job-1');
+    expect(job).toMatchObject({
+      status: 'completed',
+      assetId: 'asset-generated',
+      placedClipId: 'clip-generated',
+      placementError: null,
+    });
+    expect(mockedExecuteAgentCommand).toHaveBeenCalledWith('InsertClip', {
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-generated',
+      timelineStart: 3,
+    });
+    expect(mockedExecuteAgentCommand).toHaveBeenCalledWith('RemoveMarker', {
+      sequenceId: 'seq-1',
+      markerId: 'marker-1',
+    });
+  });
+
+  it('keeps the imported asset when automatic placement fails', async () => {
+    useVideoGenStore.setState({
+      jobs: new Map([
+        [
+          'job-1',
+          createJob({
+            placement: {
+              sequenceId: 'seq-1',
+              trackId: 'video-1',
+              timelineStart: 3,
+            },
+          }),
+        ],
+      ]),
+    });
+
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === 'download_generated_video') return { outputPath: '/project/generated.mp4' };
+      if (command === 'import_asset') return { id: 'asset-generated' };
+      if (command === 'generate_asset_thumbnail') return null;
+      throw new Error(`Unhandled invoke: ${command}`);
+    });
+    mockedExecuteAgentCommand.mockRejectedValue(new Error('track is locked'));
+
+    await useVideoGenStore.getState().onJobCompleted('job-1');
+
+    const job = useVideoGenStore.getState().getJob('job-1');
+    expect(job).toMatchObject({
+      status: 'completed',
+      assetId: 'asset-generated',
+      placedClipId: null,
+      placementError: 'track is locked',
+    });
+  });
+});

--- a/src/stores/videoGenStore.ts
+++ b/src/stores/videoGenStore.ts
@@ -131,23 +131,25 @@ function normalizeReferencePaths(values: string[] | undefined, maxItems: number)
     .slice(0, maxItems);
 }
 
-function normalizePlacement(placement?: VideoGenPlacementRequest | null): VideoGenPlacementRequest | null {
-  if (!placement) return null;
-  const sequenceId = placement.sequenceId.trim();
-  const trackId = placement.trackId.trim();
+function normalizePlacement(placement?: unknown): VideoGenPlacementRequest | null {
+  if (!placement || typeof placement !== 'object' || Array.isArray(placement)) return null;
+
+  const raw = placement as Record<string, unknown>;
+  const sequenceId = typeof raw.sequenceId === 'string' ? raw.sequenceId.trim() : '';
+  const trackId = typeof raw.trackId === 'string' ? raw.trackId.trim() : '';
   if (!sequenceId || !trackId) return null;
 
   const timelineStart =
-    typeof placement.timelineStart === 'number' && Number.isFinite(placement.timelineStart)
-      ? Math.max(0, placement.timelineStart)
+    typeof raw.timelineStart === 'number' && Number.isFinite(raw.timelineStart)
+      ? Math.max(0, raw.timelineStart)
       : 0;
 
   return {
     sequenceId,
     trackId,
     timelineStart,
-    markerId: placement.markerId?.trim() || null,
-    removeMarkerOnPlace: placement.removeMarkerOnPlace !== false,
+    markerId: typeof raw.markerId === 'string' && raw.markerId.trim() ? raw.markerId.trim() : null,
+    removeMarkerOnPlace: raw.removeMarkerOnPlace !== false,
   };
 }
 

--- a/src/stores/videoGenStore.ts
+++ b/src/stores/videoGenStore.ts
@@ -10,6 +10,7 @@ import { immer } from 'zustand/middleware/immer';
 import { enableMapSet } from 'immer';
 import { invoke } from '@tauri-apps/api/core';
 import { createLogger } from '@/services/logger';
+import { executeAgentCommand } from '@/agents/tools/commandExecutor';
 
 enableMapSet();
 
@@ -30,6 +31,14 @@ export type VideoGenJobStatus =
   | 'completed'
   | 'failed'
   | 'cancelled';
+
+export interface VideoGenPlacementRequest {
+  sequenceId: string;
+  trackId: string;
+  timelineStart: number;
+  markerId?: string | null;
+  removeMarkerOnPlace?: boolean;
+}
 
 export interface VideoGenJob {
   /** Local UUID */
@@ -54,6 +63,12 @@ export interface VideoGenJob {
   actualCostCents: number | null;
   /** Asset ID after import into project */
   assetId: string | null;
+  /** Optional timeline placement intent captured when the job was submitted */
+  placement: VideoGenPlacementRequest | null;
+  /** Clip ID created by automatic placement after import */
+  placedClipId: string | null;
+  /** Placement failure does not invalidate the generated/imported asset */
+  placementError: string | null;
   /** Error message if failed */
   error: string | null;
   /** ISO timestamp when created */
@@ -75,6 +90,7 @@ export interface SubmitGenerationParams {
   aspectRatio?: string;
   seed?: number;
   lipSyncLanguage?: string;
+  placement?: VideoGenPlacementRequest | null;
 }
 
 // =============================================================================
@@ -113,6 +129,26 @@ function normalizeReferencePaths(values: string[] | undefined, maxItems: number)
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
     .slice(0, maxItems);
+}
+
+function normalizePlacement(placement?: VideoGenPlacementRequest | null): VideoGenPlacementRequest | null {
+  if (!placement) return null;
+  const sequenceId = placement.sequenceId.trim();
+  const trackId = placement.trackId.trim();
+  if (!sequenceId || !trackId) return null;
+
+  const timelineStart =
+    typeof placement.timelineStart === 'number' && Number.isFinite(placement.timelineStart)
+      ? Math.max(0, placement.timelineStart)
+      : 0;
+
+  return {
+    sequenceId,
+    trackId,
+    timelineStart,
+    markerId: placement.markerId?.trim() || null,
+    removeMarkerOnPlace: placement.removeMarkerOnPlace !== false,
+  };
 }
 
 function trimRetainedJobs(jobs: Map<string, VideoGenJob>): void {
@@ -198,6 +234,7 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
       const referenceImages = normalizeReferencePaths(params.referenceImages, 9);
       const referenceVideos = normalizeReferencePaths(params.referenceVideos, 3);
       const referenceAudio = normalizeReferencePaths(params.referenceAudio, 3);
+      const placement = normalizePlacement(params.placement);
 
       const localId = crypto.randomUUID();
 
@@ -215,6 +252,9 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
           estimatedCostCents: 0,
           actualCostCents: null,
           assetId: null,
+          placement,
+          placedClipId: null,
+          placementError: null,
           error: null,
           createdAt: new Date().toISOString(),
           completedAt: null,
@@ -492,11 +532,51 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
           logger.warn('Thumbnail generation failed', { error: String(thumbErr) });
         }
 
+        const placement = get().jobs.get(jobId)?.placement ?? null;
+        let placedClipId: string | null = null;
+        let placementError: string | null = null;
+
+        if (placement) {
+          try {
+            const placementResult = await executeAgentCommand('InsertClip', {
+              sequenceId: placement.sequenceId,
+              trackId: placement.trackId,
+              assetId: importResult.id,
+              timelineStart: placement.timelineStart,
+            });
+            placedClipId = placementResult.createdIds[0] ?? null;
+
+            if (placement.markerId && placement.removeMarkerOnPlace) {
+              try {
+                await executeAgentCommand('RemoveMarker', {
+                  sequenceId: placement.sequenceId,
+                  markerId: placement.markerId,
+                });
+              } catch (markerError) {
+                logger.warn('Failed to remove pending generation marker after placement', {
+                  jobId,
+                  markerId: placement.markerId,
+                  error: String(markerError),
+                });
+              }
+            }
+          } catch (error) {
+            placementError = error instanceof Error ? error.message : String(error);
+            logger.error('Generated asset placement failed', {
+              jobId,
+              assetId: importResult.id,
+              error: placementError,
+            });
+          }
+        }
+
         set((state) => {
           const j = state.jobs.get(jobId);
           if (j) {
             j.status = 'completed';
             j.assetId = importResult.id;
+            j.placedClipId = placedClipId;
+            j.placementError = placementError;
             j.completedAt = new Date().toISOString();
           }
           trimRetainedJobs(state.jobs);
@@ -505,6 +585,7 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
         logger.info('Video generation completed and imported', {
           jobId,
           assetId: importResult.id,
+          placedClipId,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -430,12 +430,7 @@ export interface Transform {
 }
 
 /** Audio fade curve type */
-export type FadeType =
-  | 'linear'
-  | 'constantGain'
-  | 'constantPower'
-  | 'exponential'
-  | 'sCurve';
+export type FadeType = 'linear' | 'constantGain' | 'constantPower' | 'exponential' | 'sCurve';
 
 /** Parameters for audio ducking (auto-duck music during speech) */
 export interface AudioDuckingParams {
@@ -537,10 +532,7 @@ export interface Clip {
 
 /** Returns true if the clip has a valid active time remap curve (>= 2 keyframes). */
 export function hasActiveTimeRemap(clip: Pick<Clip, 'timeRemap'>): boolean {
-  return (
-    clip.timeRemap != null &&
-    clip.timeRemap.keyframes.length >= 2
-  );
+  return clip.timeRemap != null && clip.timeRemap.keyframes.length >= 2;
 }
 
 export interface Marker {
@@ -562,7 +554,7 @@ export type VerticalPosition = 'bottom' | 'top' | 'center';
 export type TextAlignment = 'left' | 'center' | 'right';
 
 /** Font weight */
-export type FontWeight = 'normal' | 'bold' | 'light';
+export type FontWeight = 'normal' | 'bold' | 'light' | number;
 
 /** Custom position with x/y coordinates (percentage) */
 export interface CustomPosition {
@@ -588,15 +580,23 @@ export interface CaptionStyle {
   fontFamily: string;
   fontSize: number;
   fontWeight: FontWeight;
+  bold?: boolean;
   color: CaptionColor;
+  opacity?: number;
   backgroundColor?: CaptionColor;
+  backgroundPadding?: number;
   outlineColor?: CaptionColor;
   outlineWidth: number;
   shadowColor?: CaptionColor;
   shadowOffset: number;
+  shadowOffsetX?: number;
+  shadowOffsetY?: number;
+  shadowBlur?: number;
   alignment: TextAlignment;
   italic: boolean;
   underline: boolean;
+  lineHeight?: number;
+  letterSpacing?: number;
 }
 
 /** A single caption entry with text and timing */
@@ -633,9 +633,16 @@ export const DEFAULT_CAPTION_STYLE: CaptionStyle = {
   outlineWidth: 2,
   shadowColor: { r: 0, g: 0, b: 0, a: 128 },
   shadowOffset: 2,
+  shadowOffsetX: 2,
+  shadowOffsetY: 2,
+  shadowBlur: 0,
   alignment: 'center',
   italic: false,
   underline: false,
+  opacity: 1,
+  backgroundPadding: 10,
+  lineHeight: 1.2,
+  letterSpacing: 0,
 };
 
 /** Default caption position */

--- a/src/utils/captionStyle.test.ts
+++ b/src/utils/captionStyle.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCaptionFontWeightNumber,
+  normalizeCaptionPosition,
+  normalizeCaptionStyle,
+  parseCaptionHexColor,
+} from './captionStyle';
+
+describe('captionStyle utilities', () => {
+  it('normalizes legacy partial caption style with modern defaults', () => {
+    const style = normalizeCaptionStyle({
+      fontSize: 64,
+      fontWeight: 700,
+      color: '#112233cc',
+      shadowOffset: 4,
+    });
+
+    expect(style.fontSize).toBe(64);
+    expect(style.color).toEqual({ r: 17, g: 34, b: 51, a: 204 });
+    expect(style.shadowOffsetX).toBe(4);
+    expect(style.shadowOffsetY).toBe(4);
+    expect(style.lineHeight).toBe(1.2);
+    expect(getCaptionFontWeightNumber(style)).toBe(700);
+  });
+
+  it('parses short and alpha hex colors', () => {
+    expect(parseCaptionHexColor('#abc')).toEqual({ r: 170, g: 187, b: 204, a: 255 });
+    expect(parseCaptionHexColor('#abcd')).toEqual({ r: 170, g: 187, b: 204, a: 221 });
+  });
+
+  it('normalizes custom and preset caption positions', () => {
+    expect(normalizeCaptionPosition({ type: 'custom', xPercent: 150, yPercent: -20 })).toEqual({
+      type: 'custom',
+      xPercent: 100,
+      yPercent: 0,
+    });
+
+    expect(
+      normalizeCaptionPosition({ type: 'preset', vertical: 'top', marginPercent: 60 }),
+    ).toEqual({
+      type: 'preset',
+      vertical: 'top',
+      marginPercent: 50,
+    });
+  });
+});

--- a/src/utils/captionStyle.test.ts
+++ b/src/utils/captionStyle.test.ts
@@ -23,6 +23,16 @@ describe('captionStyle utilities', () => {
     expect(getCaptionFontWeightNumber(style)).toBe(700);
   });
 
+  it('does not preserve unknown style keys during normalization', () => {
+    const style = normalizeCaptionStyle({
+      fontSize: 64,
+      unexpectedKey: 'leak',
+    });
+
+    expect(style.fontSize).toBe(64);
+    expect(style).not.toHaveProperty('unexpectedKey');
+  });
+
   it('parses short and alpha hex colors', () => {
     expect(parseCaptionHexColor('#abc')).toEqual({ r: 170, g: 187, b: 204, a: 255 });
     expect(parseCaptionHexColor('#abcd')).toEqual({ r: 170, g: 187, b: 204, a: 221 });

--- a/src/utils/captionStyle.ts
+++ b/src/utils/captionStyle.ts
@@ -1,0 +1,331 @@
+import {
+  DEFAULT_CAPTION_POSITION,
+  DEFAULT_CAPTION_STYLE,
+  type CaptionColor,
+  type CaptionPosition,
+  type CaptionStyle,
+  type FontWeight,
+  type TextAlignment,
+} from '@/types';
+
+type CaptionStyleLike = Partial<CaptionStyle> & Record<string, unknown>;
+
+const HEX_COLOR_PATTERN = /^#?([a-fA-F\d]{3}|[a-fA-F\d]{4}|[a-fA-F\d]{6}|[a-fA-F\d]{8})$/;
+
+function clamp(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(min, Math.min(max, value));
+}
+
+function readNumber(value: unknown, fallback: number, min: number, max: number): number {
+  return clamp(Number(value), min, max, fallback);
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+
+  return fallback;
+}
+
+function readAlignment(value: unknown, fallback: TextAlignment): TextAlignment {
+  return value === 'left' || value === 'center' || value === 'right' ? value : fallback;
+}
+
+function normalizeFontWeight(value: unknown, bold: boolean): FontWeight {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.round(clamp(value, 100, 900, bold ? 700 : 400));
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'bold') return 'bold';
+    if (normalized === 'light') return 'light';
+    if (normalized === 'normal') return 'normal';
+    const numeric = Number(normalized);
+    if (Number.isFinite(numeric)) {
+      return Math.round(clamp(numeric, 100, 900, bold ? 700 : 400));
+    }
+  }
+
+  return bold ? 'bold' : DEFAULT_CAPTION_STYLE.fontWeight;
+}
+
+function normalizeHex(raw: string): string | null {
+  const match = raw.trim().match(HEX_COLOR_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  let hex = match[1];
+  if (hex.length === 3 || hex.length === 4) {
+    hex = hex
+      .split('')
+      .map((char) => `${char}${char}`)
+      .join('');
+  }
+
+  return hex;
+}
+
+export function parseCaptionHexColor(raw: string): CaptionColor | null {
+  const hex = normalizeHex(raw);
+  if (!hex) {
+    return null;
+  }
+
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16),
+    a: hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) : 255,
+  };
+}
+
+export function captionColorToHex(color: CaptionColor | undefined, fallback = '#ffffff'): string {
+  if (!color) {
+    return fallback;
+  }
+
+  const toHex = (value: number): string =>
+    clamp(Math.round(value), 0, 255, 0).toString(16).padStart(2, '0');
+
+  return `#${toHex(color.r)}${toHex(color.g)}${toHex(color.b)}`;
+}
+
+export function captionColorToRgba(color: CaptionColor): string {
+  const alpha = clamp(color.a / 255, 0, 1, 1);
+  return `rgba(${clamp(color.r, 0, 255, 255)}, ${clamp(color.g, 0, 255, 255)}, ${clamp(color.b, 0, 255, 255)}, ${alpha})`;
+}
+
+function normalizeCaptionColor(value: unknown, fallback: CaptionColor): CaptionColor {
+  if (typeof value === 'string') {
+    return parseCaptionHexColor(value) ?? { ...fallback };
+  }
+
+  if (value && typeof value === 'object') {
+    const candidate = value as Partial<CaptionColor>;
+    return {
+      r: Math.round(readNumber(candidate.r, fallback.r, 0, 255)),
+      g: Math.round(readNumber(candidate.g, fallback.g, 0, 255)),
+      b: Math.round(readNumber(candidate.b, fallback.b, 0, 255)),
+      a: Math.round(readNumber(candidate.a, fallback.a, 0, 255)),
+    };
+  }
+
+  return { ...fallback };
+}
+
+function normalizeOptionalCaptionColor(value: unknown): CaptionColor | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  return normalizeCaptionColor(value, { r: 0, g: 0, b: 0, a: 255 });
+}
+
+export function getCaptionFontWeightNumber(style: CaptionStyle): number {
+  if (typeof style.fontWeight === 'number') {
+    return Math.round(clamp(style.fontWeight, 100, 900, 400));
+  }
+
+  if (style.bold) {
+    return 700;
+  }
+
+  if (style.fontWeight === 'bold') {
+    return 700;
+  }
+
+  if (style.fontWeight === 'light') {
+    return 300;
+  }
+
+  return 400;
+}
+
+export function normalizeCaptionStyle(style: unknown): CaptionStyle {
+  const source: CaptionStyleLike =
+    style && typeof style === 'object' ? (style as CaptionStyleLike) : {};
+  const defaultShadowOffset = DEFAULT_CAPTION_STYLE.shadowOffset;
+  const bold = readBoolean(source.bold, source.fontWeight === 'bold');
+  const fontWeight = normalizeFontWeight(source.fontWeight, bold);
+  const shadowOffset = readNumber(source.shadowOffset, defaultShadowOffset, -500, 500);
+
+  return {
+    ...DEFAULT_CAPTION_STYLE,
+    ...source,
+    fontFamily:
+      typeof source.fontFamily === 'string' && source.fontFamily.trim().length > 0
+        ? source.fontFamily.trim()
+        : DEFAULT_CAPTION_STYLE.fontFamily,
+    fontSize: readNumber(source.fontSize, DEFAULT_CAPTION_STYLE.fontSize, 1, 500),
+    fontWeight,
+    bold,
+    color: normalizeCaptionColor(source.color, DEFAULT_CAPTION_STYLE.color),
+    opacity: readNumber(source.opacity, DEFAULT_CAPTION_STYLE.opacity ?? 1, 0, 1),
+    backgroundColor: normalizeOptionalCaptionColor(source.backgroundColor),
+    backgroundPadding: readNumber(
+      source.backgroundPadding,
+      DEFAULT_CAPTION_STYLE.backgroundPadding ?? 10,
+      0,
+      500,
+    ),
+    outlineColor: normalizeOptionalCaptionColor(source.outlineColor),
+    outlineWidth: readNumber(source.outlineWidth, DEFAULT_CAPTION_STYLE.outlineWidth, 0, 100),
+    shadowColor: normalizeOptionalCaptionColor(source.shadowColor),
+    shadowOffset,
+    shadowOffsetX: readNumber(source.shadowOffsetX, shadowOffset, -500, 500),
+    shadowOffsetY: readNumber(source.shadowOffsetY, shadowOffset, -500, 500),
+    shadowBlur: readNumber(source.shadowBlur, DEFAULT_CAPTION_STYLE.shadowBlur ?? 0, 0, 500),
+    alignment: readAlignment(source.alignment, DEFAULT_CAPTION_STYLE.alignment),
+    italic: readBoolean(source.italic, DEFAULT_CAPTION_STYLE.italic),
+    underline: readBoolean(source.underline, DEFAULT_CAPTION_STYLE.underline),
+    lineHeight: readNumber(source.lineHeight, DEFAULT_CAPTION_STYLE.lineHeight ?? 1.2, 0.5, 5),
+    letterSpacing: readNumber(
+      source.letterSpacing,
+      DEFAULT_CAPTION_STYLE.letterSpacing ?? 0,
+      -100,
+      200,
+    ),
+  };
+}
+
+export function normalizeCaptionPosition(
+  position: CaptionPosition | null | undefined,
+): CaptionPosition {
+  if (!position || typeof position !== 'object') {
+    return DEFAULT_CAPTION_POSITION;
+  }
+
+  if (position.type === 'custom') {
+    return {
+      type: 'custom',
+      xPercent: readNumber(position.xPercent, 50, 0, 100),
+      yPercent: readNumber(position.yPercent, 90, 0, 100),
+    };
+  }
+
+  const vertical =
+    position.vertical === 'top' || position.vertical === 'center' || position.vertical === 'bottom'
+      ? position.vertical
+      : DEFAULT_CAPTION_POSITION.type === 'preset'
+        ? DEFAULT_CAPTION_POSITION.vertical
+        : 'bottom';
+
+  return {
+    type: 'preset',
+    vertical,
+    marginPercent: readNumber(position.marginPercent, 5, 0, 50),
+  };
+}
+
+export function parseCaptionPositionValue(value: unknown): CaptionPosition | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Partial<CaptionPosition> & Record<string, unknown>;
+
+  if (candidate.type === 'custom') {
+    return normalizeCaptionPosition({
+      type: 'custom',
+      xPercent: Number(candidate.xPercent),
+      yPercent: Number(candidate.yPercent),
+    });
+  }
+
+  if (candidate.type === 'preset') {
+    const vertical =
+      candidate.vertical === 'top' || candidate.vertical === 'center'
+        ? candidate.vertical
+        : 'bottom';
+    return normalizeCaptionPosition({
+      type: 'preset',
+      vertical,
+      marginPercent: Number(candidate.marginPercent),
+    });
+  }
+
+  if ('xPercent' in candidate || 'yPercent' in candidate || 'x' in candidate || 'y' in candidate) {
+    return normalizeCaptionPosition({
+      type: 'custom',
+      xPercent: Number(candidate.xPercent ?? candidate.x),
+      yPercent: Number(candidate.yPercent ?? candidate.y),
+    });
+  }
+
+  return null;
+}
+
+export function resolveCaptionAnchor(
+  style: CaptionStyle,
+  position: CaptionPosition,
+): {
+  xPercent: number;
+  yPercent: number;
+} {
+  let xPercent = 50;
+  if (style.alignment === 'left') {
+    xPercent = 10;
+  } else if (style.alignment === 'right') {
+    xPercent = 90;
+  }
+
+  let yPercent = 90;
+  if (position.type === 'custom') {
+    xPercent = position.xPercent;
+    yPercent = position.yPercent;
+  } else if (position.vertical === 'top') {
+    yPercent = position.marginPercent;
+  } else if (position.vertical === 'center') {
+    yPercent = 50;
+  } else {
+    yPercent = 100 - position.marginPercent;
+  }
+
+  return {
+    xPercent: readNumber(xPercent, 50, 0, 100),
+    yPercent: readNumber(yPercent, 90, 0, 100),
+  };
+}
+
+export function buildCaptionCssTextShadow(style: CaptionStyle): string | undefined {
+  const parts: string[] = [];
+
+  if (style.outlineColor && style.outlineWidth > 0) {
+    const width = Math.max(1, Math.round(style.outlineWidth));
+    const outline = captionColorToRgba(style.outlineColor);
+    parts.push(
+      `${-width}px 0 ${outline}`,
+      `${width}px 0 ${outline}`,
+      `0 ${-width}px ${outline}`,
+      `0 ${width}px ${outline}`,
+      `${-width}px ${-width}px ${outline}`,
+      `${width}px ${-width}px ${outline}`,
+      `${-width}px ${width}px ${outline}`,
+      `${width}px ${width}px ${outline}`,
+    );
+  }
+
+  if (style.shadowColor) {
+    const offsetX = style.shadowOffsetX ?? style.shadowOffset;
+    const offsetY = style.shadowOffsetY ?? style.shadowOffset;
+    const blur = style.shadowBlur ?? 0;
+    if (offsetX !== 0 || offsetY !== 0 || blur > 0) {
+      parts.push(`${offsetX}px ${offsetY}px ${blur}px ${captionColorToRgba(style.shadowColor)}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(', ') : undefined;
+}

--- a/src/utils/captionStyle.ts
+++ b/src/utils/captionStyle.ts
@@ -164,7 +164,6 @@ export function normalizeCaptionStyle(style: unknown): CaptionStyle {
 
   return {
     ...DEFAULT_CAPTION_STYLE,
-    ...source,
     fontFamily:
       typeof source.fontFamily === 'string' && source.fontFamily.trim().length > 0
         ? source.fontFamily.trim()


### PR DESCRIPTION
### **User description**
## Description

Adds a combined editing workflow upgrade covering rich caption styling and placement, direct program monitor text placement, and provider-neutral generative media orchestration. The branch also fixes stale timecode input confirmation and updates asset discovery documentation for approval-gated imports.

## Related Issue

Closes #697, closes #698, closes #699, closes #700, closes #701

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added shared caption style/position normalization, richer caption inspector controls, structured CLI caption positioning, agent caption styling fields, and preview/export rendering support for advanced caption styling.
- Added a text tool workflow for click-to-place program monitor text, including inline preview input, toolbar/shortcut/cursor integration, automatic track handling, custom text font names, and related preview overlay updates.
- Added generative timeline media tools, generation placement sync, SFX candidate search/import flows, generate meta-tool/playbook exposure, permission/output contract updates, and approval-gated asset discovery documentation.

## Screenshots / Videos

N/A

## Testing

Targeted TypeScript and Rust tests were run for the changed caption, preview, inspector, agent, generation, and store paths. Commit hooks also ran version sync checks, TypeScript type-checking, and ESLint for each commit.

### Test Environment

- OS: Other Linux (WSL2)
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Validation performed:

- `npm run test:run -- src/utils/captionStyle.test.ts src/components/features/inspector/Inspector.test.tsx src/components/features/inspector/TextInspector.test.tsx src/components/preview/ProxyPreviewPlayer.test.tsx src/stores/editorToolStore.test.ts src/stores/videoGenStore.test.ts src/agents/tools/captionTools.test.ts src/agents/tools/metaTools.test.ts src/agents/tools/generativeTimelineTools.test.ts src/agents/engine/adapters/tools/ToolRegistryAdapter.test.ts src/agents/engine/core/orchestrationPlaybooks.test.ts`
- `cargo test -p openreelio-cli build_schema_documents_richer_caption_surface`
- `cargo test -p openreelio test_build_filter_caption_style_maps_rgba_and_position`
- `git diff --check`


___

### **PR Type**
Enhancement, Bug fix, Documentation, Tests


___

### **Description**
- Orchestrates generative media workflows with provider-neutral tools and timeline sync.

- Adds a click-to-place text tool for direct program monitor editing.

- Enhances caption styling with rich controls for fonts, outlines, and shadows.

- Fixes stale timecode input confirmation and documents approval-gated asset imports.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Agent["AI Agent"] -- "generate_timeline_media" --> GenTools["Generative Tools"]
  GenTools -- "create marker" --> Timeline["Timeline"]
  GenTools -- "poll status" --> GenStore["Generation Store"]
  GenStore -- "auto-place" --> Timeline
  User["User"] -- "Text Tool (T)" --> Preview["Program Monitor"]
  Preview -- "commit" --> Timeline
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>generativeTimelineTools.ts</strong><dd><code>New provider-neutral generative media orchestration tools</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-918285df0c8c3ad382a59050236cb3987b76903727905af559cefed411080032">+684/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>InspectorPanels.tsx</strong><dd><code>Expanded caption inspector with rich styling controls</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-14170d9f3621a2af31b49b4c4cf50689eb453ff1d22aee8d7d16e6a0cbbf6a0a">+487/-35</a></td>

</tr>

<tr>
  <td><strong>TimelinePreviewPlayer.tsx</strong><dd><code>Integrated text placement overlay and advanced caption rendering</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-4d288d619dc53b5be764a00b666c542c6daa5d478e6fd1e7e1a6d6e4c9cf90c0">+124/-89</a></td>

</tr>

<tr>
  <td><strong>captionStyle.ts</strong><dd><code>Centralized caption style normalization and CSS/Canvas conversion</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-dce09bb8eca8556f32ae1ba347dca37fbd6d6c55d900e8acc9c7ffa18f77928b">+331/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>EditorView.tsx</strong><dd><code>Added text tool activation and preview placement handlers</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-382f457b2b2ae7d56d3a83f74c92b764a355a1f23c23ae7bb103d3ad306a63da">+118/-48</a></td>

</tr>

<tr>
  <td><strong>metaTools.ts</strong><dd><code>Exposed new 'generate' meta-tool for agent orchestration</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-842f7132c091ca5476d87b73a280cb7192ba997487dfea06a0bd4e097e1a19b7">+79/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>editorToolStore.ts</strong><dd><code>Added text tool definition to editor state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-d4abdeae43486b9f57775ad11ef886d04e06a208467bfc73e81b9e498bd5af87">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>TimecodeInput.tsx</strong><dd><code>Fix stale value confirmation in timecode input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-a0f37074a17fc17b92be12b2f701e2cfbe68fcc385573d44603eabc4fca5dfda">+11/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ASSET_DISCOVERY.md</strong><dd><code>Documented approval-gated asset import workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-4d0408e86c752396d8d6783f8da55ecc171e53a4e377b8fdc41d22d1258e2be0">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>generativeTimelineTools.test.ts</strong><dd><code>Tests for generative orchestration and stock search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-e377a8221d7dcaa3754373998d3080b2bbd30301a4cf32fd40a84805edfe1b13">+318/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>38 files</summary><table>
<tr>
  <td><strong>ci.yml</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>caption.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-57ce46b7a549091037f84030307fe41615baba99edaf2ead0fa5ad01e8d1eda8">+91/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>help_json.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>caption.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-53a364efaff2c8190669569c762f7bf8e798a18e8877ae2f434d970594d25d5e">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+79/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistryAdapter.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-d0107437d486f48872dff04f1c3a82ea641b907a9e0aba34330b10078a382ac8">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistryAdapter.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-f3778719dba36a355947514a6c8186918dff8be145ee79c8d149f111af997316">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>orchestrationPlaybooks.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-67d3eacb874ecec818bd0ce91121099f09ec003b88b4d925c6c196977bc37ece">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>orchestrationPlaybooks.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-1ee42f69433d7f5b0ae2ed0d4266e876c367fb882e94916bc493082e13145990">+107/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>permissionSubject.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-6c9e740e8475349cb8abd4b19f6826ef03e278906e8fd9e98ff331e7666eb595">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolSemantics.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-3fdd608949cbaa8fbb6897adce1b947150bf08ee9688d837030708d946bed5ee">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolReference.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+22/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolOutputContracts.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-2fe279e63827a652ff07a52579998fb029ad15e9604be67586e5659c39ddc75f">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>captionTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-f897a412b5783f9eb35969da1eab2cf87782950977e1f7992a16d9fd8dcc7811">+52/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>captionTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-31ec5d3d07a41724c99111a19643099c0ac5e33606c2f723ebc9fcb3c67e3380">+214/-8</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>generationTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-005fb6a8abb8e085c5da9219b47c436c13a0bce48b4a7ed5e7c0d03d583e62c0">+59/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-1bae2c0a07674ec354a14292cfdf65f7937938fb4c629405ba459a3993e4c560">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-fba7abc9f4898abb5634a8c17070efef12feabcf68d91924e06c08e62de4e01e">+46/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EditorPanels.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-09c35f0f54628a35f51a56137bc0b05240002f64fdda095117d3a61af500c67f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Inspector.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-e18ba051257ceae99c48e23bb8d29da126a4907d5b45925686d704c7f4c549be">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Inspector.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-d4baf848d3d3c346a280c4049f8adf0ff0b20052bb6cf927f6f7163a92614947">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TextInspector.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-7e9661566da334840ae879281db5e4e4e158a277cc79b4570f82d83dcb215de2">+44/-36</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TextInspector.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-24d73e707c518adc632711249c6bdca6325decbc9a8aee937f6ebf4356d18645">+56/-33</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ProxyPreviewPlayer.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-4fb66225fe90d51ea4b8024f67fef01be0835fa03f17429c0d53e150e85b0e04">+49/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProxyPreviewPlayer.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-647a8a156472eaa4853238581b304e360adfb643c3e29883b2aeb178bb3030a0">+106/-125</a></td>

</tr>

<tr>
  <td><strong>TextPlacementOverlay.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-9a6d9b9770071beea09f53e47efd29dbd9901a530750c2479eaffd81d7e00edf">+226/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TransformOverlay.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-64c0ffbbf713a399d29fc88b48b9497abc7d38b97c9cf5cf32504b088a565c6a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UnifiedPreviewPlayer.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-adaddc60a186fc62f38d0b905bfd7d21f7dd7f9033b84132ec8c50648b8ac82c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EnhancedTimelineToolbar.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-9e1af788c02ffa27c1e8ad687dd438c02027eda1c083e86c9fc45de72c3aa35d">+17/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Timeline.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-aa6135079648e8794f963c931644d6f4084fadee28e27a737af5a23e7d6a089d">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useCaption.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-863356f6801edff0d8db950c7965c9656633d00023294bcfbf2b6630612296fc">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useEnhancedKeyboardShortcuts.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-1df383746f7f1daa5ae889a34e70b1ebcd02656e75367bb7776599c7f48f1cf7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRazorTool.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-d72db41717c8ed4f1227df69326ab406f9aadfb773dcae5e8221e7b8a48360e7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>editorToolStore.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-3a08ab3bea72d0c4b6deb57a9f093f95efa8afd8aa7a476c126579625db563f4">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>videoGenStore.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-be02911d0b5c764aa6424aefb0ffccc1d6b64162ad28142640dea792ebddfd10">+140/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>videoGenStore.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-645dd759da902206ce1fbed758751ba743cad976c27e776f5d39bf3bfe8763ae">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476">+18/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>captionStyle.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/702/files#diff-2d797dfa3f8347810bf451344f162eb01cead1bccccf0f132a9e1fe2002b32d4">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive text-placement mode in preview with single-key shortcut and commit flow
  * Generative timeline tools: SFX discovery/import and video generation with optional timeline placement/markers
  * Caption positioning via JSON input and richer caption styling controls (shadows, outline, padding, weight, spacing)

* **Improvements**
  * Inspector and preview UI updated for advanced caption styling and precise rendering
  * Keyboard/tooling updates for seamless text tool workflow

* **Tests**
  * Expanded tests covering generative tools, placement, and caption parsing/validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openreelio/openreelio/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->