### PR TITLE
Fix async race conditions across AI, preview, timeline, and workspace sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,36 +920,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
+checksum = "2ad3e7d446bbdc05f33371b17aae2857e2c5f1dd6750848f555c129c5060725f"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
+checksum = "96ee145f9cbf7474350ee48e5c33ec2312177fa32c07e4eb395727250892a201"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
+checksum = "7025668e34c499fd0960dfaf68bc1689c961002fb67227f3dd262535c4118e52"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
+checksum = "4ad0b552e9b906fee4416b68664463e80f9024215da2cebd4065eee99d5d3008"
 dependencies = [
  "serde",
  "serde_derive",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
+checksum = "f87371fa1b0e21dc0a7943f372ce5a308c7d6b26ef8c9982a8a063218fe101ae"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
+checksum = "a24ef297d4dd3af3e571691568958ceea1d3e723bb24eef4e934bbd569c93ef6"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -997,24 +997,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
+checksum = "d65396f589d1f746f52db7370372bc8611aa7a5bc0b0322f77deaa1b62e12287"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
+checksum = "a5731530f81a1566057f9475639f34463e723210ef2484fe9f087e03d79e879a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
+checksum = "3437f152d3766d07420956f4eabaa6f89fa98543e53d387dd1e395980441c68d"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
+checksum = "c9dbb5c65123d9bd76a701523d72f78e1f9b754321caa7767a70ea9304f49be1"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1035,15 +1035,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
+checksum = "a493c7a6e01f9c6e9b5468faa7f13a06d6d882f92942f8042a0fd0a8e3e8bc2c"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
+checksum = "79bd8bd6a0a5bce75e9b24b4e9578114ef6be94795956c4d19aeaa1da607abfd"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
+checksum = "7c33438ba0b8ba75137bd45eb0d36a319efe90cf145f9fd5773b84f0b89f0edc"
 
 [[package]]
 name = "crc"
@@ -4389,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
+checksum = "fae33db3d81aa92ead4ba06f7f9bbf32b2d8ff4132a00df5fa0913fd03dfa33c"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4401,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
+checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7222,9 +7222,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
+checksum = "319b720df5e1c49b5dbc916d28a386aad3f03ed96fa3cebe2c6270eb11b6baf3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -7277,9 +7277,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
+checksum = "acc2633f356486b8c5917e2aad7aca2b5b54f0f674a8f384a166e34d48101893"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7304,18 +7304,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
+checksum = "f0e647efa7382e8cc8b668ee871af1da0f097d5f12ba2242ac865107c30996e8"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
+checksum = "acd2f0ea194190ae3d89e7d3f7a9bf95ccf7decdcb27ddef8418f7e03f5aeed5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7333,9 +7333,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aba228ec4f646cb9514be55538c842822cb96f2c306f75d664eea6b6f2e9eb"
+checksum = "13915309c8ac371ce8aaadf856aad7a7685e390fdf158df1d35c3b0b7a320c44"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7348,15 +7348,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f4a2387b0aea544aa2317e295583be54fed852e0d1a31c0070984bfd6a507"
+checksum = "08935e3f35beb765593e42432b6f97fd6df16f1c9aa629a79137a04d30a168f4"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
+checksum = "dd24355be6b01300639f3fd2e83dfbb75efc18a3d3386e955e87415c96fc105d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7381,9 +7381,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
+checksum = "d322d8644a6057b221215ca579c40e4bdf90146119d4dc5172d2b37b1a0e3bb9"
 dependencies = [
  "anyhow",
  "cc",
@@ -7397,9 +7397,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
+checksum = "307cef37d6c5563e0a408e24ab983b06ebe3ec27dd01675c7e7b12133205484c"
 dependencies = [
  "cc",
  "object",
@@ -7409,9 +7409,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
+checksum = "1f2e02bd5006f643d8787a33c71e8fb401f029a35df25cd237d25d6d2ddc1c07"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7421,24 +7421,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
+checksum = "a28b0166bd79eb87e2e2e9d6ed7bc6c593428cadfd82cbc94fd113268c29d36a"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
+checksum = "1c3295d1f1de2f3769b749a15e8f64341c38da6faa7fcd737ed485eb3fa40158"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
+checksum = "a34055eb99cdff44ddd277e3b3baec670ef0302c847465c894f1118d4e7b1e3d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7449,9 +7449,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
+checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7460,9 +7460,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
+checksum = "c08a4d8a3501080d3707f845acfcd2fedec9bb91dad3fd9078b7a17e8c8a0884"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7477,9 +7477,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c97d4e849494d290e05573298bd372e12be86b2074502dc5e02f4ef7628002"
+checksum = "cc86f7cc67cafad52959bc1b91176d73e1ed6dbcc00c7a31b3c0a30ac32e881a"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -7490,9 +7490,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eabc75a6afeac11870ee5402268ec0f61fc394728d6dcbe5091a57dc6eb5a57"
+checksum = "e53a8072429ae61b472280b33b61dc0d21173b2b21b68a18bb9cc2024d18414d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7521,9 +7521,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367b77d382241c7f9b3cde3c8cfc1c0d800f04d665622779a724b71d0a2a2028"
+checksum = "d3bd4ac921831465ff97529a528e93f786095adf748d03736e2bd7fb3b0f5623"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7714,9 +7714,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aed7ef247a05956b0a25e7905fdb709ae89e506547af42897e40301b0658d07"
+checksum = "7406efc093a6a31c9a48fb7346e721088a6c9426056217012f1c31e206d07d4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7729,9 +7729,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d5550c5f49730d0a8babd089771ff7412e598cf8f7bbe3b647b8e2147a11b"
+checksum = "57eb5ff74b0b8b35b22a484a340732dce2f6f2ebb1e54aae0bb2a7f6e72e4285"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -7743,9 +7743,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602175405f0c04fd47439ad6afc5e151c4864883259254d3676562bfb00a7ce8"
+checksum = "cba7d2d428b0753e045dd2144b02cb96e0ae7e4f17965905025391ea6810fb5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7786,9 +7786,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
+checksum = "e33afb2737056d7162813a167fc53b8d986e725724a4e6c76ca9910952bb94b5"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -116,8 +116,8 @@ meilisearch-sdk = { version = "0.27", optional = true }
 futures = { version = "0.3", optional = true }
 
 # WASM Plugin System
-wasmtime = "36.0.10"
-wasmtime-wasi = "36.0.10"
+wasmtime = "36.0.11"
+wasmtime-wasi = "36.0.11"
 
 # Workspace filesystem scanning and watching
 notify = { version = "7", features = ["macos_fsevent"] }

--- a/src-tauri/src/core/commands/asset.rs
+++ b/src-tauri/src/core/commands/asset.rs
@@ -634,7 +634,17 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join(file_name);
         std::fs::write(&path, b"test").unwrap();
-        (dir, path.to_string_lossy().to_string())
+        let path = std::fs::canonicalize(&path).unwrap_or(path);
+        (dir, strip_windows_unc_prefix(path))
+    }
+
+    fn strip_windows_unc_prefix(path: std::path::PathBuf) -> String {
+        let path = path.to_string_lossy();
+        normalize_windows_unc_prefix(&path)
+    }
+
+    fn normalize_windows_unc_prefix(path: &str) -> String {
+        path.strip_prefix(r"\\?\").unwrap_or(path).to_string()
     }
 
     #[test]
@@ -842,7 +852,7 @@ mod tests {
         update_cmd.undo(&mut state).unwrap();
 
         let asset = state.assets.get(asset_id).unwrap();
-        assert_eq!(asset.uri, uri);
+        assert_eq!(normalize_windows_unc_prefix(&asset.uri), uri);
         assert_eq!(asset.duration_sec, Some(10.0));
         assert_eq!(asset.file_size, 100);
         assert_eq!(

--- a/src/agents/external/adapters/CodexTauriAppServerTransport.test.ts
+++ b/src/agents/external/adapters/CodexTauriAppServerTransport.test.ts
@@ -295,4 +295,43 @@ describe('CodexTauriAppServerTransport', () => {
     // The early message must be replayed to the late-registering consumer.
     expect(handler).toHaveBeenCalledWith({ id: 1, result: { ready: true } });
   });
+
+  it('should replay early errors that arrive before an error consumer registers', async () => {
+    let listener: (event: { payload: CodexAppServerStreamEvent }) => void = () => undefined;
+    const invokeCommand = vi.fn().mockImplementation(async () => {
+      // Simulate startup diagnostics that arrive before start() resolves and
+      // before the consumer has a chance to attach onError.
+      listener({ payload: { type: 'error', message: 'Early failure' } });
+      listener({ payload: { type: 'exit', exitCode: 1 } });
+      return {
+        serverId: 'server-1',
+        eventName: 'codex:app-server:server-1',
+        command: 'codex',
+        args: ['app-server'],
+        bridgeCwd: '/openreelio-app-data/codex/bridge',
+      };
+    });
+    const listenEvent = vi.fn().mockImplementation(async (_eventName, handler) => {
+      listener = handler;
+      return vi.fn();
+    });
+
+    const transport = await CodexTauriAppServerTransport.start(
+      { serverId: 'server-1' },
+      { invoke: invokeCommand, listen: listenEvent },
+    );
+
+    const errorHandler = vi.fn();
+    transport.onError(errorHandler);
+
+    expect(errorHandler).toHaveBeenCalledTimes(2);
+    expect(errorHandler).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: 'Early failure' }),
+    );
+    expect(errorHandler).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: 'Codex app-server exited with exit code 1.' }),
+    );
+  });
 });

--- a/src/agents/external/adapters/CodexTauriAppServerTransport.test.ts
+++ b/src/agents/external/adapters/CodexTauriAppServerTransport.test.ts
@@ -198,7 +198,14 @@ describe('CodexTauriAppServerTransport', () => {
 
     expect(client).toBeDefined();
     expect(invokeCommand).toHaveBeenCalledWith('start_codex_app_server', {
-      input: { serverId: null, projectPath: '/project', model: null, reasoningEffort: null },
+      input: {
+        // The client now derives a server id so it can subscribe to the stream
+        // event channel before the backend spawns the process.
+        serverId: expect.any(String),
+        projectPath: '/project',
+        model: null,
+        reasoningEffort: null,
+      },
     });
   });
 
@@ -219,11 +226,73 @@ describe('CodexTauriAppServerTransport', () => {
 
     expect(invokeCommand).toHaveBeenCalledWith('start_codex_app_server', {
       input: {
-        serverId: null,
+        serverId: expect.any(String),
         projectPath: '/project',
         model: 'gpt-5.4',
         reasoningEffort: 'high',
       },
     });
+  });
+
+  it('should subscribe to the stream channel before starting the backend process', async () => {
+    const order: string[] = [];
+    const invokeCommand = vi.fn().mockImplementation(async (command: string) => {
+      order.push(`invoke:${command}`);
+      return {
+        serverId: 'server-1',
+        eventName: 'codex:app-server:server-1',
+        command: 'codex',
+        args: ['app-server'],
+        bridgeCwd: '/openreelio-app-data/codex/bridge',
+      };
+    });
+    const listenEvent = vi.fn().mockImplementation(async () => {
+      order.push('listen');
+      return vi.fn();
+    });
+
+    await CodexTauriAppServerTransport.start(
+      { serverId: 'server-1' },
+      { invoke: invokeCommand, listen: listenEvent },
+    );
+
+    // The listener must be attached before the backend spawns the process so
+    // early stderr/exit events cannot be dropped.
+    expect(order[0]).toBe('listen');
+    expect(order).toContain('invoke:start_codex_app_server');
+    expect(order.indexOf('listen')).toBeLessThan(
+      order.indexOf('invoke:start_codex_app_server'),
+    );
+  });
+
+  it('should replay events that arrive before a consumer registers', async () => {
+    let listener: (event: { payload: CodexAppServerStreamEvent }) => void = () => undefined;
+    const invokeCommand = vi.fn().mockImplementation(async () => {
+      // Simulate the backend emitting an early message before start() resolves
+      // (the readers are spawned before the command returns).
+      listener({ payload: { type: 'message', message: { id: 1, result: { ready: true } } } });
+      return {
+        serverId: 'server-1',
+        eventName: 'codex:app-server:server-1',
+        command: 'codex',
+        args: ['app-server'],
+        bridgeCwd: '/openreelio-app-data/codex/bridge',
+      };
+    });
+    const listenEvent = vi.fn().mockImplementation(async (_eventName, handler) => {
+      listener = handler;
+      return vi.fn();
+    });
+
+    const transport = await CodexTauriAppServerTransport.start(
+      { serverId: 'server-1' },
+      { invoke: invokeCommand, listen: listenEvent },
+    );
+
+    const handler = vi.fn();
+    transport.onMessage(handler);
+
+    // The early message must be replayed to the late-registering consumer.
+    expect(handler).toHaveBeenCalledWith({ id: 1, result: { ready: true } });
   });
 });

--- a/src/agents/external/adapters/CodexTauriAppServerTransport.ts
+++ b/src/agents/external/adapters/CodexTauriAppServerTransport.ts
@@ -80,7 +80,7 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
   // crash emitted right after spawn) are buffered and replayed on registration
   // so they are never silently dropped.
   private readonly bufferedMessages: CodexAppServerIncomingMessage[] = [];
-  private pendingError: Error | null = null;
+  private readonly bufferedErrors: Error[] = [];
 
   private constructor(
     readonly startResult: CodexAppServerStartResult,
@@ -190,11 +190,11 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
 
   onError(handler: (error: Error) => void): () => void {
     this.errorHandlers.add(handler);
-    // Replay an error buffered before an error consumer was registered.
-    if (this.pendingError) {
-      const error = this.pendingError;
-      this.pendingError = null;
-      handler(error);
+    // Replay any errors buffered before an error consumer was registered.
+    if (this.bufferedErrors.length > 0) {
+      for (const error of this.bufferedErrors.splice(0)) {
+        handler(error);
+      }
     }
     return () => this.errorHandlers.delete(handler);
   }
@@ -210,7 +210,7 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
     this.handlers.clear();
     this.errorHandlers.clear();
     this.bufferedMessages.length = 0;
-    this.pendingError = null;
+    this.bufferedErrors.length = 0;
 
     if (this.options.autoStopOnDispose ?? true) {
       await this.invokeCommand('stop_codex_app_server', {
@@ -257,10 +257,8 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
   private emitError(message: string): void {
     const error = new Error(message);
     if (this.errorHandlers.size === 0) {
-      // Retain the first error until an error consumer registers (see onError).
-      if (!this.pendingError) {
-        this.pendingError = error;
-      }
+      // Buffer until a consumer registers (see onError).
+      this.bufferedErrors.push(error);
       return;
     }
     for (const handler of this.errorHandlers) {

--- a/src/agents/external/adapters/CodexTauriAppServerTransport.ts
+++ b/src/agents/external/adapters/CodexTauriAppServerTransport.ts
@@ -32,6 +32,34 @@ export type CodexAppServerStreamEvent =
 type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
 type TauriListen = <T>(event: string, handler: (event: Event<T>) => void) => Promise<UnlistenFn>;
 
+// Must match the backend constant `CODEX_APP_SERVER_EVENT_PREFIX`
+// (src-tauri/src/core/codex_app_server.rs). Used only to predict the stream
+// event name so we can subscribe before the backend spawns the process; the
+// backend-reported `eventName` remains authoritative if this ever drifts.
+const CODEX_APP_SERVER_EVENT_PREFIX = 'codex:app-server';
+
+function codexAppServerEventName(serverId: string): string {
+  return `${CODEX_APP_SERVER_EVENT_PREFIX}:${serverId}`;
+}
+
+/**
+ * Generate a client-side server id so the stream event name is known before the
+ * backend spawns the codex process. The backend accepts any non-empty id
+ * (<= 128 chars) and reuses it verbatim.
+ */
+function generateCodexServerId(): string {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return cryptoObj.randomUUID();
+  }
+  return `codex-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+}
+
+function normalizeCodexServerId(serverId?: string | null): string {
+  const trimmed = serverId?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : generateCodexServerId();
+}
+
 export interface CodexTauriAppServerTransportDependencies {
   invoke?: TauriInvoke;
   listen?: TauriListen;
@@ -43,24 +71,25 @@ export interface CodexTauriAppServerTransportOptions {
 
 export class CodexTauriAppServerTransport implements CodexAppServerTransport {
   private readonly invokeCommand: TauriInvoke;
-  private readonly listenEvent: TauriListen;
   private readonly handlers = new Set<(message: CodexAppServerIncomingMessage) => void>();
   private readonly errorHandlers = new Set<(error: Error) => void>();
   private readonly unlistenPromise: Promise<UnlistenFn>;
   private disposed = false;
   private lastStderrLine: string | null = null;
+  // Events that arrive before a consumer registers (e.g. an immediate process
+  // crash emitted right after spawn) are buffered and replayed on registration
+  // so they are never silently dropped.
+  private readonly bufferedMessages: CodexAppServerIncomingMessage[] = [];
+  private pendingError: Error | null = null;
 
   private constructor(
     readonly startResult: CodexAppServerStartResult,
     dependencies: CodexTauriAppServerTransportDependencies = {},
     private readonly options: CodexTauriAppServerTransportOptions = {},
+    unlistenPromise: Promise<UnlistenFn> = Promise.resolve(() => undefined),
   ) {
     this.invokeCommand = dependencies.invoke ?? invoke;
-    this.listenEvent = dependencies.listen ?? listen;
-    this.unlistenPromise = this.listenEvent<CodexAppServerStreamEvent>(
-      startResult.eventName,
-      (event) => this.handleStreamEvent(event.payload),
-    );
+    this.unlistenPromise = unlistenPromise;
   }
 
   static async start(
@@ -69,16 +98,74 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
     options: CodexTauriAppServerTransportOptions = {},
   ): Promise<CodexTauriAppServerTransport> {
     const invokeCommand = dependencies.invoke ?? invoke;
-    const startResult = (await invokeCommand('start_codex_app_server', {
-      input: {
-        serverId: input.serverId ?? null,
-        projectPath: input.projectPath ?? null,
-        model: input.model ?? null,
-        reasoningEffort: input.reasoningEffort ?? null,
-      },
-    })) as CodexAppServerStartResult;
+    const listenEvent = dependencies.listen ?? listen;
 
-    return new CodexTauriAppServerTransport(startResult, dependencies, options);
+    // Derive the server id (and therefore the stream event name) on the client so
+    // we can subscribe BEFORE the backend spawns the codex process. The backend
+    // spawns its stdout/stderr readers before start_codex_app_server returns and
+    // Tauri does not buffer events for absent listeners, so a process that fails
+    // immediately could emit its exit/error before a post-start listener attached
+    // - leaving the caller waiting forever.
+    const serverId = normalizeCodexServerId(input.serverId);
+    const predictedEventName = codexAppServerEventName(serverId);
+
+    // Until the transport exists, route incoming events into a buffer.
+    const earlyEvents: CodexAppServerStreamEvent[] = [];
+    let sink: (event: CodexAppServerStreamEvent) => void = (event) => {
+      earlyEvents.push(event);
+    };
+
+    let unlistenPromise = listenEvent<CodexAppServerStreamEvent>(
+      predictedEventName,
+      (event) => sink(event.payload),
+    );
+    // Ensure the subscription is active before the backend can emit.
+    await unlistenPromise;
+
+    let startResult: CodexAppServerStartResult;
+    try {
+      startResult = (await invokeCommand('start_codex_app_server', {
+        input: {
+          serverId,
+          projectPath: input.projectPath ?? null,
+          model: input.model ?? null,
+          reasoningEffort: input.reasoningEffort ?? null,
+        },
+      })) as CodexAppServerStartResult;
+    } catch (error) {
+      sink = () => undefined;
+      (await unlistenPromise)();
+      throw error;
+    }
+
+    // The backend-reported event name is authoritative. If it differs from our
+    // prediction (e.g. the naming scheme changed), drop the optimistic listener
+    // and subscribe to the real channel so correctness never depends on the
+    // predicted name matching.
+    if (startResult.eventName !== predictedEventName) {
+      (await unlistenPromise)();
+      unlistenPromise = listenEvent<CodexAppServerStreamEvent>(
+        startResult.eventName,
+        (event) => sink(event.payload),
+      );
+      await unlistenPromise;
+    }
+
+    const transport = new CodexTauriAppServerTransport(
+      startResult,
+      dependencies,
+      options,
+      unlistenPromise,
+    );
+
+    // Route future events into the transport and replay any that arrived before
+    // it was constructed.
+    sink = (event) => transport.handleStreamEvent(event);
+    for (const event of earlyEvents.splice(0)) {
+      transport.handleStreamEvent(event);
+    }
+
+    return transport;
   }
 
   send(message: CodexAppServerOutgoingMessage): Promise<void> {
@@ -92,11 +179,23 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
 
   onMessage(handler: (message: CodexAppServerIncomingMessage) => void): () => void {
     this.handlers.add(handler);
+    // Replay any messages buffered before a consumer was registered.
+    if (this.bufferedMessages.length > 0) {
+      for (const message of this.bufferedMessages.splice(0)) {
+        handler(message);
+      }
+    }
     return () => this.handlers.delete(handler);
   }
 
   onError(handler: (error: Error) => void): () => void {
     this.errorHandlers.add(handler);
+    // Replay an error buffered before an error consumer was registered.
+    if (this.pendingError) {
+      const error = this.pendingError;
+      this.pendingError = null;
+      handler(error);
+    }
     return () => this.errorHandlers.delete(handler);
   }
 
@@ -110,6 +209,8 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
     unlisten();
     this.handlers.clear();
     this.errorHandlers.clear();
+    this.bufferedMessages.length = 0;
+    this.pendingError = null;
 
     if (this.options.autoStopOnDispose ?? true) {
       await this.invokeCommand('stop_codex_app_server', {
@@ -124,6 +225,11 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
     }
 
     if (event.type === 'message') {
+      if (this.handlers.size === 0) {
+        // Buffer until a consumer registers (see onMessage).
+        this.bufferedMessages.push(event.message);
+        return;
+      }
       for (const handler of this.handlers) {
         handler(event.message);
       }
@@ -150,6 +256,13 @@ export class CodexTauriAppServerTransport implements CodexAppServerTransport {
 
   private emitError(message: string): void {
     const error = new Error(message);
+    if (this.errorHandlers.size === 0) {
+      // Retain the first error until an error consumer registers (see onError).
+      if (!this.pendingError) {
+        this.pendingError = error;
+      }
+      return;
+    }
     for (const handler of this.errorHandlers) {
       handler(error);
     }

--- a/src/components/preview/FullscreenPreview.tsx
+++ b/src/components/preview/FullscreenPreview.tsx
@@ -126,6 +126,8 @@ export function FullscreenPreview({
   // videoRef kept for future PiP implementation and direct video element access
   const videoRef = useRef<HTMLVideoElement>(null);
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Holds the active window-level release listener while the seek bar is dragged.
+  const seekReleaseHandlerRef = useRef<(() => void) | null>(null);
 
   // Local state
   const [showControls, setShowControls] = useState(true);
@@ -281,13 +283,28 @@ export function FullscreenPreview({
   // Seek Bar Handling
   // ===========================================================================
 
-  const handleSeekStart = useCallback(() => {
-    setIsDraggingSeek(true);
-  }, []);
-
   const handleSeekEnd = useCallback(() => {
     setIsDraggingSeek(false);
+    if (seekReleaseHandlerRef.current) {
+      window.removeEventListener('mouseup', seekReleaseHandlerRef.current);
+      window.removeEventListener('touchend', seekReleaseHandlerRef.current);
+      seekReleaseHandlerRef.current = null;
+    }
   }, []);
+
+  const handleSeekStart = useCallback(() => {
+    setIsDraggingSeek(true);
+    // The range input's own onMouseUp/onTouchEnd does not fire when the pointer
+    // is released outside the element (common when overshooting the slider
+    // thumb), which would leave isDraggingSeek stuck true and permanently
+    // suppress the auto-hide-controls timer. Listen on window so the release is
+    // always caught regardless of where it happens.
+    if (seekReleaseHandlerRef.current) return;
+    const handleRelease = (): void => handleSeekEnd();
+    seekReleaseHandlerRef.current = handleRelease;
+    window.addEventListener('mouseup', handleRelease);
+    window.addEventListener('touchend', handleRelease);
+  }, [handleSeekEnd]);
 
   const handleSeekChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -320,6 +337,13 @@ export function FullscreenPreview({
     return () => {
       if (hideTimeoutRef.current) {
         clearTimeout(hideTimeoutRef.current);
+      }
+      // Remove any window-level seek release listener still attached if the
+      // component unmounts mid-drag.
+      if (seekReleaseHandlerRef.current) {
+        window.removeEventListener('mouseup', seekReleaseHandlerRef.current);
+        window.removeEventListener('touchend', seekReleaseHandlerRef.current);
+        seekReleaseHandlerRef.current = null;
       }
     };
   }, []);

--- a/src/components/preview/ProxyPreviewPlayer.tsx
+++ b/src/components/preview/ProxyPreviewPlayer.tsx
@@ -1067,6 +1067,18 @@ export function ProxyPreviewPlayer({
   // Track playback start time for synthetic time advancement
   const playbackStartRef = useRef<{ timestamp: number; timelineTime: number } | null>(null);
 
+  // Mirror frequently-changing playback values into refs so the RAF loop callback
+  // can read the latest values without listing them as dependencies. Keeping them
+  // out of updatePlayback's dep array gives the callback a stable identity, so the
+  // start/stop effect below runs once per play/pause transition instead of every
+  // frame (which previously orphaned a requestAnimationFrame handle each frame).
+  const currentTimeRef = useRef(currentTime);
+  currentTimeRef.current = currentTime;
+  const playbackRateRef = useRef(playbackRate);
+  playbackRateRef.current = playbackRate;
+  const durationRef = useRef(duration);
+  durationRef.current = duration;
+
   // Animation frame loop for playback
   const updatePlayback = useCallback(
     (timestamp: number) => {
@@ -1091,7 +1103,7 @@ export function ProxyPreviewPlayer({
               const offsetInSource = video.currentTime - clip.range.sourceInSec;
               const safeSpeed = getSafeClipSpeed(clip);
               const timelineTime = clip.place.timelineInSec + offsetInSource / safeSpeed;
-              const clampedTimelineTime = clampTimelineTime(timelineTime, duration);
+              const clampedTimelineTime = clampTimelineTime(timelineTime, durationRef.current);
               setCurrentTime(clampedTimelineTime, 'proxy-video-clock');
               // Update synthetic time reference
               playbackStartRef.current = { timestamp, timelineTime: clampedTimelineTime };
@@ -1104,12 +1116,13 @@ export function ProxyPreviewPlayer({
           // This ensures playback continues even when all videos fail to load
           if (!foundVideoSource && prevTimestamp > 0) {
             const elapsed = (timestamp - prevTimestamp) / 1000; // Convert to seconds
-            const timeAdvance = elapsed * playbackRate;
-            const newTime = clampTimelineTime(currentTime + timeAdvance, duration);
+            const timeAdvance = elapsed * playbackRateRef.current;
+            const currentDuration = durationRef.current;
+            const newTime = clampTimelineTime(currentTimeRef.current + timeAdvance, currentDuration);
             setCurrentTime(newTime, 'proxy-synthetic-clock');
 
             // Stop at end of duration
-            if (newTime >= duration) {
+            if (newTime >= currentDuration) {
               setIsPlaying(false);
             }
           }
@@ -1126,7 +1139,9 @@ export function ProxyPreviewPlayer({
         }
       }
     },
-    [isPlaying, renderableClips, setCurrentTime, playbackRate, currentTime, duration, setIsPlaying],
+    // currentTime, playbackRate and duration are read via refs to keep this
+    // callback's identity stable across frames (see the mirror refs above).
+    [isPlaying, renderableClips, setCurrentTime, setIsPlaying],
   );
 
   // Start/stop animation frame loop

--- a/src/core/TimelineEngine.ts
+++ b/src/core/TimelineEngine.ts
@@ -317,9 +317,20 @@ export class TimelineEngine {
     this._syncedStore?.setDuration(this._duration);
     this._emit('durationChange', { duration: this._duration });
 
-    // Clamp current time if needed
+    // Clamp current time if it now exceeds the new duration. Do not route through
+    // seek(): seek() treats reaching the end during playback as end-of-stream and
+    // pauses, which would wrongly stop playback on a routine trailing-clip trim/delete.
+    // Genuine end-of-stream detection stays in _tick.
     if (this._currentTime > this._duration) {
-      this.seek(this._duration);
+      const clampedTime = this._duration;
+      this._emit('beforeSetTime', { time: clampedTime });
+      this._currentTime = clampedTime;
+      this._syncedStore?.setCurrentTime(clampedTime);
+      if (this._isPlaying) {
+        this._playStartTime = performance.now();
+        this._playStartPosition = clampedTime;
+      }
+      this._emit('afterSetTime', { time: clampedTime });
     }
   }
 

--- a/src/hooks/useRippleEdit.ts
+++ b/src/hooks/useRippleEdit.ts
@@ -235,21 +235,25 @@ export function useRippleEdit(options: UseRippleEditOptions): UseRippleEditRetur
           });
         }
 
-        totalDelta = Math.max(totalDelta, deletedDuration);
+        totalDelta += deletedDuration;
       }
 
       // If rippling all tracks, process other tracks too
       if (rippleAllTracks && clipsByTrack.size > 0) {
-        // Find the earliest delete time across all tracks
+        // Collect every deleted clip's position and duration so each untouched-track
+        // clip can be shifted left by only the deleted time that lies before it,
+        // rather than by the sum of all deletions across every track (which would
+        // over-shift clips and desync tracks).
+        const deletions: Array<{ time: number; duration: number }> = [];
         let earliestTime = Infinity;
-        let totalDeleteDuration = 0;
 
         for (const deletedClips of clipsByTrack.values()) {
           for (const clip of deletedClips) {
-            if (clip.place.timelineInSec < earliestTime) {
-              earliestTime = clip.place.timelineInSec;
+            const time = clip.place.timelineInSec;
+            if (time < earliestTime) {
+              earliestTime = time;
             }
-            totalDeleteDuration += getClipDuration(clip);
+            deletions.push({ time, duration: getClipDuration(clip) });
           }
         }
 
@@ -258,16 +262,24 @@ export function useRippleEdit(options: UseRippleEditOptions): UseRippleEditRetur
           if (clipsByTrack.has(track.id)) continue; // Already processed
 
           for (const clip of track.clips) {
-            if (clip.place.timelineInSec >= earliestTime) {
+            const clipTime = clip.place.timelineInSec;
+            if (clipTime >= earliestTime) {
+              // Sum only the deletions positioned before this clip.
+              const deletedBefore = deletions.reduce(
+                (sum, deletion) =>
+                  deletion.time < clipTime ? sum + deletion.duration : sum,
+                0
+              );
+
               const newTime = Math.max(
                 MIN_CLIP_GAP_SEC,
-                clip.place.timelineInSec - totalDeleteDuration
+                clipTime - deletedBefore
               );
 
               affectedClips.push({
                 clipId: clip.id,
                 trackId: track.id,
-                originalTime: clip.place.timelineInSec,
+                originalTime: clipTime,
                 newTime,
               });
             }

--- a/src/hooks/useWaveformPeaks.test.ts
+++ b/src/hooks/useWaveformPeaks.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { invoke } from '@tauri-apps/api/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWaveformPeaks } from './useWaveformPeaks';
+import type { WaveformData } from '@/types';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+function createWaveformData(peaks: number[]): WaveformData {
+  return {
+    samplesPerSecond: 100,
+    peaks,
+    durationSec: peaks.length / 100,
+    channels: 1,
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useWaveformPeaks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should ignore stale generate success after the selected asset changes', async () => {
+    const staleGeneration = deferred<WaveformData | null>();
+    const currentGeneration = deferred<WaveformData | null>();
+    const currentData = createWaveformData([0.2, 0.4]);
+
+    vi.mocked(invoke).mockImplementation((command, args) => {
+      if (command === 'get_waveform_data') {
+        return Promise.resolve(null);
+      }
+      if (
+        command === 'generate_waveform_for_asset' &&
+        (args as { assetId?: string }).assetId === 'asset-a'
+      ) {
+        return staleGeneration.promise;
+      }
+      if (
+        command === 'generate_waveform_for_asset' &&
+        (args as { assetId?: string }).assetId === 'asset-b'
+      ) {
+        return currentGeneration.promise;
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    const { result, rerender } = renderHook(
+      ({ assetId }) =>
+        useWaveformPeaks(assetId, {
+          enabled: false,
+        }),
+      { initialProps: { assetId: 'asset-a' } },
+    );
+
+    act(() => {
+      void result.current.generate();
+    });
+
+    expect(result.current.isGenerating).toBe(true);
+
+    rerender({ assetId: 'asset-b' });
+
+    act(() => {
+      void result.current.generate();
+    });
+
+    await act(async () => {
+      currentGeneration.resolve(currentData);
+      await currentGeneration.promise;
+    });
+
+    expect(result.current.data).toEqual(currentData);
+    expect(result.current.isGenerating).toBe(false);
+
+    await act(async () => {
+      staleGeneration.resolve(createWaveformData([0.9]));
+      await staleGeneration.promise;
+    });
+
+    expect(result.current.data).toEqual(currentData);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isGenerating).toBe(false);
+  });
+
+  it('should ignore stale generate failure after the selected asset changes', async () => {
+    const staleGeneration = deferred<WaveformData | null>();
+    const currentGeneration = deferred<WaveformData | null>();
+    const currentData = createWaveformData([0.1, 0.3]);
+
+    vi.mocked(invoke).mockImplementation((command, args) => {
+      if (command === 'get_waveform_data') {
+        return Promise.resolve(null);
+      }
+      if (
+        command === 'generate_waveform_for_asset' &&
+        (args as { assetId?: string }).assetId === 'asset-a'
+      ) {
+        return staleGeneration.promise;
+      }
+      if (
+        command === 'generate_waveform_for_asset' &&
+        (args as { assetId?: string }).assetId === 'asset-b'
+      ) {
+        return currentGeneration.promise;
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    const { result, rerender } = renderHook(
+      ({ assetId }) =>
+        useWaveformPeaks(assetId, {
+          enabled: false,
+        }),
+      { initialProps: { assetId: 'asset-a' } },
+    );
+
+    act(() => {
+      void result.current.generate();
+    });
+
+    rerender({ assetId: 'asset-b' });
+
+    act(() => {
+      void result.current.generate();
+    });
+
+    await act(async () => {
+      currentGeneration.resolve(currentData);
+      await currentGeneration.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.isGenerating).toBe(false);
+    });
+
+    await act(async () => {
+      staleGeneration.reject(new Error('stale generation failed'));
+      await staleGeneration.promise.catch(() => null);
+    });
+
+    expect(result.current.data).toEqual(currentData);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isGenerating).toBe(false);
+  });
+});

--- a/src/hooks/useWaveformPeaks.ts
+++ b/src/hooks/useWaveformPeaks.ts
@@ -73,6 +73,10 @@ export function useWaveformPeaks(
   const isMountedRef = useRef(true);
   // Track previous assetId for change detection
   const prevAssetIdRef = useRef<string | null>(null);
+  // Track the most recently requested assetId so a slower in-flight request for a
+  // previous asset cannot overwrite the data of the asset currently selected.
+  const latestAssetIdRef = useRef<AssetId>(assetId);
+  latestAssetIdRef.current = assetId;
 
   /**
    * Fetch waveform data from cache
@@ -85,7 +89,8 @@ export function useWaveformPeaks(
         assetId,
       });
 
-      if (isMountedRef.current) {
+      // Ignore the result if the selected asset changed while this request was in flight.
+      if (isMountedRef.current && latestAssetIdRef.current === assetId) {
         setData(result);
         setError(null);
       }
@@ -94,7 +99,7 @@ export function useWaveformPeaks(
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to fetch waveform';
-      if (isMountedRef.current) {
+      if (isMountedRef.current && latestAssetIdRef.current === assetId) {
         setError(errorMessage);
         setData(null);
       }
@@ -120,7 +125,7 @@ export function useWaveformPeaks(
         }
       );
 
-      if (isMountedRef.current) {
+      if (isMountedRef.current && latestAssetIdRef.current === assetId) {
         setData(result);
         setIsGenerating(false);
       }

--- a/src/hooks/useWaveformPeaks.ts
+++ b/src/hooks/useWaveformPeaks.ts
@@ -77,6 +77,7 @@ export function useWaveformPeaks(
   // previous asset cannot overwrite the data of the asset currently selected.
   const latestAssetIdRef = useRef<AssetId>(assetId);
   latestAssetIdRef.current = assetId;
+  const generateRequestIdRef = useRef(0);
 
   /**
    * Fetch waveform data from cache
@@ -113,6 +114,7 @@ export function useWaveformPeaks(
   const generate = useCallback(async (): Promise<WaveformData | null> => {
     if (!assetId) return null;
 
+    const requestId = ++generateRequestIdRef.current;
     setIsGenerating(true);
     setError(null);
 
@@ -125,20 +127,30 @@ export function useWaveformPeaks(
         }
       );
 
-      if (isMountedRef.current && latestAssetIdRef.current === assetId) {
+      if (
+        isMountedRef.current &&
+        latestAssetIdRef.current === assetId &&
+        generateRequestIdRef.current === requestId
+      ) {
         setData(result);
-        setIsGenerating(false);
       }
 
       return result;
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Waveform generation failed';
-      if (isMountedRef.current) {
+      if (
+        isMountedRef.current &&
+        latestAssetIdRef.current === assetId &&
+        generateRequestIdRef.current === requestId
+      ) {
         setError(errorMessage);
-        setIsGenerating(false);
       }
       return null;
+    } finally {
+      if (isMountedRef.current && generateRequestIdRef.current === requestId) {
+        setIsGenerating(false);
+      }
     }
   }, [assetId, samplesPerSecond]);
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -228,6 +228,11 @@ export const useProjectStore = create<ProjectState>()(
         // Initialize workspace: setup event listeners and auto-scan
         setupWorkspaceEventListeners();
         if (shouldAutoScanWorkspaceOnOpen()) {
+          // Capture project identity + state version so a slow auto-scan cannot
+          // apply its result over a different project: the user may close this
+          // project or open another one before the scan resolves.
+          const scanProjectId = projectInfo.id;
+          const scanStateVersion = get().stateVersion;
           useWorkspaceStore
             .getState()
             .scanWorkspace()
@@ -235,6 +240,12 @@ export const useProjectStore = create<ProjectState>()(
               try {
                 const freshState = await refreshProjectState();
                 set((state) => {
+                  if (
+                    state.meta?.id !== scanProjectId ||
+                    state.stateVersion !== scanStateVersion
+                  ) {
+                    return;
+                  }
                   applyProjectState(state, freshState);
                 });
               } catch (syncError) {
@@ -353,6 +364,11 @@ export const useProjectStore = create<ProjectState>()(
         // Initialize workspace: setup event listeners and auto-scan
         setupWorkspaceEventListeners();
         if (shouldAutoScanWorkspaceOnOpen()) {
+          // Capture project identity + state version so a slow auto-scan cannot
+          // apply its result over a different project: the user may close this
+          // project or open another one before the scan resolves.
+          const scanProjectId = projectInfo.id;
+          const scanStateVersion = get().stateVersion;
           useWorkspaceStore
             .getState()
             .scanWorkspace()
@@ -360,6 +376,12 @@ export const useProjectStore = create<ProjectState>()(
               try {
                 const freshState = await refreshProjectState();
                 set((state) => {
+                  if (
+                    state.meta?.id !== scanProjectId ||
+                    state.stateVersion !== scanStateVersion
+                  ) {
+                    return;
+                  }
                   applyProjectState(state, freshState);
                 });
               } catch (syncError) {

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -98,15 +98,26 @@ function toErrorMessage(error: unknown): string {
 }
 
 /**
- * Sync project store after a filesystem mutation (rename, move, delete).
- * These operations update asset paths on the backend, so we must refresh
- * the project store to keep frontend asset data consistent.
+ * Refresh the backend project state and apply it to the project store, but only
+ * if the open project did not change while the async refresh was in flight.
+ * Shared by all workspace -> project sync paths (mutations, auto-registration,
+ * scan-complete events) to keep frontend asset data consistent without ever
+ * applying a stale project's state over a newly opened one.
  */
-async function syncProjectStoreAfterMutation(operation: string): Promise<void> {
+async function syncProjectStoreState(operation: string): Promise<void> {
   try {
-    const freshState = await refreshProjectState();
     const { useProjectStore } = await import('@/stores/projectStore');
+    // Capture the open project's identity before the async refresh so a slow sync
+    // cannot apply one project's assets over another after the user switched
+    // projects mid-flight. We intentionally do not guard on stateVersion here:
+    // these syncs run during active editing, and a concurrent edit command must
+    // not cause newly auto-registered assets to be silently dropped.
+    const projectIdAtSync = useProjectStore.getState().meta?.id ?? null;
+    const freshState = await refreshProjectState();
     useProjectStore.setState((draft) => {
+      if ((draft.meta?.id ?? null) !== projectIdAtSync) {
+        return;
+      }
       applyProjectState(draft, freshState);
     });
   } catch (syncError) {
@@ -114,6 +125,15 @@ async function syncProjectStoreAfterMutation(operation: string): Promise<void> {
       error: toErrorMessage(syncError),
     });
   }
+}
+
+/**
+ * Sync project store after a filesystem mutation (rename, move, delete).
+ * These operations update asset paths on the backend, so we must refresh
+ * the project store to keep frontend asset data consistent.
+ */
+async function syncProjectStoreAfterMutation(operation: string): Promise<void> {
+  await syncProjectStoreState(operation);
 }
 
 function scheduleWorkspaceTreeRefresh(reason: string): void {
@@ -169,20 +189,10 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
         // We import useProjectStore lazily to avoid a circular dependency
         // (projectStore already imports workspaceStore).
         if (result.autoRegisteredFiles > 0) {
-          try {
-            const freshState = await refreshProjectState();
-            const { useProjectStore } = await import('@/stores/projectStore');
-            useProjectStore.setState((draft) => {
-              applyProjectState(draft, freshState);
-            });
-            logger.info('Project store synced after auto-registration', {
-              autoRegisteredFiles: result.autoRegisteredFiles,
-            });
-          } catch (syncError) {
-            logger.warn('Failed to sync project store after auto-registration', {
-              error: toErrorMessage(syncError),
-            });
-          }
+          await syncProjectStoreState('auto-registration');
+          logger.info('Project store synced after auto-registration', {
+            autoRegisteredFiles: result.autoRegisteredFiles,
+          });
         }
       } catch (error) {
         const message = toErrorMessage(error);
@@ -412,18 +422,7 @@ export async function setupWorkspaceEventListeners(): Promise<void> {
 
         // Sync project store when new assets were auto-registered
         if (event.autoRegisteredFiles > 0) {
-          refreshProjectState()
-            .then(async (freshState) => {
-              const { useProjectStore } = await import('@/stores/projectStore');
-              useProjectStore.setState((draft) => {
-                applyProjectState(draft, freshState);
-              });
-            })
-            .catch((syncError) => {
-              logger.warn('Failed to sync project store after scan-complete event', {
-                error: toErrorMessage(syncError),
-              });
-            });
+          void syncProjectStoreState('scan-complete event');
         }
       } catch (error) {
         logger.warn('Ignoring invalid workspace:scan-complete payload', {

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -333,7 +333,9 @@ export function calculateClipDuration(
   speed: number = 1
 ): number {
   const safeSpeed = speed > 0 ? speed : 1;
-  return (sourceOut - sourceIn) / safeSpeed;
+  // Guard against inverted source ranges (sourceIn > sourceOut) which would
+  // otherwise yield a negative duration and corrupt downstream layout/preview math.
+  return Math.max(0, (sourceOut - sourceIn) / safeSpeed);
 }
 
 /**


### PR DESCRIPTION
### **User description**
﻿## Description

Fixes four race-condition and async-state bugs across Codex app-server startup, preview playback, timeline ripple math, and workspace project-state synchronization.

## Related Issue

Closes #732
Closes #733
Closes #734
Closes #735

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Harden Codex app-server startup by subscribing to the stream channel before process spawn and replaying early messages/errors.
- Stabilize preview playback async state, fullscreen seek release handling, waveform request staleness, and timeline/ripple duration math.
- Guard workspace auto-scan and project-store sync paths so stale async refreshes cannot overwrite a different open project.

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

N/A

## Testing

<!-- Describe how you tested your changes -->

Validated with commit hooks and targeted Vitest coverage for the changed transport and timeline behavior.

### Test Environment

- OS: Windows 11
- Node.js version: v22.19.0
- Rust version: rustc 1.92.0 (ded5c06cf 2025-12-08)

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->

Commands run:

- `npm run test:run -- src/agents/external/adapters/CodexTauriAppServerTransport.test.ts`
- `npm run test:run -- src/agents/external/adapters/CodexTauriAppServerTransport.test.ts src/hooks/useRippleEdit.test.ts src/core/TimelineEngine.test.ts`
- Commit hooks ran `version:check`, `type-check`, and `lint --fix` for each commit.

Untracked local `.agents/skills/` files were intentionally left out of this branch.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Fixes async race conditions in Codex server startup by pre-subscribing to event streams.

- Stabilizes preview playback by using refs for RAF loops and window-level seek listeners.

- Corrects ripple delete math to prevent over-shifting clips across multiple tracks.

- Guards workspace and project store syncs against stale state when switching projects.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "AI Transport"
    A["Client ID Generation"] -- "Pre-subscribe" --> B["Tauri Event Stream"]
    B -- "Buffer/Replay" --> C["Consumer Handlers"]
  end
  subgraph "Timeline & Preview"
    D["Ripple Math"] -- "Per-clip shift" --> E["Corrected Layout"]
    F["RAF Loop"] -- "Stable Refs" --> G["Smooth Playback"]
  end
  subgraph "Workspace Sync"
    H["Async Scan"] -- "Project ID Guard" --> I["Project Store Update"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>CodexTauriAppServerTransport.ts</strong><dd><code>Implement pre-subscription and event buffering for Codex server</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-5d69fa45229518b6792761a24c6b398e8cef485b7d305f9910f8df247dd8b8e4">+128/-15</a></td>

</tr>

<tr>
  <td><strong>FullscreenPreview.tsx</strong><dd><code>Add window-level listeners for robust seek release handling</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-50a4d392ea69a4a2a2c823f4a26cbc0a777f363e83f9dc967d9393c41a4ff061">+28/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimelineEngine.ts</strong><dd><code>Clamp duration without triggering end-of-stream seek logic</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-cf2188884826d49f46eb05a365736491d7dbab1d9838bf23a838fc2efbadbcec">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRippleEdit.ts</strong><dd><code>Calculate ripple shift based on relative deletion positions</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-2d885c8ef670be13987adcac797814b9e41c4d805092610b7bea22f87810c9d8">+21/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useWaveformPeaks.ts</strong><dd><code>Ignore stale waveform results using latest asset ID ref</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-dacb5e1b8ee9ca602949670d15d6679dcbdd300f1c911312de4dcf47e3ea482b">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>projectStore.ts</strong><dd><code>Guard auto-scan results with project identity checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-82dd55495e23fa081a4509b6e3a3279b0127026f9b690f7e0442a769f74ee6b9">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceStore.ts</strong><dd><code>Centralize project sync with stale-state protection guards</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-8099943c23d51490904cf1532b6da3c292d619eeb2ea07521eddaeabf90f68dc">+30/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>timeline.ts</strong><dd><code>Ensure clip duration is never negative</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-42780464429cbdc7c9899ea124df57f0c1f409adec3ee94911759c40a7c48207">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CodexTauriAppServerTransport.test.ts</strong><dd><code>Add tests for event replaying and subscription ordering</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-c1550c147627ef036c504162f469f60a635fac4ba09f57a2fe9a4db807fe92ce">+71/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ProxyPreviewPlayer.tsx</strong><dd><code>Stabilize RAF loop by mirroring playback state in refs</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/736/files#diff-647a8a156472eaa4853238581b304e360adfb643c3e29883b2aeb178bb3030a0">+20/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented seek-bar dragging from getting stuck when releasing outside the control
  * Fixed duration trimming so current-time adjustment no longer triggers end-of-stream behavior
  * Corrected ripple deletion so clips shift correctly across multiple tracks when deleting all tracks
  * Prevented stale waveform data (and related errors) from showing after switching assets
  * Prevented stale project state from being applied after switching projects
  * Prevented negative durations in clip/timeline calculations
  * Improved reliability of backend startup streaming and early error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->