### PR TITLE
fix: stabilize editor preview and docking behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "nanoid": "^3.3.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.12.0",
+        "react-router-dom": "^7.17.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.9"
       },
@@ -4976,9 +4976,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4998,12 +4998,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
-      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.12.0"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nanoid": "^3.3.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.17.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.9"
   },

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -310,6 +310,7 @@ pub fn get_binary_names(platform: Platform) -> (&'static str, &'static str) {
 
 struct DownloadSource {
     url: String,
+    fallback_urls: Vec<String>,
     filename: String,
     sha256: Option<String>,
 }
@@ -318,17 +319,23 @@ fn get_ffmpeg_download_url(platform: Platform, arch: Arch) -> BundlerResult<Down
     match (platform, arch) {
         (Platform::Windows, Arch::X64) => Ok(DownloadSource {
             url: "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip".to_string(),
+            fallback_urls: Vec::new(),
             filename: "ffmpeg-release-essentials.zip".to_string(),
             sha256: None,
         }),
         (Platform::MacOS, Arch::X64) | (Platform::MacOS, Arch::Arm64) => Ok(DownloadSource {
             url: "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip".to_string(),
+            fallback_urls: Vec::new(),
             filename: "ffmpeg.zip".to_string(),
             sha256: None,
         }),
         (Platform::Linux, Arch::X64) => Ok(DownloadSource {
             url: "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
                 .to_string(),
+            fallback_urls: vec![
+                "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
+                    .to_string(),
+            ],
             filename: "ffmpeg-release-amd64-static.tar.xz".to_string(),
             sha256: None,
         }),
@@ -345,6 +352,7 @@ fn get_ffprobe_download_url(
     match (platform, arch) {
         (Platform::MacOS, Arch::X64) | (Platform::MacOS, Arch::Arm64) => Ok(Some(DownloadSource {
             url: "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip".to_string(),
+            fallback_urls: Vec::new(),
             filename: "ffprobe.zip".to_string(),
             sha256: None,
         })),
@@ -353,6 +361,7 @@ fn get_ffprobe_download_url(
 }
 
 fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> BundlerResult<()> {
+    use reqwest::header::{ACCEPT, USER_AGENT};
     use std::time::Duration;
 
     let client = reqwest::blocking::Client::builder()
@@ -364,6 +373,8 @@ fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> Bundle
 
     let response = client
         .get(url)
+        .header(USER_AGENT, "OpenReelio release asset downloader")
+        .header(ACCEPT, "application/octet-stream, application/x-xz, */*")
         .send()
         .map_err(|e| BundlerError::DownloadFailed(format!("Request failed: {e}")))?;
 
@@ -389,6 +400,26 @@ fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> Bundle
     );
 
     Ok(())
+}
+
+fn download_source_blocking(
+    source: &DownloadSource,
+    output: &Path,
+    timeout_secs: u64,
+) -> BundlerResult<()> {
+    let mut errors = Vec::new();
+
+    for url in std::iter::once(&source.url).chain(source.fallback_urls.iter()) {
+        match download_file_blocking(url, output, timeout_secs) {
+            Ok(()) => return Ok(()),
+            Err(error) => errors.push(format!("{url}: {error}")),
+        }
+    }
+
+    Err(BundlerError::DownloadFailed(format!(
+        "All FFmpeg download URLs failed: {}",
+        errors.join("; ")
+    )))
 }
 
 fn verify_archive_checksum(path: &Path, expected_sha256: Option<&str>) -> BundlerResult<()> {
@@ -702,7 +733,7 @@ pub fn download_ffmpeg(output_dir: &Path, config: &BundlerConfig) -> BundlerResu
 
     // Download main FFmpeg archive
     let archive_path = temp_dir.join(&source.filename);
-    download_file_blocking(&source.url, &archive_path, config.timeout_seconds)?;
+    download_source_blocking(&source, &archive_path, config.timeout_seconds)?;
     if config.verify_checksums {
         verify_archive_checksum(&archive_path, source.sha256.as_deref())?;
     }
@@ -722,7 +753,7 @@ pub fn download_ffmpeg(output_dir: &Path, config: &BundlerConfig) -> BundlerResu
     if let Some(ffprobe_src) = ffprobe_source {
         // macOS: Download separate ffprobe
         let ffprobe_archive = temp_dir.join(&ffprobe_src.filename);
-        download_file_blocking(&ffprobe_src.url, &ffprobe_archive, config.timeout_seconds)?;
+        download_source_blocking(&ffprobe_src, &ffprobe_archive, config.timeout_seconds)?;
         if config.verify_checksums {
             verify_archive_checksum(&ffprobe_archive, ffprobe_src.sha256.as_deref())?;
         }

--- a/src/components/features/editor/hooks/useDockableAIPanel.test.tsx
+++ b/src/components/features/editor/hooks/useDockableAIPanel.test.tsx
@@ -69,7 +69,7 @@ describe('useDockableAIPanel', () => {
     expect(useWorkspaceLayoutStore.getState().layout.zones.right.activePanelId).toBe('inspector');
   });
 
-  it('should auto-close the AI panel when the viewport shrinks below the breakpoint', () => {
+  it('should keep the AI panel selected when the viewport shrinks below the breakpoint', () => {
     const { result } = renderHook(() => useDockableAIPanel({ autoCollapseBreakpoint: 1200 }));
 
     act(() => {
@@ -80,8 +80,10 @@ describe('useDockableAIPanel', () => {
 
     setViewportWidth(900);
 
-    expect(result.current.isOpen).toBe(false);
-    expect(useWorkspaceLayoutStore.getState().layout.zones.right.activePanelId).toBe('inspector');
+    expect(result.current.isOpen).toBe(true);
+    expect(useWorkspaceLayoutStore.getState().layout.zones.right.activePanelId).toBe(
+      'ai-assistant',
+    );
   });
 
   it('should allow manually opening the AI panel on a narrow viewport', () => {

--- a/src/components/features/editor/hooks/useDockableAIPanel.ts
+++ b/src/components/features/editor/hooks/useDockableAIPanel.ts
@@ -111,32 +111,6 @@ export function useDockableAIPanel({
     };
   }, [toggle]);
 
-  useEffect(() => {
-    let previousWidth = window.innerWidth;
-
-    const handleResize = () => {
-      const currentWidth = window.innerWidth;
-      const crossedBelowBreakpoint =
-        previousWidth >= autoCollapseBreakpoint && currentWidth < autoCollapseBreakpoint;
-      previousWidth = currentWidth;
-
-      const currentLayout = useWorkspaceLayoutStore.getState().layout;
-      const currentZoneId = findPanelZone(currentLayout, AI_PANEL_ID) ?? DEFAULT_AI_ZONE;
-      const currentZone = currentLayout.zones[currentZoneId];
-      const isCurrentlyOpen = currentZone.activePanelId === AI_PANEL_ID && !currentZone.collapsed;
-
-      if (crossedBelowBreakpoint && isCurrentlyOpen) {
-        closeAiPanel();
-      }
-    };
-
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, [autoCollapseBreakpoint, closeAiPanel]);
-
   return {
     isOpen,
     width,

--- a/src/components/layout/DockZone.test.tsx
+++ b/src/components/layout/DockZone.test.tsx
@@ -66,6 +66,23 @@ describe('DockZone', () => {
       render(<DockZone {...createDefaultProps({ collapsed: true })} />);
       expect(screen.queryByTestId('panel-content-explorer')).not.toBeInTheDocument();
     });
+
+    it('should keep configured active panel content mounted when collapsed', () => {
+      render(
+        <DockZone
+          {...createDefaultProps({
+            activePanelId: 'explorer',
+            collapsed: true,
+            keepMountedPanelIds: ['explorer'],
+          })}
+        />,
+      );
+
+      const content = screen.getByTestId('panel-content-explorer');
+      expect(content).toBeInTheDocument();
+      expect(content.parentElement).toHaveAttribute('aria-hidden', 'true');
+      expect(content.parentElement).toHaveClass('hidden');
+    });
   });
 
   describe('collapse toggle', () => {

--- a/src/components/layout/DockZone.tsx
+++ b/src/components/layout/DockZone.tsx
@@ -76,6 +76,8 @@ export interface DockZoneProps {
   className?: string;
   /** Optional actions rendered on the right side of the tab bar */
   headerActions?: ReactNode;
+  /** Panels that should stay mounted while this zone is collapsed */
+  keepMountedPanelIds?: readonly PanelId[];
 }
 
 // =============================================================================
@@ -148,6 +150,7 @@ export function DockZone({
   collapseDirection = 'vertical',
   className = '',
   headerActions = null,
+  keepMountedPanelIds = [],
 }: DockZoneProps): JSX.Element {
   const [isDropTarget, setIsDropTarget] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -368,6 +371,8 @@ export function DockZone({
   const actionClasses = isHorizontalCollapsed
     ? 'flex shrink-0 flex-col items-center gap-1'
     : 'flex shrink-0 items-center gap-1';
+  const shouldRenderActivePanel =
+    activePanelId !== null && (!collapsed || keepMountedPanelIds.includes(activePanelId));
 
   return (
     <div
@@ -448,11 +453,16 @@ export function DockZone({
       )}
 
       {/* Panel content */}
-      {!collapsed && activePanelId && (
+      {shouldRenderActivePanel && (
         <div
           id={`dock-panel-${activePanelId}`}
           role="tabpanel"
-          className="min-h-0 flex-1 overflow-hidden bg-editor-bg"
+          className={
+            collapsed
+              ? 'hidden'
+              : 'min-h-0 flex-1 overflow-hidden bg-editor-bg'
+          }
+          aria-hidden={collapsed ? true : undefined}
         >
           {renderPanel(activePanelId)}
         </div>

--- a/src/components/layout/DockableEditorLayout.test.tsx
+++ b/src/components/layout/DockableEditorLayout.test.tsx
@@ -82,6 +82,17 @@ describe('DockableEditorLayout', () => {
     expect(screen.queryByText('Inspector')).not.toBeInTheDocument();
   });
 
+  it('should keep the AI panel mounted when responsive auto-collapse hides the right zone', () => {
+    const store = useWorkspaceLayoutStore.getState();
+    store.setActivePanel('right', 'ai-assistant');
+    setViewport(900, 800);
+
+    render(<DockableEditorLayout header={<div>Header</div>} panelContent={panelContent} />);
+
+    expect(screen.getByTestId('dock-zone-right').parentElement).toHaveStyle({ width: '40px' });
+    expect(screen.getByText('AI').parentElement).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('should clamp expanded side widths so the center workspace remains usable', () => {
     const store = useWorkspaceLayoutStore.getState();
     store.setLeftWidth(600);

--- a/src/components/layout/DockableEditorLayout.tsx
+++ b/src/components/layout/DockableEditorLayout.tsx
@@ -49,6 +49,7 @@ const RIGHT_ZONE_AUTO_COLLAPSE_BREAKPOINT = 1100;
 const MAX_SIDE_ZONE_VIEWPORT_SHARE = 0.34;
 /** ResizeHandle thickness from Tailwind w-1 / h-1 */
 const RESIZE_HANDLE_SIZE = 4;
+const KEEP_MOUNTED_PANEL_IDS: readonly PanelId[] = ['ai-assistant'];
 
 interface ViewportSize {
   width: number;
@@ -227,6 +228,7 @@ export function DockableEditorLayout({
     onDragStart: startDrag,
     onDragEnd: endDrag,
     renderPanel,
+    keepMountedPanelIds: KEEP_MOUNTED_PANEL_IDS,
   };
 
   // Filter zone panelIds — hide tabs for panels without renderable content

--- a/src/components/timeline/Timeline.test.tsx
+++ b/src/components/timeline/Timeline.test.tsx
@@ -1296,6 +1296,42 @@ describe('Timeline', () => {
       });
     });
 
+    it('should not expand short content playback duration to the empty timeline minimum', async () => {
+      const sequenceWithShortClip: Sequence = {
+        ...mockSequence,
+        tracks: [
+          {
+            ...mockSequence.tracks[0],
+            clips: [
+              {
+                id: 'clip_duration_short_001',
+                assetId: 'asset_001',
+                range: { sourceInSec: 0, sourceOutSec: 1 },
+                place: { timelineInSec: 0, durationSec: 1 },
+                transform: {
+                  position: { x: 0.5, y: 0.5 },
+                  scale: { x: 1, y: 1 },
+                  rotationDeg: 0,
+                  anchor: { x: 0.5, y: 0.5 },
+                },
+                opacity: 1,
+                speed: 1,
+                effects: [],
+                audio: { volumeDb: 0, pan: 0, muted: false },
+              },
+            ],
+          },
+          mockSequence.tracks[1],
+        ],
+      };
+
+      render(<Timeline sequence={sequenceWithShortClip} />);
+
+      await waitFor(() => {
+        expect(usePlaybackStore.getState().duration).toBe(1);
+      });
+    });
+
     it('should disable split, duplicate, and delete buttons when no clips are selected', () => {
       render(<Timeline sequence={mockSequence} />);
 

--- a/src/components/timeline/Timeline.test.tsx
+++ b/src/components/timeline/Timeline.test.tsx
@@ -1260,6 +1260,42 @@ describe('Timeline', () => {
       expect(screen.getByTestId('enhanced-timeline-toolbar')).toBeInTheDocument();
     });
 
+    it('should sync playback duration to content length without editing tail padding', async () => {
+      const sequenceWithClip: Sequence = {
+        ...mockSequence,
+        tracks: [
+          {
+            ...mockSequence.tracks[0],
+            clips: [
+              {
+                id: 'clip_duration_001',
+                assetId: 'asset_001',
+                range: { sourceInSec: 0, sourceOutSec: 25 },
+                place: { timelineInSec: 0, durationSec: 25 },
+                transform: {
+                  position: { x: 0.5, y: 0.5 },
+                  scale: { x: 1, y: 1 },
+                  rotationDeg: 0,
+                  anchor: { x: 0.5, y: 0.5 },
+                },
+                opacity: 1,
+                speed: 1,
+                effects: [],
+                audio: { volumeDb: 0, pan: 0, muted: false },
+              },
+            ],
+          },
+          mockSequence.tracks[1],
+        ],
+      };
+
+      render(<Timeline sequence={sequenceWithClip} />);
+
+      await waitFor(() => {
+        expect(usePlaybackStore.getState().duration).toBe(25);
+      });
+    });
+
     it('should disable split, duplicate, and delete buttons when no clips are selected', () => {
       render(<Timeline sequence={mockSequence} />);
 

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -399,7 +399,9 @@ export function Timeline({
   // Playback duration is the actual sequence content length. Timeline duration
   // includes tail room for editing but must not leak into player/export timecode.
   const playbackDuration = sequence
-    ? Math.max(clipContentDuration, MIN_EMPTY_TIMELINE_DURATION_SEC)
+    ? clipContentDuration > 0
+      ? clipContentDuration
+      : MIN_EMPTY_TIMELINE_DURATION_SEC
     : DEFAULT_TIMELINE_DURATION;
   const timelineDuration = useMemo(() => {
     if (!sequence) return DEFAULT_TIMELINE_DURATION;

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -100,6 +100,9 @@ const MIN_PENDING_DROP_WIDTH_PX = 88;
 const DEFAULT_PENDING_DROP_DURATION_SEC = 10;
 const PENDING_DROP_VERTICAL_INSET_PX = 3;
 const PENDING_DROP_HEIGHT_PX = TRACK_HEIGHT - PENDING_DROP_VERTICAL_INSET_PX * 2;
+const MIN_EMPTY_TIMELINE_DURATION_SEC = 10;
+const MIN_EDITING_TAIL_PADDING_SEC = 5;
+const EDITING_TAIL_PADDING_RATIO = 0.2;
 
 interface EmptyAreaPanGesture {
   startX: number;
@@ -379,25 +382,35 @@ export function Timeline({
   // ===========================================================================
   // Derived Values
   // ===========================================================================
-  // Calculate timeline duration based on actual clip content
-  // Add padding for easier editing (20% extra or minimum 5 seconds after last clip)
-  const duration = useMemo(() => {
-    if (!sequence) return DEFAULT_TIMELINE_DURATION;
+  const clipContentDuration = useMemo(() => {
+    if (!sequence) return 0;
 
     const clipEndTimes = sequence.tracks.flatMap((track) =>
       track.clips.map((clip) => clip.place.timelineInSec + getClipTimelineDuration(clip)),
     );
 
     if (clipEndTimes.length === 0) {
-      // Empty timeline: show 10 seconds minimum
-      return 10;
+      return 0;
     }
 
-    const maxEndTime = Math.max(...clipEndTimes);
-    // Add 20% padding or minimum 5 seconds for easier editing
-    const padding = Math.max(maxEndTime * 0.2, 5);
-    return maxEndTime + padding;
+    return Math.max(0, ...clipEndTimes);
   }, [sequence]);
+
+  // Playback duration is the actual sequence content length. Timeline duration
+  // includes tail room for editing but must not leak into player/export timecode.
+  const playbackDuration = sequence
+    ? Math.max(clipContentDuration, MIN_EMPTY_TIMELINE_DURATION_SEC)
+    : DEFAULT_TIMELINE_DURATION;
+  const timelineDuration = useMemo(() => {
+    if (!sequence) return DEFAULT_TIMELINE_DURATION;
+    if (clipContentDuration <= 0) return MIN_EMPTY_TIMELINE_DURATION_SEC;
+
+    const padding = Math.max(
+      clipContentDuration * EDITING_TAIL_PADDING_RATIO,
+      MIN_EDITING_TAIL_PADDING_SEC,
+    );
+    return clipContentDuration + padding;
+  }, [clipContentDuration, sequence]);
 
   // ===========================================================================
   // Playback Engine
@@ -409,7 +422,7 @@ export function Timeline({
     seek: setPlayhead,
     stepForward,
     stepBackward,
-  } = useTimelineEngine({ duration, fps: DEFAULT_FPS });
+  } = useTimelineEngine({ duration: playbackDuration, fps: DEFAULT_FPS });
 
   const seekFromTimelineClick = useCallback(
     (time: number) => setPlayhead(time, 'timeline-click-release'),
@@ -453,7 +466,7 @@ export function Timeline({
     sequence,
     zoom,
     scrollX,
-    duration,
+    duration: timelineDuration,
     snapEnabled,
     playhead,
     trackHeaderWidth: TRACK_HEADER_WIDTH,
@@ -487,7 +500,7 @@ export function Timeline({
     playheadRef,
     zoom,
     scrollX,
-    duration,
+    duration: timelineDuration,
     trackHeaderWidth: TRACK_HEADER_WIDTH,
     playheadTrackHeaderWidth: 0, // Playhead is rendered inside a clipped container offset by the header
     isPlaying,
@@ -507,7 +520,7 @@ export function Timeline({
   // Auto-follow hook handles auto-scrolling during playback
   useAutoFollow({
     viewportWidth,
-    contentWidth: duration * zoom,
+    contentWidth: timelineDuration * zoom,
     trackHeaderWidth: TRACK_HEADER_WIDTH,
     isScrubbing,
     isDraggingPlayhead,
@@ -516,7 +529,7 @@ export function Timeline({
   // ===========================================================================
   // Timeline Panning (Hand Tool / Middle Mouse)
   // ===========================================================================
-  const maxScrollX = Math.max(0, duration * zoom - viewportWidth);
+  const maxScrollX = Math.max(0, timelineDuration * zoom - viewportWidth);
   const maxScrollY = Math.max(0, (sequence?.tracks.length ?? 0) * TRACK_HEIGHT - viewportHeight);
   const isHandToolActive = activeTool === 'hand';
 
@@ -1080,7 +1093,7 @@ export function Timeline({
     isActive: isClipDragging && dragPreview !== null,
     getMouseClientX: () => clipDragMouseXRef.current,
     scrollContainerRef: tracksAreaRef,
-    contentWidth: duration * zoom + TRACK_HEADER_WIDTH,
+    contentWidth: timelineDuration * zoom + TRACK_HEADER_WIDTH,
     // Timeline uses virtual scrolling via Zustand (`scrollX`) + transforms (not native scrollLeft).
     getScrollLeft: () => useTimelineStore.getState().scrollX,
     setScrollLeft: setScrollX,
@@ -1093,7 +1106,7 @@ export function Timeline({
     scrollX,
     scrollY,
     zoom,
-    duration,
+    duration: timelineDuration,
     zoomIn,
     zoomOut,
     setZoom,
@@ -1972,14 +1985,14 @@ export function Timeline({
           hasActiveSequence={sequence !== null}
           hasSelectedClips={selectedClipIds.length > 0}
           fps={DEFAULT_FPS}
-          duration={duration}
+          duration={playbackDuration}
         />
 
         {/* isolation: isolate creates a stacking context so playhead z-index doesn't escape to overlap modals */}
         <div className="flex-1 flex flex-col relative isolate">
           <TimelineHeaderLayer
             cacheSegments={cacheSegments}
-            duration={duration}
+            duration={timelineDuration}
             zoom={zoom}
             scrollX={scrollX}
             viewportWidth={viewportWidth}
@@ -2015,7 +2028,7 @@ export function Timeline({
                 sequence={sequence}
                 zoom={zoom}
                 scrollX={scrollX}
-                duration={duration}
+                duration={timelineDuration}
                 viewportWidth={viewportWidth}
                 selectedClipIds={selectedClipIds}
                 getTrackClips={getTrackClips}
@@ -2074,7 +2087,7 @@ export function Timeline({
               scrollX={scrollX}
               shotMarkers={shotMarkers}
               viewportWidth={viewportWidth}
-              duration={duration}
+              duration={timelineDuration}
               onSeekShotMarker={seekFromShotMarker}
               isDraggingOver={isDraggingOver}
               selectionRect={selectionRect}

--- a/src/hooks/usePreviewMode.test.ts
+++ b/src/hooks/usePreviewMode.test.ts
@@ -184,6 +184,41 @@ describe('usePreviewMode', () => {
       expect(result.current.reason).toBe('Keeping video renderer mounted across empty timeline gap');
     });
 
+    it('should switch back to canvas mode when scrubbing into a large empty gap', () => {
+      const track = createMockTrack({
+        clips: [
+          createMockClip({
+            place: { timelineInSec: 0, durationSec: 5 },
+            range: { sourceInSec: 0, sourceOutSec: 5 },
+          }),
+          createMockClip({
+            id: 'clip-2',
+            place: { timelineInSec: 100, durationSec: 5 },
+            range: { sourceInSec: 0, sourceOutSec: 5 },
+          }),
+        ],
+      });
+      const sequence = createMockSequence([track]);
+      const assets = new Map([['asset-1', createMockAsset()]]);
+
+      const { result, rerender } = renderHook(
+        ({ currentTime }: { currentTime: number }) =>
+          usePreviewMode({
+            sequence,
+            assets,
+            currentTime,
+          }),
+        { initialProps: { currentTime: 2 } },
+      );
+
+      expect(result.current.mode).toBe('video');
+
+      rerender({ currentTime: 50 });
+
+      expect(result.current.mode).toBe('canvas');
+      expect(result.current.reason).toBe('No clips at playhead');
+    });
+
     it('should ignore disabled clips when determining active preview content', () => {
       const track = createMockTrack({
         clips: [

--- a/src/hooks/usePreviewMode.test.ts
+++ b/src/hooks/usePreviewMode.test.ts
@@ -149,6 +149,41 @@ describe('usePreviewMode', () => {
       expect(result.current.reason).toBe('No clips at playhead');
     });
 
+    it('should keep the video renderer mounted across empty gaps after video playback', () => {
+      const track = createMockTrack({
+        clips: [
+          createMockClip({
+            place: { timelineInSec: 0, durationSec: 5 },
+            range: { sourceInSec: 0, sourceOutSec: 5 },
+          }),
+          createMockClip({
+            id: 'clip-2',
+            place: { timelineInSec: 10, durationSec: 5 },
+            range: { sourceInSec: 0, sourceOutSec: 5 },
+          }),
+        ],
+      });
+      const sequence = createMockSequence([track]);
+      const assets = new Map([['asset-1', createMockAsset()]]);
+
+      const { result, rerender } = renderHook(
+        ({ currentTime }: { currentTime: number }) =>
+          usePreviewMode({
+            sequence,
+            assets,
+            currentTime,
+          }),
+        { initialProps: { currentTime: 2 } },
+      );
+
+      expect(result.current.mode).toBe('video');
+
+      rerender({ currentTime: 7 });
+
+      expect(result.current.mode).toBe('video');
+      expect(result.current.reason).toBe('Keeping video renderer mounted across empty timeline gap');
+    });
+
     it('should ignore disabled clips when determining active preview content', () => {
       const track = createMockTrack({
         clips: [

--- a/src/hooks/usePreviewMode.ts
+++ b/src/hooks/usePreviewMode.ts
@@ -230,20 +230,22 @@ export function usePreviewMode({
     // Find all active clips at current time
     const activeClips = findActiveClips(sequence, currentTime, assets);
 
-    // No clips at playhead = canvas mode (show black frame)
+    // No clips at playhead: preserve the previous renderer when possible.
+    // Switching video -> canvas -> video across short gaps remounts media
+    // elements and can cause visible loading stalls at the next cut.
     if (activeClips.length === 0) {
       const previousResult = previousResultRef.current;
       const previousTime = previousTimeRef.current;
 
-      if (
-        previousResult &&
-        previousTime !== null &&
-        previousResult.mode === 'video' &&
-        Math.abs(currentTime - previousTime) <= NO_CLIP_HYSTERESIS_SEC
-      ) {
+      if (previousResult && previousResult.mode === 'video') {
+        const isNearPreviousFrame =
+          previousTime !== null &&
+          Math.abs(currentTime - previousTime) <= NO_CLIP_HYSTERESIS_SEC;
         const stabilizedResult: PreviewModeResult = {
           ...previousResult,
-          reason: 'Stabilizing mode at clip boundary',
+          reason: isNearPreviousFrame
+            ? 'Stabilizing mode at clip boundary'
+            : 'Keeping video renderer mounted across empty timeline gap',
         };
         previousResultRef.current = stabilizedResult;
         previousTimeRef.current = currentTime;

--- a/src/hooks/usePreviewMode.ts
+++ b/src/hooks/usePreviewMode.ts
@@ -7,7 +7,7 @@
 
 import { useMemo, useRef } from 'react';
 import { isTextClip, type Sequence, type Asset, type Clip, type Track } from '@/types';
-import { isClipActiveAtTime } from '@/utils/clipTiming';
+import { getClipTimelineDurationSec, isClipActiveAtTime } from '@/utils/clipTiming';
 import { isCaptionLikeClip } from '@/utils/captionClip';
 import { getEffectiveBlendMode } from '@/utils/blendModes';
 
@@ -50,6 +50,7 @@ interface ActiveClipInfo {
 const FLOAT_EPSILON = 0.0001;
 const ACTIVE_CLIP_EPSILON_SEC = 1 / 240;
 const NO_CLIP_HYSTERESIS_SEC = 1 / 30;
+const MAX_EMPTY_VIDEO_GAP_SEC = 10;
 const URI_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
 
 function nearlyEqual(a: number, b: number): boolean {
@@ -86,6 +87,58 @@ function findActiveClips(
   }
 
   return activeClips;
+}
+
+function isVideoModeCompatibleVisualClip(
+  track: Track,
+  clip: Clip,
+  assets: Map<string, Asset>,
+): boolean {
+  if (track.kind === 'audio') {
+    return false;
+  }
+
+  return getCanvasFallbackReason({
+    clip,
+    track,
+    asset: assets.get(clip.assetId) ?? null,
+  }) === null;
+}
+
+function isWithinVideoModeGap(
+  sequence: Sequence,
+  currentTime: number,
+  assets: Map<string, Asset>,
+): boolean {
+  let previousEnd: number | null = null;
+  let nextStart: number | null = null;
+
+  for (const track of sequence.tracks) {
+    if (track.muted || !track.visible) continue;
+
+    for (const clip of track.clips) {
+      if (clip.enabled === false || !isVideoModeCompatibleVisualClip(track, clip, assets)) {
+        continue;
+      }
+
+      const start = clip.place.timelineInSec;
+      const end = start + getClipTimelineDurationSec(clip);
+
+      if (end <= currentTime + FLOAT_EPSILON) {
+        previousEnd = previousEnd === null ? end : Math.max(previousEnd, end);
+      } else if (start > currentTime + FLOAT_EPSILON) {
+        nextStart = nextStart === null ? start : Math.min(nextStart, start);
+      }
+    }
+  }
+
+  return (
+    previousEnd !== null &&
+    nextStart !== null &&
+    currentTime >= previousEnd - FLOAT_EPSILON &&
+    currentTime <= nextStart + FLOAT_EPSILON &&
+    nextStart - previousEnd <= MAX_EMPTY_VIDEO_GAP_SEC
+  );
 }
 
 /**
@@ -241,6 +294,20 @@ export function usePreviewMode({
         const isNearPreviousFrame =
           previousTime !== null &&
           Math.abs(currentTime - previousTime) <= NO_CLIP_HYSTERESIS_SEC;
+        const isInVideoModeGap = isWithinVideoModeGap(sequence, currentTime, assets);
+
+        if (!isNearPreviousFrame && !isInVideoModeGap) {
+          const result: PreviewModeResult = {
+            mode: 'canvas',
+            reason: 'No clips at playhead',
+            hasGeneratingProxy: false,
+            clipsNeedingProxy: 0,
+          };
+          previousResultRef.current = result;
+          previousTimeRef.current = currentTime;
+          return result;
+        }
+
         const stabilizedResult: PreviewModeResult = {
           ...previousResult,
           reason: isNearPreviousFrame


### PR DESCRIPTION
## Description

Fixes editor stability issues around responsive docking, preview renderer lifetime, and timeline duration calculation. Follow-up review fixes now keep playback duration equal to actual content for short clips, avoid preserving the video renderer across large empty scrubs, and stabilize CI by updating React Router and hardening FFmpeg downloads.

## Related Issue

Closes #726, closes #727, closes #728

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Keep configured dock panels mounted while collapsed and apply that behavior to the AI assistant panel.
- Preserve the video renderer only across bounded video-compatible empty gaps while returning to canvas for large empty scrubs.
- Use actual content length for playback duration when clips exist, while preserving an empty-timeline minimum and padded editing duration.
- Update React Router to a non-vulnerable version for the production security audit.
- Add FFmpeg download headers and Linux fallback URL support for reliable bundler checks.

## Screenshots / Videos

N/A

## Testing

Ran focused regression tests, build/type/lint checks, Rust bundler/detection checks, a full FFmpeg download test, and confirmed GitHub Actions passed on PR #729.

### Test Environment

- OS: Ubuntu 24.04.4 LTS
- Node.js version: v22.22.0
- Rust version: rustc 1.93.1 (01f6ddf75 2026-02-11)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Local validation included `npm run test:run -- src/hooks/usePreviewMode.test.ts src/components/timeline/Timeline.test.tsx src/components/layout/DockZone.test.tsx src/components/layout/DockableEditorLayout.test.tsx src/components/features/editor/hooks/useDockableAIPanel.test.tsx`, `npm run type-check`, `npm run lint`, `npm run build`, `npm audit --omit=dev --audit-level=high`, `cargo fmt --all --check`, `SKIP_FFMPEG_DOWNLOAD=1 cargo clippy --locked --all-targets --all-features -- -D warnings`, `OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 cargo test --locked bundler --no-default-features --features bundled-ffmpeg -- --nocapture`, `cargo test --locked detection --no-default-features -- --nocapture`, and `OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 cargo test --locked test_download_ffmpeg_full --no-default-features --features bundled-ffmpeg -- --ignored --nocapture`.

GitHub Actions run `27030312123` passed all PR checks. The repository lint hook still reports the existing Fast Refresh warning in `src/components/features/agent/parts/ClipAnalysisResultCard.tsx:166`; this PR does not touch that file. A local non-sharded `npm run test:ci-local` run was stopped after extended progress with no observed failures because GitHub CI runs the frontend suite in shards.
