### PR TITLE
feat(codex): Improve agent media, Codex chat, text placement, and preview stability

### DIFF
--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -5,13 +5,19 @@ use crate::{
     output,
 };
 use clap::Args;
-use openreelio_core::commands::{get_text_data, is_text_clip};
+use openreelio_core::assets::AssetKind;
+use openreelio_core::commands::{
+    get_text_data, is_text_clip, AddTrackCommand, InsertClipCommand, LinkClipsCommand,
+    SetClipMuteCommand,
+};
 use openreelio_core::ipc::CommandPayload;
 use openreelio_core::timeline::TrackKind;
 use serde_json::Value;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+
+const DEFAULT_MEDIA_INSERT_DURATION_SEC: f64 = 10.0;
 
 #[derive(Args)]
 pub struct McpAction {
@@ -343,9 +349,22 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
             serde_json::json!({ "type": "object", "properties": {}, "additionalProperties": false }),
         ),
         tool(
+            "openreelio.annotation.read",
+            "OpenReelio asset annotation",
+            "Read cached objects/faces/OCR/shot annotations for one asset before choosing safe text or caption placement.",
+            serde_json::json!({
+                "type": "object",
+                "required": ["assetId"],
+                "properties": {
+                    "assetId": { "type": "string" }
+                },
+                "additionalProperties": false
+            }),
+        ),
+        tool(
             "openreelio.command.schema",
             "OpenReelio command schema",
-            "Read the command schema available to external agents.",
+            "Read the command schema, text/caption workflows, and payload conventions available to external agents.",
             serde_json::json!({ "type": "object", "properties": {}, "additionalProperties": false }),
         ),
         tool(
@@ -385,9 +404,36 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
 
     if state.has_active_approval_token() {
         tools.push(tool(
+            "openreelio.media.insert",
+            "OpenReelio media insert",
+            "Insert a media asset through the drag-and-drop parity path: validates visible track placement, preserves source ranges, and creates linked audio for video assets.",
+            serde_json::json!({
+                "type": "object",
+                "required": ["approvalToken", "sequenceId", "trackId", "assetId", "timelineStart"],
+                "properties": {
+                    "approvalToken": { "type": "string" },
+                    "sequenceId": { "type": "string" },
+                    "trackId": { "type": "string" },
+                    "assetId": { "type": "string" },
+                    "timelineStart": { "type": "number" },
+                    "sourceIn": { "type": "number" },
+                    "sourceOut": { "type": "number" },
+                    "audioOnly": {
+                        "type": "boolean",
+                        "description": "Set true only when intentionally placing a video asset as audio-only on an audio track."
+                    },
+                    "autoExtractLinkedAudio": {
+                        "type": "boolean",
+                        "description": "Defaults true for video assets on visual tracks."
+                    }
+                },
+                "additionalProperties": false
+            }),
+        ));
+        tools.push(tool(
             "openreelio.plan.apply",
             "OpenReelio approved plan apply",
-            "Apply a validated edit plan through the OpenReelio command log path using an approval token.",
+            "Apply a validated edit plan, including text/caption commands, through the OpenReelio command log path using an approval token.",
             serde_json::json!({
                 "type": "object",
                 "required": ["approvalToken", "plan"],
@@ -468,9 +514,11 @@ fn call_tool(state: &McpServerState, name: &str, arguments: Value) -> Result<Val
         "openreelio.diagnostics.read" => build_diagnostics(state),
         "openreelio.timeline.snapshot" => build_timeline_snapshot(state),
         "openreelio.assets.list" => build_assets_list(state),
+        "openreelio.annotation.read" => build_annotation_read(state, arguments),
         "openreelio.command.schema" => Ok(build_command_schema()),
         "openreelio.command.validate" => validate_command(arguments),
         "openreelio.plan.validate" => validate_plan(arguments),
+        "openreelio.media.insert" => apply_media_insert(state, arguments),
         "openreelio.plan.apply" => apply_plan(state, arguments),
         "openreelio.preview.describe" => Ok(build_preview_state()),
         other => Err(ToolError::UnknownTool(format!(
@@ -509,6 +557,7 @@ fn build_host_context(state: &McpServerState) -> Value {
             "timelineRead": true,
             "commandValidate": true,
             "planValidate": true,
+            "mediaInsertWithApproval": state.has_active_approval_token(),
             "planApplyWithApproval": state.has_active_approval_token(),
             "previewFrameRead": false,
             "diagnosticsRead": true,
@@ -774,6 +823,7 @@ fn build_assets_list(state: &McpServerState) -> Result<Value, ToolError> {
         .assets
         .values()
         .map(|asset| {
+            let annotation_path = annotation_path(path, &asset.id);
             serde_json::json!({
                 "id": asset.id,
                 "name": asset.name,
@@ -782,6 +832,7 @@ fn build_assets_list(state: &McpServerState) -> Result<Value, ToolError> {
                 "fileSize": asset.file_size,
                 "missing": asset.missing,
                 "workspaceManaged": asset.workspace_managed,
+                "hasAnnotation": annotation_path.exists(),
                 "tags": asset.tags,
             })
         })
@@ -794,16 +845,517 @@ fn build_assets_list(state: &McpServerState) -> Result<Value, ToolError> {
     }))
 }
 
+fn build_annotation_read(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
+    let Some(path) = &state.project else {
+        return Ok(serde_json::json!({
+            "status": "error",
+            "message": "No project path was provided"
+        }));
+    };
+    let asset_id = arguments
+        .get("assetId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::InvalidArguments("assetId is required".to_string()))?;
+
+    let annotation = load_annotation_for_asset(path, asset_id)?;
+    Ok(serde_json::json!({
+        "status": "ok",
+        "assetId": asset_id,
+        "available": annotation.is_some(),
+        "annotation": annotation,
+    }))
+}
+
+fn annotation_path(project_dir: &std::path::Path, asset_id: &str) -> PathBuf {
+    project_dir
+        .join(".openreelio")
+        .join("annotations")
+        .join(format!("{asset_id}.json"))
+}
+
+fn load_annotation_for_asset(
+    project_dir: &std::path::Path,
+    asset_id: &str,
+) -> Result<Option<Value>, ToolError> {
+    let path = annotation_path(project_dir, asset_id);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&path).map_err(|error| {
+        ToolError::Execution(format!(
+            "Failed to read annotation '{}': {error}",
+            path.display()
+        ))
+    })?;
+    serde_json::from_str::<Value>(&content)
+        .map(Some)
+        .map_err(|error| {
+            ToolError::Execution(format!(
+                "Failed to deserialize annotation '{}': {error}",
+                path.display()
+            ))
+        })
+}
+
 fn build_command_schema() -> Value {
     serde_json::json!({
         "commands": CommandPayload::SUPPORTED_COMMAND_TYPES,
         "count": CommandPayload::SUPPORTED_COMMAND_TYPES.len(),
         "cli": help_json::build_schema(),
+        "payloadHints": {
+            "CreateTrack": {
+                "required": ["sequenceId", "kind", "name"],
+                "optional": ["position"],
+                "note": "Use kind video or overlay for editable text clips. AddTextClip requires a target video/overlay track; create one first when no suitable upper text track exists."
+            },
+            "InsertClip": {
+                "required": ["sequenceId", "trackId", "assetId", "timelineStart"],
+                "optional": ["sourceIn", "sourceOut"],
+                "note": "Raw InsertClip is primitive and does not auto-create linked audio. Use openreelio.media.insert for normal media placement so video remains visible and linked audio stays in sync."
+            },
+            "ImportGeneratedCaptions": {
+                "required": ["sequenceId", "trackId", "segments"],
+                "optional": ["style", "position", "replaceExisting"],
+                "segmentShape": { "startSec": "number", "endSec": "number", "text": "string" },
+                "styleShape": "Caption style may include fontFamily, fontSize, fontWeight, bold, italic, underline, color, opacity, backgroundColor, backgroundPadding, outlineColor, outlineWidth, shadowColor, shadowOffsetX, shadowOffsetY, shadowBlur, alignment, lineHeight, and letterSpacing.",
+                "positionShape": "Caption position supports preset top/center/bottom or custom xPercent/yPercent.",
+                "note": "Use this for AI/STT transcript segments so generated captions are imported atomically and remain undoable as one command."
+            },
+            "AddTextClip": {
+                "required": ["sequenceId", "trackId", "timelineIn", "duration", "textData"],
+                "textDataShape": "TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/backgroundPadding/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow(color/offsetX/offsetY/blur), outline(color/width), rotation, and opacity.",
+                "note": "Text clips must be placed on a video or overlay track. Use SetClipTransform after creation when scale or anchor must be exact."
+            },
+            "UpdateTextClip": {
+                "required": ["sequenceId", "trackId", "clipId", "textData"],
+                "note": "Send the full updated TextClipData so style, position, shadow, outline, rotation, and opacity remain deterministic."
+            },
+            "SetClipTransform": {
+                "required": ["sequenceId", "trackId", "clipId", "transform"],
+                "transformShape": "transform includes position{x,y}, scale{x,y}, rotationDeg, and anchor{x,y}; text clips use this for preview drag/resize/rotate parity."
+            }
+        },
+        "mediaWorkflows": {
+            "timelinePlacement": [
+                "Use openreelio.media.insert when approval is available and the task places a media asset on the timeline.",
+                "Target video/image assets to video or overlay tracks and audio assets to audio tracks.",
+                "Do not put a video asset on an audio track unless audioOnly=true is intentional; that creates an audio-only clip and will not show in preview.",
+                "Let autoExtractLinkedAudio default to true for video assets with audio."
+            ]
+        },
+        "textWorkflows": {
+            "editableOverlay": [
+                "Read timeline.snapshot to find the active sequence, existing text clips, and usable video/overlay tracks.",
+                "Read annotation.read for overlapping source assets when placement should avoid faces, objects, or OCR text.",
+                "CreateTrack(kind=\"video\" or \"overlay\") when there is no unlocked non-overlapping text track above the media.",
+                "AddTextClip with complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity.",
+                "SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor."
+            ],
+            "timedSubtitles": [
+                "Use ImportGeneratedCaptions for AI transcript segments or CreateCaption/UpdateCaption for individual caption lines.",
+                "Use caption style/position metadata for subtitle readability instead of editable overlay text when the user wants semantic subtitles."
+            ],
+            "placementDefaults": {
+                "subtitle": "Bottom center around y=0.85 with outline/shadow unless it covers important visual content.",
+                "title": "Center or upper third depending on the shot composition.",
+                "lowerThird": "Lower-left or lower-center with enough safe margin and readable contrast."
+            }
+        },
         "payloadFormat": {
             "commandType": "PascalCase backend command type",
             "payload": "camelCase JSON object matching the command payload"
         }
     })
+}
+
+fn required_string_argument(arguments: &Value, key: &str) -> Result<String, ToolError> {
+    arguments
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| ToolError::InvalidArguments(format!("{key} is required")))
+}
+
+fn required_non_negative_number(arguments: &Value, key: &str) -> Result<f64, ToolError> {
+    let value = arguments
+        .get(key)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| ToolError::InvalidArguments(format!("{key} is required")))?;
+    if !value.is_finite() || value < 0.0 {
+        return Err(ToolError::InvalidArguments(format!(
+            "{key} must be a finite non-negative number"
+        )));
+    }
+    Ok(value)
+}
+
+fn optional_non_negative_number(arguments: &Value, key: &str) -> Result<Option<f64>, ToolError> {
+    let Some(value) = arguments.get(key) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(number) = value.as_f64() else {
+        return Err(ToolError::InvalidArguments(format!(
+            "{key} must be a number"
+        )));
+    };
+    if !number.is_finite() || number < 0.0 {
+        return Err(ToolError::InvalidArguments(format!(
+            "{key} must be a finite non-negative number"
+        )));
+    }
+    Ok(Some(number))
+}
+
+fn media_insert_source_range(
+    asset_id: &str,
+    asset_duration_sec: Option<f64>,
+    source_in: Option<f64>,
+    source_out: Option<f64>,
+) -> Result<(Option<(f64, f64)>, f64), ToolError> {
+    let has_explicit_range = source_in.is_some() || source_out.is_some();
+    let source_start = source_in.unwrap_or(0.0);
+
+    if !has_explicit_range && asset_duration_sec.is_none() {
+        return Ok((None, DEFAULT_MEDIA_INSERT_DURATION_SEC));
+    }
+
+    let source_end = source_out
+        .or(asset_duration_sec)
+        .unwrap_or(source_start + DEFAULT_MEDIA_INSERT_DURATION_SEC);
+    let clamped_source_end = asset_duration_sec
+        .map(|duration| source_end.min(duration))
+        .unwrap_or(source_end);
+
+    if source_start >= clamped_source_end {
+        return Err(ToolError::InvalidArguments(format!(
+            "Invalid source range for asset '{asset_id}': sourceOut must be greater than sourceIn"
+        )));
+    }
+
+    Ok((
+        Some((source_start, clamped_source_end)),
+        clamped_source_end - source_start,
+    ))
+}
+
+fn validate_media_track_compatibility(
+    asset_id: &str,
+    asset_kind: &AssetKind,
+    track_id: &str,
+    track_kind: &TrackKind,
+    audio_only: bool,
+) -> Result<(), ToolError> {
+    match asset_kind {
+        AssetKind::Video => {
+            if matches!(track_kind, TrackKind::Audio) {
+                if audio_only {
+                    return Ok(());
+                }
+                return Err(ToolError::InvalidArguments(format!(
+                    "Video asset '{asset_id}' was targeted at audio track '{track_id}'. That creates an audio-only clip and will not show in preview. Use a video/overlay track, or set audioOnly true intentionally."
+                )));
+            }
+            if matches!(track_kind, TrackKind::Video | TrackKind::Overlay) {
+                return Ok(());
+            }
+        }
+        AssetKind::Audio if matches!(track_kind, TrackKind::Audio) => return Ok(()),
+        AssetKind::Image if matches!(track_kind, TrackKind::Video | TrackKind::Overlay) => {
+            return Ok(())
+        }
+        AssetKind::Subtitle if matches!(track_kind, TrackKind::Caption) => return Ok(()),
+        _ => {}
+    }
+
+    Err(ToolError::InvalidArguments(format!(
+        "Cannot place {asset_kind:?} asset '{asset_id}' on {track_kind:?} track '{track_id}'"
+    )))
+}
+
+fn track_has_overlap(
+    track: &openreelio_core::timeline::Track,
+    timeline_start: f64,
+    duration_sec: f64,
+) -> bool {
+    let timeline_end = timeline_start + duration_sec;
+    track.clips.iter().any(|clip| {
+        let clip_start = clip.place.timeline_in_sec;
+        let clip_end = clip.place.timeline_in_sec + clip.place.duration_sec;
+        timeline_start < clip_end && timeline_end > clip_start
+    })
+}
+
+fn find_available_audio_track_id(
+    sequence: &openreelio_core::timeline::Sequence,
+    timeline_start: f64,
+    duration_sec: f64,
+) -> Option<String> {
+    sequence
+        .tracks
+        .iter()
+        .find(|track| {
+            matches!(track.kind, TrackKind::Audio)
+                && !track.locked
+                && !track_has_overlap(track, timeline_start, duration_sec)
+        })
+        .map(|track| track.id.clone())
+}
+
+fn next_audio_track_name(sequence: &openreelio_core::timeline::Sequence) -> String {
+    let mut highest_index = 0usize;
+    for track in &sequence.tracks {
+        if !matches!(track.kind, TrackKind::Audio) {
+            continue;
+        }
+        let name = track.name.trim();
+        if name == "Audio" {
+            highest_index = highest_index.max(1);
+        } else if let Some(index) = name
+            .strip_prefix("Audio ")
+            .and_then(|value| value.parse::<usize>().ok())
+        {
+            highest_index = highest_index.max(index);
+        }
+    }
+    format!("Audio {}", highest_index + 1)
+}
+
+fn default_audio_track_position(sequence: &openreelio_core::timeline::Sequence) -> usize {
+    sequence
+        .tracks
+        .iter()
+        .enumerate()
+        .filter(|(_, track)| matches!(track.kind, TrackKind::Audio))
+        .map(|(index, _)| index + 1)
+        .last()
+        .unwrap_or(sequence.tracks.len())
+}
+
+fn apply_source_range(
+    mut command: InsertClipCommand,
+    source_range: Option<(f64, f64)>,
+) -> InsertClipCommand {
+    if let Some((source_in, source_out)) = source_range {
+        command = command.with_source_range(source_in, source_out);
+    }
+    command
+}
+
+fn rollback_media_insert(
+    project: &mut openreelio_core::ActiveProject,
+    applied_count: usize,
+) -> Result<(), ToolError> {
+    for _ in 0..applied_count {
+        project.executor.undo(&mut project.state).map_err(|error| {
+            ToolError::Execution(format!("Media insert rollback failed: {error}"))
+        })?;
+    }
+    Ok(())
+}
+
+fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
+    let expected_token = state.active_approval_token(None)?;
+    let actual_token = arguments
+        .get("approvalToken")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::PermissionDenied("approvalToken is required".to_string()))?;
+    if actual_token != expected_token {
+        return Err(ToolError::PermissionDenied(
+            "approvalToken is invalid".to_string(),
+        ));
+    }
+
+    let sequence_id = required_string_argument(&arguments, "sequenceId")?;
+    let track_id = required_string_argument(&arguments, "trackId")?;
+    let asset_id = required_string_argument(&arguments, "assetId")?;
+    let timeline_start = required_non_negative_number(&arguments, "timelineStart")?;
+    let source_in = optional_non_negative_number(&arguments, "sourceIn")?;
+    let source_out = optional_non_negative_number(&arguments, "sourceOut")?;
+    let audio_only = arguments
+        .get("audioOnly")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let auto_extract_linked_audio = arguments
+        .get("autoExtractLinkedAudio")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
+    let project_path = state.project.as_ref().ok_or_else(|| {
+        ToolError::InvalidArguments("A project path is required to insert media".to_string())
+    })?;
+    let mut project = super::load_project(project_path)
+        .map_err(|error| ToolError::Execution(error.to_string()))?;
+
+    let asset = project
+        .state
+        .assets
+        .get(&asset_id)
+        .ok_or_else(|| ToolError::InvalidArguments(format!("Asset '{asset_id}' not found")))?;
+    let asset_kind = asset.kind.clone();
+    let asset_duration_sec = asset.duration_sec;
+    let asset_has_audio = asset.audio.is_some();
+    let sequence = project.state.sequences.get(&sequence_id).ok_or_else(|| {
+        ToolError::InvalidArguments(format!("Sequence '{sequence_id}' not found"))
+    })?;
+    let track = sequence
+        .tracks
+        .iter()
+        .find(|track| track.id == track_id)
+        .ok_or_else(|| ToolError::InvalidArguments(format!("Track '{track_id}' not found")))?;
+    let target_track_kind = track.kind.clone();
+    validate_media_track_compatibility(
+        &asset_id,
+        &asset_kind,
+        &track_id,
+        &target_track_kind,
+        audio_only,
+    )?;
+    let (source_range, duration_sec) =
+        media_insert_source_range(&asset_id, asset_duration_sec, source_in, source_out)?;
+
+    state.consume_approval_token()?;
+
+    let mut applied_count = 0usize;
+    let operation = (|| -> Result<Value, ToolError> {
+        let primary_command = apply_source_range(
+            InsertClipCommand::new(&sequence_id, &track_id, &asset_id, timeline_start),
+            source_range,
+        );
+        let primary_result = project
+            .executor
+            .execute(Box::new(primary_command), &mut project.state)
+            .map_err(|error| ToolError::Execution(format!("Media InsertClip failed: {error}")))?;
+        applied_count += 1;
+        let primary_clip_id = primary_result.created_ids.first().cloned().ok_or_else(|| {
+            ToolError::Execution("InsertClip did not return a created clip id".to_string())
+        })?;
+
+        let mut linked_audio = Value::Null;
+        let should_extract_linked_audio = auto_extract_linked_audio
+            && matches!(asset_kind, AssetKind::Video)
+            && !audio_only
+            && matches!(target_track_kind, TrackKind::Video | TrackKind::Overlay)
+            && asset_has_audio;
+
+        if should_extract_linked_audio {
+            let sequence = project.state.sequences.get(&sequence_id).ok_or_else(|| {
+                ToolError::Execution(format!("Sequence '{sequence_id}' not found after insert"))
+            })?;
+            let (audio_track_id, created_track) = if let Some(audio_track_id) =
+                find_available_audio_track_id(sequence, timeline_start, duration_sec)
+            {
+                (audio_track_id, false)
+            } else {
+                let track_name = next_audio_track_name(sequence);
+                let position = default_audio_track_position(sequence);
+                let create_result = project
+                    .executor
+                    .execute(
+                        Box::new(
+                            AddTrackCommand::new(&sequence_id, &track_name, TrackKind::Audio)
+                                .at_position(position),
+                        ),
+                        &mut project.state,
+                    )
+                    .map_err(|error| {
+                        ToolError::Execution(format!("Create linked audio track failed: {error}"))
+                    })?;
+                applied_count += 1;
+                let created_track_id =
+                    create_result.created_ids.first().cloned().ok_or_else(|| {
+                        ToolError::Execution(
+                            "Create linked audio track did not return an id".to_string(),
+                        )
+                    })?;
+                (created_track_id, true)
+            };
+
+            let audio_command = apply_source_range(
+                InsertClipCommand::new(&sequence_id, &audio_track_id, &asset_id, timeline_start),
+                source_range,
+            );
+            let audio_result = project
+                .executor
+                .execute(Box::new(audio_command), &mut project.state)
+                .map_err(|error| {
+                    ToolError::Execution(format!("Linked audio InsertClip failed: {error}"))
+                })?;
+            applied_count += 1;
+            let audio_clip_id = audio_result.created_ids.first().cloned().ok_or_else(|| {
+                ToolError::Execution("Linked audio InsertClip did not return a clip id".to_string())
+            })?;
+
+            project
+                .executor
+                .execute(
+                    Box::new(LinkClipsCommand::new(
+                        &sequence_id,
+                        vec![
+                            (track_id.clone(), primary_clip_id.clone()),
+                            (audio_track_id.clone(), audio_clip_id.clone()),
+                        ],
+                    )),
+                    &mut project.state,
+                )
+                .map_err(|error| ToolError::Execution(format!("LinkClips failed: {error}")))?;
+            applied_count += 1;
+
+            project
+                .executor
+                .execute(
+                    Box::new(SetClipMuteCommand::new(
+                        &sequence_id,
+                        &track_id,
+                        &primary_clip_id,
+                        true,
+                    )),
+                    &mut project.state,
+                )
+                .map_err(|error| ToolError::Execution(format!("SetClipMute failed: {error}")))?;
+            applied_count += 1;
+
+            linked_audio = serde_json::json!({
+                "trackId": audio_track_id,
+                "clipId": audio_clip_id,
+                "createdTrack": created_track
+            });
+        }
+
+        Ok(serde_json::json!({
+            "status": "ok",
+            "message": "Media inserted through the drag-and-drop parity path.",
+            "opId": primary_result.op_id,
+            "createdIds": primary_result.created_ids,
+            "clipId": primary_clip_id,
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "assetId": asset_id,
+            "timelineStart": timeline_start,
+            "sourceIn": source_range.map(|range| range.0),
+            "sourceOut": source_range.map(|range| range.1),
+            "durationSec": duration_sec,
+            "linkedAudio": linked_audio
+        }))
+    })();
+
+    let result = match operation {
+        Ok(value) => value,
+        Err(error) => {
+            if applied_count > 0 {
+                rollback_media_insert(&mut project, applied_count)?;
+            }
+            return Err(error);
+        }
+    };
+
+    super::save_project(&mut project).map_err(|error| ToolError::Execution(error.to_string()))?;
+    Ok(result)
 }
 
 fn validate_command(arguments: Value) -> Result<Value, ToolError> {
@@ -1162,8 +1714,87 @@ mod tests {
 
         assert!(names.contains(&"openreelio.host.context"));
         assert!(names.contains(&"openreelio.timeline.snapshot"));
+        assert!(names.contains(&"openreelio.annotation.read"));
         assert!(names.contains(&"openreelio.command.schema"));
         assert!(!names.contains(&"openreelio.plan.apply"));
+    }
+
+    #[test]
+    fn should_explain_text_workflows_in_command_schema() {
+        let schema = build_command_schema();
+
+        assert!(schema["payloadHints"]["AddTextClip"].is_object());
+        assert!(schema["payloadHints"]["UpdateTextClip"].is_object());
+        assert!(schema["payloadHints"]["SetClipTransform"].is_object());
+        assert_eq!(
+            schema["textWorkflows"]["placementDefaults"]["subtitle"],
+            "Bottom center around y=0.85 with outline/shadow unless it covers important visual content."
+        );
+    }
+
+    #[test]
+    fn should_read_cached_annotation_for_asset() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let project_path = temp_dir.path().join("annotation_project");
+        let project =
+            openreelio_core::ActiveProject::create("Annotation Project", project_path.clone())
+                .expect("project");
+        let asset_id = "asset-annotation-1";
+        drop(project);
+
+        let annotation_dir = project_path.join(".openreelio").join("annotations");
+        std::fs::create_dir_all(&annotation_dir).expect("annotation dir");
+        std::fs::write(
+            annotation_dir.join(format!("{asset_id}.json")),
+            serde_json::json!({
+                "version": "1",
+                "assetId": asset_id,
+                "assetHash": "hash",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "updatedAt": "2026-01-01T00:00:00Z",
+                "analysis": {
+                    "faces": {
+                        "provider": "google_cloud",
+                        "analyzedAt": "2026-01-01T00:00:00Z",
+                        "config": {},
+                        "results": [{
+                            "timeSec": 1.0,
+                            "confidence": 0.9,
+                            "boundingBox": { "left": 0.25, "top": 0.7, "width": 0.5, "height": 0.2 },
+                            "emotions": []
+                        }]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write annotation");
+
+        let state = McpServerState {
+            project: Some(project_path),
+            ..Default::default()
+        };
+        let response = handle_jsonrpc_request(
+            &state,
+            request(
+                "tools/call",
+                serde_json::json!({
+                    "name": "openreelio.annotation.read",
+                    "arguments": { "assetId": asset_id }
+                }),
+            ),
+        );
+        let text = response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("text content");
+        let value: Value = serde_json::from_str(text).expect("annotation JSON");
+
+        assert_eq!(value["status"], "ok");
+        assert_eq!(value["available"], true);
+        assert_eq!(
+            value["annotation"]["analysis"]["faces"]["results"][0]["confidence"],
+            0.9
+        );
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -14,7 +14,7 @@ use openreelio_core::ipc::CommandPayload;
 use openreelio_core::timeline::TrackKind;
 use serde_json::Value;
 use std::io::{BufRead, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 const DEFAULT_MEDIA_INSERT_DURATION_SEC: f64 = 10.0;
@@ -138,6 +138,24 @@ impl McpServerState {
             ));
         }
         *consumed = true;
+        Ok(())
+    }
+
+    fn ensure_media_insert_token_scope(&self, project_id: &str) -> Result<(), ToolError> {
+        if let Some(plan_id) = self.approval_plan_id.as_deref() {
+            return Err(ToolError::PermissionDenied(format!(
+                "approvalToken is scoped to plan '{plan_id}' and cannot be used for openreelio.media.insert"
+            )));
+        }
+
+        if let Some(expected_project_id) = self.approval_project_id.as_deref() {
+            if expected_project_id != project_id {
+                return Err(ToolError::PermissionDenied(format!(
+                    "approvalToken is scoped to project '{expected_project_id}', not '{project_id}'"
+                )));
+            }
+        }
+
         Ok(())
     }
 }
@@ -823,7 +841,9 @@ fn build_assets_list(state: &McpServerState) -> Result<Value, ToolError> {
         .assets
         .values()
         .map(|asset| {
-            let annotation_path = annotation_path(path, &asset.id);
+            let has_annotation = annotation_path(path, &asset.id)
+                .map(|annotation_path| annotation_path.exists())
+                .unwrap_or(false);
             serde_json::json!({
                 "id": asset.id,
                 "name": asset.name,
@@ -832,7 +852,7 @@ fn build_assets_list(state: &McpServerState) -> Result<Value, ToolError> {
                 "fileSize": asset.file_size,
                 "missing": asset.missing,
                 "workspaceManaged": asset.workspace_managed,
-                "hasAnnotation": annotation_path.exists(),
+                "hasAnnotation": has_annotation,
                 "tags": asset.tags,
             })
         })
@@ -857,6 +877,7 @@ fn build_annotation_read(state: &McpServerState, arguments: Value) -> Result<Val
         .and_then(Value::as_str)
         .ok_or_else(|| ToolError::InvalidArguments("assetId is required".to_string()))?;
 
+    let asset_id = validate_annotation_asset_id(asset_id)?;
     let annotation = load_annotation_for_asset(path, asset_id)?;
     Ok(serde_json::json!({
         "status": "ok",
@@ -866,18 +887,39 @@ fn build_annotation_read(state: &McpServerState, arguments: Value) -> Result<Val
     }))
 }
 
-fn annotation_path(project_dir: &std::path::Path, asset_id: &str) -> PathBuf {
-    project_dir
+fn validate_annotation_asset_id(asset_id: &str) -> Result<&str, ToolError> {
+    let trimmed = asset_id.trim();
+    if trimmed.is_empty() {
+        return Err(ToolError::InvalidArguments(
+            "assetId is required".to_string(),
+        ));
+    }
+
+    if !trimmed
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '-' || character == '_')
+    {
+        return Err(ToolError::InvalidArguments(
+            "assetId may only contain ASCII letters, numbers, hyphens, and underscores".to_string(),
+        ));
+    }
+
+    Ok(trimmed)
+}
+
+fn annotation_path(project_dir: &Path, asset_id: &str) -> Result<PathBuf, ToolError> {
+    let asset_id = validate_annotation_asset_id(asset_id)?;
+    Ok(project_dir
         .join(".openreelio")
         .join("annotations")
-        .join(format!("{asset_id}.json"))
+        .join(format!("{asset_id}.json")))
 }
 
 fn load_annotation_for_asset(
     project_dir: &std::path::Path,
     asset_id: &str,
 ) -> Result<Option<Value>, ToolError> {
-    let path = annotation_path(project_dir, asset_id);
+    let path = annotation_path(project_dir, asset_id)?;
     if !path.exists() {
         return Ok(None);
     }
@@ -1102,6 +1144,7 @@ fn find_available_audio_track_id(
         .find(|track| {
             matches!(track.kind, TrackKind::Audio)
                 && !track.locked
+                && !track.muted
                 && !track_has_overlap(track, timeline_start, duration_sec)
         })
         .map(|track| track.id.clone())
@@ -1171,6 +1214,12 @@ fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value,
         ));
     }
 
+    if let Some(plan_id) = state.approval_plan_id.as_deref() {
+        return Err(ToolError::PermissionDenied(format!(
+            "approvalToken is scoped to plan '{plan_id}' and cannot be used for openreelio.media.insert"
+        )));
+    }
+
     let sequence_id = required_string_argument(&arguments, "sequenceId")?;
     let track_id = required_string_argument(&arguments, "trackId")?;
     let asset_id = required_string_argument(&arguments, "assetId")?;
@@ -1191,6 +1240,7 @@ fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value,
     })?;
     let mut project = super::load_project(project_path)
         .map_err(|error| ToolError::Execution(error.to_string()))?;
+    state.ensure_media_insert_token_scope(&project.state.meta.id)?;
 
     let asset = project
         .state
@@ -1798,6 +1848,32 @@ mod tests {
     }
 
     #[test]
+    fn should_reject_annotation_asset_id_path_traversal() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let state = McpServerState {
+            project: Some(temp_dir.path().join("annotation_project")),
+            ..Default::default()
+        };
+
+        let response = handle_jsonrpc_request(
+            &state,
+            request(
+                "tools/call",
+                serde_json::json!({
+                    "name": "openreelio.annotation.read",
+                    "arguments": { "assetId": "../secret" }
+                }),
+            ),
+        );
+
+        assert_eq!(response["error"]["code"], -32602);
+        assert!(response["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("assetId"));
+    }
+
+    #[test]
     fn should_return_openreelio_host_context_when_agent_calls_context_tool() {
         let state = McpServerState::default();
         let response = handle_jsonrpc_request(
@@ -1943,6 +2019,63 @@ mod tests {
             .as_str()
             .expect("error message")
             .contains("expected-plan"));
+    }
+
+    #[test]
+    fn should_reject_media_insert_when_approval_token_is_plan_scoped() {
+        let state = McpServerState {
+            approval_token: Some("scoped-token".to_string()),
+            approval_plan_id: Some("plan-1".to_string()),
+            ..Default::default()
+        };
+
+        let error = apply_media_insert(
+            &state,
+            serde_json::json!({
+                "approvalToken": "scoped-token",
+                "sequenceId": "seq-1",
+                "trackId": "track-1",
+                "assetId": "asset-1",
+                "timelineStart": 0
+            }),
+        )
+        .expect_err("plan-scoped token should be rejected");
+
+        assert!(error.to_string().contains("plan-1"));
+        assert!(error.to_string().contains("openreelio.media.insert"));
+    }
+
+    #[test]
+    fn should_reject_media_insert_when_approval_token_project_scope_differs() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let project_path = temp_dir.path().join("wrong_media_project_scope");
+        let project =
+            openreelio_core::ActiveProject::create("Wrong Media Scope", project_path.clone())
+                .expect("project");
+        let actual_project_id = project.state.meta.id.clone();
+        drop(project);
+
+        let state = McpServerState {
+            project: Some(project_path),
+            approval_token: Some("project-token".to_string()),
+            approval_project_id: Some("expected-project".to_string()),
+            ..Default::default()
+        };
+
+        let error = apply_media_insert(
+            &state,
+            serde_json::json!({
+                "approvalToken": "project-token",
+                "sequenceId": "seq-1",
+                "trackId": "track-1",
+                "assetId": "asset-1",
+                "timelineStart": 0
+            }),
+        )
+        .expect_err("wrong project-scoped token should be rejected");
+
+        assert!(error.to_string().contains("expected-project"));
+        assert!(error.to_string().contains(&actual_project_id));
     }
 
     #[test]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,6 +10,19 @@
 use std::env;
 use std::path::PathBuf;
 
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+fn configure_build_command(command: &mut std::process::Command) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(target_os = "windows"))]
+    let _ = command;
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=icons");
     println!("cargo:rerun-if-changed=tauri.conf.json");
@@ -654,7 +667,9 @@ fn verify_binary(path: &Path) -> BundlerResult<()> {
         )));
     }
 
-    let output = std::process::Command::new(path)
+    let mut command = std::process::Command::new(path);
+    configure_build_command(&mut command);
+    let output = command
         .arg("-version")
         .output()
         .map_err(|e| BundlerError::VerificationFailed(format!("Failed to execute binary: {e}")))?;

--- a/src-tauri/src/core/assets/metadata.rs
+++ b/src-tauri/src/core/assets/metadata.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::core::assets::{AudioInfo, VideoInfo};
+use crate::core::process::configure_std_command;
 use crate::core::{CoreError, CoreResult, Ratio};
 
 // =============================================================================
@@ -97,7 +98,9 @@ impl MetadataExtractor {
         }
 
         // Run FFprobe
-        let output = Command::new("ffprobe")
+        let mut command = Command::new("ffprobe");
+        configure_std_command(&mut command);
+        let output = command
             .args([
                 "-v",
                 "quiet",
@@ -227,7 +230,9 @@ impl MetadataExtractor {
 
     /// Check if FFprobe is available on the system
     pub fn is_available() -> bool {
-        Command::new("ffprobe")
+        let mut command = Command::new("ffprobe");
+        configure_std_command(&mut command);
+        command
             .arg("-version")
             .output()
             .map(|o| o.status.success())

--- a/src-tauri/src/core/credentials/mod.rs
+++ b/src-tauri/src/core/credentials/mod.rs
@@ -36,6 +36,9 @@ use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use crate::core::process::configure_std_command;
+
 /// Credential type identifier for logging and validation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -346,7 +349,9 @@ impl CredentialVault {
         #[cfg(target_os = "windows")]
         {
             // Use Windows machine GUID if available
-            if let Ok(output) = std::process::Command::new("powershell")
+            let mut command = std::process::Command::new("powershell");
+            configure_std_command(&mut command);
+            if let Ok(output) = command
                 .args([
                     "-Command",
                     "(Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Cryptography' -Name MachineGuid).MachineGuid",
@@ -362,7 +367,9 @@ impl CredentialVault {
         #[cfg(target_os = "macos")]
         {
             // Use macOS hardware UUID
-            if let Ok(output) = std::process::Command::new("ioreg")
+            let mut command = std::process::Command::new("ioreg");
+            configure_std_command(&mut command);
+            if let Ok(output) = command
                 .args(["-rd1", "-c", "IOPlatformExpertDevice"])
                 .output()
             {

--- a/src-tauri/src/core/indexing/shots.rs
+++ b/src-tauri/src/core/indexing/shots.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use super::db::IndexDb;
-use crate::core::process::configure_tokio_command;
+use crate::core::process::{configure_std_command, configure_tokio_command};
 use crate::core::{AssetId, CoreError, CoreResult};
 
 // =============================================================================
@@ -635,7 +635,9 @@ impl ShotDetector {
 
     /// Checks if FFmpeg is available on the system
     pub fn is_ffmpeg_available() -> bool {
-        std::process::Command::new("ffmpeg")
+        let mut command = std::process::Command::new("ffmpeg");
+        configure_std_command(&mut command);
+        command
             .arg("-version")
             .output()
             .map(|o| o.status.success())

--- a/src-tauri/src/ipc/commands/workspace.rs
+++ b/src-tauri/src/ipc/commands/workspace.rs
@@ -21,6 +21,7 @@ use crate::core::fs::{
     validate_local_input_path, validate_scoped_output_path, validate_workspace_relative_path,
     write_bytes_atomic_no_symlink,
 };
+use crate::core::process::configure_std_command;
 use crate::core::project::{OpKind, Operation};
 use crate::core::workspace::{
     ignore::IgnoreRules,
@@ -691,6 +692,7 @@ pub async fn reveal_in_explorer(
     {
         let path_str = abs_path.to_string_lossy().to_string();
         let mut command = std::process::Command::new("explorer");
+        configure_std_command(&mut command);
         if abs_path.is_file() {
             command.args(["/select,", &path_str]);
         } else {
@@ -703,7 +705,9 @@ pub async fn reveal_in_explorer(
 
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        let mut command = std::process::Command::new("open");
+        configure_std_command(&mut command);
+        command
             .args(["-R", &abs_path.to_string_lossy()])
             .spawn()
             .map_err(|e| format!("Failed to open Finder: {}", e))?;
@@ -717,7 +721,9 @@ pub async fn reveal_in_explorer(
         } else {
             abs_path.clone()
         };
-        std::process::Command::new("xdg-open")
+        let mut command = std::process::Command::new("xdg-open");
+        configure_std_command(&mut command);
+        command
             .arg(&target)
             .spawn()
             .map_err(|e| format!("Failed to open file manager: {}", e))?;

--- a/src/agents/ToolRegistry.ts
+++ b/src/agents/ToolRegistry.ts
@@ -15,7 +15,7 @@ import type { ToolOutputContract } from './toolOutputContracts';
 
 /** JSON Schema for tool parameters */
 export interface JsonSchema {
-  type: string;
+  type: string | string[];
   properties?: Record<string, JsonSchema>;
   required?: string[];
   items?: JsonSchema;
@@ -42,6 +42,14 @@ export interface AgentContext {
 }
 
 const logger = createLogger('ToolRegistry');
+
+export function describeExpectedJsonTypes(types: readonly string[]): string {
+  if (types.length === 1) {
+    return types[0] === 'integer' ? 'a number' : `a ${types[0]}`;
+  }
+
+  return `one of: ${types.join(', ')}`;
+}
 
 // =============================================================================
 // Types
@@ -407,43 +415,49 @@ export class ToolRegistry {
   private validateType(name: string, value: unknown, schema: JsonSchema): string | undefined {
     const actualType = typeof value;
 
+    const acceptedTypes = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const matchesType = acceptedTypes.some((type) => {
+      if (type === 'null') {
+        return value === null;
+      }
+      if (type === 'array') {
+        return Array.isArray(value);
+      }
+      if (type === 'object') {
+        return actualType === 'object' && value !== null && !Array.isArray(value);
+      }
+      if (type === 'integer') {
+        return actualType === 'number';
+      }
+      return actualType === type;
+    });
+
+    if (!matchesType) {
+      return `Parameter '${name}' must be ${describeExpectedJsonTypes(acceptedTypes)}, got ${value === null ? 'null' : actualType}`;
+    }
+
+    if (
+      acceptedTypes.includes('integer') &&
+      !acceptedTypes.includes('number') &&
+      actualType === 'number' &&
+      !Number.isInteger(value)
+    ) {
+      return `Parameter '${name}' must be an integer`;
+    }
+
+    if (schema.enum && !schema.enum.includes(value)) {
+      return `Parameter '${name}' must be one of: ${schema.enum.join(', ')}`;
+    }
+
     switch (schema.type) {
       case 'string':
-        if (actualType !== 'string') {
-          return `Parameter '${name}' must be a string, got ${actualType}`;
-        }
-        // Check enum
-        if (schema.enum && !schema.enum.includes(value)) {
-          return `Parameter '${name}' must be one of: ${schema.enum.join(', ')}`;
-        }
         break;
 
       case 'number':
       case 'integer':
-        if (actualType !== 'number') {
-          return `Parameter '${name}' must be a number, got ${actualType}`;
-        }
-        if (schema.type === 'integer' && !Number.isInteger(value)) {
-          return `Parameter '${name}' must be an integer`;
-        }
-        break;
-
       case 'boolean':
-        if (actualType !== 'boolean') {
-          return `Parameter '${name}' must be a boolean, got ${actualType}`;
-        }
-        break;
-
       case 'array':
-        if (!Array.isArray(value)) {
-          return `Parameter '${name}' must be an array`;
-        }
-        break;
-
       case 'object':
-        if (actualType !== 'object' || value === null || Array.isArray(value)) {
-          return `Parameter '${name}' must be an object`;
-        }
         break;
     }
 

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.ts
@@ -15,7 +15,11 @@ import type {
   BatchExecutionResult,
 } from '../../ports/IToolExecutor';
 import type { RiskLevel, ValidationResult, SideEffect } from '../../core/types';
-import { ToolRegistry, type ToolDefinition as LegacyToolDef } from '@/agents/ToolRegistry';
+import {
+  ToolRegistry,
+  describeExpectedJsonTypes,
+  type ToolDefinition as LegacyToolDef,
+} from '@/agents/ToolRegistry';
 import { isMetaToolsEnabled } from '@/config/featureFlags';
 import {
   getVisibleMetaToolNames,
@@ -505,46 +509,56 @@ export class ToolRegistryAdapter implements IToolExecutor {
   private validateType(
     name: string,
     value: unknown,
-    schema: { type?: string; enum?: unknown[] },
+    schema: { type?: string | string[]; enum?: unknown[] },
   ): string | undefined {
+    if (!schema.type) {
+      return undefined;
+    }
+
     const actualType = typeof value;
+    const acceptedTypes = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const matchesType = acceptedTypes.some((type) => {
+      if (type === 'null') {
+        return value === null;
+      }
+      if (type === 'array') {
+        return Array.isArray(value);
+      }
+      if (type === 'object') {
+        return actualType === 'object' && value !== null && !Array.isArray(value);
+      }
+      if (type === 'integer') {
+        return actualType === 'number';
+      }
+      return actualType === type;
+    });
+
+    if (!matchesType) {
+      return `Parameter '${name}' must be ${describeExpectedJsonTypes(acceptedTypes)}, got ${value === null ? 'null' : actualType}`;
+    }
+
+    if (
+      acceptedTypes.includes('integer') &&
+      !acceptedTypes.includes('number') &&
+      actualType === 'number' &&
+      !Number.isInteger(value)
+    ) {
+      return `Parameter '${name}' must be an integer`;
+    }
+
+    if (schema.enum && !schema.enum.includes(value)) {
+      return `Parameter '${name}' must be one of: ${schema.enum.join(', ')}`;
+    }
 
     switch (schema.type) {
       case 'string':
-        if (actualType !== 'string') {
-          return `Parameter '${name}' must be a string, got ${actualType}`;
-        }
-        if (schema.enum && !schema.enum.includes(value)) {
-          return `Parameter '${name}' must be one of: ${schema.enum.join(', ')}`;
-        }
         break;
 
       case 'number':
       case 'integer':
-        if (actualType !== 'number') {
-          return `Parameter '${name}' must be a number, got ${actualType}`;
-        }
-        if (schema.type === 'integer' && !Number.isInteger(value)) {
-          return `Parameter '${name}' must be an integer`;
-        }
-        break;
-
       case 'boolean':
-        if (actualType !== 'boolean') {
-          return `Parameter '${name}' must be a boolean, got ${actualType}`;
-        }
-        break;
-
       case 'array':
-        if (!Array.isArray(value)) {
-          return `Parameter '${name}' must be an array`;
-        }
-        break;
-
       case 'object':
-        if (actualType !== 'object' || value === null || Array.isArray(value)) {
-          return `Parameter '${name}' must be an object`;
-        }
         break;
     }
 

--- a/src/agents/engine/phases/Planner.ts
+++ b/src/agents/engine/phases/Planner.ts
@@ -489,7 +489,7 @@ export class Planner {
       '11. Use canonical argument names from the validation schemas. Important: insert_clip and insert_clip_from_file require timelineStart, split_clip requires splitTime, and insert_clip_from_file requires file. Do not emit timelineIn, atTimelineSec, or filePath in plan JSON.',
     );
     parts.push(
-      '12. Tool output contracts: insert_clip exposes data.clipId; split_clip exposes data.newClipId for the newly created right-hand segment. For repeated segmentation, first reference data.clipId from insert_clip, then chain later split_clip steps through data.newClipId.',
+      '12. Tool output contracts: insert_clip exposes data.clipId and may expose data.linkedAudio; split_clip exposes data.newClipId for the newly created right-hand segment. For repeated segmentation, first reference data.clipId from insert_clip, then chain later split_clip steps through data.newClipId.',
     );
     parts.push(
       '13. Match near-synonyms to the exact available tool or action name. Example: splitClip -> split_clip, add_subtitle -> add_caption, remove_clip -> delete_clip.',
@@ -502,6 +502,9 @@ export class Planner {
     );
     parts.push(
       '16. When the target track is known, prefer get_track_clips(trackId) over get_clips_at_time(time) so later steps can reference data.clips[n].id without cross-track ambiguity.',
+    );
+    parts.push(
+      '17. For media placement, target video/image assets to video or overlay tracks and audio assets to audio tracks. insert_clip and insert_clip_from_file automatically preserve sourceIn/sourceOut and linked audio parity; set audioOnly=true only when intentionally extracting audio from a video asset.',
     );
     parts.push('');
     parts.push(...ORCHESTRATION_PLAYBOOK_LINES);

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -67,8 +67,8 @@ const QUERY_ACTIONS = `## Query Actions (meta-tool: query)
 - compare_edit_structure(sequenceId?, esdId) → compare current cut structure to a reference style`;
 
 const EDIT_ACTIONS = `## Edit Actions (meta-tool: edit, all require sequenceId)
-- insert_clip(trackId, assetId, timelineStart) → place asset on timeline; result exposes data.clipId
-- insert_clip_from_file(file, trackId, timelineStart) → insert by filename (auto-imports); result exposes data.clipId
+- insert_clip(trackId, assetId, timelineStart, sourceIn?, sourceOut?, audioOnly?) → place asset on timeline through drag-and-drop parity; video/image assets must target video/overlay tracks, result exposes data.clipId and data.linkedAudio
+- insert_clip_from_file(file, trackId, timelineStart, sourceIn?, sourceOut?, audioOnly?) → insert by filename (auto-imports) through drag-and-drop parity; result exposes data.clipId and data.linkedAudio
 - move_clip(trackId, clipId, newTimelineIn, newTrackId?) → reposition or cross-track move
 - trim_clip(trackId, clipId, newSourceIn?, newSourceOut?) → adjust source boundaries
 - split_clip(trackId, clipId, splitTime) → divide into two clips at time point; result exposes data.newClipId for the right-hand segment
@@ -108,19 +108,23 @@ const EFFECTS_ACTIONS = `## Effects Actions (meta-tool: effects)
 - remove_transition(transitionId) → remove transition
 - set_transition_duration(transitionId, duration) → change transition length`;
 
-const TEXT_ACTIONS = `## Text Actions (meta-tool: text, require sequenceId)
+const TEXT_ACTIONS = `## Text Actions (meta-tool: text)
+Editable text overlays default to the active sequence when sequenceId is omitted. Caption-track actions require sequenceId unless the context already supplies one.
+- Use editable text overlay actions for titles, lower thirds, callouts, burned-in subtitle-style text, and anything the user may drag/resize in the preview.
+- Use caption-track actions for semantic timed subtitles/captions and AI transcript import.
 - list_text_clips() → inspect editable text overlay clips with textData, style, transform, trackId, and clipId
-- add_text_clip(text, startTime, duration?, endTime?, trackId?, preset?, style?, position?, shadow?, outline?, transform?) → add editable on-video text; video text track auto-created if needed
-- update_text_clip(clipId, text?, style?, position?, shadow?, outline?, transform?) → edit text content, font, size, weight, color, outline, shadow, rotation, opacity, and transform
-- set_text_transform(clipId, transform? or transformX/transformY/scaleX/scaleY/rotationDeg) → move, resize, or rotate a text clip
+- add_text_clip(text, startTime, duration?, endTime?, trackId?, preset?, style?, position?, x?, y?, xPercent?, yPercent?, shadow?, outline?, transform?, autoPlacement?, placementIntent?) → add editable on-video text; video text track auto-created if needed. Auto-placement is on by default when no explicit position is supplied.
+- update_text_clip(clipId, text?, style?, fontFamily?, fontSize?, fontWeight?, color?, backgroundColor?, backgroundPadding?, alignment?, bold?, italic?, underline?, lineHeight?, letterSpacing?, position?, x?, y?, shadow?, outline?, clearShadow?, clearOutline?, clearBackground?, opacity?, rotation?, transform?, autoPlacement?) → edit text content, font, size, weight, color, outline, shadow, background, rotation, opacity, and transform
+- set_text_transform(clipId, transform? or transformX/transformY/scaleX/scaleY/rotationDeg/anchorX/anchorY) → move, resize, rotate, or re-anchor a text clip
 - delete_text_clip(clipId) → remove an editable text overlay clip
 - add_caption(text, startTime, endTime) → add subtitle (track auto-created if needed)
 - update_caption(captionId, text?, startTime?, endTime?) → edit caption
 - delete_caption(captionId) → remove caption
-- style_caption(captionId, fontSize?, fontFamily?, color?, backgroundColor?, position?) → style caption
+- style_caption(captionId, fontSize?, fontFamily?, fontWeight?, bold?, italic?, underline?, color?, opacity?, backgroundColor?, backgroundPadding?, outlineColor?, outlineWidth?, shadowColor?, shadowOffsetX?, shadowOffsetY?, shadowBlur?, alignment?, lineHeight?, letterSpacing?, position?, xPercent?, yPercent?) → style caption metadata
 - auto_transcribe(assetId, language?, model?, provider?, async?) → transcribe audio/video into timed text segments; uses local Whisper when available, otherwise a configured transcript analysis provider
 - add_captions_from_transcription(segments, trackId?, replaceExisting?) → create captions from timed transcript segments as one atomic caption import
-- import_captions_from_file(relativePath, format?, trackId?) → import SRT/VTT subtitle files from the workspace`;
+- import_captions_from_file(relativePath, format?, trackId?) → import SRT/VTT subtitle files from the workspace
+- Placement defaults: add_text_clip auto-places when no exact position is supplied, scoring default candidate regions against available faces/objects/OCR annotations and existing text. Use autoPlacement:false only when the user explicitly wants the preset's raw position.`;
 
 const GENERATE_ACTIONS = `## Generate Actions (meta-tool: generate)
 - generate_timeline_media(prompt, mediaType?, provider?, sequenceId?, trackId?, timelineStart?) → submit provider-neutral generation or SFX discovery; video jobs can create a pending marker and auto-place when ready
@@ -171,12 +175,15 @@ const COMMON_WORKFLOWS = `## Common Workflows
 9. Deep source inspection/editing: find_workspace_file or get_asset_catalog → read_source_analysis_report (this already writes the default ".analysis.md" report beside the asset) → check data.quality.status and do not silently edit from an insufficient/partial report; refresh or use build_source_selects with analyzeMissing=true when source selection depends on transcript or frame semantics → search_source_analysis_report / search_source_library → build_source_selects or edit actions
 10. Generative edit: generate_timeline_media with sequenceId/trackId/timelineStart creates a pending timeline marker and stores placement intent; the generation store imports and places the asset when the provider job completes. Use resolve_generation_job for explicit status checks.
 11. SFX discovery/import: search_sound_for_scene → present usable candidates and license policy → import_asset_candidate only with licenseAck=true → insert_clip on an audio track.
-12. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
+12. AI subtitles: auto_transcribe(assetId) → inspect returned segments → add_captions_from_transcription(segments, replaceExisting?) → style_caption for readable typography when needed.
+13. Editable on-video text: list_text_clips when editing existing text, otherwise add_text_clip with preset and style → set_text_transform for exact preview position/size/rotation.
+14. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
 
 const CLI_REFERENCE = `## CLI (headless alternative)
 openreelio-cli <group> <command> --path <dir> [--args]
-Groups: project, asset, analysis, timeline, caption, plan, state, render
+Groups: project, asset, analysis, timeline, caption, text, plan, state, render
 Key analysis commands: analysis report --path <dir> --id <asset_id>, analysis search --path <dir> --id <asset_id> --query "crowd cheer", analysis search-library --path <dir> --query "crowd cheer", analysis build-selects --path <dir> --query "crowd cheer"
+Key text commands: text add --text "Title" --start 0 --duration 3 --preset title --font-family Inter --font-size 72 --x 0.5 --y 0.2, text update --id <clip_id> --font-weight 700 --color "#FFFFFF", text transform --id <clip_id> --x 0.5 --y 0.82 --scale-x 1.1 --scale-y 1.1
 Key: plan execute --file <plan.json> for atomic batch operations
 Run help-json for machine-readable full schema.`;
 

--- a/src/agents/external/adapters/CodexAppServerClient.test.ts
+++ b/src/agents/external/adapters/CodexAppServerClient.test.ts
@@ -301,4 +301,28 @@ describe('CodexAppServerClient', () => {
 
     await expect(interruptPromise).resolves.toBeUndefined();
   });
+
+  it('sends turn steering with the expected active turn precondition', async () => {
+    const transport = new MockCodexTransport();
+    const client = new CodexAppServerClient(transport);
+    const initPromise = client.initialize();
+    transport.receive({ id: 1, result: {} });
+    await initPromise;
+
+    const steerPromise = client.steerTurn('thr_123', 'turn_456', 'Also keep the captions lower');
+    await waitForSent(transport, 3);
+
+    expect(transport.sent[2]).toEqual({
+      method: 'turn/steer',
+      id: 2,
+      params: {
+        threadId: 'thr_123',
+        expectedTurnId: 'turn_456',
+        input: [{ type: 'text', text: 'Also keep the captions lower' }],
+      },
+    });
+    transport.receive({ id: 2, result: { turnId: 'turn_456' } });
+
+    await expect(steerPromise).resolves.toEqual({ turnId: 'turn_456' });
+  });
 });

--- a/src/agents/external/adapters/CodexAppServerClient.ts
+++ b/src/agents/external/adapters/CodexAppServerClient.ts
@@ -99,6 +99,10 @@ export interface CodexTurnStartResult {
   turn: CodexTurn;
 }
 
+export interface CodexTurnSteerResult {
+  turnId: string;
+}
+
 export interface CodexAppServerNotification {
   method: string;
   params?: CodexJsonObject;
@@ -280,6 +284,19 @@ export class CodexAppServerClient {
     );
 
     return result.turn;
+  }
+
+  async steerTurn(
+    threadId: string,
+    expectedTurnId: string,
+    text: string,
+  ): Promise<CodexTurnSteerResult> {
+    await this.initialize();
+    return await this.request<CodexTurnSteerResult>('turn/steer', {
+      threadId,
+      expectedTurnId,
+      input: [{ type: 'text', text }],
+    });
   }
 
   async interruptTurn(threadId: string, turnId: string): Promise<void> {

--- a/src/agents/external/adapters/CodexReferenceAdapter.test.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.test.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { insertAgentMediaClip } from '@/agents/tools/mediaInsertion';
 import { CodexReferenceAdapter } from './CodexReferenceAdapter';
 import {
   isCodexDynamicToolCallOutputTextItem,
@@ -23,10 +24,15 @@ vi.mock('@/stores/projectStore', () => ({
   },
 }));
 
+vi.mock('@/agents/tools/mediaInsertion', () => ({
+  insertAgentMediaClip: vi.fn(),
+}));
+
 describe('CodexReferenceAdapter', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     projectStoreMocks.refreshFromBackendMutation.mockResolvedValue(1);
+    vi.mocked(insertAgentMediaClip).mockReset();
   });
 
   afterEach(() => {
@@ -145,6 +151,7 @@ describe('CodexReferenceAdapter', () => {
           expect.objectContaining({ namespace: 'openreelio', name: 'host_context' }),
           expect.objectContaining({ namespace: 'openreelio', name: 'stock_media_search' }),
           expect.objectContaining({ namespace: 'openreelio', name: 'stock_media_import' }),
+          expect.objectContaining({ namespace: 'openreelio', name: 'media_insert' }),
           expect.objectContaining({ namespace: 'openreelio', name: 'command_execute' }),
         ]),
       }),
@@ -197,6 +204,33 @@ describe('CodexReferenceAdapter', () => {
     });
     expect(appServerClient.interruptTurn).toHaveBeenCalledWith('thr_123', 'turn_2');
     expect(appServerClient.unsubscribeThread).toHaveBeenCalledWith('thr_123');
+  });
+
+  it('should steer an active Codex turn instead of starting a queued follow-up turn', async () => {
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      steerTurn: vi.fn().mockResolvedValue({ turnId: 'turn_1' }),
+      interruptTurn: vi.fn().mockResolvedValue(undefined),
+      unsubscribeThread: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter = new CodexReferenceAdapter(undefined, { appServerClient });
+    const session = await adapter.startSession({ projectId: 'project-1' });
+
+    await adapter.sendMessage(session.sessionId, { content: 'Add captions', cwd: '/project' });
+    await adapter.sendMessage(session.sessionId, {
+      content: 'Actually keep them in the lower third',
+      cwd: '/project',
+    });
+    await adapter.interrupt(session.sessionId);
+
+    expect(appServerClient.startTurn).toHaveBeenCalledTimes(1);
+    expect(appServerClient.steerTurn).toHaveBeenCalledWith(
+      'thr_123',
+      'turn_1',
+      'Actually keep them in the lower third',
+    );
+    expect(appServerClient.interruptTurn).toHaveBeenCalledWith('thr_123', 'turn_1');
   });
 
   it('should resume a persisted Codex thread before sending a follow-up message', async () => {
@@ -448,6 +482,26 @@ describe('CodexReferenceAdapter', () => {
           isDirty: false,
         };
       }
+      if (command === 'get_annotation') {
+        return {
+          status: 'completed',
+          annotation: {
+            version: '1',
+            assetId: 'asset-1',
+            assetHash: 'hash',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+            analysis: {
+              faces: {
+                provider: 'google_cloud',
+                analyzedAt: '2026-01-01T00:00:00Z',
+                config: {},
+                results: [],
+              },
+            },
+          },
+        };
+      }
       throw new Error(`Unexpected command: ${command}`);
     });
     const adapter = new CodexReferenceAdapter(undefined, { appServerClient });
@@ -521,6 +575,26 @@ describe('CodexReferenceAdapter', () => {
           isDirty: false,
         };
       }
+      if (command === 'get_annotation') {
+        return {
+          status: 'completed',
+          annotation: {
+            version: '1',
+            assetId: 'asset-1',
+            assetHash: 'hash',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+            analysis: {
+              faces: {
+                provider: 'google_cloud',
+                analyzedAt: '2026-01-01T00:00:00Z',
+                config: {},
+                results: [],
+              },
+            },
+          },
+        };
+      }
       throw new Error(`Unexpected command: ${command}`);
     });
     const adapter = new CodexReferenceAdapter(undefined, { appServerClient });
@@ -554,6 +628,17 @@ describe('CodexReferenceAdapter', () => {
         input: '{}',
       },
     })) as any;
+    const annotationResponse = (await respondToRequest({
+      id: 16,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_annotation_read',
+        tool: 'openreelio.annotation_read',
+        input: '{"assetId":"asset-1"}',
+      },
+    })) as any;
 
     expect(projectStateResponse.success).toBe(true);
     expect(getFirstTextContent(projectStateResponse)).toContain('"contextToken"');
@@ -562,8 +647,13 @@ describe('CodexReferenceAdapter', () => {
     expect(getFirstTextContent(commandSchemaResponse)).toContain('"mutationTool"');
     expect(getFirstTextContent(commandSchemaResponse)).toContain('"ImportGeneratedCaptions"');
     expect(getFirstTextContent(commandSchemaResponse)).toContain('"AddTextClip"');
+    expect(getFirstTextContent(commandSchemaResponse)).toContain('"textWorkflows"');
+    expect(getFirstTextContent(commandSchemaResponse)).toContain('"SetClipTransform"');
     expect(getFirstTextContent(commandSchemaResponse)).toContain('"vertical_1080"');
     expect(getFirstTextContent(commandSchemaResponse)).toContain('"1080x1920"');
+    expect(annotationResponse.success).toBe(true);
+    expect(getFirstTextContent(annotationResponse)).toContain('"analysisStatus"');
+    expect(getFirstTextContent(annotationResponse)).toContain('"asset-1"');
   });
 
   it('should expose stock media search through the Codex bridge', async () => {
@@ -760,6 +850,132 @@ describe('CodexReferenceAdapter', () => {
       }),
     );
     expect(projectStoreMocks.refreshFromBackendMutation).toHaveBeenCalled();
+  });
+
+  it('should place media through the Codex bridge using the drag-and-drop parity path', async () => {
+    const requestHandlers: Array<(request: any) => unknown> = [];
+    const approvalDecisionProvider = vi.fn().mockResolvedValue('accept');
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onServerRequest: vi.fn((handler: (request: any) => unknown) => {
+        requestHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_project_state') {
+        return {
+          meta: { name: 'Project' },
+          activeSequenceId: 'seq-1',
+          assets: [],
+          sequences: [],
+          isDirty: false,
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    vi.mocked(insertAgentMediaClip).mockResolvedValue({
+      insertResult: {
+        opId: 'op-video',
+        changes: [],
+        createdIds: ['clip-video'],
+        deletedIds: [],
+      },
+      clipId: 'clip-video',
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-video',
+      timelineStart: 4,
+      sourceIn: 1,
+      sourceOut: 6,
+      durationSec: 5,
+      linkedAudio: {
+        trackId: 'audio-1',
+        clipId: 'clip-audio',
+        createdTrack: false,
+      },
+    });
+    projectStoreMocks.refreshFromBackendMutation.mockResolvedValue(11);
+    const adapter = new CodexReferenceAdapter(undefined, {
+      appServerClient,
+      approvalDecisionProvider,
+    });
+
+    await adapter.startSession({ projectId: 'project-1', cwd: '/project' });
+    const respondToRequest = requestHandlers[0];
+    if (!respondToRequest) {
+      throw new Error('Expected Codex server request handler to be registered');
+    }
+
+    const contextResponse = (await respondToRequest({
+      id: 19,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_context',
+        namespace: 'openreelio',
+        tool: 'project_state',
+        arguments: {},
+      },
+    })) as any;
+    const contextToken = JSON.parse(getFirstTextContent(contextResponse)).contextToken;
+
+    const response = (await respondToRequest({
+      id: 20,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_media_insert',
+        namespace: 'openreelio',
+        tool: 'media_insert',
+        arguments: {
+          sequenceId: 'seq-1',
+          trackId: 'video-1',
+          assetId: 'asset-video',
+          timelineStart: 4,
+          sourceIn: 1,
+          sourceOut: 6,
+          reason: 'Place the selected interview range on the timeline.',
+          contextToken,
+        },
+      },
+    })) as any;
+
+    expect(response.success).toBe(true);
+    expect(approvalDecisionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalType: 'openreelio_edit_command',
+        tool: 'OpenReelio edit',
+        args: expect.objectContaining({
+          commandType: 'MediaInsert',
+          payload: expect.objectContaining({
+            sequenceId: 'seq-1',
+            trackId: 'video-1',
+            assetId: 'asset-video',
+            sourceIn: 1,
+            sourceOut: 6,
+          }),
+        }),
+      }),
+    );
+    expect(insertAgentMediaClip).toHaveBeenCalledWith({
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-video',
+      timelineStart: 4,
+      sourceIn: 1,
+      sourceOut: 6,
+      audioOnly: false,
+      autoExtractLinkedAudio: undefined,
+    });
+    expect(getFirstTextContent(response)).toContain('drag-and-drop parity path');
+    expect(getFirstTextContent(response)).toContain('"clip-audio"');
+    expect(getFirstTextContent(response)).toContain('"stateVersion": 11');
   });
 
   it('should reject stock media search without a query before invoking Tauri', async () => {

--- a/src/agents/external/adapters/CodexReferenceAdapter.test.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.test.ts
@@ -233,6 +233,52 @@ describe('CodexReferenceAdapter', () => {
     expect(appServerClient.interruptTurn).toHaveBeenCalledWith('thr_123', 'turn_1');
   });
 
+  it('should start a new Codex turn after a terminal failure notification', async () => {
+    const notificationHandlers: Array<(notification: any) => void> = [];
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi
+        .fn()
+        .mockResolvedValueOnce({ id: 'turn_1', status: 'inProgress' })
+        .mockResolvedValueOnce({ id: 'turn_2', status: 'inProgress' }),
+      steerTurn: vi.fn().mockResolvedValue({ turnId: 'turn_1' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onNotification: vi.fn((handler: (notification: any) => void) => {
+        notificationHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    const adapter = new CodexReferenceAdapter(undefined, { appServerClient });
+
+    const session = await adapter.startSession({
+      projectId: 'project-1',
+      prompt: 'Initial request',
+    });
+    const emitNotification = notificationHandlers[0];
+    if (!emitNotification) {
+      throw new Error('Expected Codex notification handler to be registered');
+    }
+
+    emitNotification({
+      method: 'turn/failed',
+      params: {
+        threadId: 'thr_123',
+        turn: { id: 'turn_1', status: 'failed' },
+      },
+    });
+    await adapter.sendMessage(session.sessionId, { content: 'Try again', cwd: '/project' });
+
+    expect(appServerClient.startTurn).toHaveBeenCalledTimes(2);
+    expect(appServerClient.startTurn).toHaveBeenLastCalledWith('thr_123', 'Try again', {
+      model: 'gpt-5.5',
+      effort: 'medium',
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+    });
+    expect(appServerClient.steerTurn).not.toHaveBeenCalled();
+  });
+
   it('should resume a persisted Codex thread before sending a follow-up message', async () => {
     const appServerClient = {
       startThread: vi.fn(),
@@ -976,6 +1022,127 @@ describe('CodexReferenceAdapter', () => {
     expect(getFirstTextContent(response)).toContain('drag-and-drop parity path');
     expect(getFirstTextContent(response)).toContain('"clip-audio"');
     expect(getFirstTextContent(response)).toContain('"stateVersion": 11');
+  });
+
+  it('should route command_execute InsertClip approvals through the media insert surface', async () => {
+    const requestHandlers: Array<(request: any) => unknown> = [];
+    const approvalDecisionProvider = vi.fn().mockResolvedValue('accept');
+    const appServerClient = {
+      startThread: vi.fn().mockResolvedValue({ id: 'thr_123' }),
+      startTurn: vi.fn().mockResolvedValue({ id: 'turn_1', status: 'inProgress' }),
+      interruptTurn: vi.fn(),
+      unsubscribeThread: vi.fn(),
+      onServerRequest: vi.fn((handler: (request: any) => unknown) => {
+        requestHandlers.push(handler);
+        return vi.fn();
+      }),
+    };
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_project_state') {
+        return {
+          meta: { name: 'Project' },
+          activeSequenceId: 'seq-1',
+          assets: [],
+          sequences: [],
+          isDirty: false,
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    vi.mocked(insertAgentMediaClip).mockResolvedValue({
+      insertResult: {
+        opId: 'op-video',
+        changes: [],
+        createdIds: ['clip-video'],
+        deletedIds: [],
+      },
+      clipId: 'clip-video',
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-video',
+      timelineStart: 4,
+      sourceIn: 1,
+      sourceOut: 6,
+      durationSec: 5,
+    });
+    projectStoreMocks.refreshFromBackendMutation.mockResolvedValue(12);
+    const adapter = new CodexReferenceAdapter(undefined, {
+      appServerClient,
+      approvalDecisionProvider,
+    });
+
+    await adapter.startSession({ projectId: 'project-1', cwd: '/project' });
+    const respondToRequest = requestHandlers[0];
+    if (!respondToRequest) {
+      throw new Error('Expected Codex server request handler to be registered');
+    }
+
+    const contextResponse = (await respondToRequest({
+      id: 21,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_context',
+        namespace: 'openreelio',
+        tool: 'project_state',
+        arguments: {},
+      },
+    })) as any;
+    const contextToken = JSON.parse(getFirstTextContent(contextResponse)).contextToken;
+
+    const response = (await respondToRequest({
+      id: 22,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thr_123',
+        turnId: 'turn_1',
+        callId: 'tool_insert_clip',
+        namespace: 'openreelio',
+        tool: 'command_execute',
+        arguments: {
+          commandType: 'InsertClip',
+          payload: {
+            sequenceId: 'seq-1',
+            trackId: 'video-1',
+            assetId: 'asset-video',
+            timelineStart: 4,
+            sourceIn: 1,
+            sourceOut: 6,
+          },
+          reason: 'Place the selected interview range on the timeline.',
+          contextToken,
+        },
+      },
+    })) as any;
+
+    expect(response.success).toBe(true);
+    expect(approvalDecisionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalType: 'openreelio_edit_command',
+        args: expect.objectContaining({
+          commandType: 'MediaInsert',
+          payload: expect.objectContaining({
+            sequenceId: 'seq-1',
+            trackId: 'video-1',
+            assetId: 'asset-video',
+          }),
+        }),
+      }),
+    );
+    expect(invoke).not.toHaveBeenCalledWith('validate_command_payload', expect.anything());
+    expect(insertAgentMediaClip).toHaveBeenCalledWith({
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-video',
+      timelineStart: 4,
+      sourceIn: 1,
+      sourceOut: 6,
+      audioOnly: false,
+      autoExtractLinkedAudio: undefined,
+    });
+    expect(getFirstTextContent(response)).toContain('drag-and-drop parity path');
+    expect(getFirstTextContent(response)).toContain('"stateVersion": 12');
   });
 
   it('should reject stock media search without a query before invoking Tauri', async () => {

--- a/src/agents/external/adapters/CodexReferenceAdapter.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.ts
@@ -44,11 +44,14 @@ type CodexAppServerClientPort = Pick<
   CodexAppServerClient,
   'startThread' | 'startTurn' | 'interruptTurn' | 'unsubscribeThread'
 > &
-  Partial<Pick<CodexAppServerClient, 'resumeThread' | 'onNotification' | 'onServerRequest'>>;
+  Partial<
+    Pick<CodexAppServerClient, 'resumeThread' | 'steerTurn' | 'onNotification' | 'onServerRequest'>
+  >;
 
 interface CodexSessionState {
   threadId: string;
   lastTurnId: string | null;
+  activeTurnId: string | null;
   projectId: string;
   cwd: string | null;
 }
@@ -133,6 +136,7 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     this.sessions.set(sessionId, {
       threadId: thread.id,
       lastTurnId: null,
+      activeTurnId: null,
       projectId: input.projectId,
       cwd: input.cwd ?? null,
     });
@@ -170,6 +174,7 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     this.sessions.set(thread.id, {
       threadId: thread.id,
       lastTurnId: null,
+      activeTurnId: null,
       projectId: input.projectId,
       cwd: input.cwd ?? null,
     });
@@ -181,6 +186,16 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     const client = await this.getAppServerClient();
     const session = this.requireSession(sessionId);
     session.cwd = message.cwd ?? session.cwd;
+    if (session.activeTurnId && client.steerTurn) {
+      const result = await client.steerTurn(
+        session.threadId,
+        session.activeTurnId,
+        message.content,
+      );
+      this.rememberSteeredTurn(sessionId, result.turnId);
+      return;
+    }
+
     const turn = await client.startTurn(session.threadId, message.content, {
       model: this.resolveModel(),
       effort: this.resolveReasoningEffort(),
@@ -193,11 +208,15 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
   async interrupt(sessionId: string): Promise<void> {
     const client = await this.getAppServerClient();
     const session = this.requireSession(sessionId);
-    if (!session.lastTurnId) {
+    const turnId = session.activeTurnId ?? session.lastTurnId;
+    if (!turnId) {
       throw new Error(`Codex session ${sessionId} has no active turn to interrupt`);
     }
 
-    await client.interruptTurn(session.threadId, session.lastTurnId);
+    await client.interruptTurn(session.threadId, turnId);
+    if (session.activeTurnId === turnId) {
+      session.activeTurnId = null;
+    }
   }
 
   async shutdown(sessionId: string): Promise<void> {
@@ -208,6 +227,9 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     clearOpenReelioCodexSession(sessionId);
     if (session.lastTurnId) {
       this.turnSessionIds.delete(session.lastTurnId);
+    }
+    if (session.activeTurnId) {
+      this.turnSessionIds.delete(session.activeTurnId);
     }
   }
 
@@ -279,7 +301,15 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
   private rememberTurn(sessionId: string, turn: CodexTurn): void {
     const session = this.requireSession(sessionId);
     session.lastTurnId = turn.id;
+    session.activeTurnId = isTerminalCodexTurnStatus(turn.status) ? null : turn.id;
     this.turnSessionIds.set(turn.id, sessionId);
+  }
+
+  private rememberSteeredTurn(sessionId: string, turnId: string): void {
+    const session = this.requireSession(sessionId);
+    session.lastTurnId = turnId;
+    session.activeTurnId = turnId;
+    this.turnSessionIds.set(turnId, sessionId);
   }
 
   private attachClientHandlers(client: CodexAppServerClientPort): void {
@@ -429,6 +459,11 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     const session = this.sessions.get(threadId);
     if (session) {
       session.lastTurnId = turnId;
+      if (notification.method === 'turn/started') {
+        session.activeTurnId = turnId;
+      } else if (notification.method === 'turn/completed' && session.activeTurnId === turnId) {
+        session.activeTurnId = null;
+      }
     }
   }
 
@@ -523,6 +558,10 @@ function isDangerousOsCommand(command: string): boolean {
   ];
 
   return dangerousPatterns.some((pattern) => pattern.test(normalized));
+}
+
+function isTerminalCodexTurnStatus(status: string | null | undefined): boolean {
+  return status === 'completed' || status === 'failed' || status === 'interrupted';
 }
 
 function getString(input: CodexJsonObject | null | undefined, key: string): string | null {

--- a/src/agents/external/adapters/CodexReferenceAdapter.ts
+++ b/src/agents/external/adapters/CodexReferenceAdapter.ts
@@ -458,10 +458,14 @@ export class CodexReferenceAdapter implements ExternalAgentRuntimeAdapter {
     this.turnSessionIds.set(turnId, threadId);
     const session = this.sessions.get(threadId);
     if (session) {
+      const status = getString(turn, 'status') ?? getString(params, 'status');
       session.lastTurnId = turnId;
       if (notification.method === 'turn/started') {
         session.activeTurnId = turnId;
-      } else if (notification.method === 'turn/completed' && session.activeTurnId === turnId) {
+      } else if (
+        session.activeTurnId === turnId &&
+        isTerminalCodexTurnNotification(notification.method, status)
+      ) {
         session.activeTurnId = null;
       }
     }
@@ -562,6 +566,18 @@ function isDangerousOsCommand(command: string): boolean {
 
 function isTerminalCodexTurnStatus(status: string | null | undefined): boolean {
   return status === 'completed' || status === 'failed' || status === 'interrupted';
+}
+
+function isTerminalCodexTurnNotification(
+  method: string,
+  status: string | null | undefined,
+): boolean {
+  return (
+    method === 'turn/completed' ||
+    method === 'turn/failed' ||
+    method === 'turn/interrupted' ||
+    isTerminalCodexTurnStatus(status)
+  );
 }
 
 function getString(input: CodexJsonObject | null | undefined, key: string): string | null {

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1062,6 +1062,19 @@ async function executeApprovedCommand(
     };
   }
 
+  if (commandType === 'InsertClip') {
+    const mediaArgs: CodexJsonObject = {
+      ...payload,
+      reason,
+      contextToken,
+    };
+    if (mediaArgs.timelineStart === undefined && mediaArgs.timelineIn !== undefined) {
+      mediaArgs.timelineStart = mediaArgs.timelineIn;
+    }
+
+    return insertMediaToolCall(mediaArgs, request, context);
+  }
+
   const payloadValidation = await validateCommandPayload(commandType, payload);
   if (!payloadValidation.valid) {
     return {
@@ -1090,10 +1103,6 @@ async function executeApprovedCommand(
       message:
         'The OpenReelio command was not approved. Approve it with the chat approval card; plain chat replies do not grant tool execution.',
     };
-  }
-
-  if (commandType === 'InsertClip') {
-    return executeApprovedInsertClipViaMediaPath(payload, context);
   }
 
   const plan: AgentPlan = {
@@ -1142,71 +1151,6 @@ async function executeApprovedCommand(
     result,
     refresh,
   };
-}
-
-async function executeApprovedInsertClipViaMediaPath(
-  payload: CodexJsonObject,
-  context: OpenReelioCodexToolContext,
-): Promise<CodexJsonObject> {
-  const sequenceId = getRequiredStringArg(payload, 'sequenceId', 'command_execute InsertClip');
-  const trackId = getRequiredStringArg(payload, 'trackId', 'command_execute InsertClip');
-  const assetId = getRequiredStringArg(payload, 'assetId', 'command_execute InsertClip');
-  const timelineStartValue = payload.timelineStart ?? payload.timelineIn;
-  if (
-    typeof timelineStartValue !== 'number' ||
-    !Number.isFinite(timelineStartValue) ||
-    timelineStartValue < 0
-  ) {
-    throw new Error(
-      'OpenReelio command_execute InsertClip requires timelineStart to be a finite non-negative number.',
-    );
-  }
-  const sourceIn = getFiniteNonNegativeNumberArg(
-    payload,
-    'sourceIn',
-    'command_execute InsertClip',
-  );
-  const sourceOut = getFiniteNonNegativeNumberArg(
-    payload,
-    'sourceOut',
-    'command_execute InsertClip',
-  );
-
-  try {
-    const insert = await insertAgentMediaClip({
-      sequenceId,
-      trackId,
-      assetId,
-      timelineStart: timelineStartValue,
-      sourceIn,
-      sourceOut,
-    });
-    const refresh = await refreshProjectStoreAfterMutation();
-
-    return {
-      status: 'ok',
-      commandType: 'InsertClip',
-      routedThrough: 'openreelio.media_insert',
-      message:
-        'Raw InsertClip was executed through the media insertion path to preserve preview visibility and linked audio parity.',
-      result: {
-        opId: insert.insertResult.opId,
-        createdIds: insert.insertResult.createdIds,
-        clipId: insert.clipId,
-        sequenceId: insert.sequenceId,
-        trackId: insert.trackId,
-        assetId: insert.assetId,
-        timelineStart: insert.timelineStart,
-        sourceIn: insert.sourceIn ?? null,
-        sourceOut: insert.sourceOut ?? null,
-        durationSec: insert.durationSec,
-        linkedAudio: insert.linkedAudio ?? null,
-      },
-      refresh,
-    };
-  } finally {
-    contextTokensBySessionId.delete(context.sessionId);
-  }
 }
 
 async function validateCommandToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
@@ -2219,7 +2163,8 @@ function buildCommandSchema(): CodexJsonObject {
         'Use caption style/position metadata for subtitle readability instead of editable overlay text when the user wants semantic subtitles.',
       ],
       placementDefaults: {
-        subtitle: 'Bottom center around y=0.85 with outline/shadow unless it covers important visual content.',
+        subtitle:
+          'Bottom center around y=0.85 with outline/shadow unless it covers important visual content.',
         title: 'Center or upper third depending on the shot composition.',
         lowerThird: 'Lower-left or lower-center with enough safe margin and readable contrast.',
       },

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1,13 +1,14 @@
 import { invoke } from '@tauri-apps/api/core';
 
-import type {
-  AgentPlan,
-  AgentPlanResult,
-  PlanRiskLevel,
-  ProjectInfo,
-  ProjectStateDto,
-  StockMediaImportResult,
-  StockMediaSearchResult,
+import {
+  commands,
+  type AgentPlan,
+  type AgentPlanResult,
+  type PlanRiskLevel,
+  type ProjectInfo,
+  type ProjectStateDto,
+  type StockMediaImportResult,
+  type StockMediaSearchResult,
 } from '@/bindings';
 
 import type { ExternalAgentApprovalDecisionProvider, ExternalAgentApprovalRequest } from '../types';
@@ -19,6 +20,7 @@ import type {
 } from './CodexAppServerClient';
 import { runProjectBackendMutation } from '@/services/projectMutationGateway';
 import { issueAgentPlanApprovalProof } from '@/services/agentPlanApprovalProof';
+import { insertAgentMediaClip } from '@/agents/tools/mediaInsertion';
 
 export interface OpenReelioCodexSessionContext {
   projectId: string;
@@ -144,6 +146,19 @@ const EMPTY_OBJECT_SCHEMA: CodexJsonObject = {
   additionalProperties: false,
 };
 
+const ANNOTATION_READ_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['assetId'],
+  properties: {
+    assetId: {
+      type: 'string',
+      description:
+        'Project asset ID whose cached analysis annotation should be read for placement or edit planning.',
+    },
+  },
+  additionalProperties: false,
+};
+
 const COMMAND_EXECUTE_SCHEMA: CodexJsonObject = {
   type: 'object',
   required: ['commandType', 'payload', 'reason', 'contextToken'],
@@ -210,6 +225,58 @@ const PLAN_APPLY_SCHEMA: CodexJsonObject = {
     reason: {
       type: 'string',
       description: 'Short user-facing reason for the plan approval prompt.',
+    },
+    contextToken: {
+      type: 'string',
+      description:
+        'Fresh mutation context token returned by openreelio.project_state, timeline_snapshot, assets_list, or selection_read in this session.',
+    },
+  },
+  additionalProperties: false,
+};
+
+const MEDIA_INSERT_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['sequenceId', 'trackId', 'assetId', 'timelineStart', 'reason', 'contextToken'],
+  properties: {
+    sequenceId: {
+      type: 'string',
+      description: 'Target sequence ID.',
+    },
+    trackId: {
+      type: 'string',
+      description:
+        'Target visible video/overlay track for video/image media, or audio track for audio media.',
+    },
+    assetId: {
+      type: 'string',
+      description: 'Project asset ID to place on the timeline.',
+    },
+    timelineStart: {
+      type: 'number',
+      description: 'Timeline start in seconds.',
+    },
+    sourceIn: {
+      type: 'number',
+      description: 'Optional source media in point in seconds.',
+    },
+    sourceOut: {
+      type: 'number',
+      description: 'Optional source media out point in seconds.',
+    },
+    audioOnly: {
+      type: 'boolean',
+      description:
+        'Set true only when intentionally placing the audio stream from a video asset onto an audio track.',
+    },
+    autoExtractLinkedAudio: {
+      type: 'boolean',
+      description:
+        'Defaults true for video on visual tracks: create matching linked audio, link clips, and mute source video audio.',
+    },
+    reason: {
+      type: 'string',
+      description: 'Short user-facing reason for the edit approval prompt.',
     },
     contextToken: {
       type: 'string',
@@ -337,6 +404,13 @@ export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
   },
   {
     namespace: 'openreelio',
+    name: 'annotation_read',
+    description:
+      'Read cached objects/faces/OCR/shot annotations for one asset. Use this before choosing safe text/caption placement when exact visual position matters.',
+    inputSchema: ANNOTATION_READ_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
     name: 'stock_media_search',
     description:
       'Search configured stock providers for video, image, or audio candidates. Returns provider references, previews, license info, and license policy decisions. Does not import or place media.',
@@ -374,7 +448,7 @@ export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
     namespace: 'openreelio',
     name: 'command_schema',
     description:
-      'Read the supported OpenReelio event-sourced edit command types and payload conventions.',
+      'Read the supported OpenReelio event-sourced edit command types, text/caption workflows, and payload conventions.',
     inputSchema: EMPTY_OBJECT_SCHEMA,
   },
   {
@@ -397,6 +471,13 @@ export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
     description:
       'Preview a non-mutating structural summary of an OpenReelio AgentPlan after validation.',
     inputSchema: PLAN_VALIDATE_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'media_insert',
+    description:
+      'Insert a media asset like the OpenReelio UI drag-and-drop path: validates track/asset compatibility, supports sourceIn/sourceOut, and auto-creates linked audio for video clips.',
+    inputSchema: MEDIA_INSERT_SCHEMA,
   },
   {
     namespace: 'openreelio',
@@ -442,9 +523,12 @@ export function buildOpenReelioCodexDeveloperInstructions(
     '- Use OpenReelio dynamic tools before claiming project, timeline, asset, or selection facts.',
     '- Use openreelio.host_context first when the user asks where you are, what you can use, or what environment this is.',
     '- Use openreelio.timeline_snapshot, openreelio.assets_list, openreelio.selection_read, and openreelio.command_schema before proposing concrete edits.',
+    '- Use openreelio.annotation_read for the source asset before deciding exact text placement that should avoid faces, objects, or existing OCR text.',
     '- Use openreelio.stock_media_search for stock video, image, BGM, or SFX candidates before falling back to generic web links.',
     '- Use openreelio.stock_media_import to bring a selected stock candidate into the project before placing it on the timeline. Do not pass stock URLs directly to ImportAsset.',
-    '- Prefer openreelio.plan_validate and openreelio.plan_apply for multi-step edits. Use openreelio.command_execute only for a narrow single-command edit.',
+    '- Use openreelio.media_insert when placing media assets on the timeline. It is the drag-and-drop parity path for source ranges, visible video placement, linked audio, clip linking, muting, undo, and UI refresh.',
+    '- For editable on-video text, titles, lower thirds, and callouts, use AddTextClip/UpdateTextClip/SetClipTransform with full TextClipData and preview transform data. For timed subtitles from speech or files, use CreateCaption/UpdateCaption/ImportGeneratedCaptions.',
+    '- Prefer openreelio.plan_validate and openreelio.plan_apply for multi-step non-media edits. Use openreelio.command_execute only for a narrow single-command edit; do not use raw InsertClip for normal asset placement.',
     '- Apply edits with the fresh contextToken returned by openreelio.project_state, openreelio.timeline_snapshot, openreelio.assets_list, or openreelio.selection_read so the app can validate, approve, persist, undo, and refresh the UI.',
     '- Do not manually edit .openreelio state files or invent command payloads without checking the schema and current IDs.',
     '- Do not use shell or filesystem tools to mutate OpenReelio project state; OpenReelio edits must go through the command log.',
@@ -485,6 +569,10 @@ export async function handleOpenReelioCodexDynamicToolCall(
         return toolResponse(buildTimelineSnapshot(await readProjectState(), context));
       case 'assets_list':
         return toolResponse(buildAssetsList(await readProjectState(), context));
+      case 'annotation_read': {
+        const result = await readAnnotationToolCall(toolCall.arguments);
+        return toolResponse(result, result.status === 'ok');
+      }
       case 'stock_media_search': {
         const result = await searchStockMediaToolCall(toolCall.arguments);
         return toolResponse(result, result.status === 'ok');
@@ -511,6 +599,10 @@ export async function handleOpenReelioCodexDynamicToolCall(
       }
       case 'diff_preview': {
         const result = await previewPlanDiff(toolCall.arguments);
+        return toolResponse(result, result.status === 'ok');
+      }
+      case 'media_insert': {
+        const result = await insertMediaToolCall(toolCall.arguments, request, context);
         return toolResponse(result, result.status === 'ok');
       }
       case 'plan_apply': {
@@ -664,10 +756,12 @@ async function buildHostContext(context: OpenReelioCodexToolContext): Promise<Co
       projectStateRead: true,
       timelineRead: true,
       assetRead: true,
+      annotationRead: true,
       commandSchemaRead: true,
       commandValidate: true,
       stockMediaSearch: true,
       stockMediaImport: true,
+      mediaInsert: true,
       planValidate: true,
       planApplyWithApproval: true,
       diffPreview: true,
@@ -678,7 +772,7 @@ async function buildHostContext(context: OpenReelioCodexToolContext): Promise<Co
       undoableCommandLog: true,
     },
     policy: {
-      mutationPath: 'openreelio.plan_apply',
+      mutationPath: 'openreelio.media_insert or openreelio.plan_apply',
       approvalRequiredForMutations: true,
       directStateFileEdits: 'forbidden',
       contextTokenRequiredForMutations: true,
@@ -823,6 +917,104 @@ async function buildPreviewDescription(): Promise<CodexJsonObject> {
   };
 }
 
+async function insertMediaToolCall(
+  args: CodexJsonObject | null,
+  request: CodexAppServerRequest,
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
+  if (!args) {
+    throw new Error('OpenReelio media_insert requires object arguments.');
+  }
+
+  const sequenceId = getRequiredStringArg(args, 'sequenceId', 'media_insert');
+  const trackId = getRequiredStringArg(args, 'trackId', 'media_insert');
+  const assetId = getRequiredStringArg(args, 'assetId', 'media_insert');
+  const timelineStart = getFiniteNonNegativeNumberArg(args, 'timelineStart', 'media_insert', true);
+  if (timelineStart === undefined) {
+    throw new Error('OpenReelio media_insert requires timelineStart.');
+  }
+  const sourceIn = getFiniteNonNegativeNumberArg(args, 'sourceIn', 'media_insert');
+  const sourceOut = getFiniteNonNegativeNumberArg(args, 'sourceOut', 'media_insert');
+  const audioOnly = args.audioOnly === true;
+  const autoExtractLinkedAudio =
+    typeof args.autoExtractLinkedAudio === 'boolean' ? args.autoExtractLinkedAudio : undefined;
+  const reason =
+    getString(args, 'reason')?.trim() || `Insert media asset ${assetId} on the timeline`;
+  const contextToken = getString(args, 'contextToken')?.trim() ?? null;
+  const tokenValidation = validateContextToken(context, contextToken);
+  if (!tokenValidation.valid) {
+    return {
+      status: 'error',
+      message: tokenValidation.message.replace(/command_execute/g, 'media_insert'),
+    };
+  }
+
+  const payload: CodexJsonObject = {
+    sequenceId,
+    trackId,
+    assetId,
+    timelineStart,
+    ...(sourceIn !== undefined ? { sourceIn } : {}),
+    ...(sourceOut !== undefined ? { sourceOut } : {}),
+    ...(audioOnly ? { audioOnly } : {}),
+    ...(autoExtractLinkedAudio !== undefined ? { autoExtractLinkedAudio } : {}),
+  };
+  const decision = context.approvalDecisionProvider
+    ? await context.approvalDecisionProvider(
+        buildCommandApprovalRequest({
+          request,
+          context,
+          commandType: 'MediaInsert',
+          payload,
+          reason,
+        }),
+      )
+    : 'decline';
+
+  if (decision !== 'accept' && decision !== 'acceptForSession') {
+    return {
+      status: 'denied',
+      message:
+        'The OpenReelio media insert was not approved. Approve it with the chat approval card; plain chat replies do not grant tool execution.',
+    };
+  }
+
+  try {
+    const insert = await insertAgentMediaClip({
+      sequenceId,
+      trackId,
+      assetId,
+      timelineStart,
+      sourceIn,
+      sourceOut,
+      audioOnly,
+      autoExtractLinkedAudio,
+    });
+    const refresh = await refreshProjectStoreAfterMutation();
+
+    return {
+      status: 'ok',
+      message: 'Media inserted through the drag-and-drop parity path.',
+      result: {
+        opId: insert.insertResult.opId,
+        createdIds: insert.insertResult.createdIds,
+        clipId: insert.clipId,
+        sequenceId: insert.sequenceId,
+        trackId: insert.trackId,
+        assetId: insert.assetId,
+        timelineStart: insert.timelineStart,
+        sourceIn: insert.sourceIn ?? null,
+        sourceOut: insert.sourceOut ?? null,
+        durationSec: insert.durationSec,
+        linkedAudio: insert.linkedAudio ?? null,
+      },
+      refresh,
+    };
+  } finally {
+    contextTokensBySessionId.delete(context.sessionId);
+  }
+}
+
 async function executeApprovedCommand(
   args: CodexJsonObject | null,
   request: CodexAppServerRequest,
@@ -900,6 +1092,10 @@ async function executeApprovedCommand(
     };
   }
 
+  if (commandType === 'InsertClip') {
+    return executeApprovedInsertClipViaMediaPath(payload, context);
+  }
+
   const plan: AgentPlan = {
     id: `codex-command-${context.sessionId}-${request.id}`,
     goal: reason,
@@ -946,6 +1142,71 @@ async function executeApprovedCommand(
     result,
     refresh,
   };
+}
+
+async function executeApprovedInsertClipViaMediaPath(
+  payload: CodexJsonObject,
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
+  const sequenceId = getRequiredStringArg(payload, 'sequenceId', 'command_execute InsertClip');
+  const trackId = getRequiredStringArg(payload, 'trackId', 'command_execute InsertClip');
+  const assetId = getRequiredStringArg(payload, 'assetId', 'command_execute InsertClip');
+  const timelineStartValue = payload.timelineStart ?? payload.timelineIn;
+  if (
+    typeof timelineStartValue !== 'number' ||
+    !Number.isFinite(timelineStartValue) ||
+    timelineStartValue < 0
+  ) {
+    throw new Error(
+      'OpenReelio command_execute InsertClip requires timelineStart to be a finite non-negative number.',
+    );
+  }
+  const sourceIn = getFiniteNonNegativeNumberArg(
+    payload,
+    'sourceIn',
+    'command_execute InsertClip',
+  );
+  const sourceOut = getFiniteNonNegativeNumberArg(
+    payload,
+    'sourceOut',
+    'command_execute InsertClip',
+  );
+
+  try {
+    const insert = await insertAgentMediaClip({
+      sequenceId,
+      trackId,
+      assetId,
+      timelineStart: timelineStartValue,
+      sourceIn,
+      sourceOut,
+    });
+    const refresh = await refreshProjectStoreAfterMutation();
+
+    return {
+      status: 'ok',
+      commandType: 'InsertClip',
+      routedThrough: 'openreelio.media_insert',
+      message:
+        'Raw InsertClip was executed through the media insertion path to preserve preview visibility and linked audio parity.',
+      result: {
+        opId: insert.insertResult.opId,
+        createdIds: insert.insertResult.createdIds,
+        clipId: insert.clipId,
+        sequenceId: insert.sequenceId,
+        trackId: insert.trackId,
+        assetId: insert.assetId,
+        timelineStart: insert.timelineStart,
+        sourceIn: insert.sourceIn ?? null,
+        sourceOut: insert.sourceOut ?? null,
+        durationSec: insert.durationSec,
+        linkedAudio: insert.linkedAudio ?? null,
+      },
+      refresh,
+    };
+  } finally {
+    contextTokensBySessionId.delete(context.sessionId);
+  }
 }
 
 async function validateCommandToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
@@ -1752,6 +2013,40 @@ function buildAssetsList(
   };
 }
 
+async function readAnnotationToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
+  const assetId = getString(args, 'assetId')?.trim();
+  if (!assetId) {
+    return {
+      status: 'error',
+      message: 'assetId is required.',
+    };
+  }
+
+  try {
+    const result = await commands.getAnnotation(assetId);
+    if (result.status === 'error') {
+      return {
+        status: 'error',
+        assetId,
+        message: String(result.error),
+      };
+    }
+
+    return {
+      status: 'ok',
+      assetId,
+      analysisStatus: result.data.status,
+      annotation: result.data.annotation,
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      assetId,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 function issueContextToken(
   context: OpenReelioCodexToolContext,
   state: ProjectStateDto | null,
@@ -1848,16 +2143,30 @@ function buildCommandSchema(): CodexJsonObject {
         ],
         note: 'Use youtube_shorts or 1080x1920 for Shorts/vertical edits. A newly created sequence becomes the active timeline.',
       },
+      CreateTrack: {
+        required: ['sequenceId', 'kind', 'name'],
+        optional: ['position'],
+        note: 'Use kind video or overlay for editable text clips. AddTextClip requires a target video/overlay track; create one first when no suitable upper text track exists.',
+      },
+      InsertClip: {
+        required: ['sequenceId', 'trackId', 'assetId', 'timelineStart'],
+        optional: ['sourceIn', 'sourceOut'],
+        note: 'Raw InsertClip is a primitive command and does not auto-create linked audio. Use openreelio.media_insert for normal asset placement so video stays visible and linked audio stays in sync.',
+      },
       ImportGeneratedCaptions: {
         required: ['sequenceId', 'trackId', 'segments'],
         optional: ['style', 'position', 'replaceExisting'],
         segmentShape: { startSec: 'number', endSec: 'number', text: 'string' },
+        styleShape:
+          'Caption style may include fontFamily, fontSize, fontWeight, bold, italic, underline, color, opacity, backgroundColor, backgroundPadding, outlineColor, outlineWidth, shadowColor, shadowOffsetX, shadowOffsetY, shadowBlur, alignment, lineHeight, and letterSpacing.',
+        positionShape:
+          'Caption position supports preset top/center/bottom or custom xPercent/yPercent.',
         note: 'Use this for AI/STT transcript segments so generated captions are imported atomically and remain undoable as one command.',
       },
       AddTextClip: {
         required: ['sequenceId', 'trackId', 'timelineIn', 'duration', 'textData'],
         textDataShape:
-          'TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow, outline, rotation, and opacity.',
+          'TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/backgroundPadding/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow(color/offsetX/offsetY/blur), outline(color/width), rotation, and opacity.',
         note: 'Text clips must be placed on a video or overlay track. Use SetClipTransform after creation when scale or anchor must be exact.',
       },
       UpdateTextClip: {
@@ -1875,15 +2184,46 @@ function buildCommandSchema(): CodexJsonObject {
       payload: 'CamelCase JSON object matching the selected command type',
       contextToken:
         'Fresh mutation contextToken returned by project_state, timeline_snapshot, or assets_list',
-      mutationTool: 'openreelio.command_execute',
+      mutationTool:
+        'Use openreelio.media_insert for asset placement; use openreelio.command_execute for primitive single-command edits.',
+      mediaMutationTool: 'openreelio.media_insert',
+      commandMutationTool: 'openreelio.command_execute',
     },
     rules: [
       'Read project_state or timeline_snapshot before using IDs and before every mutation.',
-      'Pass the returned contextToken to command_execute.',
+      'Pass the returned contextToken to media_insert, plan_apply, or command_execute.',
+      'Use media_insert instead of raw InsertClip when placing video, image, or audio assets on the timeline.',
       'Never edit .openreelio state files directly.',
       'command_execute prompts the user for approval and persists through the OpenReelio command log.',
       'Workspace filesystem commands are intentionally not exposed through command_execute.',
     ],
+    mediaWorkflows: {
+      timelinePlacement: [
+        'Read timeline_snapshot and assets_list to copy exact sequence, track, and asset IDs.',
+        'Choose a visible video or overlay track for video/image assets and an audio track for audio assets.',
+        'Call openreelio.media_insert with timelineStart and optional sourceIn/sourceOut.',
+        'Do not put a video asset on an audio track unless audioOnly=true is intentional; that creates an audio-only clip and will not show in preview.',
+        'For video assets, let autoExtractLinkedAudio default to true so the matching audio clip is created, linked, and the source video clip is muted.',
+      ],
+    },
+    textWorkflows: {
+      editableOverlay: [
+        'Read timeline_snapshot to find active sequence, existing text clips, and usable video/overlay tracks.',
+        'Read annotation_read for overlapping source assets when placement should avoid faces, objects, or OCR text.',
+        'CreateTrack(kind="video" or "overlay") when there is no unlocked non-overlapping text track above the media.',
+        'AddTextClip with complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity.',
+        'SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor.',
+      ],
+      timedSubtitles: [
+        'Use ImportGeneratedCaptions for AI transcript segments or CreateCaption/UpdateCaption for individual caption lines.',
+        'Use caption style/position metadata for subtitle readability instead of editable overlay text when the user wants semantic subtitles.',
+      ],
+      placementDefaults: {
+        subtitle: 'Bottom center around y=0.85 with outline/shadow unless it covers important visual content.',
+        title: 'Center or upper third depending on the shot composition.',
+        lowerThird: 'Lower-left or lower-center with enough safe margin and readable contrast.',
+      },
+    },
   };
 }
 
@@ -1925,6 +2265,35 @@ function asObject(value: unknown): CodexJsonObject | null {
 function getString(input: CodexJsonObject | null | undefined, key: string): string | null {
   const value = input?.[key];
   return typeof value === 'string' ? value : null;
+}
+
+function getRequiredStringArg(input: CodexJsonObject, key: string, toolName: string): string {
+  const value = getString(input, key)?.trim();
+  if (!value) {
+    throw new Error(`OpenReelio ${toolName} requires ${key}.`);
+  }
+  return value;
+}
+
+function getFiniteNonNegativeNumberArg(
+  input: CodexJsonObject,
+  key: string,
+  toolName: string,
+  required = false,
+): number | undefined {
+  const value = input[key];
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new Error(`OpenReelio ${toolName} requires ${key}.`);
+    }
+    return undefined;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`OpenReelio ${toolName} requires ${key} to be a finite non-negative number.`);
+  }
+
+  return value;
 }
 
 function getFirstProperty(input: CodexJsonObject, keys: string[]): unknown {

--- a/src/agents/external/chatRuntime.test.ts
+++ b/src/agents/external/chatRuntime.test.ts
@@ -228,6 +228,72 @@ describe('ExternalAgentChatRuntimeController', () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
+  it('should keep active-turn steering output ordered after the steering user message', async () => {
+    const conversation = new FakeConversationGateway();
+    const adapter = new FakeExternalAgentAdapter();
+    const controller = new ExternalAgentChatRuntimeController({
+      adapter,
+      conversation,
+      projectId: 'project-1',
+    });
+
+    await controller.sendMessage('Add captions');
+    adapter.emit({
+      type: 'tool_started',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      itemId: 'tool_1',
+      tool: 'openreelio.command_execute',
+      description: 'Add text clip',
+      args: { commandType: 'AddTextClip' },
+    });
+
+    await controller.sendMessage('Keep the captions lower');
+    adapter.emit({
+      type: 'assistant_delta',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      itemId: 'item_2',
+      content: 'Adjusted placement.',
+    });
+    adapter.emit({
+      type: 'tool_completed',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      itemId: 'tool_1',
+      tool: 'openreelio.command_execute',
+      success: true,
+      result: { ok: true },
+      durationMs: 12,
+    });
+    adapter.emit({
+      type: 'turn_completed',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      turnId: 'turn_1',
+      status: 'completed',
+    });
+
+    expect(adapter.sendMessage).toHaveBeenCalledTimes(2);
+    expect(conversation.getMessageParts('assistant-1')).toEqual([
+      expect.objectContaining({
+        type: 'tool_call',
+        stepId: 'tool_1',
+        status: 'completed',
+      }),
+      expect.objectContaining({
+        type: 'tool_result',
+        stepId: 'tool_1',
+        success: true,
+      }),
+    ]);
+    expect(conversation.getMessageParts('assistant-2')).toEqual([
+      { type: 'text', content: 'Adjusted placement.' },
+    ]);
+    expect(conversation.finalizeMessage).toHaveBeenCalledWith('assistant-1');
+    expect(conversation.finalizeMessage).toHaveBeenCalledWith('assistant-2');
+  });
+
   it('should keep external runtime state isolated per conversation session', async () => {
     const conversation = new FakeConversationGateway();
     const adapter = new FakeExternalAgentAdapter();
@@ -312,6 +378,37 @@ describe('ExternalAgentChatRuntimeController', () => {
     await controller.interrupt();
 
     expect(adapter.interrupt).toHaveBeenCalledWith('thr_123');
+  });
+
+  it('should clear running state when interrupt succeeds before Codex emits completion', async () => {
+    const conversation = new FakeConversationGateway();
+    const adapter = new FakeExternalAgentAdapter();
+    const onAbort = vi.fn();
+    const controller = new ExternalAgentChatRuntimeController({
+      adapter,
+      conversation,
+      projectId: 'project-1',
+      onAbort,
+    });
+
+    await controller.sendMessage('Long task');
+    await controller.interrupt();
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'aborted',
+      isRunning: false,
+    });
+    expect(conversation.finalizeMessage).toHaveBeenCalledWith('assistant-1');
+    expect(onAbort).toHaveBeenCalledTimes(1);
+
+    adapter.emit({
+      type: 'turn_completed',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      turnId: 'turn_1',
+      status: 'interrupted',
+    });
+    expect(onAbort).toHaveBeenCalledTimes(1);
   });
 
   it('should resume a persisted external session instead of creating a duplicate runtime session', async () => {
@@ -576,7 +673,7 @@ describe('ExternalAgentChatRuntimeController', () => {
     expect(conversation.finalizeMessage).not.toHaveBeenCalled();
   });
 
-  it('should shut down tracked runtime sessions before switching adapters', async () => {
+  it('should defer adapter replacement while a runtime session is still running', async () => {
     const conversation = new FakeConversationGateway();
     const adapter = new FakeExternalAgentAdapter();
     const nextAdapter = new FakeExternalAgentAdapter();
@@ -587,6 +684,21 @@ describe('ExternalAgentChatRuntimeController', () => {
     });
 
     await controller.sendMessage('Start a session');
+    controller.updateContext({
+      adapter: nextAdapter,
+      projectId: 'project-1',
+    });
+
+    expect(adapter.shutdown).not.toHaveBeenCalled();
+    expect(nextAdapter.shutdown).not.toHaveBeenCalled();
+
+    adapter.emit({
+      type: 'turn_completed',
+      runtimeId: 'codex',
+      sessionId: 'thr_123',
+      turnId: 'turn_1',
+      status: 'completed',
+    });
     controller.updateContext({
       adapter: nextAdapter,
       projectId: 'project-1',

--- a/src/agents/external/chatRuntime.ts
+++ b/src/agents/external/chatRuntime.ts
@@ -241,24 +241,23 @@ export class ExternalAgentChatRuntimeController {
       return;
     }
 
-    const initialConversationSessionId = this.options.conversation.getActiveSessionId();
-    if (!this.getState(initialConversationSessionId).isRunning) {
-      this.setState(
-        {
-          phase: 'starting',
-          isRunning: true,
-          error: null,
-        },
-        initialConversationSessionId,
-      );
-    }
-
     const conversationSessionId = await this.options.conversation.ensureSession(
       this.options.adapter.id,
     );
     if (!conversationSessionId) {
       this.fail(new Error('Unable to create an OpenReelio AI session'));
       return;
+    }
+
+    if (!this.getState(conversationSessionId).isRunning) {
+      this.setState(
+        {
+          phase: 'starting',
+          isRunning: true,
+          error: null,
+        },
+        conversationSessionId,
+      );
     }
 
     let targetExternalSessionId: string | null = null;

--- a/src/agents/external/chatRuntime.ts
+++ b/src/agents/external/chatRuntime.ts
@@ -72,6 +72,13 @@ export interface ExternalAgentChatRuntimeControllerOptions {
   onError?: (error: Error) => void;
 }
 
+interface ExternalAgentRuntimeCallbackUpdate {
+  onStateChange?: ((state: ExternalAgentChatRuntimeState) => void) | null;
+  onComplete?: () => void;
+  onAbort?: () => void;
+  onError?: (error: Error) => void;
+}
+
 const INITIAL_STATE: ExternalAgentChatRuntimeState = {
   phase: 'idle',
   isRunning: false,
@@ -100,9 +107,10 @@ export class ExternalAgentChatRuntimeController {
   private readonly sessionByConversationSessionId = new Map<string, ExternalAgentSessionHandle>();
   private readonly conversationSessionIdByExternalSessionId = new Map<string, string>();
   private readonly messageIdByExternalSessionId = new Map<string, string>();
+  private readonly messageIdsByExternalSessionId = new Map<string, Set<string>>();
   private readonly textDeltaMessages = new Set<string>();
-  private readonly itemPartIndex = new Map<string, number>();
-  private readonly patchPartIndex = new Map<string, number>();
+  private readonly itemPartIndex = new Map<string, { messageId: string; partIndex: number }>();
+  private readonly patchPartIndex = new Map<string, { messageId: string; partIndex: number }>();
   private readonly approvalPartIndex = new Map<string, { messageId: string; partIndex: number }>();
   private readonly conversationSessionsPendingPersistence = new Set<string>();
   private activeConversationSessionId: string | null = null;
@@ -155,11 +163,20 @@ export class ExternalAgentChatRuntimeController {
     projectId: string | null;
     cwd?: string | null;
     enabled?: boolean;
+    onStateChange?: ((state: ExternalAgentChatRuntimeState) => void) | null;
     onComplete?: () => void;
     onAbort?: () => void;
     onError?: (error: Error) => void;
   }): void {
     if (input.adapter && input.adapter !== this.options.adapter) {
+      if (this.hasRunningState()) {
+        this.projectId = input.projectId;
+        this.cwd = input.cwd ?? null;
+        this.enabled = input.enabled ?? true;
+        this.updateCallbacks(input);
+        return;
+      }
+
       const previousAdapter = this.options.adapter;
       this.shutdownTrackedExternalSessions(previousAdapter);
       this.unsubscribe?.();
@@ -171,12 +188,31 @@ export class ExternalAgentChatRuntimeController {
     this.projectId = input.projectId;
     this.cwd = input.cwd ?? null;
     this.enabled = input.enabled ?? true;
+    this.updateCallbacks(input);
+  }
+
+  updateCallbacks(input: ExternalAgentRuntimeCallbackUpdate): void {
     this.callbacks = {
       ...this.callbacks,
-      onComplete: input.onComplete,
-      onAbort: input.onAbort,
-      onError: input.onError,
+      ...('onStateChange' in input ? { onStateChange: input.onStateChange ?? undefined } : {}),
+      ...('onComplete' in input ? { onComplete: input.onComplete } : {}),
+      ...('onAbort' in input ? { onAbort: input.onAbort } : {}),
+      ...('onError' in input ? { onError: input.onError } : {}),
     };
+  }
+
+  hasRunningState(): boolean {
+    if (this.fallbackState.isRunning) {
+      return true;
+    }
+
+    for (const state of this.stateByConversationSessionId.values()) {
+      if (state.isRunning) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   getState(
@@ -205,14 +241,17 @@ export class ExternalAgentChatRuntimeController {
       return;
     }
 
-    this.setState(
-      {
-        phase: 'starting',
-        isRunning: true,
-        error: null,
-      },
-      this.options.conversation.getActiveSessionId(),
-    );
+    const initialConversationSessionId = this.options.conversation.getActiveSessionId();
+    if (!this.getState(initialConversationSessionId).isRunning) {
+      this.setState(
+        {
+          phase: 'starting',
+          isRunning: true,
+          error: null,
+        },
+        initialConversationSessionId,
+      );
+    }
 
     const conversationSessionId = await this.options.conversation.ensureSession(
       this.options.adapter.id,
@@ -222,17 +261,16 @@ export class ExternalAgentChatRuntimeController {
       return;
     }
 
+    let targetExternalSessionId: string | null = null;
     try {
       const externalSession = await this.ensureExternalSession(conversationSessionId);
+      targetExternalSessionId = externalSession.sessionId;
       this.activeConversationSessionId = conversationSessionId;
       this.conversationSessionIdByExternalSessionId.set(
         externalSession.sessionId,
         conversationSessionId,
       );
-      this.messageIdByExternalSessionId.set(
-        externalSession.sessionId,
-        this.options.conversation.startAssistantMessage(conversationSessionId),
-      );
+      this.startExternalAssistantMessage(externalSession.sessionId, conversationSessionId);
       this.setState({ phase: 'running', isRunning: true, error: null }, conversationSessionId);
       await this.options.adapter.sendMessage(externalSession.sessionId, {
         content,
@@ -240,7 +278,10 @@ export class ExternalAgentChatRuntimeController {
       });
       await this.persistExternalSessionAfterTurnStart(conversationSessionId, externalSession);
     } catch (error) {
-      this.fail(error instanceof Error ? error : new Error(String(error)));
+      this.fail(
+        error instanceof Error ? error : new Error(String(error)),
+        targetExternalSessionId ?? undefined,
+      );
     }
   }
 
@@ -258,8 +299,12 @@ export class ExternalAgentChatRuntimeController {
 
     try {
       await this.options.adapter.interrupt(externalSession.sessionId);
+      this.finishActiveMessage('aborted', externalSession.sessionId);
     } catch (error) {
-      this.fail(error instanceof Error ? error : new Error(String(error)));
+      this.fail(
+        error instanceof Error ? error : new Error(String(error)),
+        externalSession.sessionId,
+      );
     }
   }
 
@@ -467,7 +512,10 @@ export class ExternalAgentChatRuntimeController {
       status: 'running',
       startedAt: Date.now(),
     });
-    this.itemPartIndex.set(this.itemKey(event.sessionId, event.itemId), partIndex);
+    this.itemPartIndex.set(this.itemKey(event.sessionId, event.itemId), {
+      messageId,
+      partIndex,
+    });
     const sessionState = this.getStateForExternalSession(event.sessionId);
     this.setState(
       {
@@ -481,7 +529,9 @@ export class ExternalAgentChatRuntimeController {
   private handleToolCompleted(
     event: Extract<ExternalAgentRuntimeEvent, { type: 'tool_completed' }>,
   ): void {
-    const messageId = this.messageIdByExternalSessionId.get(event.sessionId);
+    const indexedPart = this.itemPartIndex.get(this.itemKey(event.sessionId, event.itemId));
+    const messageId =
+      indexedPart?.messageId ?? this.messageIdByExternalSessionId.get(event.sessionId);
     if (!messageId) {
       return;
     }
@@ -525,13 +575,13 @@ export class ExternalAgentChatRuntimeController {
     };
 
     if (existingIndex !== undefined) {
-      this.options.conversation.updatePart(messageId, existingIndex, patch);
+      this.options.conversation.updatePart(existingIndex.messageId, existingIndex.partIndex, patch);
       return;
     }
 
     const partIndex = this.options.conversation.getMessageParts(messageId)?.length ?? 0;
     this.options.conversation.appendPart(messageId, patch);
-    this.patchPartIndex.set(key, partIndex);
+    this.patchPartIndex.set(key, { messageId, partIndex });
   }
 
   private handleApprovalRequest(
@@ -641,13 +691,12 @@ export class ExternalAgentChatRuntimeController {
     itemId: string,
     update: Partial<MessagePart>,
   ): void {
-    const messageId = this.messageIdByExternalSessionId.get(externalSessionId);
-    const partIndex = this.itemPartIndex.get(this.itemKey(externalSessionId, itemId));
-    if (!messageId || partIndex === undefined) {
+    const indexedPart = this.itemPartIndex.get(this.itemKey(externalSessionId, itemId));
+    if (!indexedPart) {
       return;
     }
 
-    this.options.conversation.updatePart(messageId, partIndex, update);
+    this.options.conversation.updatePart(indexedPart.messageId, indexedPart.partIndex, update);
   }
 
   private fail(error: Error, externalSessionId?: string): void {
@@ -660,7 +709,11 @@ export class ExternalAgentChatRuntimeController {
         messageId,
         createErrorPart('EXTERNAL_AGENT_ERROR', error.message, 'external_agent', true),
       );
-      this.options.conversation.finalizeMessage(messageId);
+      if (externalSessionId) {
+        this.finalizeMessagesForExternalSession(externalSessionId);
+      } else {
+        this.options.conversation.finalizeMessage(messageId);
+      }
     }
 
     this.setState(
@@ -676,24 +729,64 @@ export class ExternalAgentChatRuntimeController {
     phase: 'completed' | 'aborted',
     externalSessionId?: string | null,
   ): void {
+    const conversationSessionId = externalSessionId
+      ? this.getConversationSessionIdForExternalSession(externalSessionId)
+      : this.activeConversationSessionId;
+    const previousState = this.getState(conversationSessionId);
+    const shouldNotify =
+      previousState.isRunning ||
+      previousState.phase === 'starting' ||
+      previousState.phase === 'running';
+
     const messageId = externalSessionId
       ? this.messageIdByExternalSessionId.get(externalSessionId)
       : this.getActiveMessageId();
 
-    if (messageId) {
+    if (externalSessionId) {
+      this.finalizeMessagesForExternalSession(externalSessionId);
+    } else if (messageId) {
       this.options.conversation.finalizeMessage(messageId);
     }
 
-    this.setState(
-      { phase, isRunning: false, error: null },
-      externalSessionId
-        ? this.getConversationSessionIdForExternalSession(externalSessionId)
-        : this.activeConversationSessionId,
-    );
+    this.setState({ phase, isRunning: false, error: null }, conversationSessionId);
+    if (!shouldNotify) {
+      return;
+    }
+
     if (phase === 'aborted') {
       this.callbacks.onAbort?.();
     } else {
       this.callbacks.onComplete?.();
+    }
+  }
+
+  private startExternalAssistantMessage(
+    externalSessionId: string,
+    conversationSessionId: string,
+  ): string {
+    const messageId = this.options.conversation.startAssistantMessage(conversationSessionId);
+    this.messageIdByExternalSessionId.set(externalSessionId, messageId);
+    let messageIds = this.messageIdsByExternalSessionId.get(externalSessionId);
+    if (!messageIds) {
+      messageIds = new Set<string>();
+      this.messageIdsByExternalSessionId.set(externalSessionId, messageIds);
+    }
+    messageIds.add(messageId);
+    return messageId;
+  }
+
+  private finalizeMessagesForExternalSession(externalSessionId: string): void {
+    const messageIds = this.messageIdsByExternalSessionId.get(externalSessionId);
+    if (!messageIds?.size) {
+      const messageId = this.messageIdByExternalSessionId.get(externalSessionId);
+      if (messageId) {
+        this.options.conversation.finalizeMessage(messageId);
+      }
+      return;
+    }
+
+    for (const messageId of messageIds) {
+      this.options.conversation.finalizeMessage(messageId);
     }
   }
 
@@ -775,6 +868,7 @@ export class ExternalAgentChatRuntimeController {
     this.sessionByConversationSessionId.clear();
     this.conversationSessionIdByExternalSessionId.clear();
     this.messageIdByExternalSessionId.clear();
+    this.messageIdsByExternalSessionId.clear();
     this.textDeltaMessages.clear();
     this.itemPartIndex.clear();
     this.patchPartIndex.clear();

--- a/src/agents/external/useExternalAgentChatRuntime.test.tsx
+++ b/src/agents/external/useExternalAgentChatRuntime.test.tsx
@@ -153,4 +153,73 @@ describe('useExternalAgentChatRuntime', () => {
 
     expect(adapter.shutdown).toHaveBeenCalledWith('thr_123');
   });
+
+  it('should dispose a retained Codex controller after it becomes idle', async () => {
+    const adapter = new FakeExternalAgentAdapter();
+    const firstHook = renderHook(() =>
+      useExternalAgentChatRuntime({
+        adapter,
+        projectId: 'project-1',
+        cwd: '/project',
+        enabled: true,
+        retainAcrossUnmount: true,
+      }),
+    );
+
+    await act(async () => {
+      await firstHook.result.current.executeMessage('Short edit');
+    });
+    act(() => {
+      adapter.emit({
+        type: 'turn_completed',
+        runtimeId: 'codex',
+        sessionId: 'thr_123',
+        turnId: 'turn_1',
+        status: 'completed',
+      });
+    });
+    await waitFor(() => {
+      expect(firstHook.result.current.isRunning).toBe(false);
+    });
+
+    firstHook.unmount();
+
+    expect(adapter.shutdown).toHaveBeenCalledWith('thr_123');
+
+    const nextAdapter = new FakeExternalAgentAdapter();
+    const secondHook = renderHook(() =>
+      useExternalAgentChatRuntime({
+        adapter: nextAdapter,
+        projectId: 'project-1',
+        cwd: '/project',
+        enabled: true,
+        retainAcrossUnmount: true,
+      }),
+    );
+
+    await act(async () => {
+      await secondHook.result.current.executeMessage('Fresh edit');
+    });
+
+    expect(nextAdapter.startSession).toHaveBeenCalledTimes(1);
+    expect(nextAdapter.sendMessage).toHaveBeenCalledWith('thr_123', {
+      content: 'Fresh edit',
+      cwd: '/project',
+    });
+    expect(adapter.sendMessage).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      nextAdapter.emit({
+        type: 'turn_completed',
+        runtimeId: 'codex',
+        sessionId: 'thr_123',
+        turnId: 'turn_2',
+        status: 'completed',
+      });
+    });
+    await waitFor(() => {
+      expect(secondHook.result.current.isRunning).toBe(false);
+    });
+    secondHook.unmount();
+  });
 });

--- a/src/agents/external/useExternalAgentChatRuntime.test.tsx
+++ b/src/agents/external/useExternalAgentChatRuntime.test.tsx
@@ -1,0 +1,156 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useConversationStore } from '@/stores/conversationStore';
+
+import { useExternalAgentChatRuntime } from './useExternalAgentChatRuntime';
+import type {
+  ExternalAgentRuntimeAdapter,
+  ExternalAgentRuntimeEvent,
+  ExternalAgentRuntimeEventHandler,
+} from './types';
+
+class FakeExternalAgentAdapter implements ExternalAgentRuntimeAdapter {
+  readonly id = 'codex' as const;
+  readonly displayName = 'Codex';
+  readonly startSession = vi.fn(async () => ({ sessionId: 'thr_123', runtimeId: this.id }));
+  readonly sendMessage = vi.fn(async () => undefined);
+  readonly interrupt = vi.fn(async () => undefined);
+  readonly shutdown = vi.fn(async () => undefined);
+  private handler: ExternalAgentRuntimeEventHandler | null = null;
+
+  async detect() {
+    return {
+      runtimeId: this.id,
+      displayName: this.displayName,
+      installStatus: 'installed' as const,
+      authStatus: 'signed-in' as const,
+      available: true,
+      version: '1.0.0',
+      reason: null,
+    };
+  }
+
+  async authStatus() {
+    return 'signed-in' as const;
+  }
+
+  async capabilities() {
+    return {
+      streamingEvents: true,
+      interrupt: true,
+      mcpClient: true,
+      approvalAware: true,
+      localAccountAuth: true,
+      sessionResume: true,
+      structuredToolCalls: true,
+    };
+  }
+
+  subscribe(handler: ExternalAgentRuntimeEventHandler): () => void {
+    this.handler = handler;
+    return () => {
+      this.handler = null;
+    };
+  }
+
+  emit(event: ExternalAgentRuntimeEvent): void {
+    this.handler?.(event);
+  }
+}
+
+describe('useExternalAgentChatRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useConversationStore.setState((state) => ({
+      ...state,
+      activeProjectId: 'project-1',
+      activeSessionId: 'session-1',
+      activeConversation: {
+        id: 'session-1',
+        projectId: 'project-1',
+        messages: [],
+        createdAt: 100,
+        updatedAt: 100,
+      },
+      conversationsBySessionId: {},
+      sessionGenerationBySessionId: {},
+      isGenerating: false,
+      streamingMessageId: null,
+    }));
+  });
+
+  it('should retain a running Codex controller across chat surface unmounts', async () => {
+    const adapter = new FakeExternalAgentAdapter();
+    const firstHook = renderHook(() =>
+      useExternalAgentChatRuntime({
+        adapter,
+        projectId: 'project-1',
+        cwd: '/project',
+        enabled: true,
+        retainAcrossUnmount: true,
+      }),
+    );
+
+    await act(async () => {
+      await firstHook.result.current.executeMessage('Long running edit');
+    });
+
+    await waitFor(() => {
+      expect(firstHook.result.current.isRunning).toBe(true);
+    });
+
+    firstHook.unmount();
+
+    expect(adapter.shutdown).not.toHaveBeenCalled();
+
+    act(() => {
+      adapter.emit({
+        type: 'assistant_delta',
+        runtimeId: 'codex',
+        sessionId: 'thr_123',
+        itemId: 'item_1',
+        content: 'Still working',
+      });
+    });
+
+    const nextAdapter = new FakeExternalAgentAdapter();
+    const secondHook = renderHook(() =>
+      useExternalAgentChatRuntime({
+        adapter: nextAdapter,
+        projectId: 'project-1',
+        cwd: '/project',
+        enabled: true,
+        retainAcrossUnmount: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(secondHook.result.current.isRunning).toBe(true);
+    });
+
+    expect(adapter.shutdown).not.toHaveBeenCalled();
+    expect(nextAdapter.startSession).not.toHaveBeenCalled();
+    expect(useConversationStore.getState().activeConversation?.messages[0]?.parts).toEqual([
+      { type: 'text', content: 'Still working' },
+    ]);
+
+    act(() => {
+      adapter.emit({
+        type: 'turn_completed',
+        runtimeId: 'codex',
+        sessionId: 'thr_123',
+        turnId: 'turn_1',
+        status: 'completed',
+      });
+    });
+
+    await waitFor(() => {
+      expect(secondHook.result.current.isRunning).toBe(false);
+    });
+
+    secondHook.unmount();
+
+    expect(adapter.shutdown).toHaveBeenCalledWith('thr_123');
+  });
+});

--- a/src/agents/external/useExternalAgentChatRuntime.ts
+++ b/src/agents/external/useExternalAgentChatRuntime.ts
@@ -41,12 +41,15 @@ const INITIAL_STATE: ExternalAgentChatRuntimeState = {
 
 const retainedRuntimeControllers = new Map<string, ExternalAgentChatRuntimeController>();
 
-function getRetainedRuntimeKey(options: UseExternalAgentChatRuntimeOptions): string | null {
-  if (!options.retainAcrossUnmount) {
+function getRetainedRuntimeKey(
+  options: UseExternalAgentChatRuntimeOptions,
+  activeSessionId: string | null,
+): string | null {
+  if (!options.retainAcrossUnmount || !options.projectId || !activeSessionId) {
     return null;
   }
 
-  return options.adapter.id;
+  return `${options.adapter.id}:${options.projectId}:${activeSessionId}`;
 }
 
 export function useExternalAgentChatRuntime(
@@ -57,7 +60,7 @@ export function useExternalAgentChatRuntime(
   const controllerRef = useRef<ExternalAgentChatRuntimeController | null>(null);
   const retainKeyRef = useRef<string | null>(null);
   const activeSessionId = useConversationStore((store) => store.activeSessionId);
-  const retainKey = getRetainedRuntimeKey(options);
+  const retainKey = getRetainedRuntimeKey(options, activeSessionId);
 
   if (!controllerRef.current) {
     controllerRef.current =
@@ -84,6 +87,23 @@ export function useExternalAgentChatRuntime(
       retainKeyRef.current = retainKey;
     }
   }
+
+  useEffect(() => {
+    const controller = controllerRef.current;
+    if (!controller || retainKey === retainKeyRef.current) {
+      return;
+    }
+
+    const previousKey = retainKeyRef.current;
+    if (previousKey && retainedRuntimeControllers.get(previousKey) === controller) {
+      retainedRuntimeControllers.delete(previousKey);
+    }
+
+    if (retainKey !== null) {
+      retainedRuntimeControllers.set(retainKey, controller);
+    }
+    retainKeyRef.current = retainKey;
+  }, [retainKey]);
 
   useEffect(() => {
     controllerRef.current?.updateContext({

--- a/src/agents/external/useExternalAgentChatRuntime.ts
+++ b/src/agents/external/useExternalAgentChatRuntime.ts
@@ -17,6 +17,7 @@ export interface UseExternalAgentChatRuntimeOptions {
   enabled?: boolean;
   approvalBroker?: ExternalAgentApprovalBroker;
   sessionPersistence?: ExternalAgentSessionPersistence;
+  retainAcrossUnmount?: boolean;
   onComplete?: () => void;
   onAbort?: () => void;
   onError?: (error: Error) => void;
@@ -38,28 +39,50 @@ const INITIAL_STATE: ExternalAgentChatRuntimeState = {
   pendingToolPermissionRequest: null,
 };
 
+const retainedRuntimeControllers = new Map<string, ExternalAgentChatRuntimeController>();
+
+function getRetainedRuntimeKey(options: UseExternalAgentChatRuntimeOptions): string | null {
+  if (!options.retainAcrossUnmount) {
+    return null;
+  }
+
+  return options.adapter.id;
+}
+
 export function useExternalAgentChatRuntime(
   options: UseExternalAgentChatRuntimeOptions,
 ): UseExternalAgentChatRuntimeResult {
   const [state, setState] = useState<ExternalAgentChatRuntimeState>(INITIAL_STATE);
   const conversation = useMemo(() => createConversationStoreExternalAgentGateway(), []);
   const controllerRef = useRef<ExternalAgentChatRuntimeController | null>(null);
+  const retainKeyRef = useRef<string | null>(null);
   const activeSessionId = useConversationStore((store) => store.activeSessionId);
+  const retainKey = getRetainedRuntimeKey(options);
 
   if (!controllerRef.current) {
-    controllerRef.current = new ExternalAgentChatRuntimeController({
-      adapter: options.adapter,
-      conversation,
-      projectId: options.projectId,
-      cwd: options.cwd,
-      enabled: options.enabled,
-      approvalBroker: options.approvalBroker,
-      sessionPersistence: options.sessionPersistence,
-      onStateChange: setState,
-      onComplete: options.onComplete,
-      onAbort: options.onAbort,
-      onError: options.onError,
-    });
+    controllerRef.current =
+      retainKey !== null ? (retainedRuntimeControllers.get(retainKey) ?? null) : null;
+
+    if (!controllerRef.current) {
+      controllerRef.current = new ExternalAgentChatRuntimeController({
+        adapter: options.adapter,
+        conversation,
+        projectId: options.projectId,
+        cwd: options.cwd,
+        enabled: options.enabled,
+        approvalBroker: options.approvalBroker,
+        sessionPersistence: options.sessionPersistence,
+        onStateChange: setState,
+        onComplete: options.onComplete,
+        onAbort: options.onAbort,
+        onError: options.onError,
+      });
+    }
+
+    if (retainKey !== null) {
+      retainedRuntimeControllers.set(retainKey, controllerRef.current);
+      retainKeyRef.current = retainKey;
+    }
   }
 
   useEffect(() => {
@@ -68,6 +91,7 @@ export function useExternalAgentChatRuntime(
       projectId: options.projectId,
       cwd: options.cwd,
       enabled: options.enabled,
+      onStateChange: setState,
       onComplete: options.onComplete,
       onAbort: options.onAbort,
       onError: options.onError,
@@ -84,7 +108,18 @@ export function useExternalAgentChatRuntime(
 
   useEffect(() => {
     return () => {
-      controllerRef.current?.dispose();
+      const controller = controllerRef.current;
+      controller?.updateCallbacks({ onStateChange: null });
+      const retainedKey = retainKeyRef.current;
+      if (controller && retainedKey && controller.hasRunningState()) {
+        controllerRef.current = null;
+        return;
+      }
+
+      controller?.dispose();
+      if (retainedKey && retainedRuntimeControllers.get(retainedKey) === controller) {
+        retainedRuntimeControllers.delete(retainedKey);
+      }
       controllerRef.current = null;
     };
   }, []);

--- a/src/agents/toolNameNormalization.ts
+++ b/src/agents/toolNameNormalization.ts
@@ -1,22 +1,68 @@
 const SEMANTIC_TOOL_ALIASES: Record<string, string> = {
   add_clip: 'insert_clip',
+  add_lower_third: 'add_text_clip',
+  add_lowerthird: 'add_text_clip',
   add_text: 'add_text_clip',
+  add_text_overlay: 'add_text_clip',
   add_title: 'add_text_clip',
   add_subtitle: 'add_caption',
+  auto_caption: 'auto_transcribe',
+  auto_captions: 'auto_transcribe',
+  auto_subtitle: 'auto_transcribe',
+  auto_subtitles: 'auto_transcribe',
+  batch_add_captions: 'add_captions_from_transcription',
+  batch_add_subtitles: 'add_captions_from_transcription',
+  caption_style: 'style_caption',
+  change_text: 'update_text_clip',
+  create_caption: 'add_caption',
+  create_lower_third: 'add_text_clip',
+  create_lowerthird: 'add_text_clip',
+  create_subtitle: 'add_caption',
+  create_text: 'add_text_clip',
+  create_text_clip: 'add_text_clip',
+  create_text_overlay: 'add_text_clip',
+  create_title: 'add_text_clip',
   delete_subtitle: 'delete_caption',
   delete_text: 'delete_text_clip',
+  delete_title: 'delete_text_clip',
+  edit_text: 'update_text_clip',
+  generate_caption: 'auto_transcribe',
+  generate_captions: 'auto_transcribe',
+  generate_subtitle: 'auto_transcribe',
+  generate_subtitles: 'auto_transcribe',
   get_timeline: 'get_timeline_info',
+  import_subtitle_file: 'import_captions_from_file',
+  import_subtitles: 'import_captions_from_file',
   import_subtitles_from_file: 'import_captions_from_file',
+  modify_text: 'update_text_clip',
+  move_text: 'set_text_transform',
+  move_title: 'set_text_transform',
   place_clip: 'insert_clip',
   place_text: 'add_text_clip',
+  place_title: 'add_text_clip',
+  remove_title: 'delete_text_clip',
   remove_clip: 'delete_clip',
   remove_text: 'delete_text_clip',
+  reposition_text: 'set_text_transform',
+  resize_text: 'set_text_transform',
+  rotate_text: 'set_text_transform',
   style_text: 'update_text_clip',
   style_subtitle: 'style_caption',
   timeline_info: 'get_timeline_info',
+  transcribe_captions: 'auto_transcribe',
+  transcribe_subtitles: 'auto_transcribe',
+  transform_text: 'set_text_transform',
   update_text: 'update_text_clip',
+  update_title: 'update_text_clip',
   update_subtitle: 'update_caption',
 };
+
+export function getSemanticToolAliasesForTargets(targets: readonly string[]): string[] {
+  const targetSet = new Set(targets);
+  return Object.entries(SEMANTIC_TOOL_ALIASES)
+    .filter(([, target]) => targetSet.has(target))
+    .map(([alias]) => alias);
+}
 
 export function normalizeToolNameCandidate(name: string): string {
   const trimmed = name.trim();

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -80,6 +80,13 @@ function matchesInsertClipPath(path: string): boolean {
   return (
     path === 'data' ||
     path === 'data.clipId' ||
+    path === 'data.linkedAudio' ||
+    path === 'data.linkedAudio.trackId' ||
+    path === 'data.linkedAudio.clipId' ||
+    path === 'data.linkedAudio.createdTrack' ||
+    path === 'data.sourceIn' ||
+    path === 'data.sourceOut' ||
+    path === 'data.durationSec' ||
     path === 'data.operationId' ||
     path === 'data.createdIds' ||
     /^data\.createdIds\[\d+\]$/.test(path)

--- a/src/agents/tools/analysisTools.test.ts
+++ b/src/agents/tools/analysisTools.test.ts
@@ -4402,11 +4402,26 @@ describe('reference style transfer analysis tools', () => {
         .mockResolvedValueOnce({ annotation: null, status: 'notAnalyzed' });
 
       vi.mocked(executeAgentCommand)
-        .mockResolvedValueOnce({
+        .mockImplementationOnce(async (_commandType, payload) => {
+          const createdTrack = createTrack({
+            id: 'new-track-id',
+            name:
+              typeof payload.name === 'string'
+                ? payload.name
+                : 'Source Selects',
+          });
+          useProjectStore.setState((state) => {
+            const sequence = state.sequences.get('seq_001');
+            if (sequence) {
+              sequence.tracks.push(createdTrack);
+            }
+          });
+          return {
           opId: 'op-create-track',
           changes: [],
           createdIds: ['new-track-id'],
           deletedIds: [],
+          };
         })
         .mockResolvedValueOnce({
           opId: 'op-insert-1',

--- a/src/agents/tools/analysisTools.ts
+++ b/src/agents/tools/analysisTools.ts
@@ -41,6 +41,7 @@ import { calculatePearsonCorrelation, getPrimaryTrackClips } from '@/utils/refer
 import { getClipTimelineEndSec } from '@/utils/clipTiming';
 import { useProjectStore } from '@/stores/projectStore';
 import { executeAgentCommand } from './commandExecutor';
+import { insertAgentMediaClip } from './mediaInsertion';
 import {
   readWorkspaceDocumentFromBackend,
   writeWorkspaceDocumentToBackend,
@@ -3443,12 +3444,11 @@ async function ensureSelectsTrack(options: {
 
 async function rollbackInsertedSelectClips(
   sequenceId: string,
-  trackId: string,
-  clipIds: string[],
+  clipRefs: Array<{ trackId: string; clipId: string }>,
 ): Promise<string[]> {
   const rollbackFailures: string[] = [];
 
-  for (const clipId of [...clipIds].reverse()) {
+  for (const { trackId, clipId } of [...clipRefs].reverse()) {
     try {
       await executeAgentCommand('RemoveClip', {
         sequenceId,
@@ -5935,11 +5935,12 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
                       ),
                     )
                   : 0;
-            const createdClipIds: string[] = [];
+            const createdClipRefs: Array<{ trackId: string; clipId: string }> = [];
+            const createdAudioTrackIds: string[] = [];
 
             try {
               for (const select of selects) {
-                const result = await executeAgentCommand('InsertClip', {
+                const insert = await insertAgentMediaClip({
                   sequenceId,
                   trackId: ensuredTrack.trackId,
                   assetId: select.assetId,
@@ -5947,18 +5948,34 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
                   sourceIn: select.sourceInSec,
                   sourceOut: select.sourceOutSec,
                 });
-                const createdClipId = result.createdIds[0];
-                if (!createdClipId) {
-                  throw new Error('InsertClip did not return a created clip id');
+                createdClipRefs.push({
+                  trackId: ensuredTrack.trackId,
+                  clipId: insert.clipId,
+                });
+                if (insert.linkedAudio) {
+                  createdClipRefs.push({
+                    trackId: insert.linkedAudio.trackId,
+                    clipId: insert.linkedAudio.clipId,
+                  });
+                  if (insert.linkedAudio.createdTrack) {
+                    createdAudioTrackIds.push(insert.linkedAudio.trackId);
+                  }
                 }
-                createdClipIds.push(createdClipId);
               }
             } catch (error) {
               const rollbackFailures = await rollbackInsertedSelectClips(
                 sequenceId,
-                ensuredTrack.trackId,
-                createdClipIds,
+                createdClipRefs,
               );
+              for (const audioTrackId of [...createdAudioTrackIds].reverse()) {
+                const trackRollbackFailure = await rollbackCreatedSelectsTrack(
+                  sequenceId,
+                  audioTrackId,
+                );
+                if (trackRollbackFailure) {
+                  rollbackFailures.push(trackRollbackFailure);
+                }
+              }
               if (ensuredTrack.createdTrack) {
                 const trackRollbackFailure = await rollbackCreatedSelectsTrack(
                   sequenceId,
@@ -5975,7 +5992,7 @@ const ANALYSIS_TOOLS: ToolDefinition[] = [
                 );
               }
               throw new Error(
-                `Failed to apply source selects: ${message}. Rolled back ${createdClipIds.length} clip(s).`,
+                `Failed to apply source selects: ${message}. Rolled back ${createdClipRefs.length} clip(s).`,
               );
             }
 

--- a/src/agents/tools/editingTools.ts
+++ b/src/agents/tools/editingTools.ts
@@ -11,10 +11,10 @@ import { createLogger } from '@/services/logger';
 import { invoke } from '@tauri-apps/api/core';
 import { getTimelineSnapshot, findWorkspaceFile } from './storeAccessor';
 import { executeAgentCommand } from './commandExecutor';
+import { insertAgentMediaClip } from './mediaInsertion';
 import { normalizeMarkerColor } from './markerColor';
 import { useProjectStore } from '@/stores/projectStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { probeMedia } from '@/utils/ffmpeg';
 import { getClipTimelineEndSec } from '@/utils/clipTiming';
 import { refreshProjectState } from '@/utils/stateRefreshHelper';
 import { runProjectBackendMutation } from '@/services/projectMutationGateway';
@@ -25,11 +25,10 @@ import {
   buildSlideEditPlan,
   type PlannedCommandStep,
 } from './compoundEditPlanning';
-import type { Asset, Sequence, Track, CommandResult } from '@/types';
+import type { Sequence, Track, CommandResult } from '@/types';
 import type { AgentPlanResult, StylePlanResult } from '@/bindings';
 
 const logger = createLogger('EditingTools');
-const DEFAULT_INSERT_CLIP_DURATION_SEC = 10;
 const DEFAULT_FREEZE_FRAME_RATE = 30;
 const SPLIT_TIME_EPSILON = 1e-6;
 const MAX_INTERVAL_SPLIT_OPERATIONS = 5000;
@@ -186,98 +185,6 @@ function estimateTimelineIntervalSplitOperations(
   return estimatedOperations;
 }
 
-function getAssetInsertDurationSec(asset: Asset): number {
-  if (
-    typeof asset.durationSec === 'number' &&
-    Number.isFinite(asset.durationSec) &&
-    asset.durationSec > 0
-  ) {
-    return asset.durationSec;
-  }
-
-  return DEFAULT_INSERT_CLIP_DURATION_SEC;
-}
-
-function trackHasOverlap(track: Track, timelineIn: number, durationSec: number): boolean {
-  const end = timelineIn + durationSec;
-  return track.clips.some((clip) => {
-    const clipStart = clip.place.timelineInSec;
-    const clipEnd = getClipTimelineEndSec(clip);
-    return timelineIn < clipEnd && end > clipStart;
-  });
-}
-
-function canInsertClipOnTrack(track: Track, timelineIn: number, durationSec: number): boolean {
-  return !track.locked && !trackHasOverlap(track, timelineIn, durationSec);
-}
-
-function findAvailableAudioTrack(
-  sequence: Sequence,
-  timelineIn: number,
-  durationSec: number,
-): Track | undefined {
-  return sequence.tracks.find(
-    (track) => track.kind === 'audio' && canInsertClipOnTrack(track, timelineIn, durationSec),
-  );
-}
-
-function getNextAudioTrackName(sequence: Sequence): string {
-  const baseLabel = 'Audio';
-  let highestIndex = 0;
-
-  for (const track of sequence.tracks) {
-    if (track.kind !== 'audio') {
-      continue;
-    }
-
-    const trimmedName = track.name.trim();
-    if (trimmedName === baseLabel) {
-      highestIndex = Math.max(highestIndex, 1);
-      continue;
-    }
-
-    const match = /^Audio\s+(\d+)$/.exec(trimmedName);
-    if (match) {
-      highestIndex = Math.max(highestIndex, parseInt(match[1], 10));
-    }
-  }
-
-  return `${baseLabel} ${highestIndex + 1}`;
-}
-
-function getDefaultAudioTrackInsertPosition(sequence: Sequence): number {
-  let lastAudioIndex = -1;
-  for (let index = 0; index < sequence.tracks.length; index += 1) {
-    if (sequence.tracks[index].kind === 'audio') {
-      lastAudioIndex = index;
-    }
-  }
-
-  return lastAudioIndex !== -1 ? lastAudioIndex + 1 : sequence.tracks.length;
-}
-
-async function resolveAssetHasLinkedAudio(asset: Asset): Promise<boolean> {
-  if (asset.kind !== 'video') {
-    return false;
-  }
-
-  if (asset.audio) {
-    return true;
-  }
-
-  try {
-    const mediaInfo = await probeMedia(asset.uri);
-    return Boolean(mediaInfo.audio);
-  } catch (error) {
-    logger.warn('Unable to probe inserted video for audio stream detection', {
-      assetId: asset.id,
-      uri: asset.uri,
-      error,
-    });
-    return false;
-  }
-}
-
 interface PlannedExecutionResult {
   success: boolean;
   results: CommandResult[];
@@ -354,78 +261,6 @@ async function executePlannedCommands(
 // =============================================================================
 // Shared Helpers
 // =============================================================================
-
-/**
- * Handles linked audio extraction after inserting a video clip.
- * If the video has an audio stream, creates a separate audio clip on an
- * audio track and mutes the video clip's embedded audio.
- */
-async function handleLinkedAudio(
-  asset: Asset,
-  sequenceId: string,
-  videoTrackId: string,
-  videoClipId: string | undefined,
-  timelineStart: number,
-): Promise<void> {
-  const shouldAutoExtractLinkedAudio = true;
-  if (asset.kind !== 'video' || !shouldAutoExtractLinkedAudio) return;
-
-  const hasLinkedAudio = await resolveAssetHasLinkedAudio(asset);
-  if (!hasLinkedAudio) return;
-
-  const durationSec = getAssetInsertDurationSec(asset);
-  const project = useProjectStore.getState();
-  const sequence = project.sequences.get(sequenceId);
-  if (!sequence) return;
-
-  let audioTrack = findAvailableAudioTrack(sequence, timelineStart, durationSec);
-
-  if (!audioTrack) {
-    const createTrackResult = await executeAgentCommand('CreateTrack', {
-      sequenceId,
-      kind: 'audio',
-      name: getNextAudioTrackName(sequence),
-      position: getDefaultAudioTrackInsertPosition(sequence),
-    });
-
-    const createdTrackId = createTrackResult.createdIds[0];
-    if (createdTrackId) {
-      const refreshedProject = useProjectStore.getState();
-      const refreshedSequence = refreshedProject.sequences.get(sequenceId);
-      audioTrack = refreshedSequence?.tracks.find((track) => track.id === createdTrackId);
-    }
-  }
-
-  if (!audioTrack) return;
-
-  await executeAgentCommand('InsertClip', {
-    sequenceId,
-    trackId: audioTrack.id,
-    assetId: asset.id,
-    timelineStart,
-  });
-
-  if (videoClipId) {
-    try {
-      await executeAgentCommand('SetClipMute', {
-        sequenceId,
-        trackId: videoTrackId,
-        clipId: videoClipId,
-        muted: true,
-      });
-    } catch (muteError) {
-      logger.error('Failed to mute source video clip audio after linked audio insertion', {
-        sequenceId,
-        trackId: videoTrackId,
-        clipId: videoClipId,
-        error: muteError,
-      });
-      throw new Error(
-        `Linked audio inserted but failed to mute original video clip audio: ${muteError instanceof Error ? muteError.message : String(muteError)}`,
-      );
-    }
-  }
-}
 
 // =============================================================================
 // Tool Definitions
@@ -908,6 +743,19 @@ const EDITING_TOOLS: ToolDefinition[] = [
           type: 'number',
           description: 'Timeline position in seconds where the clip should start',
         },
+        sourceIn: {
+          type: 'number',
+          description: 'Optional source media in point in seconds for inserting a trimmed range',
+        },
+        sourceOut: {
+          type: 'number',
+          description: 'Optional source media out point in seconds for inserting a trimmed range',
+        },
+        audioOnly: {
+          type: 'boolean',
+          description:
+            'Set true only when intentionally placing the audio stream from a video asset onto an audio track',
+        },
       },
       required: ['sequenceId', 'trackId', 'assetId', 'timelineStart'],
     },
@@ -917,54 +765,34 @@ const EDITING_TOOLS: ToolDefinition[] = [
         const trackId = args.trackId as string;
         const assetId = args.assetId as string;
         const timelineStart = args.timelineStart as number;
+        const sourceIn = typeof args.sourceIn === 'number' ? args.sourceIn : undefined;
+        const sourceOut = typeof args.sourceOut === 'number' ? args.sourceOut : undefined;
+        const audioOnly = args.audioOnly === true;
 
-        const result = await executeAgentCommand('InsertClip', {
+        const insert = await insertAgentMediaClip({
           sequenceId,
           trackId,
           assetId,
           timelineStart,
+          sourceIn,
+          sourceOut,
+          audioOnly,
         });
-        const clipId = result.createdIds[0];
 
-        if (!clipId) {
-          logger.error('insert_clip failed to produce a clip id', {
-            sequenceId,
-            trackId,
-            assetId,
-          });
-          return { success: false, error: 'InsertClip did not return a created clip id' };
-        }
-
-        const project = useProjectStore.getState();
-        const asset = project.assets.get(assetId);
-        const targetTrack = project.sequences
-          .get(sequenceId)
-          ?.tracks.find((track) => track.id === trackId);
-        const shouldAutoExtractLinkedAudio = targetTrack ? targetTrack.kind !== 'audio' : true;
-
-        if (asset && shouldAutoExtractLinkedAudio) {
-          try {
-            await handleLinkedAudio(asset, sequenceId, trackId, clipId, timelineStart);
-          } catch (linkedAudioError) {
-            const msg =
-              linkedAudioError instanceof Error
-                ? linkedAudioError.message
-                : String(linkedAudioError);
-            logger.error('insert_clip: linked audio handling failed', { error: msg });
-            return { success: false, error: msg };
-          }
-        }
-
-        logger.debug('insert_clip executed', { opId: result.opId });
+        logger.debug('insert_clip executed', { opId: insert.insertResult.opId });
         return {
           success: true,
           result: {
-            ...result,
+            ...insert.insertResult,
             assetId,
-            clipId,
+            clipId: insert.clipId,
             sequenceId,
             timelineStart,
             trackId,
+            sourceIn: insert.sourceIn,
+            sourceOut: insert.sourceOut,
+            durationSec: insert.durationSec,
+            linkedAudio: insert.linkedAudio ?? null,
           },
         };
       } catch (error) {
@@ -1004,6 +832,19 @@ const EDITING_TOOLS: ToolDefinition[] = [
           type: 'number',
           description: 'Timeline position in seconds where the clip should start',
         },
+        sourceIn: {
+          type: 'number',
+          description: 'Optional source media in point in seconds for inserting a trimmed range',
+        },
+        sourceOut: {
+          type: 'number',
+          description: 'Optional source media out point in seconds for inserting a trimmed range',
+        },
+        audioOnly: {
+          type: 'boolean',
+          description:
+            'Set true only when intentionally placing the audio stream from a video file onto an audio track',
+        },
       },
       required: ['file', 'sequenceId', 'trackId', 'timelineStart'],
     },
@@ -1013,6 +854,9 @@ const EDITING_TOOLS: ToolDefinition[] = [
         const sequenceId = args.sequenceId as string;
         const trackId = args.trackId as string;
         const timelineStart = args.timelineStart as number;
+        const sourceIn = typeof args.sourceIn === 'number' ? args.sourceIn : undefined;
+        const sourceOut = typeof args.sourceOut === 'number' ? args.sourceOut : undefined;
+        const audioOnly = args.audioOnly === true;
 
         // 1. Find the file in the workspace
         const matches = findWorkspaceFile(file);
@@ -1068,34 +912,15 @@ const EDITING_TOOLS: ToolDefinition[] = [
         }
 
         // 3. Insert the clip
-        const result = await executeAgentCommand('InsertClip', {
+        const insert = await insertAgentMediaClip({
           sequenceId,
           trackId,
           assetId,
           timelineStart,
+          sourceIn,
+          sourceOut,
+          audioOnly,
         });
-
-        // 4. Handle linked audio for video files
-        const project = useProjectStore.getState();
-        const asset = project.assets.get(assetId);
-        if (asset) {
-          try {
-            await handleLinkedAudio(
-              asset,
-              sequenceId,
-              trackId,
-              result.createdIds[0],
-              timelineStart,
-            );
-          } catch (linkedAudioError) {
-            const msg =
-              linkedAudioError instanceof Error
-                ? linkedAudioError.message
-                : String(linkedAudioError);
-            logger.error('insert_clip_from_file: linked audio handling failed', { error: msg });
-            return { success: false, error: msg };
-          }
-        }
 
         logger.debug('insert_clip_from_file executed', {
           file: targetFile.relativePath,
@@ -1105,10 +930,15 @@ const EDITING_TOOLS: ToolDefinition[] = [
         return {
           success: true,
           result: {
-            ...result,
+            ...insert.insertResult,
             assetId,
+            clipId: insert.clipId,
             relativePath: targetFile.relativePath,
             wasAutoRegistered: !targetFile.registered,
+            sourceIn: insert.sourceIn,
+            sourceOut: insert.sourceOut,
+            durationSec: insert.durationSec,
+            linkedAudio: insert.linkedAudio ?? null,
           },
         };
       } catch (error) {

--- a/src/agents/tools/mediaInsertion.test.ts
+++ b/src/agents/tools/mediaInsertion.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useProjectStore } from '@/stores/projectStore';
+import { insertAgentMediaClip } from './mediaInsertion';
+import type { Asset, Command, CommandResult, Sequence, Track } from '@/types';
+
+const originalExecuteCommand = useProjectStore.getState().executeCommand;
+const originalUndo = useProjectStore.getState().undo;
+
+function createTrack(id: string, kind: Track['kind'], name: string): Track {
+  return {
+    id,
+    kind,
+    name,
+    clips: [],
+    blendMode: 'normal',
+    muted: false,
+    locked: false,
+    visible: true,
+    volume: 1,
+  };
+}
+
+function createVideoAsset(overrides: Partial<Asset> = {}): Asset {
+  return {
+    id: 'asset-video',
+    kind: 'video',
+    name: 'Interview',
+    uri: '/project/media/interview.mp4',
+    hash: 'hash-video',
+    durationSec: 12,
+    fileSize: 1024,
+    importedAt: '2026-05-26T00:00:00.000Z',
+    video: {
+      width: 1920,
+      height: 1080,
+      fps: { num: 30, den: 1 },
+      codec: 'h264',
+      hasAlpha: false,
+    },
+    audio: {
+      sampleRate: 48000,
+      channels: 2,
+      codec: 'aac',
+    },
+    license: {
+      source: 'user',
+      licenseType: 'unknown',
+      allowedUse: [],
+    },
+    tags: [],
+    proxyStatus: 'notNeeded',
+    ...overrides,
+  };
+}
+
+function createSequence(tracks: Track[]): Sequence {
+  return {
+    id: 'seq-1',
+    name: 'Main',
+    format: {
+      canvas: { width: 1920, height: 1080 },
+      fps: { num: 30, den: 1 },
+      audioSampleRate: 48000,
+      audioChannels: 2,
+    },
+    tracks,
+    markers: [],
+  };
+}
+
+describe('insertAgentMediaClip', () => {
+  let executeCommand: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executeCommand = vi.fn(async (command: Command): Promise<CommandResult> => {
+      if (command.type === 'InsertClip') {
+        return {
+          opId: command.payload.trackId === 'audio-1' ? 'op-audio' : 'op-video',
+          changes: [],
+          createdIds: [command.payload.trackId === 'audio-1' ? 'clip-audio' : 'clip-video'],
+          deletedIds: [],
+        };
+      }
+
+      return {
+        opId: `op-${command.type}`,
+        changes: [],
+        createdIds: [],
+        deletedIds: [],
+      };
+    });
+
+    const videoTrack = createTrack('video-1', 'video', 'Video 1');
+    const audioTrack = createTrack('audio-1', 'audio', 'Audio 1');
+    useProjectStore.setState({
+      isLoaded: true,
+      meta: {
+        id: 'project-1',
+        name: 'Project',
+        path: '/project',
+        createdAt: '2026-05-26T00:00:00.000Z',
+        modifiedAt: '2026-05-26T00:00:00.000Z',
+      },
+      assets: new Map([['asset-video', createVideoAsset()]]),
+      sequences: new Map([['seq-1', createSequence([videoTrack, audioTrack])]]),
+      activeSequenceId: 'seq-1',
+      executeCommand: executeCommand as unknown as (command: Command) => Promise<CommandResult>,
+      undo: vi.fn(async () => ({ success: true, canUndo: false, canRedo: false })),
+    });
+  });
+
+  afterEach(() => {
+    useProjectStore.setState({
+      isLoaded: false,
+      meta: null,
+      assets: new Map(),
+      sequences: new Map(),
+      activeSequenceId: null,
+      executeCommand: originalExecuteCommand,
+      undo: originalUndo,
+    });
+  });
+
+  it('should insert video through visual track and mirror the source range to linked audio', async () => {
+    const result = await insertAgentMediaClip({
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-video',
+      timelineStart: 2,
+      sourceIn: 1,
+      sourceOut: 5,
+    });
+
+    expect(result).toMatchObject({
+      clipId: 'clip-video',
+      durationSec: 4,
+      linkedAudio: {
+        trackId: 'audio-1',
+        clipId: 'clip-audio',
+        createdTrack: false,
+      },
+    });
+    expect(executeCommand).toHaveBeenNthCalledWith(1, {
+      type: 'InsertClip',
+      payload: {
+        sequenceId: 'seq-1',
+        trackId: 'video-1',
+        assetId: 'asset-video',
+        timelineStart: 2,
+        sourceIn: 1,
+        sourceOut: 5,
+      },
+    });
+    expect(executeCommand).toHaveBeenNthCalledWith(2, {
+      type: 'InsertClip',
+      payload: {
+        sequenceId: 'seq-1',
+        trackId: 'audio-1',
+        assetId: 'asset-video',
+        timelineStart: 2,
+        sourceIn: 1,
+        sourceOut: 5,
+      },
+    });
+    expect(executeCommand).toHaveBeenNthCalledWith(3, {
+      type: 'LinkClips',
+      payload: {
+        sequenceId: 'seq-1',
+        clipRefs: [
+          { trackId: 'video-1', clipId: 'clip-video' },
+          { trackId: 'audio-1', clipId: 'clip-audio' },
+        ],
+      },
+    });
+    expect(executeCommand).toHaveBeenNthCalledWith(4, {
+      type: 'SetClipMute',
+      payload: {
+        sequenceId: 'seq-1',
+        trackId: 'video-1',
+        clipId: 'clip-video',
+        muted: true,
+      },
+    });
+  });
+
+  it('should reject accidental video insertion onto audio tracks before creating invisible preview clips', async () => {
+    await expect(
+      insertAgentMediaClip({
+        sequenceId: 'seq-1',
+        trackId: 'audio-1',
+        assetId: 'asset-video',
+        timelineStart: 0,
+      }),
+    ).rejects.toThrow('will not show in preview');
+
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/tools/mediaInsertion.test.ts
+++ b/src/agents/tools/mediaInsertion.test.ts
@@ -196,4 +196,41 @@ describe('insertAgentMediaClip', () => {
 
     expect(executeCommand).not.toHaveBeenCalled();
   });
+
+  it('should reject invalid timeline starts before executing commands', async () => {
+    await expect(
+      insertAgentMediaClip({
+        sequenceId: 'seq-1',
+        trackId: 'video-1',
+        assetId: 'asset-video',
+        timelineStart: Number.NaN,
+      }),
+    ).rejects.toThrow('timelineStart must be a finite non-negative number');
+
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('should rollback already-applied media commands when linked audio insertion fails', async () => {
+    const undo = vi.fn(async () => ({ success: true, canUndo: false, canRedo: false }));
+    useProjectStore.setState({ undo });
+    executeCommand
+      .mockResolvedValueOnce({
+        opId: 'op-video',
+        changes: [],
+        createdIds: ['clip-video'],
+        deletedIds: [],
+      })
+      .mockRejectedValueOnce(new Error('linked audio insert failed'));
+
+    await expect(
+      insertAgentMediaClip({
+        sequenceId: 'seq-1',
+        trackId: 'video-1',
+        assetId: 'asset-video',
+        timelineStart: 2,
+      }),
+    ).rejects.toThrow('linked audio insert failed');
+
+    expect(undo).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/tools/mediaInsertion.ts
+++ b/src/agents/tools/mediaInsertion.ts
@@ -1,0 +1,474 @@
+import { createLogger } from '@/services/logger';
+import { useProjectStore } from '@/stores/projectStore';
+import { getClipTimelineEndSec } from '@/utils/clipTiming';
+import { probeMedia } from '@/utils/ffmpeg';
+import { executeAgentCommand } from './commandExecutor';
+import type { Asset, CommandResult, Sequence, Track } from '@/types';
+
+const logger = createLogger('AgentMediaInsertion');
+const DEFAULT_INSERT_CLIP_DURATION_SEC = 10;
+
+export interface AgentMediaInsertOptions {
+  sequenceId: string;
+  trackId: string;
+  assetId: string;
+  timelineStart: number;
+  sourceIn?: number;
+  sourceOut?: number;
+  audioOnly?: boolean;
+  autoExtractLinkedAudio?: boolean;
+}
+
+export interface AgentMediaInsertResult {
+  insertResult: CommandResult;
+  clipId: string;
+  sequenceId: string;
+  trackId: string;
+  assetId: string;
+  timelineStart: number;
+  sourceIn?: number;
+  sourceOut?: number;
+  durationSec: number;
+  linkedAudio?: {
+    trackId: string;
+    clipId: string;
+    createdTrack: boolean;
+  };
+}
+
+interface ResolvedSourceRange {
+  sourceIn?: number;
+  sourceOut?: number;
+  durationSec: number;
+}
+
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function getAssetInsertDurationSec(asset: Asset): number {
+  if (
+    typeof asset.durationSec === 'number' &&
+    Number.isFinite(asset.durationSec) &&
+    asset.durationSec > 0
+  ) {
+    return asset.durationSec;
+  }
+
+  return DEFAULT_INSERT_CLIP_DURATION_SEC;
+}
+
+async function resolveAssetDurationSec(asset: Asset): Promise<number | null> {
+  if (
+    typeof asset.durationSec === 'number' &&
+    Number.isFinite(asset.durationSec) &&
+    asset.durationSec > 0
+  ) {
+    return asset.durationSec;
+  }
+
+  if (asset.kind !== 'video' && asset.kind !== 'audio') {
+    return null;
+  }
+
+  try {
+    const mediaInfo = await probeMedia(asset.uri);
+    return Number.isFinite(mediaInfo.durationSec) && mediaInfo.durationSec > 0
+      ? mediaInfo.durationSec
+      : null;
+  } catch (error) {
+    logger.warn('Unable to probe inserted asset duration', {
+      assetId: asset.id,
+      uri: asset.uri,
+      error,
+    });
+    return null;
+  }
+}
+
+async function resolveSourceRange(
+  asset: Asset,
+  sourceInInput: unknown,
+  sourceOutInput: unknown,
+): Promise<ResolvedSourceRange> {
+  const requestedSourceIn = finiteNonNegative(sourceInInput);
+  const requestedSourceOut = finiteNonNegative(sourceOutInput);
+  const hasExplicitRange = requestedSourceIn !== undefined || requestedSourceOut !== undefined;
+  const assetDurationSec = await resolveAssetDurationSec(asset);
+  const sourceIn = requestedSourceIn ?? 0;
+
+  if (!hasExplicitRange && assetDurationSec == null) {
+    return {
+      durationSec: getAssetInsertDurationSec(asset),
+    };
+  }
+
+  const sourceOut =
+    requestedSourceOut ?? assetDurationSec ?? sourceIn + getAssetInsertDurationSec(asset);
+  const clampedSourceOut =
+    assetDurationSec != null ? Math.min(sourceOut, assetDurationSec) : sourceOut;
+
+  if (sourceIn >= clampedSourceOut) {
+    throw new Error(
+      `Invalid source range for asset '${asset.id}': sourceOut must be greater than sourceIn.`,
+    );
+  }
+
+  return {
+    sourceIn,
+    sourceOut: clampedSourceOut,
+    durationSec: clampedSourceOut - sourceIn,
+  };
+}
+
+function trackHasOverlap(track: Track, timelineIn: number, durationSec: number): boolean {
+  const end = timelineIn + durationSec;
+  return track.clips.some((clip) => {
+    const clipStart = clip.place.timelineInSec;
+    const clipEnd = getClipTimelineEndSec(clip);
+    return timelineIn < clipEnd && end > clipStart;
+  });
+}
+
+function canInsertClipOnTrack(track: Track, timelineIn: number, durationSec: number): boolean {
+  return !track.locked && !trackHasOverlap(track, timelineIn, durationSec);
+}
+
+function findAvailableAudioTrack(
+  sequence: Sequence,
+  timelineIn: number,
+  durationSec: number,
+): Track | undefined {
+  return sequence.tracks.find(
+    (track) => track.kind === 'audio' && canInsertClipOnTrack(track, timelineIn, durationSec),
+  );
+}
+
+function getNextAudioTrackName(sequence: Sequence): string {
+  const baseLabel = 'Audio';
+  let highestIndex = 0;
+
+  for (const track of sequence.tracks) {
+    if (track.kind !== 'audio') {
+      continue;
+    }
+
+    const trimmedName = track.name.trim();
+    if (trimmedName === baseLabel) {
+      highestIndex = Math.max(highestIndex, 1);
+      continue;
+    }
+
+    const match = /^Audio\s+(\d+)$/.exec(trimmedName);
+    if (match) {
+      highestIndex = Math.max(highestIndex, parseInt(match[1], 10));
+    }
+  }
+
+  return `${baseLabel} ${highestIndex + 1}`;
+}
+
+function getDefaultAudioTrackInsertPosition(sequence: Sequence): number {
+  let lastAudioIndex = -1;
+  for (let index = 0; index < sequence.tracks.length; index += 1) {
+    if (sequence.tracks[index].kind === 'audio') {
+      lastAudioIndex = index;
+    }
+  }
+
+  return lastAudioIndex !== -1 ? lastAudioIndex + 1 : sequence.tracks.length;
+}
+
+async function resolveAssetHasLinkedAudio(asset: Asset): Promise<boolean> {
+  if (asset.kind !== 'video') {
+    return false;
+  }
+
+  if (asset.audio) {
+    return true;
+  }
+
+  try {
+    const mediaInfo = await probeMedia(asset.uri);
+    return Boolean(mediaInfo.audio);
+  } catch (error) {
+    logger.warn('Unable to probe inserted video for audio stream detection', {
+      assetId: asset.id,
+      uri: asset.uri,
+      error,
+    });
+    return false;
+  }
+}
+
+function assertTrackCanReceiveAsset(asset: Asset, track: Track, audioOnly: boolean): void {
+  if (asset.kind === 'video') {
+    if (track.kind === 'audio') {
+      if (audioOnly) {
+        return;
+      }
+
+      throw new Error(
+        `Video asset '${asset.id}' was targeted at audio track '${track.id}'. ` +
+          'That creates an audio-only clip and will not show in preview. Use a video/overlay track, or set audioOnly true intentionally.',
+      );
+    }
+
+    if (track.kind === 'video' || track.kind === 'overlay') {
+      return;
+    }
+  }
+
+  if (asset.kind === 'audio' && track.kind === 'audio') {
+    return;
+  }
+
+  if (asset.kind === 'image' && (track.kind === 'video' || track.kind === 'overlay')) {
+    return;
+  }
+
+  if (asset.kind === 'subtitle' && track.kind === 'caption') {
+    return;
+  }
+
+  throw new Error(
+    `Cannot place ${asset.kind} asset '${asset.id}' on ${track.kind} track '${track.id}'.`,
+  );
+}
+
+async function rollbackAppliedCommands(appliedCount: number): Promise<boolean> {
+  if (appliedCount === 0) {
+    return true;
+  }
+
+  const project = useProjectStore.getState() as {
+    undo?: () => Promise<{ success: boolean }>;
+  };
+
+  if (typeof project.undo !== 'function') {
+    logger.warn('Media insert rollback skipped: undo API unavailable', { appliedCount });
+    return false;
+  }
+
+  for (let index = 0; index < appliedCount; index += 1) {
+    try {
+      const result = await project.undo();
+      if (!result.success) {
+        return false;
+      }
+    } catch (error) {
+      logger.error('Media insert rollback failed', {
+        step: index + 1,
+        appliedCount,
+        error,
+      });
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function buildInsertPayload(options: {
+  sequenceId: string;
+  trackId: string;
+  assetId: string;
+  timelineStart: number;
+  range: ResolvedSourceRange;
+}): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    sequenceId: options.sequenceId,
+    trackId: options.trackId,
+    assetId: options.assetId,
+    timelineStart: options.timelineStart,
+  };
+
+  if (options.range.sourceIn !== undefined) {
+    payload.sourceIn = options.range.sourceIn;
+  }
+  if (options.range.sourceOut !== undefined) {
+    payload.sourceOut = options.range.sourceOut;
+  }
+
+  return payload;
+}
+
+async function insertLinkedAudio(options: {
+  asset: Asset;
+  sequenceId: string;
+  videoTrackId: string;
+  videoClipId: string;
+  timelineStart: number;
+  range: ResolvedSourceRange;
+  markApplied: () => void;
+}): Promise<AgentMediaInsertResult['linkedAudio']> {
+  const hasLinkedAudio = await resolveAssetHasLinkedAudio(options.asset);
+  if (!hasLinkedAudio) {
+    return undefined;
+  }
+
+  const project = useProjectStore.getState();
+  const sequence = project.sequences.get(options.sequenceId);
+  if (!sequence) {
+    return undefined;
+  }
+
+  let createdAudioTrack = false;
+  let audioTrack = findAvailableAudioTrack(
+    sequence,
+    options.timelineStart,
+    options.range.durationSec,
+  );
+
+  if (!audioTrack) {
+    const createTrackResult = await executeAgentCommand('CreateTrack', {
+      sequenceId: options.sequenceId,
+      kind: 'audio',
+      name: getNextAudioTrackName(sequence),
+      position: getDefaultAudioTrackInsertPosition(sequence),
+    });
+    options.markApplied();
+
+    const createdTrackId = createTrackResult.createdIds[0];
+    if (!createdTrackId) {
+      throw new Error('CreateTrack did not return a linked audio track id');
+    }
+
+    createdAudioTrack = true;
+    const refreshedProject = useProjectStore.getState();
+    const refreshedSequence = refreshedProject.sequences.get(options.sequenceId);
+    audioTrack = refreshedSequence?.tracks.find((track) => track.id === createdTrackId);
+    if (!audioTrack) {
+      throw new Error(`Created linked audio track '${createdTrackId}' was not found after refresh`);
+    }
+  }
+
+  if (!audioTrack) {
+    return undefined;
+  }
+
+  const audioResult = await executeAgentCommand(
+    'InsertClip',
+    buildInsertPayload({
+      sequenceId: options.sequenceId,
+      trackId: audioTrack.id,
+      assetId: options.asset.id,
+      timelineStart: options.timelineStart,
+      range: options.range,
+    }),
+  );
+  options.markApplied();
+
+  const audioClipId = audioResult.createdIds[0];
+  if (!audioClipId) {
+    throw new Error('Linked audio InsertClip did not return a created clip id');
+  }
+
+  await executeAgentCommand('LinkClips', {
+    sequenceId: options.sequenceId,
+    clipRefs: [
+      { trackId: options.videoTrackId, clipId: options.videoClipId },
+      { trackId: audioTrack.id, clipId: audioClipId },
+    ],
+  });
+  options.markApplied();
+
+  await executeAgentCommand('SetClipMute', {
+    sequenceId: options.sequenceId,
+    trackId: options.videoTrackId,
+    clipId: options.videoClipId,
+    muted: true,
+  });
+  options.markApplied();
+
+  return {
+    trackId: audioTrack.id,
+    clipId: audioClipId,
+    createdTrack: createdAudioTrack,
+  };
+}
+
+export async function insertAgentMediaClip(
+  options: AgentMediaInsertOptions,
+): Promise<AgentMediaInsertResult> {
+  let appliedCommands = 0;
+  const markApplied = (): void => {
+    appliedCommands += 1;
+  };
+
+  try {
+    const project = useProjectStore.getState();
+    const sequence = project.sequences.get(options.sequenceId);
+    if (!sequence) {
+      throw new Error(`Sequence '${options.sequenceId}' not found`);
+    }
+
+    const track = sequence.tracks.find((entry) => entry.id === options.trackId);
+    if (!track) {
+      throw new Error(`Track '${options.trackId}' not found`);
+    }
+
+    const asset = project.assets.get(options.assetId);
+    if (!asset) {
+      throw new Error(`Asset '${options.assetId}' not found`);
+    }
+
+    const audioOnly = options.audioOnly === true;
+    assertTrackCanReceiveAsset(asset, track, audioOnly);
+
+    const range = await resolveSourceRange(asset, options.sourceIn, options.sourceOut);
+    const insertResult = await executeAgentCommand(
+      'InsertClip',
+      buildInsertPayload({
+        sequenceId: options.sequenceId,
+        trackId: options.trackId,
+        assetId: options.assetId,
+        timelineStart: options.timelineStart,
+        range,
+      }),
+    );
+    markApplied();
+
+    const clipId = insertResult.createdIds[0];
+    if (!clipId) {
+      throw new Error('InsertClip did not return a created clip id');
+    }
+
+    const shouldExtractLinkedAudio =
+      options.autoExtractLinkedAudio !== false &&
+      asset.kind === 'video' &&
+      !audioOnly &&
+      (track.kind === 'video' || track.kind === 'overlay');
+    const linkedAudio = shouldExtractLinkedAudio
+      ? await insertLinkedAudio({
+          asset,
+          sequenceId: options.sequenceId,
+          videoTrackId: options.trackId,
+          videoClipId: clipId,
+          timelineStart: options.timelineStart,
+          range,
+          markApplied,
+        })
+      : undefined;
+
+    return {
+      insertResult,
+      clipId,
+      sequenceId: options.sequenceId,
+      trackId: options.trackId,
+      assetId: options.assetId,
+      timelineStart: options.timelineStart,
+      sourceIn: range.sourceIn,
+      sourceOut: range.sourceOut,
+      durationSec: range.durationSec,
+      linkedAudio,
+    };
+  } catch (error) {
+    const rolledBack = await rollbackAppliedCommands(appliedCommands);
+    const message = error instanceof Error ? error.message : String(error);
+    if (appliedCommands > 0 && !rolledBack) {
+      throw new Error(`${message}. Automatic rollback failed after ${appliedCommands} command(s).`);
+    }
+    throw error;
+  }
+}

--- a/src/agents/tools/mediaInsertion.ts
+++ b/src/agents/tools/mediaInsertion.ts
@@ -131,7 +131,7 @@ function trackHasOverlap(track: Track, timelineIn: number, durationSec: number):
 }
 
 function canInsertClipOnTrack(track: Track, timelineIn: number, durationSec: number): boolean {
-  return !track.locked && !trackHasOverlap(track, timelineIn, durationSec);
+  return !track.locked && !track.muted && !trackHasOverlap(track, timelineIn, durationSec);
 }
 
 function findAvailableAudioTrack(
@@ -397,6 +397,10 @@ export async function insertAgentMediaClip(
   };
 
   try {
+    if (!Number.isFinite(options.timelineStart) || options.timelineStart < 0) {
+      throw new Error('timelineStart must be a finite non-negative number.');
+    }
+
     const project = useProjectStore.getState();
     const sequence = project.sequences.get(options.sequenceId);
     if (!sequence) {

--- a/src/agents/tools/metaTools.test.ts
+++ b/src/agents/tools/metaTools.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { globalToolRegistry, type ToolDefinition } from '@/agents';
 import { createToolRegistryAdapter } from '@/agents/engine/adapters/tools/ToolRegistryAdapter';
 import { registerCaptionTools, unregisterCaptionTools } from './captionTools';
+import { registerTextTools, unregisterTextTools } from './textTools';
 import {
   normalizeMetaToolArgsForValidation,
   registerMetaTools,
@@ -12,11 +13,13 @@ describe('metaTools', () => {
   beforeEach(() => {
     globalToolRegistry.clear();
     registerCaptionTools();
+    registerTextTools();
     registerMetaTools();
   });
 
   afterEach(() => {
     unregisterMetaTools();
+    unregisterTextTools();
     unregisterCaptionTools();
     globalToolRegistry.clear();
   });
@@ -52,6 +55,86 @@ describe('metaTools', () => {
 
     expect(aliased.valid).toBe(false);
     expect(aliased.errors.some((error) => error.includes('sequenceId'))).toBe(true);
+  });
+
+  it('exposes rich editable text overlay fields through the text meta-tool schema', () => {
+    const textTool = globalToolRegistry.get('text');
+    const properties = textTool?.parameters.properties ?? {};
+
+    expect(properties.clipId).toBeDefined();
+    expect(properties.duration).toBeDefined();
+    expect(properties.preset).toBeDefined();
+    expect(properties.style).toBeDefined();
+    expect(properties.fontWeight).toBeDefined();
+    expect(properties.backgroundPadding).toBeDefined();
+    expect(properties.alignment).toBeDefined();
+    expect(properties.shadow).toBeDefined();
+    expect(properties.outline).toBeDefined();
+    expect(properties.clearShadow).toBeDefined();
+    expect(properties.clearOutline).toBeDefined();
+    expect(properties.transform).toBeDefined();
+    expect(properties.transformX).toBeDefined();
+    expect(properties.scaleX).toBeDefined();
+    expect(properties.anchorX).toBeDefined();
+    expect(properties.autoPlacement).toBeDefined();
+    expect(properties.placementIntent).toBeDefined();
+    expect(properties.safeMargin).toBeDefined();
+  });
+
+  it('allows rich editable text creation without explicit sequenceId when context can supply it', () => {
+    const adapter = createToolRegistryAdapter(globalToolRegistry);
+
+    const valid = adapter.validateArgs('text', {
+      action: 'create_title',
+      text: 'Launch title',
+      startTime: 0,
+      duration: 3,
+      preset: 'title',
+      style: {
+        fontFamily: 'Inter',
+        fontSize: 72,
+        fontWeight: 800,
+        color: '#FFFFFF',
+        alignment: 'center',
+      },
+      position: { x: 0.5, y: 0.2 },
+      shadow: { color: '#00000099', offsetX: 2, offsetY: 4, blur: 8 },
+      outline: { color: '#000000', width: 3 },
+      transform: {
+        position: { x: 0.5, y: 0.2 },
+        scale: { x: 1.1, y: 1.1 },
+        rotationDeg: -4,
+        anchor: { x: 0.5, y: 0.5 },
+      },
+      autoPlacement: true,
+      placementIntent: 'title',
+    });
+
+    expect(valid.valid).toBe(true);
+  });
+
+  it('allows nullable effect clears and transform aliases for editable text updates', () => {
+    const adapter = createToolRegistryAdapter(globalToolRegistry);
+
+    const valid = adapter.validateArgs('text', {
+      action: 'move_text',
+      clipId: 'clip-text-1',
+      transformX: 0.45,
+      transformY: 0.82,
+      scaleX: 1.2,
+      scaleY: 1.2,
+      rotationDeg: 8,
+    });
+    const update = adapter.validateArgs('text', {
+      action: 'modify_text',
+      clipId: 'clip-text-1',
+      shadow: null,
+      outline: null,
+      clearBackground: true,
+    });
+
+    expect(valid.valid).toBe(true);
+    expect(update.valid).toBe(true);
   });
 
   it('normalizes asset discovery query aliases for validation', () => {

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -31,7 +31,10 @@ import { getCaptionToolNames } from './captionTools';
 import { getTextToolNames } from './textTools';
 import { getGenerationToolNames } from './generationTools';
 import { getGenerativeTimelineToolNames } from './generativeTimelineTools';
-import { canonicalizeToolNameCandidate } from '../toolNameNormalization';
+import {
+  canonicalizeToolNameCandidate,
+  getSemanticToolAliasesForTargets,
+} from '../toolNameNormalization';
 
 const logger = createLogger('MetaTools');
 
@@ -209,6 +212,17 @@ const EFFECTS_ACTIONS = [...getEffectToolNames(), ...getTransitionToolNames()];
 const TEXT_ACTIONS = [...getCaptionToolNames(), ...getTextToolNames()];
 const GENERATE_ACTIONS = [...getGenerativeTimelineToolNames(), ...getGenerationToolNames()];
 
+function buildPromptActionEnum(actions: readonly string[]): string[] {
+  return Array.from(new Set([...actions, ...getSemanticToolAliasesForTargets(actions)]));
+}
+
+const QUERY_ACTION_ENUM = buildPromptActionEnum(QUERY_ACTIONS);
+const EDIT_ACTION_ENUM = buildPromptActionEnum(EDIT_ACTIONS);
+const AUDIO_ACTION_ENUM = buildPromptActionEnum(AUDIO_ACTIONS);
+const EFFECTS_ACTION_ENUM = buildPromptActionEnum(EFFECTS_ACTIONS);
+const TEXT_ACTION_ENUM = buildPromptActionEnum(TEXT_ACTIONS);
+const GENERATE_ACTION_ENUM = buildPromptActionEnum(GENERATE_ACTIONS);
+
 // =============================================================================
 // 6. Execute Plan Meta-Tool (batch execution)
 // =============================================================================
@@ -233,7 +247,7 @@ const META_TOOLS: ToolDefinition[] = [
         action: {
           type: 'string',
           description: 'The query action to perform',
-          enum: [...QUERY_ACTIONS],
+          enum: QUERY_ACTION_ENUM,
         },
         sequenceId: { type: 'string', description: 'Sequence ID' },
         trackId: { type: 'string', description: 'Track ID' },
@@ -349,7 +363,7 @@ const META_TOOLS: ToolDefinition[] = [
         action: {
           type: 'string',
           description: 'The editing action to perform',
-          enum: [...EDIT_ACTIONS],
+          enum: EDIT_ACTION_ENUM,
         },
         sequenceId: { type: 'string', description: 'Sequence ID' },
         trackId: { type: 'string', description: 'Track ID' },
@@ -417,7 +431,7 @@ const META_TOOLS: ToolDefinition[] = [
         action: {
           type: 'string',
           description: 'The audio action to perform',
-          enum: [...AUDIO_ACTIONS],
+          enum: AUDIO_ACTION_ENUM,
         },
         sequenceId: { type: 'string', description: 'Sequence ID' },
         trackId: { type: 'string', description: 'Track ID' },
@@ -449,7 +463,7 @@ const META_TOOLS: ToolDefinition[] = [
         action: {
           type: 'string',
           description: 'The effect/transition action to perform',
-          enum: [...EFFECTS_ACTIONS],
+          enum: EFFECTS_ACTION_ENUM,
         },
         sequenceId: { type: 'string', description: 'Sequence ID' },
         trackId: { type: 'string', description: 'Track ID' },
@@ -477,7 +491,7 @@ const META_TOOLS: ToolDefinition[] = [
   // ---------------------------------------------------------------------------
   {
     name: 'text',
-    description: `Create and edit on-screen text, captions, and subtitles. Use when the user asks for subtitles, captions, or text styling. Actions: ${TEXT_ACTIONS.join(', ')}. Note: auto_transcribe uses local Whisper when available and falls back to a configured transcript analysis provider; for on-screen text or lyrics, use the query meta-tool with analyze_asset action and analysisTypes ["textOcr"] instead.`,
+    description: `Create and edit editable on-video text overlays, titles, lower thirds, captions, and subtitles. Use add_text_clip/update_text_clip/set_text_transform/delete_text_clip for preview-positioned text clips with font, size, weight, color, shadow, outline, background, opacity, rotation, and drag/resize transform data. Use add_caption/update_caption/style_caption/import_captions_from_file/add_captions_from_transcription for timed subtitle tracks. Actions: ${TEXT_ACTIONS.join(', ')}. Note: auto_transcribe uses local Whisper when available and falls back to a configured transcript analysis provider; for on-screen text or lyrics, use the query meta-tool with analyze_asset action and analysisTypes ["textOcr"] instead.`,
     category: 'clip',
     parameters: {
       type: 'object',
@@ -485,15 +499,35 @@ const META_TOOLS: ToolDefinition[] = [
         action: {
           type: 'string',
           description: 'The text/caption action to perform',
-          enum: [...TEXT_ACTIONS],
+          enum: TEXT_ACTION_ENUM,
         },
-        sequenceId: { type: 'string', description: 'Sequence ID' },
-        trackId: { type: 'string', description: 'Track ID' },
-        captionId: { type: 'string', description: 'Caption ID' },
+        sequenceId: {
+          type: 'string',
+          description:
+            'Sequence ID. Editable text overlay tools can default to the active sequence; caption-track tools require it.',
+        },
+        trackId: {
+          type: 'string',
+          description:
+            'Track ID. Text overlays use video/overlay tracks and auto-create one when omitted for add_text_clip; captions use caption tracks.',
+        },
+        clipId: { type: 'string', description: 'Editable text clip ID' },
+        captionId: { type: 'string', description: 'Caption ID for caption-track actions' },
         assetId: { type: 'string', description: 'Asset ID for transcription' },
-        text: { type: 'string', description: 'Caption text content' },
+        text: { type: 'string', description: 'Text or caption content' },
+        content: { type: 'string', description: 'Legacy alias for editable text content' },
         startTime: { type: 'number', description: 'Start time in seconds' },
         endTime: { type: 'number', description: 'End time in seconds' },
+        duration: {
+          type: 'number',
+          description: 'Editable text clip duration in seconds; use endTime for captions',
+        },
+        preset: {
+          type: 'string',
+          description:
+            'Editable text starter preset: default, title, lower_third, or subtitle',
+          enum: ['default', 'title', 'lower_third', 'subtitle'],
+        },
         segments: {
           type: 'array',
           description: 'Timed text segments for batch caption creation',
@@ -507,11 +541,105 @@ const META_TOOLS: ToolDefinition[] = [
             required: ['startTime', 'endTime', 'text'],
           },
         },
-        fontSize: { type: 'number', description: 'Font size' },
-        fontFamily: { type: 'string', description: 'Font family' },
-        color: { type: 'string', description: 'Text color (hex)' },
-        backgroundColor: { type: 'string', description: 'Background color (hex)' },
-        position: { type: 'string', description: 'Position: top, center, bottom' },
+        replaceExisting: {
+          type: 'boolean',
+          description: 'When importing generated captions, replace existing captions on the track',
+        },
+        style: {
+          type: 'object',
+          description:
+            'Editable text style object: fontFamily, fontSize, fontWeight, color, backgroundColor, backgroundPadding, alignment, bold, italic, underline, lineHeight, letterSpacing',
+        },
+        fontSize: { type: 'number', description: 'Font size in pixels' },
+        fontFamily: { type: 'string', description: 'Font family name' },
+        fontWeight: { type: 'number', description: 'Numeric font weight, 100 to 900' },
+        bold: { type: 'boolean', description: 'Enable bold styling' },
+        italic: { type: 'boolean', description: 'Enable italic styling' },
+        underline: { type: 'boolean', description: 'Enable underline styling' },
+        color: { type: 'string', description: 'Text color (hex, optional alpha)' },
+        opacity: { type: 'number', description: 'Text opacity from 0 to 1' },
+        backgroundColor: {
+          type: ['string', 'null'],
+          description: 'Background color (hex, optional alpha), or null to remove it',
+        },
+        backgroundPadding: { type: 'number', description: 'Background padding in pixels' },
+        clearBackground: {
+          type: 'boolean',
+          description: 'Remove editable text background fill',
+        },
+        alignment: {
+          type: 'string',
+          description: 'Text alignment',
+          enum: ['left', 'center', 'right'],
+        },
+        lineHeight: { type: 'number', description: 'Line-height multiplier' },
+        letterSpacing: { type: 'number', description: 'Letter spacing in pixels' },
+        position: {
+          type: ['string', 'object'],
+          description:
+            'Position preset (top, center, bottom, lower_third) or object with x/y 0..1 or xPercent/yPercent. Use bottom for normal subtitles.',
+        },
+        x: { type: 'number', description: 'Editable text normalized X position, 0 to 1' },
+        y: { type: 'number', description: 'Editable text normalized Y position, 0 to 1' },
+        xPercent: { type: 'number', description: 'Custom X position as percent from left' },
+        yPercent: { type: 'number', description: 'Custom Y position as percent from top' },
+        shadow: {
+          type: ['object', 'null'],
+          description:
+            'Editable text shadow object { color, offsetX, offsetY, blur }, or null to disable',
+        },
+        shadowColor: { type: 'string', description: 'Shadow color hex with optional alpha' },
+        shadowOffsetX: { type: 'number', description: 'Shadow horizontal offset in pixels' },
+        shadowOffsetY: { type: 'number', description: 'Shadow vertical offset in pixels' },
+        shadowBlur: { type: 'number', description: 'Shadow blur radius in pixels' },
+        clearShadow: { type: 'boolean', description: 'Remove editable text shadow' },
+        outline: {
+          type: ['object', 'null'],
+          description: 'Editable text outline object { color, width }, or null to disable',
+        },
+        outlineColor: { type: 'string', description: 'Outline color hex with optional alpha' },
+        outlineWidth: { type: 'number', description: 'Outline width in pixels' },
+        clearOutline: { type: 'boolean', description: 'Remove editable text outline' },
+        rotation: { type: 'number', description: 'Editable text rotation in degrees' },
+        transform: {
+          type: 'object',
+          description:
+            'Clip transform object with position{x,y}, scale{x,y}, rotationDeg, and anchor{x,y}',
+        },
+        transformX: { type: 'number', description: 'Normalized transform X position, 0 to 1' },
+        transformY: { type: 'number', description: 'Normalized transform Y position, 0 to 1' },
+        scaleX: { type: 'number', description: 'Horizontal scale multiplier' },
+        scaleY: { type: 'number', description: 'Vertical scale multiplier' },
+        rotationDeg: { type: 'number', description: 'Transform rotation in degrees' },
+        anchorX: { type: 'number', description: 'Normalized transform anchor X, 0 to 1' },
+        anchorY: { type: 'number', description: 'Normalized transform anchor Y, 0 to 1' },
+        autoPlacement: {
+          type: 'boolean',
+          description:
+            'Automatically choose a safe preview text position using timeline context and available faces/objects/OCR annotations',
+        },
+        placement: {
+          type: ['string', 'object', 'boolean'],
+          description:
+            'Placement intent or options. String values: default, title, subtitle, lower_third, callout. False disables auto-placement.',
+        },
+        placementIntent: {
+          type: 'string',
+          description: 'Placement intent: default, title, subtitle, lower_third, callout',
+        },
+        safeMargin: {
+          type: 'number',
+          description: 'Normalized safe-area margin for automatic placement, 0.02 to 0.2',
+        },
+        avoidFaces: { type: 'boolean', description: 'Avoid detected face boxes when auto-placing' },
+        avoidObjects: {
+          type: 'boolean',
+          description: 'Avoid detected object boxes when auto-placing',
+        },
+        avoidText: {
+          type: 'boolean',
+          description: 'Avoid detected OCR text and existing editable text clips when auto-placing',
+        },
         language: { type: 'string', description: 'Language code for transcription' },
         model: { type: 'string', description: 'Transcription model name' },
         provider: { type: 'string', description: 'Optional transcript analysis provider fallback' },
@@ -540,7 +668,7 @@ const META_TOOLS: ToolDefinition[] = [
         action: {
           type: 'string',
           description: 'The generation orchestration action to perform',
-          enum: [...GENERATE_ACTIONS],
+          enum: GENERATE_ACTION_ENUM,
         },
         prompt: { type: 'string', description: 'Generation or discovery prompt' },
         mediaType: { type: 'string', description: 'Media type: video, image, music, or sfx' },

--- a/src/agents/tools/textPlacement.test.ts
+++ b/src/agents/tools/textPlacement.test.ts
@@ -5,6 +5,7 @@ import {
   annotationToTextPlacementObstacles,
   parseTextPlacementOptions,
   resolveSmartTextPlacement,
+  type TextPlacementObstacle,
 } from './textPlacement';
 
 function sequence(): Sequence {
@@ -78,5 +79,26 @@ describe('textPlacement', () => {
     });
 
     expect(decision.candidate).not.toBe('center');
+  });
+
+  it('should ignore OCR and existing text obstacles when avoidText is disabled', () => {
+    const textData = createTitleTextClipData('Readable title');
+    const obstacle: TextPlacementObstacle = {
+      type: 'ocr',
+      box: { left: 0.25, top: 0.35, width: 0.5, height: 0.3 },
+      weight: 8,
+      confidence: 0.95,
+    };
+
+    const decision = resolveSmartTextPlacement({
+      textData,
+      sequence: sequence(),
+      options: parseTextPlacementOptions({ placementIntent: 'title', avoidText: false }),
+      obstacles: [obstacle],
+      existingText: [{ textData: createTitleTextClipData('Existing title'), weight: 8 }],
+    });
+
+    expect(decision.candidate).toBe('center');
+    expect(decision.obstacleCount).toBe(0);
   });
 });

--- a/src/agents/tools/textPlacement.test.ts
+++ b/src/agents/tools/textPlacement.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { AssetAnnotation } from '@/bindings';
+import { createSubtitleTextClipData, createTitleTextClipData, type Sequence } from '@/types';
+import {
+  annotationToTextPlacementObstacles,
+  parseTextPlacementOptions,
+  resolveSmartTextPlacement,
+} from './textPlacement';
+
+function sequence(): Sequence {
+  return {
+    id: 'seq-1',
+    name: 'Main',
+    format: {
+      canvas: { width: 1920, height: 1080 },
+      fps: { num: 30, den: 1 },
+      audioSampleRate: 48000,
+      audioChannels: 2,
+    },
+    tracks: [],
+    markers: [],
+  };
+}
+
+function annotationWithFaceAtBottom(): AssetAnnotation {
+  return {
+    version: '1',
+    assetId: 'asset-1',
+    assetHash: 'hash',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    analysis: {
+      faces: {
+        provider: 'google_cloud',
+        analyzedAt: '2026-01-01T00:00:00Z',
+        config: {},
+        results: [
+          {
+            timeSec: 2,
+            confidence: 0.95,
+            boundingBox: { left: 0.25, top: 0.72, width: 0.5, height: 0.2 },
+            emotions: [],
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('textPlacement', () => {
+  it('should move subtitle placement away from detected lower-frame faces', () => {
+    const textData = createSubtitleTextClipData('Readable subtitle');
+    const obstacles = annotationToTextPlacementObstacles(annotationWithFaceAtBottom(), 2, 0.5);
+
+    const decision = resolveSmartTextPlacement({
+      textData,
+      sequence: sequence(),
+      options: parseTextPlacementOptions({ placementIntent: 'subtitle' }),
+      obstacles,
+      existingText: [],
+    });
+
+    expect(decision.candidate).toBe('upper_center');
+    expect(decision.position.y).toBeLessThan(0.3);
+    expect(decision.obstacleCount).toBe(1);
+  });
+
+  it('should avoid an existing title when auto-placing another title', () => {
+    const textData = createTitleTextClipData('Second title');
+    const existingTitle = createTitleTextClipData('Main title');
+
+    const decision = resolveSmartTextPlacement({
+      textData,
+      sequence: sequence(),
+      options: parseTextPlacementOptions({ placementIntent: 'title' }),
+      obstacles: [],
+      existingText: [{ textData: existingTitle, weight: 8 }],
+    });
+
+    expect(decision.candidate).not.toBe('center');
+  });
+});

--- a/src/agents/tools/textPlacement.ts
+++ b/src/agents/tools/textPlacement.ts
@@ -123,26 +123,26 @@ export function resolveSmartTextPlacement({
     right: 1 - options.safeMargin,
     bottom: 1 - options.safeMargin,
   };
-  const existingObstacles = existingText.map((entry): TextPlacementObstacle => ({
-    type: 'existing_text',
-    box: rectToBox(estimateTextRect(entry.textData, sequence)),
-    weight: entry.weight ?? 4,
-    label: 'existing text',
-  }));
+  const existingObstacles = existingText.map(
+    (entry): TextPlacementObstacle => ({
+      type: 'existing_text',
+      box: rectToBox(estimateTextRect(entry.textData, sequence)),
+      weight: entry.weight ?? 4,
+      label: 'existing text',
+    }),
+  );
   const effectiveObstacles = [
     ...obstacles.filter((obstacle) => shouldUseObstacle(obstacle, options)),
     ...(options.avoidText ? existingObstacles : []),
   ];
 
   const candidates = buildPlacementCandidates(options.intent, textData.style.alignment);
-  let best:
-    | {
-        candidate: PlacementCandidate;
-        rect: Rect;
-        score: number;
-        reason: string;
-      }
-    | null = null;
+  let best: {
+    candidate: PlacementCandidate;
+    rect: Rect;
+    score: number;
+    reason: string;
+  } | null = null;
 
   for (const candidate of candidates) {
     const rect = rectAtPosition(
@@ -233,7 +233,14 @@ export function annotationToTextPlacementObstacles(
 
   for (const text of annotation.analysis.textOcr?.results ?? []) {
     const detection = text as TextDetection;
-    addDetection('ocr', detection.timeSec, detection.boundingBox, detection.confidence, 5, detection.text);
+    addDetection(
+      'ocr',
+      detection.timeSec,
+      detection.boundingBox,
+      detection.confidence,
+      5,
+      detection.text,
+    );
   }
 
   return obstacles;
@@ -364,18 +371,27 @@ function clampPositionForRect(
   };
 }
 
-function shouldUseObstacle(obstacle: TextPlacementObstacle, options: TextPlacementOptions): boolean {
+function shouldUseObstacle(
+  obstacle: TextPlacementObstacle,
+  options: TextPlacementOptions,
+): boolean {
   if (obstacle.type === 'face') {
     return options.avoidFaces;
   }
   if (obstacle.type === 'object') {
     return options.avoidObjects;
   }
+  if (obstacle.type === 'ocr' || obstacle.type === 'existing_text') {
+    return options.avoidText;
+  }
   return true;
 }
 
 function normalizePlacementIntent(value: string | undefined): TextPlacementIntent {
-  const normalized = value?.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
   if (normalized === 'title') return 'title';
   if (normalized === 'subtitle' || normalized === 'caption') return 'subtitle';
   if (normalized === 'lower_third' || normalized === 'lowerthird') return 'lower_third';

--- a/src/agents/tools/textPlacement.ts
+++ b/src/agents/tools/textPlacement.ts
@@ -1,0 +1,482 @@
+import type {
+  AssetAnnotation,
+  BoundingBox,
+  FaceDetection,
+  ObjectDetection,
+  TextDetection,
+} from '@/bindings';
+import type { Sequence, TextClipAlignment, TextClipData, TextPosition } from '@/types';
+
+export type TextPlacementIntent = 'default' | 'title' | 'subtitle' | 'lower_third' | 'callout';
+
+export interface TextPlacementOptions {
+  intent: TextPlacementIntent;
+  safeMargin: number;
+  avoidFaces: boolean;
+  avoidObjects: boolean;
+  avoidText: boolean;
+}
+
+export interface TextPlacementObstacle {
+  type: 'face' | 'object' | 'ocr' | 'existing_text';
+  box: BoundingBox;
+  weight: number;
+  label?: string;
+  confidence?: number;
+}
+
+export interface ExistingTextPlacement {
+  textData: TextClipData;
+  weight?: number;
+}
+
+export interface TextPlacementDecision {
+  position: TextPosition;
+  candidate: string;
+  score: number;
+  reason: string;
+  obstacleCount: number;
+}
+
+interface PlacementCandidate {
+  id: string;
+  position: TextPosition;
+  alignment?: TextClipAlignment;
+  priority: number;
+}
+
+interface Rect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_SAFE_MARGIN = 0.08;
+
+export function parseTextPlacementOptions(args: Record<string, unknown>): TextPlacementOptions {
+  const placementArg = objectArg(args.placement);
+  const rawIntent =
+    readString(args.placementIntent) ??
+    readString(args.intent) ??
+    readString(placementArg?.intent) ??
+    (typeof args.placement === 'string' ? args.placement : undefined);
+
+  return {
+    intent: normalizePlacementIntent(rawIntent),
+    safeMargin: clampFinite(
+      numberArg(args.safeMargin) ?? numberArg(placementArg?.safeMargin),
+      0.02,
+      0.2,
+      DEFAULT_SAFE_MARGIN,
+    ),
+    avoidFaces: booleanArg(args.avoidFaces) ?? booleanArg(placementArg?.avoidFaces) ?? true,
+    avoidObjects: booleanArg(args.avoidObjects) ?? booleanArg(placementArg?.avoidObjects) ?? true,
+    avoidText: booleanArg(args.avoidText) ?? booleanArg(placementArg?.avoidText) ?? true,
+  };
+}
+
+export function shouldAutoPlaceText(args: Record<string, unknown>, isCreate: boolean): boolean {
+  if (args.autoPlacement === false || args.placement === false) {
+    return false;
+  }
+
+  if (
+    args.autoPlacement === true ||
+    args.placement !== undefined ||
+    args.placementIntent !== undefined ||
+    args.intent !== undefined
+  ) {
+    return true;
+  }
+
+  return isCreate && !hasExplicitTextPosition(args);
+}
+
+export function hasExplicitTextPosition(args: Record<string, unknown>): boolean {
+  if (args.position !== undefined || args.x !== undefined || args.y !== undefined) {
+    return true;
+  }
+
+  return args.xPercent !== undefined || args.yPercent !== undefined;
+}
+
+export function resolveSmartTextPlacement({
+  textData,
+  sequence,
+  options,
+  obstacles,
+  existingText,
+}: {
+  textData: TextClipData;
+  sequence: Sequence;
+  options: TextPlacementOptions;
+  obstacles: TextPlacementObstacle[];
+  existingText: ExistingTextPlacement[];
+}): TextPlacementDecision {
+  const estimatedRect = estimateTextRect(textData, sequence);
+  const safeRect = {
+    left: options.safeMargin,
+    top: options.safeMargin,
+    right: 1 - options.safeMargin,
+    bottom: 1 - options.safeMargin,
+  };
+  const existingObstacles = existingText.map((entry): TextPlacementObstacle => ({
+    type: 'existing_text',
+    box: rectToBox(estimateTextRect(entry.textData, sequence)),
+    weight: entry.weight ?? 4,
+    label: 'existing text',
+  }));
+  const effectiveObstacles = [
+    ...obstacles.filter((obstacle) => shouldUseObstacle(obstacle, options)),
+    ...(options.avoidText ? existingObstacles : []),
+  ];
+
+  const candidates = buildPlacementCandidates(options.intent, textData.style.alignment);
+  let best:
+    | {
+        candidate: PlacementCandidate;
+        rect: Rect;
+        score: number;
+        reason: string;
+      }
+    | null = null;
+
+  for (const candidate of candidates) {
+    const rect = rectAtPosition(
+      estimatedRect,
+      candidate.position,
+      candidate.alignment ?? textData.style.alignment,
+    );
+    const score = scoreCandidate(rect, candidate, safeRect, effectiveObstacles);
+    if (!best || score > best.score) {
+      best = {
+        candidate,
+        rect,
+        score,
+        reason: summarizeCandidate(candidate, score, effectiveObstacles.length),
+      };
+    }
+  }
+
+  const fallback = candidates[0];
+  const selected = best?.candidate ?? fallback;
+  return {
+    position: clampPositionForRect(
+      selected.position,
+      best?.rect ??
+        rectAtPosition(
+          estimatedRect,
+          selected.position,
+          selected.alignment ?? textData.style.alignment,
+        ),
+      safeRect,
+      selected.alignment ?? textData.style.alignment,
+    ),
+    candidate: selected.id,
+    score: round(best?.score ?? 0),
+    reason: best?.reason ?? `Selected ${selected.id} from default ${options.intent} placement.`,
+    obstacleCount: effectiveObstacles.length,
+  };
+}
+
+export function annotationToTextPlacementObstacles(
+  annotation: AssetAnnotation | null | undefined,
+  sourceTimeSec: number,
+  toleranceSec: number,
+): TextPlacementObstacle[] {
+  if (!annotation) {
+    return [];
+  }
+
+  const obstacles: TextPlacementObstacle[] = [];
+  const addDetection = (
+    type: TextPlacementObstacle['type'],
+    timeSec: number,
+    box: BoundingBox | null | undefined,
+    confidence: number,
+    weight: number,
+    label?: string,
+  ) => {
+    if (!box || Math.abs(timeSec - sourceTimeSec) > toleranceSec) {
+      return;
+    }
+    obstacles.push({
+      type,
+      box: clampBox(box),
+      confidence,
+      weight: weight * Math.max(0.35, Math.min(1, confidence || 1)),
+      label,
+    });
+  };
+
+  for (const face of annotation.analysis.faces?.results ?? []) {
+    const detection = face as FaceDetection;
+    addDetection('face', detection.timeSec, detection.boundingBox, detection.confidence, 6, 'face');
+  }
+
+  for (const object of annotation.analysis.objects?.results ?? []) {
+    const detection = object as ObjectDetection;
+    const labels = detection.labels ?? [];
+    const isPerson = labels.some((label) => /person|face|head|speaker|host|presenter/i.test(label));
+    addDetection(
+      'object',
+      detection.timeSec,
+      detection.boundingBox,
+      detection.confidence,
+      isPerson ? 4 : 1.5,
+      labels.slice(0, 3).join(', '),
+    );
+  }
+
+  for (const text of annotation.analysis.textOcr?.results ?? []) {
+    const detection = text as TextDetection;
+    addDetection('ocr', detection.timeSec, detection.boundingBox, detection.confidence, 5, detection.text);
+  }
+
+  return obstacles;
+}
+
+export function estimateTextRect(textData: TextClipData, sequence: Sequence): Rect {
+  const canvas = sequence.format.canvas;
+  const style = textData.style;
+  const lines = textData.content.split(/\r?\n/);
+  const maxLineLength = Math.max(1, ...lines.map((line) => line.length));
+  const lineCount = Math.max(1, lines.length);
+  const fontSize = clampFinite(style.fontSize, 1, 500, 48);
+  const padding = clampFinite(style.backgroundPadding, 0, 500, 0);
+  const letterSpacing = clampFinite(style.letterSpacing, -500, 500, 0);
+  const widthPx = Math.min(
+    canvas.width * 0.86,
+    Math.max(fontSize * 3, maxLineLength * (fontSize * 0.56 + letterSpacing) + padding * 2),
+  );
+  const heightPx = Math.min(
+    canvas.height * 0.4,
+    lineCount * fontSize * clampFinite(style.lineHeight, 0.1, 10, 1.2) + padding * 2,
+  );
+  const width = clampFinite(widthPx / canvas.width, 0.08, 0.86, 0.35);
+  const height = clampFinite(heightPx / canvas.height, 0.035, 0.4, 0.08);
+
+  return rectAtPosition(
+    { left: 0, top: 0, right: width, bottom: height, width, height },
+    textData.position,
+    style.alignment,
+  );
+}
+
+function buildPlacementCandidates(
+  intent: TextPlacementIntent,
+  alignment: TextClipAlignment,
+): PlacementCandidate[] {
+  switch (intent) {
+    case 'subtitle':
+      return [
+        candidate('bottom_center', 0.5, 0.85, alignment, 10),
+        candidate('upper_center', 0.5, 0.18, alignment, 8),
+        candidate('lower_left', 0.12, 0.78, 'left', 5),
+        candidate('lower_right', 0.88, 0.78, 'right', 5),
+      ];
+    case 'title':
+      return [
+        candidate('center', 0.5, 0.5, alignment, 10),
+        candidate('upper_center', 0.5, 0.24, alignment, 8),
+        candidate('lower_center', 0.5, 0.74, alignment, 6),
+      ];
+    case 'lower_third':
+      return [
+        candidate('lower_left', 0.1, 0.78, 'left', 10),
+        candidate('lower_right', 0.9, 0.78, 'right', 9),
+        candidate('lower_center', 0.5, 0.8, alignment, 6),
+        candidate('upper_left', 0.1, 0.22, 'left', 5),
+      ];
+    case 'callout':
+      return [
+        candidate('upper_left', 0.12, 0.22, 'left', 9),
+        candidate('upper_right', 0.88, 0.22, 'right', 9),
+        candidate('middle_left', 0.1, 0.5, 'left', 7),
+        candidate('middle_right', 0.9, 0.5, 'right', 7),
+      ];
+    default:
+      return [
+        candidate('center', 0.5, 0.5, alignment, 8),
+        candidate('bottom_center', 0.5, 0.85, alignment, 7),
+        candidate('upper_center', 0.5, 0.2, alignment, 6),
+        candidate('lower_left', 0.12, 0.78, 'left', 5),
+        candidate('lower_right', 0.88, 0.78, 'right', 5),
+      ];
+  }
+}
+
+function scoreCandidate(
+  rect: Rect,
+  candidate: PlacementCandidate,
+  safeRect: Pick<Rect, 'left' | 'top' | 'right' | 'bottom'>,
+  obstacles: TextPlacementObstacle[],
+): number {
+  let score = candidate.priority;
+
+  if (
+    rect.left < safeRect.left ||
+    rect.right > safeRect.right ||
+    rect.top < safeRect.top ||
+    rect.bottom > safeRect.bottom
+  ) {
+    score -= 8;
+  }
+
+  for (const obstacle of obstacles) {
+    const overlap = intersectionArea(rect, boxToRect(obstacle.box));
+    if (overlap <= 0) {
+      continue;
+    }
+    const normalizedOverlap = overlap / Math.max(0.001, rect.width * rect.height);
+    score -= normalizedOverlap * obstacle.weight * 10;
+  }
+
+  return score;
+}
+
+function clampPositionForRect(
+  position: TextPosition,
+  rect: Rect,
+  safeRect: Pick<Rect, 'left' | 'top' | 'right' | 'bottom'>,
+  alignment: TextClipAlignment,
+): TextPosition {
+  let x = position.x;
+  if (alignment === 'left') {
+    x = clampFinite(x, safeRect.left, safeRect.right - rect.width, position.x);
+  } else if (alignment === 'right') {
+    x = clampFinite(x, safeRect.left + rect.width, safeRect.right, position.x);
+  } else {
+    x = clampFinite(x, safeRect.left + rect.width / 2, safeRect.right - rect.width / 2, position.x);
+  }
+
+  return {
+    x,
+    y: clampFinite(
+      position.y,
+      safeRect.top + rect.height / 2,
+      safeRect.bottom - rect.height / 2,
+      position.y,
+    ),
+  };
+}
+
+function shouldUseObstacle(obstacle: TextPlacementObstacle, options: TextPlacementOptions): boolean {
+  if (obstacle.type === 'face') {
+    return options.avoidFaces;
+  }
+  if (obstacle.type === 'object') {
+    return options.avoidObjects;
+  }
+  return true;
+}
+
+function normalizePlacementIntent(value: string | undefined): TextPlacementIntent {
+  const normalized = value?.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (normalized === 'title') return 'title';
+  if (normalized === 'subtitle' || normalized === 'caption') return 'subtitle';
+  if (normalized === 'lower_third' || normalized === 'lowerthird') return 'lower_third';
+  if (normalized === 'callout' || normalized === 'label') return 'callout';
+  return 'default';
+}
+
+function candidate(
+  id: string,
+  x: number,
+  y: number,
+  alignment: TextClipAlignment,
+  priority: number,
+): PlacementCandidate {
+  return { id, position: { x, y }, alignment, priority };
+}
+
+function rectAtPosition(rect: Rect, position: TextPosition, alignment: TextClipAlignment): Rect {
+  let left = position.x - rect.width / 2;
+  if (alignment === 'left') {
+    left = position.x;
+  } else if (alignment === 'right') {
+    left = position.x - rect.width;
+  }
+  const top = position.y - rect.height / 2;
+  return {
+    left,
+    top,
+    right: left + rect.width,
+    bottom: top + rect.height,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function intersectionArea(left: Rect, right: Rect): number {
+  const width = Math.max(0, Math.min(left.right, right.right) - Math.max(left.left, right.left));
+  const height = Math.max(0, Math.min(left.bottom, right.bottom) - Math.max(left.top, right.top));
+  return width * height;
+}
+
+function boxToRect(box: BoundingBox): Rect {
+  const left = box.left;
+  const top = box.top;
+  const width = box.width;
+  const height = box.height;
+  return { left, top, right: left + width, bottom: top + height, width, height };
+}
+
+function rectToBox(rect: Rect): BoundingBox {
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function clampBox(box: BoundingBox): BoundingBox {
+  const left = clampFinite(box.left, 0, 1, 0);
+  const top = clampFinite(box.top, 0, 1, 0);
+  const width = clampFinite(box.width, 0, 1 - left, 0);
+  const height = clampFinite(box.height, 0, 1 - top, 0);
+  return { left, top, width, height };
+}
+
+function summarizeCandidate(
+  candidate: PlacementCandidate,
+  score: number,
+  obstacleCount: number,
+): string {
+  if (obstacleCount === 0) {
+    return `Selected ${candidate.id} from default placement candidates.`;
+  }
+  return `Selected ${candidate.id} after scoring ${obstacleCount} visual obstacle(s); score ${round(score)}.`;
+}
+
+function objectArg(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function numberArg(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanArg(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function clampFinite(value: unknown, min: number, max: number, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(min, Math.min(max, value))
+    : fallback;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/src/agents/tools/textTools.test.ts
+++ b/src/agents/tools/textTools.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { commands } from '@/bindings';
 import { globalToolRegistry, type AgentContext } from '@/agents';
 import { registerTextTools, unregisterTextTools } from './textTools';
 import { useProjectStore } from '@/stores/projectStore';
 import { TEXT_ASSET_PREFIX, type Clip, type Effect, type Sequence, type Track } from '@/types';
+
+vi.mock('@/bindings', () => ({
+  commands: {
+    getAnnotation: vi.fn(),
+  },
+}));
 
 vi.mock('@/stores/projectStore', () => ({
   useProjectStore: {
@@ -125,6 +132,10 @@ describe('textTools', () => {
       deletedIds: [],
       changes: [],
     });
+    vi.mocked(commands.getAnnotation).mockResolvedValue({
+      status: 'ok',
+      data: { annotation: null, status: 'notAnalyzed' },
+    });
   });
 
   afterEach(() => {
@@ -238,6 +249,121 @@ describe('textTools', () => {
           scale: { x: 1.25, y: 1.1 },
           rotationDeg: -8,
         },
+      },
+    });
+  });
+
+  it('should add editable text through an alias using the active sequence from context', async () => {
+    mockProject(createSequence({ tracks: [createTrack()] }));
+
+    const result = await globalToolRegistry.execute(
+      'create_title',
+      {
+        content: 'Context title',
+        startTime: 0.5,
+        duration: 2.5,
+        preset: 'title',
+        position: { x: 0.5, y: 0.22 },
+      },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    expect(executeCommandMock.mock.calls[0][0]).toMatchObject({
+      type: 'AddTextClip',
+      payload: {
+        sequenceId: 'seq-1',
+        trackId: 'track-video-1',
+        timelineIn: 0.5,
+        duration: 2.5,
+        textData: {
+          content: 'Context title',
+          position: { x: 0.5, y: 0.22 },
+        },
+      },
+    });
+  });
+
+  it('should auto-place new subtitle-style text away from detected faces', async () => {
+    const mediaClip = createClip({
+      id: 'clip-video-1',
+      assetId: 'asset-video-1',
+      place: { timelineInSec: 0, durationSec: 8 },
+      range: { sourceInSec: 0, sourceOutSec: 8 },
+    });
+    mockProject(createSequence({ tracks: [createTrack({ clips: [mediaClip] })] }));
+    vi.mocked(commands.getAnnotation).mockResolvedValue({
+      status: 'ok',
+      data: {
+        status: 'completed',
+        annotation: {
+          version: '1',
+          assetId: 'asset-video-1',
+          assetHash: 'hash',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+          analysis: {
+            faces: {
+              provider: 'google_cloud',
+              analyzedAt: '2026-01-01T00:00:00Z',
+              config: {},
+              results: [
+                {
+                  timeSec: 1,
+                  confidence: 0.95,
+                  boundingBox: { left: 0.25, top: 0.72, width: 0.5, height: 0.2 },
+                  emotions: [],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    executeCommandMock
+      .mockResolvedValueOnce({
+        opId: 'op-track',
+        createdIds: ['track-video-created'],
+        deletedIds: [],
+        changes: [],
+      })
+      .mockResolvedValueOnce({
+        opId: 'op-add',
+        createdIds: ['clip-text-created', 'effect-text-created'],
+        deletedIds: [],
+        changes: [],
+      });
+
+    const tool = globalToolRegistry.get('add_text_clip');
+    const result = await tool!.handler(
+      {
+        sequenceId: 'seq-1',
+        text: 'Auto placed subtitle',
+        startTime: 1,
+        duration: 2,
+        preset: 'subtitle',
+      },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(executeCommandMock.mock.calls[1][0]).toMatchObject({
+      type: 'AddTextClip',
+      payload: {
+        textData: {
+          position: { x: 0.5, y: expect.any(Number) },
+        },
+      },
+    });
+    const addPayload = executeCommandMock.mock.calls[1][0].payload as {
+      textData: { position: { y: number } };
+    };
+    expect(addPayload.textData.position.y).toBeLessThan(0.3);
+    expect(result.result).toMatchObject({
+      placement: {
+        candidate: 'upper_center',
+        obstacleCount: 1,
       },
     });
   });

--- a/src/agents/tools/textTools.test.ts
+++ b/src/agents/tools/textTools.test.ts
@@ -158,6 +158,17 @@ describe('textTools', () => {
     } as unknown as ReturnType<typeof useProjectStore.getState>);
   }
 
+  function findExecutedCommand(commandType: string): { type: string; payload: unknown } {
+    const command = executeCommandMock.mock.calls
+      .map(([executedCommand]) => executedCommand as { type?: string; payload?: unknown })
+      .find((executedCommand) => executedCommand.type === commandType);
+    if (!command?.type) {
+      throw new Error(`Expected ${commandType} command to be executed`);
+    }
+
+    return { type: command.type, payload: command.payload };
+  }
+
   it('should add a styled text clip and auto-create a video text track when needed', async () => {
     mockProject(createSequence());
     executeCommandMock
@@ -270,7 +281,7 @@ describe('textTools', () => {
 
     expect(result.success).toBe(true);
     expect(executeCommandMock).toHaveBeenCalledTimes(1);
-    expect(executeCommandMock.mock.calls[0][0]).toMatchObject({
+    expect(findExecutedCommand('AddTextClip')).toMatchObject({
       type: 'AddTextClip',
       payload: {
         sequenceId: 'seq-1',
@@ -348,7 +359,7 @@ describe('textTools', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(executeCommandMock.mock.calls[1][0]).toMatchObject({
+    expect(findExecutedCommand('AddTextClip')).toMatchObject({
       type: 'AddTextClip',
       payload: {
         textData: {
@@ -356,7 +367,7 @@ describe('textTools', () => {
         },
       },
     });
-    const addPayload = executeCommandMock.mock.calls[1][0].payload as {
+    const addPayload = findExecutedCommand('AddTextClip').payload as {
       textData: { position: { y: number } };
     };
     expect(addPayload.textData.position.y).toBeLessThan(0.3);
@@ -366,6 +377,46 @@ describe('textTools', () => {
         obstacleCount: 1,
       },
     });
+  });
+
+  it('should ignore hidden tracks and disabled clips when collecting placement obstacles', async () => {
+    const hiddenClip = createClip({
+      id: 'clip-hidden',
+      assetId: 'asset-hidden',
+      place: { timelineInSec: 0, durationSec: 8 },
+      range: { sourceInSec: 0, sourceOutSec: 8 },
+    });
+    const disabledClip = createClip({
+      id: 'clip-disabled',
+      assetId: 'asset-disabled',
+      enabled: false,
+      place: { timelineInSec: 0, durationSec: 8 },
+      range: { sourceInSec: 0, sourceOutSec: 8 },
+    });
+    mockProject(
+      createSequence({
+        tracks: [
+          createTrack({ id: 'track-hidden', visible: false, clips: [hiddenClip] }),
+          createTrack({ id: 'track-disabled', clips: [disabledClip] }),
+          createTrack({ id: 'track-visible', clips: [] }),
+        ],
+      }),
+    );
+
+    const tool = globalToolRegistry.get('add_text_clip');
+    const result = await tool!.handler(
+      {
+        sequenceId: 'seq-1',
+        text: 'Visible placement',
+        startTime: 1,
+        duration: 2,
+        preset: 'subtitle',
+      },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(commands.getAnnotation).not.toHaveBeenCalled();
   });
 
   it('should update text data and clip transform while preserving existing style fields', async () => {

--- a/src/agents/tools/textTools.ts
+++ b/src/agents/tools/textTools.ts
@@ -6,6 +6,7 @@
  */
 
 import { globalToolRegistry, type AgentContext, type ToolDefinition } from '../ToolRegistry';
+import { commands, type AssetAnnotation } from '@/bindings';
 import { createLogger } from '@/services/logger';
 import { executeAgentCommand } from './commandExecutor';
 import { useProjectStore } from '@/stores/projectStore';
@@ -28,6 +29,15 @@ import {
   type Track,
   type Transform,
 } from '@/types';
+import {
+  annotationToTextPlacementObstacles,
+  parseTextPlacementOptions,
+  resolveSmartTextPlacement,
+  shouldAutoPlaceText,
+  type ExistingTextPlacement,
+  type TextPlacementDecision,
+  type TextPlacementObstacle,
+} from './textPlacement';
 
 const logger = createLogger('TextTools');
 
@@ -42,6 +52,86 @@ const TEXT_TOOL_NAMES = [
 const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
 type TextPresetName = 'default' | 'title' | 'lower_third' | 'subtitle';
+
+const TEXT_STYLE_PARAMETER_PROPERTIES = {
+  fontFamily: { type: 'string', description: 'Font family name' },
+  fontSize: { type: 'number', description: 'Font size in pixels' },
+  fontWeight: { type: 'number', description: 'Numeric font weight, 100 to 900' },
+  color: { type: 'string', description: 'Text color hex with optional alpha' },
+  backgroundColor: {
+    type: ['string', 'null'],
+    description: 'Background color hex with optional alpha, or null to remove it',
+  },
+  backgroundPadding: { type: 'number', description: 'Background padding in pixels' },
+  clearBackground: { type: 'boolean', description: 'Remove the text background fill' },
+  alignment: {
+    type: 'string',
+    description: 'Text alignment',
+    enum: ['left', 'center', 'right'],
+  },
+  bold: { type: 'boolean', description: 'Enable bold styling' },
+  italic: { type: 'boolean', description: 'Enable italic styling' },
+  underline: { type: 'boolean', description: 'Enable underline styling' },
+  lineHeight: { type: 'number', description: 'Line-height multiplier' },
+  letterSpacing: { type: 'number', description: 'Letter spacing in pixels' },
+} satisfies NonNullable<ToolDefinition['parameters']['properties']>;
+
+const TEXT_POSITION_PARAMETER_PROPERTIES = {
+  x: { type: 'number', description: 'Normalized text X position, 0 to 1' },
+  y: { type: 'number', description: 'Normalized text Y position, 0 to 1' },
+  xPercent: { type: 'number', description: 'Text X position as percent from left' },
+  yPercent: { type: 'number', description: 'Text Y position as percent from top' },
+} satisfies NonNullable<ToolDefinition['parameters']['properties']>;
+
+const TEXT_EFFECT_PARAMETER_PROPERTIES = {
+  shadowColor: { type: 'string', description: 'Shadow color hex with optional alpha' },
+  shadowOffsetX: { type: 'number', description: 'Shadow horizontal offset in pixels' },
+  shadowOffsetY: { type: 'number', description: 'Shadow vertical offset in pixels' },
+  shadowBlur: { type: 'number', description: 'Shadow blur radius in pixels' },
+  clearShadow: { type: 'boolean', description: 'Remove the text shadow' },
+  outlineColor: { type: 'string', description: 'Outline color hex with optional alpha' },
+  outlineWidth: { type: 'number', description: 'Outline width in pixels' },
+  clearOutline: { type: 'boolean', description: 'Remove the text outline' },
+  rotation: { type: 'number', description: 'Text data rotation in degrees' },
+  opacity: { type: 'number', description: 'Text opacity from 0 to 1' },
+} satisfies NonNullable<ToolDefinition['parameters']['properties']>;
+
+const TEXT_TRANSFORM_PARAMETER_PROPERTIES = {
+  transformX: { type: 'number', description: 'Normalized transform X position, 0 to 1' },
+  transformY: { type: 'number', description: 'Normalized transform Y position, 0 to 1' },
+  scaleX: { type: 'number', description: 'Horizontal scale multiplier' },
+  scaleY: { type: 'number', description: 'Vertical scale multiplier' },
+  rotationDeg: { type: 'number', description: 'Transform rotation in degrees' },
+  anchorX: { type: 'number', description: 'Normalized transform anchor X, 0 to 1' },
+  anchorY: { type: 'number', description: 'Normalized transform anchor Y, 0 to 1' },
+} satisfies NonNullable<ToolDefinition['parameters']['properties']>;
+
+const TEXT_AUTO_PLACEMENT_PARAMETER_PROPERTIES = {
+  autoPlacement: {
+    type: 'boolean',
+    description:
+      'Automatically select a safe preview position using timeline context and available faces/objects/OCR annotations',
+  },
+  placement: {
+    type: ['string', 'object', 'boolean'],
+    description:
+      'Placement intent or options. String values: default, title, subtitle, lower_third, callout. False disables auto-placement.',
+  },
+  placementIntent: {
+    type: 'string',
+    description: 'Placement intent: default, title, subtitle, lower_third, callout',
+  },
+  safeMargin: {
+    type: 'number',
+    description: 'Normalized safe-area margin for automatic placement, 0.02 to 0.2',
+  },
+  avoidFaces: { type: 'boolean', description: 'Avoid detected face boxes when auto-placing' },
+  avoidObjects: { type: 'boolean', description: 'Avoid detected object boxes when auto-placing' },
+  avoidText: {
+    type: 'boolean',
+    description: 'Avoid detected OCR text and existing editable text clips when auto-placing',
+  },
+} satisfies NonNullable<ToolDefinition['parameters']['properties']>;
 
 interface ResolvedTextClip {
   sequence: Sequence;
@@ -414,7 +504,7 @@ function mergeTextStyle(base: TextStyle, args: Record<string, unknown>): TextSty
   const color = normalizeHexColor(get('color'), 'color');
   const backgroundColorValue = get('backgroundColor');
   const backgroundColor =
-    backgroundColorValue === null
+    args.clearBackground === true || backgroundColorValue === null
       ? null
       : normalizeHexColor(backgroundColorValue, 'backgroundColor');
   const alignment = get('alignment');
@@ -533,7 +623,7 @@ function mergeTextShadow(
   base: TextShadow | undefined,
   args: Record<string, unknown>,
 ): TextShadow | undefined {
-  if (args.shadow === null) {
+  if (args.clearShadow === true || args.shadow === null) {
     return undefined;
   }
 
@@ -576,7 +666,7 @@ function mergeTextOutline(
   base: TextOutline | undefined,
   args: Record<string, unknown>,
 ): TextOutline | undefined {
-  if (args.outline === null) {
+  if (args.clearOutline === true || args.outline === null) {
     return undefined;
   }
 
@@ -749,6 +839,153 @@ function serializeTextClip(resolved: ResolvedTextClip): Record<string, unknown> 
   };
 }
 
+function rangesOverlap(start: number, duration: number, clip: Clip): boolean {
+  const end = start + duration;
+  const clipStart = clip.place.timelineInSec;
+  const clipEnd = clipStart + clip.place.durationSec;
+  return start < clipEnd && end > clipStart;
+}
+
+function resolveSourceTimeAtTimeline(clip: Clip, timelineTime: number): number {
+  const clipStart = clip.place.timelineInSec;
+  const clipEnd = clipStart + clip.place.durationSec;
+  const clampedTimeline = clampFinite(timelineTime, clipStart, clipEnd, clipStart);
+  const localOffset = Math.max(0, clampedTimeline - clipStart) * Math.max(0.01, clip.speed || 1);
+  if (clip.reverse) {
+    return Math.max(clip.range.sourceInSec, clip.range.sourceOutSec - localOffset);
+  }
+
+  return Math.min(clip.range.sourceOutSec, clip.range.sourceInSec + localOffset);
+}
+
+async function readAnnotationForPlacement(
+  assetId: string,
+  cache: Map<string, AssetAnnotation | null>,
+): Promise<AssetAnnotation | null> {
+  if (cache.has(assetId)) {
+    return cache.get(assetId) ?? null;
+  }
+
+  try {
+    const result = await commands.getAnnotation(assetId);
+    const annotation = result.status === 'ok' ? result.data.annotation : null;
+    cache.set(assetId, annotation);
+    return annotation;
+  } catch (error) {
+    logger.debug('Text auto-placement could not read annotation', {
+      assetId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    cache.set(assetId, null);
+    return null;
+  }
+}
+
+async function collectPlacementObstacles(
+  sequence: Sequence,
+  timelineIn: number,
+  duration: number,
+): Promise<TextPlacementObstacle[]> {
+  const midpoint = timelineIn + duration / 2;
+  const toleranceSec = Math.max(0.75, Math.min(3, duration / 2 + 0.25));
+  const annotationCache = new Map<string, AssetAnnotation | null>();
+  const obstacles: TextPlacementObstacle[] = [];
+
+  for (const track of sequence.tracks) {
+    if (track.kind !== 'video' && track.kind !== 'overlay') {
+      continue;
+    }
+
+    for (const clip of track.clips) {
+      if (!rangesOverlap(timelineIn, duration, clip) || isTextClip(clip.assetId)) {
+        continue;
+      }
+
+      const annotation = await readAnnotationForPlacement(clip.assetId, annotationCache);
+      const sourceTime = resolveSourceTimeAtTimeline(clip, midpoint);
+      obstacles.push(
+        ...annotationToTextPlacementObstacles(annotation, sourceTime, toleranceSec),
+      );
+    }
+  }
+
+  return obstacles;
+}
+
+function collectExistingTextPlacements(
+  sequence: Sequence,
+  timelineIn: number,
+  duration: number,
+  excludeClipId?: string,
+): ExistingTextPlacement[] {
+  const placements: ExistingTextPlacement[] = [];
+
+  for (const track of sequence.tracks) {
+    for (const clip of track.clips) {
+      if (
+        clip.id === excludeClipId ||
+        !rangesOverlap(timelineIn, duration, clip) ||
+        !isTextClip(clip.assetId)
+      ) {
+        continue;
+      }
+
+      placements.push({ textData: parseEffectTextData(clip), weight: 4 });
+    }
+  }
+
+  return placements;
+}
+
+async function applyAutomaticTextPlacement(
+  textData: TextClipData,
+  args: Record<string, unknown>,
+  options: {
+    sequence: Sequence;
+    timelineIn: number;
+    duration: number;
+    isCreate: boolean;
+    preset?: TextPresetName;
+    excludeClipId?: string;
+  },
+): Promise<{ textData: TextClipData; placement: TextPlacementDecision | null }> {
+  if (!shouldAutoPlaceText(args, options.isCreate)) {
+    return { textData, placement: null };
+  }
+
+  const placementArgs =
+    args.placementIntent === undefined && args.intent === undefined && args.placement === undefined
+      ? { ...args, placementIntent: options.preset }
+      : args;
+  const placementOptions = parseTextPlacementOptions(placementArgs);
+  const [obstacles, existingText] = await Promise.all([
+    collectPlacementObstacles(options.sequence, options.timelineIn, options.duration),
+    Promise.resolve(
+      collectExistingTextPlacements(
+        options.sequence,
+        options.timelineIn,
+        options.duration,
+        options.excludeClipId,
+      ),
+    ),
+  ]);
+  const decision = resolveSmartTextPlacement({
+    textData,
+    sequence: options.sequence,
+    options: placementOptions,
+    obstacles,
+    existingText,
+  });
+
+  return {
+    textData: {
+      ...textData,
+      position: decision.position,
+    },
+    placement: decision,
+  };
+}
+
 const TEXT_TOOLS: ToolDefinition[] = [
   {
     name: 'list_text_clips',
@@ -791,14 +1028,15 @@ const TEXT_TOOLS: ToolDefinition[] = [
   {
     name: 'add_text_clip',
     description:
-      'Create an editable text overlay clip, auto-creating a video text track when no usable track is provided',
-    category: 'utility',
+      'Create an editable on-video text overlay clip with full style, position, shadow, outline, and transform data; auto-creates a video text track when no usable track is provided',
+    category: 'clip',
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Sequence ID' },
+        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
         trackId: { type: 'string', description: 'Optional video or overlay track ID' },
         text: { type: 'string', description: 'Text content' },
+        content: { type: 'string', description: 'Legacy alias for text content' },
         startTime: { type: 'number', description: 'Timeline start in seconds' },
         duration: { type: 'number', description: 'Duration in seconds' },
         endTime: { type: 'number', description: 'Optional end time in seconds' },
@@ -808,12 +1046,21 @@ const TEXT_TOOLS: ToolDefinition[] = [
           description: 'Optional starter text preset',
         },
         style: { type: 'object', description: 'Text style overrides' },
-        position: { type: 'object', description: 'Text position object or preset string' },
-        shadow: { type: 'object', description: 'Shadow object, or null to disable' },
-        outline: { type: 'object', description: 'Outline object, or null to disable' },
+        ...TEXT_STYLE_PARAMETER_PROPERTIES,
+        position: {
+          type: ['string', 'object'],
+          description:
+            'Text position preset (top, center, bottom, lower_third) or object with x/y 0..1 or xPercent/yPercent',
+        },
+        ...TEXT_POSITION_PARAMETER_PROPERTIES,
+        shadow: { type: ['object', 'null'], description: 'Shadow object, or null to disable' },
+        outline: { type: ['object', 'null'], description: 'Outline object, or null to disable' },
+        ...TEXT_EFFECT_PARAMETER_PROPERTIES,
         transform: { type: 'object', description: 'Optional clip transform including scale' },
+        ...TEXT_TRANSFORM_PARAMETER_PROPERTIES,
+        ...TEXT_AUTO_PLACEMENT_PARAMETER_PROPERTIES,
       },
-      required: ['sequenceId', 'text', 'startTime'],
+      required: ['startTime'],
     },
     handler: async (args, context) => {
       let createdClipId: string | undefined;
@@ -823,7 +1070,8 @@ const TEXT_TOOLS: ToolDefinition[] = [
       try {
         const sequenceId = resolveSequenceId(args, context);
         const sequence = getSequence(sequenceId);
-        const text = typeof args.text === 'string' ? args.text.trim() : '';
+        const rawText = args.text ?? args.content;
+        const text = typeof rawText === 'string' ? rawText.trim() : '';
         if (!text) {
           throw new Error('text must be a non-empty string.');
         }
@@ -854,7 +1102,18 @@ const TEXT_TOOLS: ToolDefinition[] = [
           args.preset === 'title' || args.preset === 'lower_third' || args.preset === 'subtitle'
             ? args.preset
             : 'default';
-        const textData = buildTextData(textDataFromPreset(preset, text), args);
+        const placementResult = await applyAutomaticTextPlacement(
+          buildTextData(textDataFromPreset(preset, text), args),
+          args,
+          {
+            sequence,
+            timelineIn: startTime,
+            duration,
+            isCreate: true,
+            preset,
+          },
+        );
+        const textData = placementResult.textData;
         const track = await ensureTextTrack(
           sequenceId,
           sequence,
@@ -900,6 +1159,7 @@ const TEXT_TOOLS: ToolDefinition[] = [
             createdTrack,
             textData,
             transform: transform ?? null,
+            placement: placementResult.placement,
           },
         };
       } catch (error) {
@@ -925,21 +1185,31 @@ const TEXT_TOOLS: ToolDefinition[] = [
     name: 'update_text_clip',
     description:
       'Update a text overlay clip content, style, position, effects, and optional transform',
-    category: 'utility',
+    category: 'clip',
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Sequence ID' },
+        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
         trackId: { type: 'string', description: 'Optional track ID' },
         clipId: { type: 'string', description: 'Text clip ID' },
         text: { type: 'string', description: 'New text content' },
+        content: { type: 'string', description: 'Legacy alias for new text content' },
         style: { type: 'object', description: 'Text style overrides' },
-        position: { type: 'object', description: 'Text data position object or preset string' },
-        shadow: { type: 'object', description: 'Shadow object, or null to disable' },
-        outline: { type: 'object', description: 'Outline object, or null to disable' },
+        ...TEXT_STYLE_PARAMETER_PROPERTIES,
+        position: {
+          type: ['string', 'object'],
+          description:
+            'Text position preset (top, center, bottom, lower_third) or object with x/y 0..1 or xPercent/yPercent',
+        },
+        ...TEXT_POSITION_PARAMETER_PROPERTIES,
+        shadow: { type: ['object', 'null'], description: 'Shadow object, or null to disable' },
+        outline: { type: ['object', 'null'], description: 'Outline object, or null to disable' },
+        ...TEXT_EFFECT_PARAMETER_PROPERTIES,
         transform: { type: 'object', description: 'Optional clip transform including scale' },
+        ...TEXT_TRANSFORM_PARAMETER_PROPERTIES,
+        ...TEXT_AUTO_PLACEMENT_PARAMETER_PROPERTIES,
       },
-      required: ['sequenceId', 'clipId'],
+      required: ['clipId'],
     },
     handler: async (args, context) => {
       const appliedResults: CommandResult[] = [];
@@ -955,7 +1225,18 @@ const TEXT_TOOLS: ToolDefinition[] = [
           clipId,
           typeof args.trackId === 'string' ? args.trackId : undefined,
         );
-        const nextTextData = buildTextData(resolved.textData, args);
+        const placementResult = await applyAutomaticTextPlacement(
+          buildTextData(resolved.textData, args),
+          args,
+          {
+            sequence: resolved.sequence,
+            timelineIn: resolved.clip.place.timelineInSec,
+            duration: resolved.clip.place.durationSec,
+            isCreate: false,
+            excludeClipId: clipId,
+          },
+        );
+        const nextTextData = placementResult.textData;
         const transform = mergeTransform(resolved.clip.transform, args);
 
         const updateResult = await executeAgentCommand('UpdateTextClip', {
@@ -983,6 +1264,7 @@ const TEXT_TOOLS: ToolDefinition[] = [
             trackId: resolved.track.id,
             textData: nextTextData,
             transform: transform ?? null,
+            placement: placementResult.placement,
           },
         };
       } catch (error) {
@@ -1001,11 +1283,11 @@ const TEXT_TOOLS: ToolDefinition[] = [
   {
     name: 'set_text_transform',
     description: 'Move, scale, rotate, or change the anchor of a timeline text clip',
-    category: 'utility',
+    category: 'clip',
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Sequence ID' },
+        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
         trackId: { type: 'string', description: 'Optional track ID' },
         clipId: { type: 'string', description: 'Text clip ID' },
         transform: { type: 'object', description: 'Full or partial transform' },
@@ -1014,8 +1296,10 @@ const TEXT_TOOLS: ToolDefinition[] = [
         scaleX: { type: 'number', description: 'Scale X multiplier' },
         scaleY: { type: 'number', description: 'Scale Y multiplier' },
         rotationDeg: { type: 'number', description: 'Rotation in degrees' },
+        anchorX: { type: 'number', description: 'Normalized anchor X, 0 to 1' },
+        anchorY: { type: 'number', description: 'Normalized anchor Y, 0 to 1' },
       },
-      required: ['sequenceId', 'clipId'],
+      required: ['clipId'],
     },
     handler: async (args, context) => {
       try {
@@ -1062,15 +1346,15 @@ const TEXT_TOOLS: ToolDefinition[] = [
     name: 'delete_text_clip',
     aliases: ['remove_text_clip'],
     description: 'Remove a timeline text overlay clip',
-    category: 'utility',
+    category: 'clip',
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Sequence ID' },
+        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
         trackId: { type: 'string', description: 'Optional track ID' },
         clipId: { type: 'string', description: 'Text clip ID' },
       },
-      required: ['sequenceId', 'clipId'],
+      required: ['clipId'],
     },
     handler: async (args, context) => {
       try {

--- a/src/agents/tools/textTools.ts
+++ b/src/agents/tools/textTools.ts
@@ -892,20 +892,26 @@ async function collectPlacementObstacles(
   const obstacles: TextPlacementObstacle[] = [];
 
   for (const track of sequence.tracks) {
+    if (track.visible === false) {
+      continue;
+    }
+
     if (track.kind !== 'video' && track.kind !== 'overlay') {
       continue;
     }
 
     for (const clip of track.clips) {
-      if (!rangesOverlap(timelineIn, duration, clip) || isTextClip(clip.assetId)) {
+      if (
+        clip.enabled === false ||
+        !rangesOverlap(timelineIn, duration, clip) ||
+        isTextClip(clip.assetId)
+      ) {
         continue;
       }
 
       const annotation = await readAnnotationForPlacement(clip.assetId, annotationCache);
       const sourceTime = resolveSourceTimeAtTimeline(clip, midpoint);
-      obstacles.push(
-        ...annotationToTextPlacementObstacles(annotation, sourceTime, toleranceSec),
-      );
+      obstacles.push(...annotationToTextPlacementObstacles(annotation, sourceTime, toleranceSec));
     }
   }
 
@@ -921,8 +927,13 @@ function collectExistingTextPlacements(
   const placements: ExistingTextPlacement[] = [];
 
   for (const track of sequence.tracks) {
+    if (track.visible === false) {
+      continue;
+    }
+
     for (const clip of track.clips) {
       if (
+        clip.enabled === false ||
         clip.id === excludeClipId ||
         !rangesOverlap(timelineIn, duration, clip) ||
         !isTextClip(clip.assetId)
@@ -1033,7 +1044,10 @@ const TEXT_TOOLS: ToolDefinition[] = [
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
+        sequenceId: {
+          type: 'string',
+          description: 'Optional sequence ID. Defaults to active sequence.',
+        },
         trackId: { type: 'string', description: 'Optional video or overlay track ID' },
         text: { type: 'string', description: 'Text content' },
         content: { type: 'string', description: 'Legacy alias for text content' },
@@ -1189,7 +1203,10 @@ const TEXT_TOOLS: ToolDefinition[] = [
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
+        sequenceId: {
+          type: 'string',
+          description: 'Optional sequence ID. Defaults to active sequence.',
+        },
         trackId: { type: 'string', description: 'Optional track ID' },
         clipId: { type: 'string', description: 'Text clip ID' },
         text: { type: 'string', description: 'New text content' },
@@ -1287,7 +1304,10 @@ const TEXT_TOOLS: ToolDefinition[] = [
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
+        sequenceId: {
+          type: 'string',
+          description: 'Optional sequence ID. Defaults to active sequence.',
+        },
         trackId: { type: 'string', description: 'Optional track ID' },
         clipId: { type: 'string', description: 'Text clip ID' },
         transform: { type: 'object', description: 'Full or partial transform' },
@@ -1350,7 +1370,10 @@ const TEXT_TOOLS: ToolDefinition[] = [
     parameters: {
       type: 'object',
       properties: {
-        sequenceId: { type: 'string', description: 'Optional sequence ID. Defaults to active sequence.' },
+        sequenceId: {
+          type: 'string',
+          description: 'Optional sequence ID. Defaults to active sequence.',
+        },
         trackId: { type: 'string', description: 'Optional track ID' },
         clipId: { type: 'string', description: 'Text clip ID' },
       },

--- a/src/architecture/processCommandWindowGuard.test.ts
+++ b/src/architecture/processCommandWindowGuard.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Process Command Window Guard
+ *
+ * Architecture rule:
+ * - Tauri runtime subprocesses must be configured through core::process helpers.
+ * - Build-script subprocesses must also use a Windows no-window command helper.
+ * - On Windows, console binaries can flash a command window when spawned from
+ *   the GUI process unless CREATE_NO_WINDOW is applied.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const TAURI_RUNTIME_SRC_ROOT = path.resolve(process.cwd(), 'src-tauri/src');
+const TAURI_BUILD_SCRIPT_PATH = 'src-tauri/build.rs';
+const PROCESS_HELPER_PATH = 'src-tauri/src/core/process.rs';
+const PROCESS_SCAN_PATHS = [
+  TAURI_RUNTIME_SRC_ROOT,
+  path.resolve(process.cwd(), TAURI_BUILD_SCRIPT_PATH),
+];
+const COMMAND_CREATION_CONTEXT_LINES = 8;
+
+interface CommandCreation {
+  file: string;
+  line: number;
+  variableName: string | null;
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function collectRustFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectRustFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && fullPath.endsWith('.rs')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function collectRustFilesFromPath(targetPath: string): string[] {
+  const stat = fs.statSync(targetPath);
+  if (stat.isFile()) {
+    return targetPath.endsWith('.rs') ? [targetPath] : [];
+  }
+
+  return collectRustFiles(targetPath);
+}
+
+function lineWithoutComment(line: string): string {
+  return line.replace(/\/\/.*$/, '');
+}
+
+function importsProcessCommand(content: string, processModule: 'std' | 'tokio'): boolean {
+  const directImport = new RegExp(`^\\s*use\\s+${processModule}::process::Command\\s*;`, 'm');
+  const groupedImport = new RegExp(
+    `^\\s*use\\s+${processModule}::process::\\{[^}]*\\bCommand\\b[^}]*\\}\\s*;`,
+    'm',
+  );
+  const nestedImport = new RegExp(
+    `^\\s*use\\s+${processModule}::\\{[^;]*\\bprocess::Command\\b[^;]*\\}\\s*;`,
+    'm',
+  );
+
+  return directImport.test(content) || groupedImport.test(content) || nestedImport.test(content);
+}
+
+function unsupportedProcessCommandAliases(content: string): string[] {
+  const violations: string[] = [];
+  const aliasPatterns = [
+    /\buse\s+(?:std|tokio)::process::\{[^}]*\bCommand\s+as\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+    /\buse\s+(?:std|tokio)::process\s+as\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+  ];
+
+  for (const pattern of aliasPatterns) {
+    for (const match of content.matchAll(pattern)) {
+      violations.push(match[1]);
+    }
+  }
+
+  return violations;
+}
+
+function isProcessCommandCreation(
+  line: string,
+  hasStdCommandImport: boolean,
+  hasTokioCommandImport: boolean,
+): boolean {
+  if (/\bstd::process::Command::new\s*\(/.test(line)) return true;
+  if (/\btokio::process::Command::new\s*\(/.test(line)) return true;
+  if (!/\bCommand::new\s*\(/.test(line)) return false;
+
+  return hasStdCommandImport || hasTokioCommandImport;
+}
+
+function commandVariableName(line: string): string | null {
+  const match = line.match(
+    /\b(?:let\s+mut\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:(?:std|tokio)::process::)?Command::new\s*\(/,
+  );
+
+  return match?.[1] ?? null;
+}
+
+function collectProcessCommandCreations(filePath: string, content: string): CommandCreation[] {
+  const hasStdCommandImport = importsProcessCommand(content, 'std');
+  const hasTokioCommandImport = importsProcessCommand(content, 'tokio');
+  const lines = content.split('\n');
+  const creations: CommandCreation[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lineWithoutComment(lines[index]);
+    if (!isProcessCommandCreation(line, hasStdCommandImport, hasTokioCommandImport)) {
+      continue;
+    }
+
+    creations.push({
+      file: normalizePath(path.relative(process.cwd(), filePath)),
+      line: index + 1,
+      variableName: commandVariableName(line),
+    });
+  }
+
+  return creations;
+}
+
+function isConfiguredAfterCreation(
+  lines: string[],
+  creationLineIndex: number,
+  variableName: string,
+  normalizedPath: string,
+): boolean {
+  const helperNames =
+    normalizedPath === TAURI_BUILD_SCRIPT_PATH
+      ? ['configure_build_command']
+      : ['configure_std_command', 'configure_tokio_command'];
+  const configurePattern = new RegExp(
+    `\\b(?:crate::core::process::)?(?:${helperNames.join('|')})\\s*\\(\\s*&mut\\s+${variableName}\\s*\\)`,
+  );
+  const endIndex = Math.min(lines.length - 1, creationLineIndex + COMMAND_CREATION_CONTEXT_LINES);
+
+  for (let index = creationLineIndex; index <= endIndex; index += 1) {
+    if (configurePattern.test(lineWithoutComment(lines[index]))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+describe('Process command window guard', () => {
+  it('configures every Tauri runtime and build-script subprocess command through no-window helpers', () => {
+    const violations: string[] = [];
+
+    for (const filePath of PROCESS_SCAN_PATHS.flatMap(collectRustFilesFromPath)) {
+      const normalizedPath = normalizePath(path.relative(process.cwd(), filePath));
+      if (normalizedPath === PROCESS_HELPER_PATH) {
+        continue;
+      }
+
+      const content = fs.readFileSync(filePath, 'utf8');
+      const lines = content.split('\n');
+
+      for (const alias of unsupportedProcessCommandAliases(content)) {
+        violations.push(
+          `${normalizedPath} imports process Command through unsupported alias ${alias}`,
+        );
+      }
+
+      for (const creation of collectProcessCommandCreations(filePath, content)) {
+        if (!creation.variableName) {
+          violations.push(`${creation.file}:${creation.line} creates a process command inline`);
+          continue;
+        }
+
+        if (
+          !isConfiguredAfterCreation(
+            lines,
+            creation.line - 1,
+            creation.variableName,
+            normalizedPath,
+          )
+        ) {
+          violations.push(
+            `${creation.file}:${creation.line} creates ${creation.variableName} without configure_*_command`,
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/components/features/agent/AgentRuntimeChatShell.test.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.test.tsx
@@ -16,12 +16,14 @@ function renderRuntimeShell({
   abort = vi.fn(),
   phase = 'executing',
   isRunning = true,
+  submitWhileRunning,
   pendingToolPermissionRequest = null,
 }: {
   executeMessage?: ReturnType<typeof vi.fn>;
   abort?: ReturnType<typeof vi.fn>;
   phase?: ComponentProps<typeof AgentRuntimeChatShell>['phase'];
   isRunning?: boolean;
+  submitWhileRunning?: ComponentProps<typeof AgentRuntimeChatShell>['submitWhileRunning'];
   pendingToolPermissionRequest?: ComponentProps<
     typeof AgentRuntimeChatShell
   >['pendingToolPermissionRequest'];
@@ -49,6 +51,7 @@ function renderRuntimeShell({
       onToolAllow={() => {}}
       onToolAllowAlways={() => {}}
       onToolDeny={() => {}}
+      submitWhileRunning={submitWhileRunning}
     />,
   );
 }
@@ -147,6 +150,48 @@ describe('AgentRuntimeChatShell', () => {
 
     expect(messageArea).toContainElement(overlay);
     expect(screen.getByTestId('chat-input-area')).toBeInTheDocument();
+  });
+
+  it('submits immediately instead of queueing when running submissions steer the active turn', async () => {
+    const user = userEvent.setup();
+    const executeMessage = vi.fn().mockResolvedValue(undefined);
+    const onSubmit = vi.fn();
+
+    render(
+      <AgentRuntimeChatShell
+        chatTestId="agent-runtime-shell"
+        executeMessage={executeMessage}
+        abort={vi.fn()}
+        phase="executing"
+        isRunning={true}
+        isEnabled={true}
+        error={null}
+        runtimeSummary={{ startedTools: 1, completedTools: 0, latestIteration: 0 }}
+        plan={null}
+        pendingClarificationQuestion={null}
+        pendingToolPermissionRequest={null}
+        onSubmit={onSubmit}
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRetry={() => {}}
+        onToolAllow={() => {}}
+        onToolAllowAlways={() => {}}
+        onToolDeny={() => {}}
+        submitWhileRunning="steer"
+      />,
+    );
+
+    await user.type(screen.getByTestId('chat-input-field'), 'Keep it lower');
+    await user.click(screen.getByTestId('chat-input-submit-btn'));
+
+    expect(onSubmit).toHaveBeenCalledWith('Keep it lower');
+    await waitFor(() => {
+      expect(executeMessage).toHaveBeenCalledWith('Keep it lower');
+    });
+    expect(useMessageQueueStore.getState().queue).toHaveLength(0);
+    expect(useConversationStore.getState().activeConversation?.messages[0]).toMatchObject({
+      role: 'user',
+    });
   });
 
   it('does not dequeue queued prompts after the user stops execution', async () => {

--- a/src/components/features/agent/AgentRuntimeChatShell.tsx
+++ b/src/components/features/agent/AgentRuntimeChatShell.tsx
@@ -65,6 +65,7 @@ export interface AgentRuntimeChatShellProps extends MessageActionProps {
   className?: string;
   clearQueueOnProjectSwitch?: boolean;
   clearQueueOnUnmount?: boolean;
+  submitWhileRunning?: 'queue' | 'steer';
   onUnmount?: () => void;
 }
 
@@ -93,6 +94,7 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
       className = '',
       clearQueueOnProjectSwitch = false,
       clearQueueOnUnmount = false,
+      submitWhileRunning = 'queue',
       onUnmount,
       onApprove,
       onReject,
@@ -166,7 +168,7 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
 
       setInput('');
 
-      if (isRunning) {
+      if (isRunning && submitWhileRunning === 'queue') {
         const currentState = useConversationStore.getState();
         const queuedMessageId = addUserMessage(userInput, { persist: false });
         enqueue(userInput, {
@@ -197,6 +199,7 @@ export const AgentRuntimeChatShell = forwardRef<AgentRuntimeChatHandle, AgentRun
       loadForProject,
       onSubmit,
       stopState,
+      submitWhileRunning,
     ]);
 
     const handleStop = useCallback(() => {

--- a/src/components/features/agent/ExternalAgentChat.tsx
+++ b/src/components/features/agent/ExternalAgentChat.tsx
@@ -94,6 +94,7 @@ export const ExternalAgentChat = forwardRef<AgentRuntimeChatHandle, ExternalAgen
       enabled: ready,
       approvalBroker,
       sessionPersistence,
+      retainAcrossUnmount: true,
       onComplete,
       onAbort,
       onError,
@@ -136,7 +137,7 @@ export const ExternalAgentChat = forwardRef<AgentRuntimeChatHandle, ExternalAgen
         onToolAllowAlways={() => runtime.resolveApproval('acceptForSession')}
         onToolDeny={() => runtime.resolveApproval('decline')}
         clearQueueOnProjectSwitch
-        clearQueueOnUnmount
+        submitWhileRunning="steer"
       />
     );
   },

--- a/src/components/preview/ProxyPreviewPlayer.test.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.test.tsx
@@ -192,6 +192,136 @@ describe('ProxyPreviewPlayer', () => {
     expect(screen.getByTestId('proxy-video-clip-bottom')).toBeInTheDocument();
   });
 
+  it('preloads the next adjacent video clip before a cut without showing it', () => {
+    usePlaybackStore.setState({ currentTime: 9.75 });
+    const firstClip = createClip('clip-first', 'asset-first');
+    const secondClip = createClip('clip-second', 'asset-second');
+    secondClip.place = { timelineInSec: 10, durationSec: 10 };
+
+    const sequence = {
+      ...createSequence(),
+      tracks: [createVideoTrack('track-main', firstClip)],
+    };
+    sequence.tracks[0].clips.push(secondClip);
+
+    const assets = new Map<string, Asset>([
+      ['asset-first', createVideoAsset('asset-first', 'https://example.com/first.mp4')],
+      ['asset-second', createVideoAsset('asset-second', 'https://example.com/second.mp4')],
+    ]);
+
+    render(<ProxyPreviewPlayer sequence={sequence} assets={assets} showControls />);
+
+    const firstVideo = screen.getByTestId('proxy-video-clip-first') as HTMLVideoElement;
+    const secondVideo = screen.getByTestId('proxy-video-clip-second') as HTMLVideoElement;
+
+    expect(firstVideo.style.visibility).toBe('visible');
+    expect(firstVideo.style.opacity).toBe('1');
+    expect(secondVideo.style.visibility).toBe('hidden');
+    expect(secondVideo.style.opacity).toBe('0');
+  });
+
+  it('uses render graph timing to preload adjacent cut clips', async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true);
+    usePlaybackStore.setState({ currentTime: 9.75 });
+
+    const firstClip = createClip('clip-first', 'asset-first');
+    const secondClip = createClip('clip-second', 'asset-second');
+    secondClip.place = { timelineInSec: 10, durationSec: 10 };
+    const track = createVideoTrack('track-main', firstClip);
+    track.visible = false;
+    track.clips.push(secondClip);
+    const sequence = {
+      ...createSequence(),
+      tracks: [track],
+    };
+
+    const renderGraph: RenderGraph = {
+      graphVersion: 1,
+      sequenceId: sequence.id,
+      format: sequence.format,
+      durationSec: 20,
+      durationFrames: 600,
+      visualLayers: [
+        {
+          layerIndex: 0,
+          trackId: track.id,
+          trackKind: 'video',
+          trackIndex: 0,
+          clipId: firstClip.id,
+          timelineInSec: 0,
+          timelineOutSec: 10,
+          timelineInFrame: 0,
+          timelineOutFrame: 300,
+          durationFrames: 300,
+          sourceInSec: 0,
+          sourceOutSec: 10,
+          sourceInFrame: 0,
+          sourceOutFrame: 300,
+          transform: firstClip.transform,
+          opacity: 1,
+          blendMode: 'normal',
+          effects: [],
+          source: {
+            type: 'media',
+            assetId: firstClip.assetId,
+          },
+        },
+        {
+          layerIndex: 1,
+          trackId: track.id,
+          trackKind: 'video',
+          trackIndex: 0,
+          clipId: secondClip.id,
+          timelineInSec: 10,
+          timelineOutSec: 20,
+          timelineInFrame: 300,
+          timelineOutFrame: 600,
+          durationFrames: 300,
+          sourceInSec: 0,
+          sourceOutSec: 10,
+          sourceInFrame: 0,
+          sourceOutFrame: 300,
+          transform: secondClip.transform,
+          opacity: 1,
+          blendMode: 'normal',
+          effects: [],
+          source: {
+            type: 'media',
+            assetId: secondClip.assetId,
+          },
+        },
+      ],
+      audioLayers: [],
+    };
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === 'get_sequence_render_graph') {
+        return renderGraph;
+      }
+
+      return [];
+    });
+
+    const assets = new Map<string, Asset>([
+      ['asset-first', createVideoAsset('asset-first', 'https://example.com/first.mp4')],
+      ['asset-second', createVideoAsset('asset-second', 'https://example.com/second.mp4')],
+    ]);
+
+    render(<ProxyPreviewPlayer sequence={sequence} assets={assets} showControls />);
+
+    await waitFor(() => {
+      expect(mockedInvoke).toHaveBeenCalledWith('get_sequence_render_graph', {
+        sequenceId: sequence.id,
+      });
+    });
+
+    await waitFor(() => {
+      const firstVideo = screen.getByTestId('proxy-video-clip-first') as HTMLVideoElement;
+      const secondVideo = screen.getByTestId('proxy-video-clip-second') as HTMLVideoElement;
+      expect(firstVideo.style.visibility).toBe('visible');
+      expect(secondVideo.style.visibility).toBe('hidden');
+    });
+  });
+
   it('ignores a stale render graph from a different sequence and keeps raw-track fallback', async () => {
     runtimeMocks.isTauriRuntime.mockReturnValue(true);
     const sequence = createSequence();

--- a/src/components/preview/ProxyPreviewPlayer.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.tsx
@@ -7,6 +7,7 @@
 
 import { useRef, useMemo, useCallback, useEffect, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import type { VisualRenderLayer } from '@/bindings';
 import {
   PLAYBACK_EVENTS,
   type PlaybackSeekEventDetail,
@@ -17,7 +18,6 @@ import { useTimelineStore } from '@/stores/timelineStore';
 import { createLogger } from '@/services/logger';
 import { PlayerControls } from './PlayerControls';
 import { normalizeFileUriToPath } from '@/utils/uri';
-import { getActiveMediaVisualLayers } from '@/utils/renderGraphLayers';
 import { useSequenceRenderGraph } from '@/hooks/useSequenceRenderGraph';
 import { useSequenceTextClipData } from '@/hooks/useSequenceTextClipData';
 import { textRenderSpecToTextClipData } from '@/utils/renderGraphText';
@@ -34,6 +34,7 @@ import {
   resolveCaptionAnchor as resolveCaptionAnchorValue,
 } from '@/utils/captionStyle';
 import {
+  getClipTimelineEndSec,
   getClipSourceTimeAtTimelineTime,
   getSafeClipSpeed,
   isClipActiveAtTime,
@@ -75,6 +76,7 @@ interface ActiveClip {
   asset: Asset;
   trackId: string;
   trackIndex: number;
+  isActive: boolean;
 }
 
 interface RenderableClip extends ActiveClip {
@@ -112,6 +114,8 @@ const PRECISE_SEEK_TOLERANCE = 0.008; // ~0.5 frame at 60fps for paused scrubbin
 const DRIFT_SEEK_TOLERANCE = 0.12; // reduce micro-stutter from overly frequent drift seeks
 const HARD_SEEK_DETECTION_DELTA = 0.25; // Treat as explicit jump when delta exceeds this
 const TIME_CHANGE_EPSILON = 0.001;
+const CLIP_BOUNDARY_PRELOAD_SEC = 0.5;
+const CLIP_BOUNDARY_RETAIN_SEC = 0.15;
 const TRACK_LAYER_Z_INDEX_STEP = 10;
 const CAPTION_LAYER_Z_INDEX_OFFSET = 5;
 const TEXT_LAYER_Z_INDEX_OFFSET = 6;
@@ -126,6 +130,50 @@ function isWindowsAbsolutePath(path: string): boolean {
 
 function isClipEnabled(clip: Clip): boolean {
   return clip.enabled !== false;
+}
+
+function getFiniteClipTimelineStartSec(clip: Clip): number | null {
+  const timelineInSec = clip.place?.timelineInSec;
+  return Number.isFinite(timelineInSec) ? timelineInSec : null;
+}
+
+function isTimelineRangeActive(startSec: number, endSec: number, timeSec: number): boolean {
+  return (
+    Number.isFinite(timeSec) &&
+    Number.isFinite(startSec) &&
+    Number.isFinite(endSec) &&
+    endSec > startSec &&
+    timeSec >= startSec &&
+    timeSec < endSec
+  );
+}
+
+function isTimelineRangeInVideoMountWindow(
+  startSec: number,
+  endSec: number,
+  timeSec: number,
+): boolean {
+  return (
+    Number.isFinite(timeSec) &&
+    Number.isFinite(startSec) &&
+    Number.isFinite(endSec) &&
+    endSec > startSec &&
+    timeSec >= startSec - CLIP_BOUNDARY_PRELOAD_SEC &&
+    timeSec < endSec + CLIP_BOUNDARY_RETAIN_SEC
+  );
+}
+
+function shouldMountClipNearPlaybackTime(clip: Clip, timeSec: number): boolean {
+  const startSec = getFiniteClipTimelineStartSec(clip);
+  if (startSec == null) {
+    return false;
+  }
+
+  return isTimelineRangeInVideoMountWindow(startSec, getClipTimelineEndSec(clip), timeSec);
+}
+
+function shouldMountLayerNearPlaybackTime(layer: VisualRenderLayer, timeSec: number): boolean {
+  return isTimelineRangeInVideoMountWindow(layer.timelineInSec, layer.timelineOutSec, timeSec);
 }
 
 function clampTimelineTime(time: number, duration: number): number {
@@ -418,41 +466,45 @@ export function ProxyPreviewPlayer({
   // Cache previous active clip result to stabilize the reference when the same
   // clips are active across consecutive frames. This prevents unnecessary
   // downstream re-renders and effect re-fires during steady-state playback.
-  const prevActiveClipsRef = useRef<ActiveClip[]>([]);
+  const prevPreviewClipsRef = useRef<ActiveClip[]>([]);
 
-  // Find active clips at current time (sorted by layer/track)
-  const activeClips = useMemo((): ActiveClip[] => {
+  // Keep clips mounted slightly before/after cut boundaries so the browser can
+  // load and seek the next video before it becomes visible.
+  const previewClips = useMemo((): ActiveClip[] => {
     if (!sequence) {
-      if (prevActiveClipsRef.current.length === 0) return prevActiveClipsRef.current;
-      prevActiveClipsRef.current = [];
-      return prevActiveClipsRef.current;
+      if (prevPreviewClipsRef.current.length === 0) return prevPreviewClipsRef.current;
+      prevPreviewClipsRef.current = [];
+      return prevPreviewClipsRef.current;
     }
 
     const graphForSequence = renderGraph?.sequenceId === sequence.id ? renderGraph : null;
-    const graphLayers = getActiveMediaVisualLayers(graphForSequence, assets, currentTime, {
-      trackKinds: ['video'],
-    });
-    const clips: ActiveClip[] =
-      graphLayers.length > 0
-        ? graphLayers
-            .filter(({ asset }) => asset?.kind === 'video')
-            .map(({ layer, asset }) => {
-              const clip = clipById.get(layer.clipId);
-              if (!clip || !asset) {
-                return null;
-              }
+    const clips: ActiveClip[] = [];
 
-              return {
-                clip,
-                asset,
-                trackId: layer.trackId,
-                trackIndex: layer.trackIndex,
-              };
-            })
-            .filter((clip): clip is ActiveClip => clip !== null)
-        : [];
+    if (graphForSequence) {
+      for (const layer of graphForSequence.visualLayers) {
+        if (
+          layer.trackKind !== 'video' ||
+          layer.source.type !== 'media' ||
+          !shouldMountLayerNearPlaybackTime(layer, currentTime)
+        ) {
+          continue;
+        }
 
-    if (clips.length === 0 && !graphForSequence) {
+        const clip = clipById.get(layer.clipId);
+        const asset = assets.get(layer.source.assetId);
+        if (!clip || !asset || asset.kind !== 'video' || !isClipEnabled(clip)) {
+          continue;
+        }
+
+        clips.push({
+          clip,
+          asset,
+          trackId: layer.trackId,
+          trackIndex: layer.trackIndex,
+          isActive: isTimelineRangeActive(layer.timelineInSec, layer.timelineOutSec, currentTime),
+        });
+      }
+    } else {
       sequence.tracks.forEach((track, trackIndex) => {
         if (track.muted || !track.visible) return;
 
@@ -464,19 +516,22 @@ export function ProxyPreviewPlayer({
             continue;
           }
 
-          if (isClipActiveAtTime(clip, currentTime)) {
-            const asset = assets.get(clip.assetId);
-            if (!asset || asset.kind !== 'video') {
-              continue;
-            }
-
-            clips.push({
-              clip,
-              asset,
-              trackId: track.id,
-              trackIndex,
-            });
+          if (!shouldMountClipNearPlaybackTime(clip, currentTime)) {
+            continue;
           }
+
+          const asset = assets.get(clip.assetId);
+          if (!asset || asset.kind !== 'video') {
+            continue;
+          }
+
+          clips.push({
+            clip,
+            asset,
+            trackId: track.id,
+            trackIndex,
+            isActive: isClipActiveAtTime(clip, currentTime),
+          });
         }
       });
 
@@ -485,9 +540,9 @@ export function ProxyPreviewPlayer({
       clips.sort((a, b) => b.trackIndex - a.trackIndex);
     }
 
-    // Return the same reference if the active clip set hasn't changed.
+    // Return the same reference if the mounted clip set hasn't changed.
     // This avoids cascading re-renders when playhead moves within the same clip.
-    const prev = prevActiveClipsRef.current;
+    const prev = prevPreviewClipsRef.current;
     if (
       clips.length === prev.length &&
       clips.every(
@@ -495,13 +550,14 @@ export function ProxyPreviewPlayer({
           clipInfo.clip === prev[index].clip &&
           clipInfo.asset === prev[index].asset &&
           clipInfo.trackId === prev[index].trackId &&
-          clipInfo.trackIndex === prev[index].trackIndex,
+          clipInfo.trackIndex === prev[index].trackIndex &&
+          clipInfo.isActive === prev[index].isActive,
       )
     ) {
       return prev;
     }
 
-    prevActiveClipsRef.current = clips;
+    prevPreviewClipsRef.current = clips;
     return clips;
   }, [sequence, renderGraph, currentTime, assets, clipById]);
 
@@ -568,14 +624,14 @@ export function ProxyPreviewPlayer({
   const renderableClips = useMemo((): RenderableClip[] => {
     const clips: RenderableClip[] = [];
 
-    for (const clipInfo of activeClips) {
+    for (const clipInfo of previewClips) {
       const src = getVideoSrc(clipInfo.asset);
       if (!src) continue;
       clips.push({ ...clipInfo, src });
     }
 
     return clips;
-  }, [activeClips, getVideoSrc]);
+  }, [previewClips, getVideoSrc]);
 
   const activeCaptions = useMemo((): ActiveCaption[] => {
     if (!sequence) {
@@ -932,11 +988,12 @@ export function ProxyPreviewPlayer({
 
         const clampedSourceTime = getClampedSourceTime(clip, safeTimelineTime);
         const safeSpeed = getSafeClipSpeed(clip);
+        const shouldPlayClip = isClipActiveAtTime(clip, safeTimelineTime);
 
         const tolerance = forceSeek || !isPlaying ? PRECISE_SEEK_TOLERANCE : DRIFT_SEEK_TOLERANCE;
         // During active playback, avoid forcing currentTime while the element is
         // already seeking. Re-seeking a seeking element can cause visible jitter.
-        if (!forceSeek && isPlaying && video.seeking) {
+        if (!forceSeek && isPlaying && shouldPlayClip && video.seeking) {
           return;
         }
 
@@ -950,6 +1007,13 @@ export function ProxyPreviewPlayer({
         // ProxyPreviewPlayer video elements stay muted; Web Audio owns timeline audio output.
         // Keep volume at zero as a defensive fallback even if browser muted state changes.
         video.volume = 0;
+
+        if (!shouldPlayClip) {
+          if (!video.paused) {
+            video.pause();
+          }
+          return;
+        }
 
         // Sync play state
         if (isPlaying && video.paused) {
@@ -1384,6 +1448,8 @@ export function ProxyPreviewPlayer({
     );
   }
 
+  const hasActiveRenderableClip = renderableClips.some((clipInfo) => clipInfo.isActive);
+
   return (
     <div
       ref={containerRef}
@@ -1397,67 +1463,73 @@ export function ProxyPreviewPlayer({
     >
       {/* Video Layers */}
       <div className="absolute inset-0 pointer-events-none" data-testid="proxy-video-layer">
-        {renderableClips.length === 0 ? (
+        {!hasActiveRenderableClip && (
           <div className="w-full h-full flex items-center justify-center text-gray-500">
             <p>No clips at current time</p>
           </div>
-        ) : (
-          renderableClips.map(({ clip, asset, trackIndex, src }) => {
-            const error = videoErrors.get(clip.id);
+        )}
+        {renderableClips.map(({ clip, asset, trackIndex, src, isActive }) => {
+          const error = videoErrors.get(clip.id);
 
-            // Show error state if video failed to load
-            if (error) {
-              return (
-                <div
-                  key={clip.id}
-                  data-testid={`proxy-video-error-${clip.id}`}
-                  className="absolute inset-0 flex items-center justify-center bg-gray-900 pointer-events-none"
-                  style={{
-                    zIndex: (sequence.tracks.length - trackIndex) * TRACK_LAYER_Z_INDEX_STEP,
-                  }}
-                >
-                  <div className="text-center text-red-400">
-                    <svg
-                      className="w-12 h-12 mx-auto mb-2"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={1.5}
-                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                      />
-                    </svg>
-                    <p className="text-sm">Failed to load video</p>
-                    <p className="text-xs text-gray-500 mt-1">{asset.name}</p>
-                  </div>
-                </div>
-              );
-            }
-
+          // Show error state if video failed to load
+          if (error && isActive) {
             return (
-              <video
+              <div
                 key={clip.id}
-                ref={(el) => setVideoRef(clip.id, el)}
-                data-testid={`proxy-video-${clip.id}`}
-                src={src}
-                className="absolute inset-0 w-full h-full object-contain pointer-events-none"
+                data-testid={`proxy-video-error-${clip.id}`}
+                className="absolute inset-0 flex items-center justify-center bg-gray-900 pointer-events-none"
                 style={{
-                  opacity: clip.opacity,
                   zIndex: (sequence.tracks.length - trackIndex) * TRACK_LAYER_Z_INDEX_STEP,
                 }}
-                playsInline
-                muted
-                onLoadedData={() => handleVideoLoaded(clip.id)}
-                onError={(e) =>
-                  handleVideoError(clip.id, e.currentTarget.error?.message || 'Unknown error')
-                }
-              />
+              >
+                <div className="text-center text-red-400">
+                  <svg
+                    className="w-12 h-12 mx-auto mb-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                  <p className="text-sm">Failed to load video</p>
+                  <p className="text-xs text-gray-500 mt-1">{asset.name}</p>
+                </div>
+              </div>
             );
-          })
-        )}
+          }
+
+          if (error) {
+            return null;
+          }
+
+          return (
+            <video
+              key={clip.id}
+              ref={(el) => setVideoRef(clip.id, el)}
+              data-testid={`proxy-video-${clip.id}`}
+              src={src}
+              className="absolute inset-0 w-full h-full object-contain pointer-events-none"
+              style={{
+                opacity: isActive ? clip.opacity : 0,
+                visibility: isActive ? 'visible' : 'hidden',
+                zIndex: (sequence.tracks.length - trackIndex) * TRACK_LAYER_Z_INDEX_STEP,
+              }}
+              aria-hidden={!isActive}
+              playsInline
+              muted
+              preload="auto"
+              onLoadedData={() => handleVideoLoaded(clip.id)}
+              onError={(e) =>
+                handleVideoError(clip.id, e.currentTarget.error?.message || 'Unknown error')
+              }
+            />
+          );
+        })}
       </div>
 
       {/* Caption overlays (rendered in proxy mode to avoid canvas fallback for captions) */}

--- a/src/components/preview/ProxyPreviewPlayer.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.tsx
@@ -76,6 +76,8 @@ interface ActiveClip {
   asset: Asset;
   trackId: string;
   trackIndex: number;
+  timelineInSec: number;
+  timelineOutSec: number;
   isActive: boolean;
 }
 
@@ -501,6 +503,8 @@ export function ProxyPreviewPlayer({
           asset,
           trackId: layer.trackId,
           trackIndex: layer.trackIndex,
+          timelineInSec: layer.timelineInSec,
+          timelineOutSec: layer.timelineOutSec,
           isActive: isTimelineRangeActive(layer.timelineInSec, layer.timelineOutSec, currentTime),
         });
       }
@@ -530,6 +534,8 @@ export function ProxyPreviewPlayer({
             asset,
             trackId: track.id,
             trackIndex,
+            timelineInSec: clip.place.timelineInSec,
+            timelineOutSec: getClipTimelineEndSec(clip),
             isActive: isClipActiveAtTime(clip, currentTime),
           });
         }
@@ -551,6 +557,8 @@ export function ProxyPreviewPlayer({
           clipInfo.asset === prev[index].asset &&
           clipInfo.trackId === prev[index].trackId &&
           clipInfo.trackIndex === prev[index].trackIndex &&
+          clipInfo.timelineInSec === prev[index].timelineInSec &&
+          clipInfo.timelineOutSec === prev[index].timelineOutSec &&
           clipInfo.isActive === prev[index].isActive,
       )
     ) {
@@ -982,13 +990,17 @@ export function ProxyPreviewPlayer({
     (timelineTime: number, forceSeek: boolean = false) => {
       const safeTimelineTime = clampTimelineTime(timelineTime, duration);
 
-      renderableClips.forEach(({ clip }) => {
+      renderableClips.forEach(({ clip, timelineInSec, timelineOutSec }) => {
         const video = videoRefs.current.get(clip.id);
         if (!video) return;
 
         const clampedSourceTime = getClampedSourceTime(clip, safeTimelineTime);
         const safeSpeed = getSafeClipSpeed(clip);
-        const shouldPlayClip = isClipActiveAtTime(clip, safeTimelineTime);
+        const shouldPlayClip = isTimelineRangeActive(
+          timelineInSec,
+          timelineOutSec,
+          safeTimelineTime,
+        );
 
         const tolerance = forceSeek || !isPlaying ? PRECISE_SEEK_TOLERANCE : DRIFT_SEEK_TOLERANCE;
         // During active playback, avoid forcing currentTime while the element is

--- a/src/components/preview/TimelinePreviewPlayer.test.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.test.tsx
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TimelinePreviewPlayer } from './TimelinePreviewPlayer';
+import { usePlaybackStore } from '@/stores/playbackStore';
+import { useProjectStore } from '@/stores/projectStore';
+import type { Asset, Clip, Sequence, Track } from '@/types';
+
+const frameBufferMock = vi.hoisted(() => ({
+  getFrame: vi.fn(),
+}));
+
+vi.mock('@/services/videoFrameBuffer', () => ({
+  videoFrameBuffer: frameBufferMock,
+}));
+
+interface MockCanvasContext {
+  canvas: HTMLCanvasElement;
+  fillStyle: string;
+  strokeStyle: string;
+  lineWidth: number;
+  globalAlpha: number;
+  globalCompositeOperation: GlobalCompositeOperation;
+  fillRect: ReturnType<typeof vi.fn>;
+  clearRect: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  translate: ReturnType<typeof vi.fn>;
+  rotate: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  measureText: ReturnType<typeof vi.fn>;
+  fillText: ReturnType<typeof vi.fn>;
+  strokeText: ReturnType<typeof vi.fn>;
+  beginPath: ReturnType<typeof vi.fn>;
+  closePath: ReturnType<typeof vi.fn>;
+  moveTo: ReturnType<typeof vi.fn>;
+  lineTo: ReturnType<typeof vi.fn>;
+  arc: ReturnType<typeof vi.fn>;
+  stroke: ReturnType<typeof vi.fn>;
+  fill: ReturnType<typeof vi.fn>;
+  setLineDash: ReturnType<typeof vi.fn>;
+}
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+let contextByCanvas: WeakMap<HTMLCanvasElement, MockCanvasContext>;
+
+function createMockContext(canvas: HTMLCanvasElement): MockCanvasContext {
+  return {
+    canvas,
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    fillRect: vi.fn(),
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    scale: vi.fn(),
+    measureText: vi.fn(() => ({ width: 0 })),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    arc: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    setLineDash: vi.fn(),
+  };
+}
+
+function installCanvasMock(): void {
+  contextByCanvas = new WeakMap();
+  HTMLCanvasElement.prototype.getContext = vi.fn(function getContext(
+    this: HTMLCanvasElement,
+    contextId: string,
+  ) {
+    if (contextId !== '2d') {
+      return null;
+    }
+
+    let context = contextByCanvas.get(this);
+    if (!context) {
+      context = createMockContext(this);
+      contextByCanvas.set(this, context);
+    }
+
+    return context as unknown as CanvasRenderingContext2D;
+  }) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+}
+
+function createClip(id: string, assetId: string): Clip {
+  return {
+    id,
+    assetId,
+    label: id,
+    place: { timelineInSec: 0, durationSec: 10 },
+    range: { sourceInSec: 0, sourceOutSec: 10 },
+    transform: {
+      position: { x: 0.5, y: 0.5 },
+      scale: { x: 1, y: 1 },
+      rotationDeg: 0,
+      anchor: { x: 0.5, y: 0.5 },
+    },
+    speed: 1,
+    opacity: 1,
+    effects: [],
+    audio: { volumeDb: 0, pan: 0, muted: false },
+  };
+}
+
+function createVideoTrack(id: string, clip: Clip): Track {
+  return {
+    id,
+    name: id,
+    kind: 'video',
+    clips: [clip],
+    blendMode: 'normal',
+    muted: false,
+    visible: true,
+    locked: false,
+    volume: 1,
+  };
+}
+
+function createVideoAsset(id: string): Asset {
+  return {
+    id,
+    kind: 'video',
+    name: `${id}.mp4`,
+    uri: `/tmp/${id}.mp4`,
+    hash: id,
+    fileSize: 100,
+    importedAt: '2026-01-01T00:00:00.000Z',
+    license: {
+      source: 'user',
+      licenseType: 'unknown',
+      allowedUse: [],
+    },
+    tags: [],
+    proxyStatus: 'notNeeded',
+  };
+}
+
+function createSequence(): Sequence {
+  const clip = createClip('clip-1', 'asset-1');
+
+  return {
+    id: 'sequence-1',
+    name: 'Sequence 1',
+    format: {
+      canvas: { width: 640, height: 360 },
+      fps: { num: 30, den: 1 },
+      audioSampleRate: 48000,
+      audioChannels: 2,
+    },
+    tracks: [createVideoTrack('track-1', clip)],
+    markers: [],
+  };
+}
+
+describe('TimelinePreviewPlayer', () => {
+  beforeEach(() => {
+    installCanvasMock();
+    frameBufferMock.getFrame.mockReturnValue(new Promise<string | null>(() => {}));
+    usePlaybackStore.getState().reset();
+    usePlaybackStore.setState({
+      currentTime: 2,
+      duration: 10,
+      isPlaying: false,
+      syncWithTimeline: true,
+    });
+
+    const sequence = createSequence();
+    const asset = createVideoAsset('asset-1');
+    useProjectStore.setState({
+      activeSequenceId: sequence.id,
+      sequences: new Map([[sequence.id, sequence]]),
+      assets: new Map([[asset.id, asset]]),
+      stateVersion: 0,
+    });
+  });
+
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+  });
+
+  it('keeps the visible canvas intact while the next frame is still extracting', async () => {
+    render(<TimelinePreviewPlayer showControls={false} />);
+
+    await waitFor(() => {
+      expect(frameBufferMock.getFrame).toHaveBeenCalledWith('asset-1', '/tmp/asset-1.mp4', 2);
+    });
+
+    const visibleCanvas = screen.getByTestId('preview-canvas') as HTMLCanvasElement;
+    const visibleContext = contextByCanvas.get(visibleCanvas);
+
+    expect(visibleContext).toBeDefined();
+    expect(visibleContext!.fillRect).not.toHaveBeenCalled();
+    expect(visibleContext!.clearRect).not.toHaveBeenCalled();
+    expect(visibleContext!.drawImage).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/preview/TimelinePreviewPlayer.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.tsx
@@ -185,6 +185,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
   onTextPlacementCommit,
 }: TimelinePreviewPlayerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frameCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ width, height });
   const [isMultiFrameLoading, setIsMultiFrameLoading] = useState(false);
@@ -618,6 +619,12 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         return true;
       };
 
+      if (!activeSequence) {
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        return;
+      }
+
       const activeClips = getActiveClipsAtTime(activeSequence, time);
 
       if (activeClips.length === 0) {
@@ -627,9 +634,22 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         return;
       }
 
-      if (!activeSequence) {
-        ctx.fillStyle = '#000000';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      let frameCanvas = frameCanvasRef.current;
+      if (!frameCanvas || frameCanvas.ownerDocument !== canvas.ownerDocument) {
+        frameCanvas = canvas.ownerDocument.createElement('canvas');
+        frameCanvasRef.current = frameCanvas;
+      }
+
+      if (frameCanvas.width !== canvas.width) {
+        frameCanvas.width = canvas.width;
+      }
+      if (frameCanvas.height !== canvas.height) {
+        frameCanvas.height = canvas.height;
+      }
+
+      const frameCtx = frameCanvas.getContext('2d');
+      if (!frameCtx) {
+        console.error('TimelinePreviewPlayer: Failed to get 2D canvas context');
         return;
       }
 
@@ -641,11 +661,12 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         setIsMultiFrameLoading(true);
       }
 
-      // Clear canvas before compositing
-      ctx.fillStyle = '#000000';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      // Compose into an offscreen canvas first. Clearing the visible canvas
+      // before async frame extraction completes exposes the black background at cuts.
+      frameCtx.fillStyle = '#000000';
+      frameCtx.fillRect(0, 0, frameCanvas.width, frameCanvas.height);
       const completed = await renderSequenceToCanvas(
-        ctx,
+        frameCtx,
         activeSequence,
         time,
         time,
@@ -656,6 +677,9 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
       if (!completed) {
         return;
       }
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(frameCanvas, 0, 0);
 
       // Clear multi-frame loading state (only if mounted and was loading)
       const wasLoadingAtEnd = isLoadingRef.current;

--- a/src/components/preview/TimelinePreviewPlayer.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.tsx
@@ -661,34 +661,36 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         setIsMultiFrameLoading(true);
       }
 
-      // Compose into an offscreen canvas first. Clearing the visible canvas
-      // before async frame extraction completes exposes the black background at cuts.
-      frameCtx.fillStyle = '#000000';
-      frameCtx.fillRect(0, 0, frameCanvas.width, frameCanvas.height);
-      const completed = await renderSequenceToCanvas(
-        frameCtx,
-        activeSequence,
-        time,
-        time,
-        new Set([activeSequence.id]),
-        0,
-      );
+      try {
+        // Compose into an offscreen canvas first. Clearing the visible canvas
+        // before async frame extraction completes exposes the black background at cuts.
+        frameCtx.fillStyle = '#000000';
+        frameCtx.fillRect(0, 0, frameCanvas.width, frameCanvas.height);
+        const completed = await renderSequenceToCanvas(
+          frameCtx,
+          activeSequence,
+          time,
+          time,
+          new Set([activeSequence.id]),
+          0,
+        );
 
-      if (!completed) {
-        return;
+        if (!completed) {
+          return;
+        }
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(frameCanvas, 0, 0);
+
+        onFrameRender?.(time);
+      } finally {
+        // Clear multi-frame loading state even when a stale render exits early.
+        const wasLoadingAtEnd = isLoadingRef.current;
+        isLoadingRef.current = false;
+        if (wasLoadingAtEnd && isMountedRef.current) {
+          setIsMultiFrameLoading(false);
+        }
       }
-
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(frameCanvas, 0, 0);
-
-      // Clear multi-frame loading state (only if mounted and was loading)
-      const wasLoadingAtEnd = isLoadingRef.current;
-      isLoadingRef.current = false;
-      if (wasLoadingAtEnd && isMountedRef.current) {
-        setIsMultiFrameLoading(false);
-      }
-
-      onFrameRender?.(time);
     },
     [
       activeSequence,

--- a/src/stores/videoGenStore.test.ts
+++ b/src/stores/videoGenStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import { executeAgentCommand } from '@/agents/tools/commandExecutor';
+import { insertAgentMediaClip } from '@/agents/tools/mediaInsertion';
 import { useVideoGenStore, type VideoGenJob, type VideoGenPlacementRequest } from './videoGenStore';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -11,8 +12,13 @@ vi.mock('@/agents/tools/commandExecutor', () => ({
   executeAgentCommand: vi.fn(),
 }));
 
+vi.mock('@/agents/tools/mediaInsertion', () => ({
+  insertAgentMediaClip: vi.fn(),
+}));
+
 const mockedInvoke = vi.mocked(invoke);
 const mockedExecuteAgentCommand = vi.mocked(executeAgentCommand);
+const mockedInsertAgentMediaClip = vi.mocked(insertAgentMediaClip);
 
 function createJob(overrides: Partial<VideoGenJob> = {}): VideoGenJob {
   return {
@@ -41,6 +47,7 @@ describe('videoGenStore placement sync', () => {
   beforeEach(() => {
     mockedInvoke.mockReset();
     mockedExecuteAgentCommand.mockReset();
+    mockedInsertAgentMediaClip.mockReset();
     useVideoGenStore.getState().stopPolling();
     useVideoGenStore.setState({
       jobs: new Map(),
@@ -75,10 +82,24 @@ describe('videoGenStore placement sync', () => {
       if (command === 'generate_asset_thumbnail') return null;
       throw new Error(`Unhandled invoke: ${command}`);
     });
+    mockedInsertAgentMediaClip.mockResolvedValue({
+      insertResult: {
+        opId: 'op-insert',
+        changes: [],
+        createdIds: ['clip-generated'],
+        deletedIds: [],
+      },
+      clipId: 'clip-generated',
+      sequenceId: 'seq-1',
+      trackId: 'video-1',
+      assetId: 'asset-generated',
+      timelineStart: 3,
+      durationSec: 6,
+    });
     mockedExecuteAgentCommand.mockImplementation(async (commandType) => ({
-      opId: commandType === 'InsertClip' ? 'op-insert' : 'op-marker',
+      opId: commandType === 'RemoveMarker' ? 'op-marker' : 'op-command',
       changes: [],
-      createdIds: commandType === 'InsertClip' ? ['clip-generated'] : [],
+      createdIds: [],
       deletedIds: commandType === 'RemoveMarker' ? ['marker-1'] : [],
     }));
 
@@ -91,7 +112,7 @@ describe('videoGenStore placement sync', () => {
       placedClipId: 'clip-generated',
       placementError: null,
     });
-    expect(mockedExecuteAgentCommand).toHaveBeenCalledWith('InsertClip', {
+    expect(mockedInsertAgentMediaClip).toHaveBeenCalledWith({
       sequenceId: 'seq-1',
       trackId: 'video-1',
       assetId: 'asset-generated',
@@ -146,7 +167,7 @@ describe('videoGenStore placement sync', () => {
       if (command === 'generate_asset_thumbnail') return null;
       throw new Error(`Unhandled invoke: ${command}`);
     });
-    mockedExecuteAgentCommand.mockRejectedValue(new Error('track is locked'));
+    mockedInsertAgentMediaClip.mockRejectedValue(new Error('track is locked'));
 
     await useVideoGenStore.getState().onJobCompleted('job-1');
 

--- a/src/stores/videoGenStore.ts
+++ b/src/stores/videoGenStore.ts
@@ -11,6 +11,7 @@ import { enableMapSet } from 'immer';
 import { invoke } from '@tauri-apps/api/core';
 import { createLogger } from '@/services/logger';
 import { executeAgentCommand } from '@/agents/tools/commandExecutor';
+import { insertAgentMediaClip } from '@/agents/tools/mediaInsertion';
 
 enableMapSet();
 
@@ -540,13 +541,13 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
 
         if (placement) {
           try {
-            const placementResult = await executeAgentCommand('InsertClip', {
+            const placementResult = await insertAgentMediaClip({
               sequenceId: placement.sequenceId,
               trackId: placement.trackId,
               assetId: importResult.id,
               timelineStart: placement.timelineStart,
             });
-            placedClipId = placementResult.createdIds[0] ?? null;
+            placedClipId = placementResult.clipId;
 
             if (placement.markerId && placement.removeMarkerOnPlace) {
               try {


### PR DESCRIPTION
### **User description**
## Description

Adds safer agent-driven media and text editing flows, improves Codex external-agent integration, and fixes preview/core stability issues uncovered while preparing those workflows.

## Related Issue

Closes #709
Closes #710
Closes #711
Closes #712
Closes #713
Closes #714

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added a shared agent media insertion path with source range preservation, linked audio parity, output contracts, source-select rollback support, generated media placement integration, and Codex/MCP media insertion plus annotation tools.
- Improved Codex external chat behavior with active-turn steering, runtime retention across chat remounts, interrupt state cleanup, and richer text/caption tool schemas with semantic aliases and automatic safe text placement.
- Fixed Windows subprocess console-window flashes and preview cut stability by configuring subprocess helpers, adding an architecture guard test, preloading adjacent preview clips, and composing timeline frames offscreen before visible canvas swaps.

## Screenshots / Videos

N/A

## Testing

Validated the committed branch with focused frontend tests, Rust MCP tests, TypeScript type-checking, and Rust GUI check. Commit hooks also ran version sync checks, TypeScript type-checking, and ESLint fix/pass for each commit.

### Test Environment

- OS: Linux WSL2 (`6.6.87.2-microsoft-standard-WSL2`)
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 / cargo 1.93.1

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Commands run:

- `npm run type-check`
- `cargo check -p openreelio --features gui`
- `npm run test:run -- src/agents/external/adapters/CodexAppServerClient.test.ts src/agents/external/adapters/CodexReferenceAdapter.test.ts src/agents/external/chatRuntime.test.ts src/agents/external/useExternalAgentChatRuntime.test.tsx src/agents/tools/analysisTools.test.ts src/agents/tools/mediaInsertion.test.ts src/agents/tools/textPlacement.test.ts src/agents/tools/metaTools.test.ts src/agents/tools/textTools.test.ts src/components/features/agent/AgentRuntimeChatShell.test.tsx src/components/preview/ProxyPreviewPlayer.test.tsx src/components/preview/TimelinePreviewPlayer.test.tsx src/stores/videoGenStore.test.ts src/architecture/processCommandWindowGuard.test.ts`
- `cargo test -p openreelio-cli mcp`

`cargo test -p openreelio-cli mcp` still reports pre-existing dead-code warnings from unrelated library code, but all targeted tests pass.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Added `media_insert` and `annotation_read` tools to Codex.

- Implemented smart text placement using visual annotations.

- Enabled steering of active Codex chat turns.

- Fixed Windows subprocess console flashes and preview stability.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User Message"] -- "Steer active turn" --> Runtime["Chat Runtime"]
  Runtime -- "Tool Call" --> MediaTool["Media Insertion Path"]
  MediaTool -- "Auto-link" --> Audio["Linked Audio Track"]
  Runtime -- "Analyze" --> Annotation["Annotation Read"]
  Annotation -- "Avoid Obstacles" --> TextPlacement["Smart Text Placement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>openreelioCodexTools.ts</strong><dd><code>Expose media insertion and annotation tools to Codex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-78b40377e0e9fccbf98b98f67b7c52e322184ae79113f5293cc6ad0e085d548d">+383/-14</a></td>

</tr>

<tr>
  <td><strong>textPlacement.ts</strong><dd><code>Implement smart text placement logic avoiding visual obstacles</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-b750550ea21fadd66b3434fd1c6585752ab787d0a59d0aa61e004e90ad3a83b9">+482/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mediaInsertion.ts</strong><dd><code>Create shared media insertion path with linked audio support</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-da2ef95c37e87129db187e5e00a3eaaebe2a0563e7d6623b872d825ac72cee0a">+474/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>textTools.ts</strong><dd><code>Integrate automatic placement into text creation tools</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-b0b4a063ada79baf234334dea412b7938775274b8387b4201156c3927324b686">+309/-25</a></td>

</tr>

<tr>
  <td><strong>metaTools.ts</strong><dd><code>Expand text meta-tool with richer styling parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-842f7132c091ca5476d87b73a280cb7192ba997487dfea06a0bd4e097e1a19b7">+145/-17</a></td>

</tr>

<tr>
  <td><strong>ExternalAgentChat.tsx</strong><dd><code>Enable runtime retention and steering for external chat</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-31c95c913c0ed50348c9b6223e7fbdfb8650c35a4a0476a301fd35946a09f4c8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp.rs</strong><dd><code>Expose media and annotation tools via MCP server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+634/-3</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ProxyPreviewPlayer.tsx</strong><dd><code>Improve preview stability by preloading clips near cuts</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-647a8a156472eaa4853238581b304e360adfb643c3e29883b2aeb178bb3030a0">+171/-99</a></td>

</tr>

<tr>
  <td><strong>workspace.rs</strong><dd><code>Suppress console windows for Windows subprocess calls</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-2aa7e8c8079bfc9abff9c3d2b43e3c43adefcf6015e00370641c1b455c036f14">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>processCommandWindowGuard.test.ts</strong><dd><code>Add architecture test for Windows subprocess window suppression</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-49b09c0a0abda11ed28fdd3c0bc74c6383f74c4038c4799d63047a388421322c">+205/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>32 files</summary><table>
<tr>
  <td><strong>build.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-7d1ef5b0b986fee369d8f5fa4361f21fa3075601e5416738ba4f4d1ea5dfb2ed">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metadata.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-f92f01c44c85ff6773b02ad6ee5a319c6137723869c318812765f636253545b4">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-15e4af2c0cd8ff43e8090cc77d69039816793e87a5a45391e59866069aa6b507">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shots.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-b4bb34737d2a0ca75c02ba72c4a93615516c943401223439932b4807057c810b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistry.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-33b448915f16ba7fb666139fa3841361de9019f553c37151b40d7f31cfbe5122">+43/-29</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistryAdapter.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-f3778719dba36a355947514a6c8186918dff8be145ee79c8d149f111af997316">+43/-29</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Planner.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-1e5ea3140bf5195731831d1f841eab96267fb69ecd723c29629de81b92fca9e6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolReference.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+17/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CodexAppServerClient.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-7db5424c715334f55f416c92dbb7e71f5cf53d07ff8104fe3ba2cf22121a4ca0">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexAppServerClient.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-56fc3e9dbc1425f3ef07598b3ecf7e21c4032c8d9ab52bc5b1ca686fe2cdff8b">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodexReferenceAdapter.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-fdfb6a18bfafa2be87c1e63fd4c5113048bac88026cc6372c364ec3fd683d53a">+216/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CodexReferenceAdapter.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-24a34cb421e858c46bdd7ca2827ea3a87dd8fc920e92fbd83134b770ed17ad96">+42/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatRuntime.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-672bc6f38ffd376b8a5cef8a466aec15fe47ae89d5bf15c48f0c05377e50d664">+113/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>chatRuntime.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-f92a170cff36d13bbdb22254f87f676115c20d195016519dd5b5bd43c00606e7">+129/-35</a></td>

</tr>

<tr>
  <td><strong>useExternalAgentChatRuntime.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-2a0596b825c04e606c8c4fcf384685dde835f6a3ef2b0d66235c83ac162fac71">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useExternalAgentChatRuntime.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-2c130fb40e6a5e933a4323eb79deac53f91f197dd18892d02fbad58bdc1acaeb">+49/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>toolNameNormalization.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-6de6df289c812492e043f4f847b936be1dc811506c279b984a2f6ed014ebbdd0">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolOutputContracts.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-2fe279e63827a652ff07a52579998fb029ad15e9604be67586e5659c39ddc75f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysisTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-ebc3842977d35600a53a65876d8082c469318e39e66177c38b0353647045f040">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysisTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-717609a79d522c08834e29f962677b6c063796dd112f1c4bf93d697292f48a4a">+29/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>editingTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-feff783abcf967fed37830f7fe4794b447012a538bea6a9d96f778cd37b01c7d">+55/-225</a></td>

</tr>

<tr>
  <td><strong>mediaInsertion.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-e53a8674ccfae134ff375b3acbc8430dc8642f5f40f04580db9e29bdd53e4490">+199/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-fba7abc9f4898abb5634a8c17070efef12feabcf68d91924e06c08e62de4e01e">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>textPlacement.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-ea9ceaf1ecd94a24be4b1a993d9739944a16691bb6fd913c347ec8d4377080e6">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>textTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-dff1268b515f3f068adc1e6f9626da204744ba6560ef1be7c1e6cd24cbbb872f">+126/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-969b5e31db360c6d5fc816fb11979bd7020a7e0e24223f25032b805ca9b1bcac">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentRuntimeChatShell.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-cfbd011a7c5d0d30bcefdf80916bd1a897e3da724bc64d6bf16e4fc2430c9233">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProxyPreviewPlayer.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-4fb66225fe90d51ea4b8024f67fef01be0835fa03f17429c0d53e150e85b0e04">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TimelinePreviewPlayer.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-1d323dfd0f9ee6f59ec0c8894eaadedfc0db4647f07cbcc16019ffe23c9f7955">+208/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TimelinePreviewPlayer.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-4d288d619dc53b5be764a00b666c542c6daa5d478e6fd1e7e1a6d6e4c9cf90c0">+31/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>videoGenStore.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-be02911d0b5c764aa6424aefb0ffccc1d6b64162ad28142640dea792ebddfd10">+25/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>videoGenStore.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/715/files#diff-645dd759da902206ce1fbed758751ba743cad976c27e776f5d39bf3bfe8763ae">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart text placement with obstacle-aware auto-placement
  * Approval-gated media insertion (with linked-audio support and rollback)
  * Asset annotation reading tool
  * Turn-steering for continued mid-conversation interactions

* **Improvements**
  * Retain chat runtime across unmounts for smoother sessions
  * Preview/player rendering with boundary preloading and offscreen compositing
  * Richer text styling/editing and updated tool guidance
  * Safer platform command handling during background tasks
  * Expanded tool argument validation and workflow hints

* **Bug Fixes**
  * Prevented Windows console windows during background verification
  * Fixed multi-type tool parameter validation and related edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->