### PR TITLE
fix: stabilize v0.1.5 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    env:
+      GGML_NATIVE: 'OFF'
 
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.0",
  "cexpr",
@@ -500,7 +500,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -529,7 +529,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -1639,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1668,7 +1668,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1807,7 +1807,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2569,7 +2569,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2783,7 +2783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4471,7 +4471,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4939,7 +4939,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4952,7 +4952,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5827,7 +5827,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -6268,7 +6268,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7692,23 +7692,24 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
  "bindgen",
  "cfg-if",
  "cmake",
  "fs_extra",
+ "semver",
 ]
 
 [[package]]
@@ -7774,7 +7775,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8381,7 +8382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -1319,7 +1319,7 @@ fn default_audio_track_position(sequence: &openreelio_core::timeline::Sequence) 
         .enumerate()
         .filter(|(_, track)| matches!(track.kind, TrackKind::Audio))
         .map(|(index, _)| index + 1)
-        .last()
+        .next_back()
         .unwrap_or(sequence.tracks.len())
 }
 
@@ -1804,10 +1804,12 @@ mod tests {
             .expect("add text clip");
         let text_clip_id = text_result.created_ids[0].clone();
 
-        let mut transform = Transform::default();
-        transform.position = Point2D::new(0.42, 0.66);
-        transform.scale = Point2D::new(1.2, 0.9);
-        transform.rotation_deg = 18.0;
+        let transform = Transform {
+            position: Point2D::new(0.42, 0.66),
+            scale: Point2D::new(1.2, 0.9),
+            rotation_deg: 18.0,
+            ..Default::default()
+        };
         project
             .executor
             .execute(

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -40,6 +40,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Project lifecycle operations (create, open, info, save)
     Project {

--- a/scripts/prepare-bundled-ffmpeg.mjs
+++ b/scripts/prepare-bundled-ffmpeg.mjs
@@ -66,6 +66,9 @@ const targets = {
         name: 'ffmpeg',
         format: 'tar.xz',
         url: 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz',
+        fallbackUrls: [
+          'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz',
+        ],
         filename: 'ffmpeg-release-amd64-static.tar.xz',
         binaries: ['ffmpeg', 'ffprobe'],
       },
@@ -115,7 +118,7 @@ async function prepareBundledFfmpeg(releaseTarget, releaseConfig) {
       const extractDir = path.join(downloadRoot, `${source.name}-extracted`);
 
       await mkdir(extractDir, { recursive: true });
-      await downloadFile(source.url, archivePath);
+      await downloadFile(source, archivePath);
       await extractArchive(source.format, archivePath, extractDir);
 
       for (const binaryName of source.binaries) {
@@ -148,14 +151,37 @@ async function prepareBundledFfmpeg(releaseTarget, releaseConfig) {
   }
 }
 
-async function downloadFile(url, outputPath) {
+async function downloadFile(source, outputPath) {
+  const urls = [source.url, ...(source.fallbackUrls ?? [])];
+  let lastError;
+
+  for (const url of urls) {
+    try {
+      await downloadUrl(url, outputPath);
+      return;
+    } catch (error) {
+      lastError = error;
+      console.warn(`Download failed for ${url}: ${error.message}`);
+    }
+  }
+
+  throw lastError ?? new Error(`No download URLs configured for ${source.name}`);
+}
+
+async function downloadUrl(url, outputPath) {
   console.log(`Downloading ${url}`);
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
 
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/octet-stream, application/x-xz, application/zip, */*',
+        'User-Agent': 'OpenReelio release asset downloader',
+      },
+    });
     if (!response.ok || !response.body) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -109,7 +109,7 @@ hound = "3.5"
 webrtc-vad = "0.4"
 
 # Whisper transcription (optional - enabled via whisper feature)
-whisper-rs = { version = "0.15", optional = true }
+whisper-rs = { version = "0.16", optional = true }
 
 # Meilisearch client (optional - enabled via meilisearch feature)
 meilisearch-sdk = { version = "0.27", optional = true }


### PR DESCRIPTION
## Summary

Recovery fix for the v0.1.5 release workflow after the initial tag run exposed two release-only failures:

- Linux release build could fail while downloading the bundled FFmpeg archive from the primary upstream URL with `HTTP 415`; the downloader now sends explicit release download headers and falls back to the BtbN GitHub-hosted Linux FFmpeg archive.
- macOS ARM release build failed while compiling `whisper-rs-sys`/ggml ARM i8mm code; `whisper-rs` is updated to 0.16.0 / `whisper-rs-sys` 0.15.0, and release builds set `GGML_NATIVE=OFF` so release artifacts are not tied to the runner CPU.
- Cleaned up current clippy findings in the CLI while validating the release recovery branch.

## Verification

- `npm run version:check`
- `cargo metadata --format-version=1 --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets --all-features`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo build --locked --release -p openreelio-cli --target x86_64-unknown-linux-gnu`
- `cargo test --locked -p openreelio-cli --all-features`
- `cargo test --locked --manifest-path src-tauri/Cargo.toml whisper --all-features`
- Verified both Linux FFmpeg primary and fallback URLs return 200 with the release downloader headers.