### PR TITLE
feat(render): native export destination picker with session-scoped write allow-list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,10 @@ jobs:
 
       - name: Cargo Audit
         run: |
+          # Advisories below are transitive/unfixable here or outside the app's
+          # threat model: RUSTSEC-2026-0194/0195 (quick-xml) are DoS-only and the
+          # app parses no untrusted XML; RUSTSEC-2026-0188 (wasmtime-wasi) is not
+          # reachable because WASI is not wired into the plugin host.
           cargo audit \
             --ignore RUSTSEC-2024-0411 \
             --ignore RUSTSEC-2024-0412 \
@@ -447,4 +451,7 @@ jobs:
             --ignore RUSTSEC-2025-0100 \
             --ignore RUSTSEC-2025-0141 \
             --ignore RUSTSEC-2026-0097 \
-            --ignore RUSTSEC-2026-0105
+            --ignore RUSTSEC-2026-0105 \
+            --ignore RUSTSEC-2026-0188 \
+            --ignore RUSTSEC-2026-0194 \
+            --ignore RUSTSEC-2026-0195

--- a/scripts/prepare-bundled-ffmpeg.mjs
+++ b/scripts/prepare-bundled-ffmpeg.mjs
@@ -16,6 +16,9 @@ const targets = {
         name: 'ffmpeg',
         format: 'zip',
         url: 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip',
+        fallbackUrls: [
+          'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip',
+        ],
         filename: 'ffmpeg-release-essentials.zip',
         binaries: ['ffmpeg.exe', 'ffprobe.exe'],
       },

--- a/src-tauri/src/core/fs/mod.rs
+++ b/src-tauri/src/core/fs/mod.rs
@@ -281,6 +281,28 @@ pub fn default_export_allowed_roots(project_dir: &Path) -> Vec<PathBuf> {
     roots
 }
 
+/// Builds the full set of directories the GUI is willing to write user exports into.
+///
+/// This combines [`default_export_allowed_roots`] with a session-scoped allow-list of
+/// directories the user explicitly confirmed via the native save dialog
+/// (`pick_export_destination`). The approved set can only be populated through that
+/// user-driven dialog, never from a path argument supplied by the renderer, so a
+/// compromised webview cannot widen the allow-list by forging an output path.
+///
+/// Security note: the returned roots are still subject to the `..`/symlink/directory
+/// safety checks inside [`validate_scoped_output_path`]. This helper only widens *where*
+/// the user may save, not *how* the path is validated.
+pub fn export_allowed_roots(
+    project_dir: &Path,
+    approved_dirs: &std::collections::HashSet<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut roots = default_export_allowed_roots(project_dir);
+    for dir in approved_dirs {
+        roots.push(dir.clone());
+    }
+    roots
+}
+
 /// Async version of `validate_local_input_path`.
 ///
 /// Uses tokio's async filesystem operations to avoid blocking the async runtime.
@@ -1282,6 +1304,74 @@ mod tests {
             result.is_err(),
             "expected output in prefix-sibling dir to be rejected"
         );
+    }
+
+    #[test]
+    fn test_export_allowed_roots_includes_project_and_approved_dirs() {
+        let project = TempDir::new().unwrap();
+        let approved = TempDir::new().unwrap();
+
+        let mut approved_dirs = std::collections::HashSet::new();
+        approved_dirs.insert(approved.path().to_path_buf());
+
+        let roots = export_allowed_roots(project.path(), &approved_dirs);
+
+        assert!(
+            roots.iter().any(|r| r == project.path()),
+            "project directory must always be an allowed root"
+        );
+        assert!(
+            roots.iter().any(|r| r == approved.path()),
+            "user-approved directory must be an allowed root"
+        );
+    }
+
+    #[test]
+    fn test_validate_scoped_output_path_allows_within_approved_dir() {
+        // A directory outside the default roots becomes valid once it is approved.
+        let project = TempDir::new().unwrap();
+        let approved = TempDir::new().unwrap();
+
+        let mut approved_dirs = std::collections::HashSet::new();
+        approved_dirs.insert(approved.path().to_path_buf());
+
+        let out = approved.path().join("export.mp4");
+        let out_str = out.to_string_lossy().to_string();
+
+        let roots = export_allowed_roots(project.path(), &approved_dirs);
+        let root_refs: Vec<&Path> = roots.iter().map(|p| p.as_path()).collect();
+
+        let result = validate_scoped_output_path(&out_str, "Output path", &root_refs);
+        assert!(
+            result.is_ok(),
+            "path under an approved directory must validate: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_scoped_output_path_rejects_outside_default_and_approved_dirs() {
+        // A forged path that is neither under the default roots nor approved must be rejected.
+        let project = TempDir::new().unwrap();
+        let approved = TempDir::new().unwrap();
+        let forged = TempDir::new().unwrap();
+
+        let mut approved_dirs = std::collections::HashSet::new();
+        approved_dirs.insert(approved.path().to_path_buf());
+
+        let out = forged.path().join("evil.mp4");
+        let out_str = out.to_string_lossy().to_string();
+
+        let roots = export_allowed_roots(project.path(), &approved_dirs);
+        let root_refs: Vec<&Path> = roots.iter().map(|p| p.as_path()).collect();
+
+        let result = validate_scoped_output_path(&out_str, "Output path", &root_refs);
+        assert!(
+            result.is_err(),
+            "path outside default roots and approved dirs must be rejected"
+        );
+        assert!(result
+            .unwrap_err()
+            .contains("must be within an allowed directory"));
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/core/jobs/worker.rs
+++ b/src-tauri/src/core/jobs/worker.rs
@@ -1506,7 +1506,7 @@ impl JobProcessor {
     async fn process_final_render(&self, job: &Job) -> Result<serde_json::Value, String> {
         #[cfg(not(test))]
         use crate::core::{
-            fs::{default_export_allowed_roots, validate_scoped_output_path},
+            fs::{export_allowed_roots, validate_scoped_output_path},
             render::{
                 build_render_graph, build_render_plan, validate_export_settings, ExportEngine,
                 ExportPreset, ExportSettings,
@@ -1574,8 +1574,14 @@ impl JobProcessor {
             };
 
             // 2. Validate output path security
-            // Use same logic as IPC command: restrict to user dirs + project dir
-            let roots = default_export_allowed_roots(&project_path);
+            // Use same logic as IPC command: restrict to user dirs + project dir +
+            // session-scoped directories the user approved via the native save dialog.
+            let approved_dirs = self
+                .app_handle
+                .state::<crate::AppState>()
+                .approved_export_dirs_snapshot()
+                .await;
+            let roots = export_allowed_roots(&project_path, &approved_dirs);
             let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
 
             let validated_output_path =

--- a/src-tauri/src/ipc/commands/export_dialog.rs
+++ b/src-tauri/src/ipc/commands/export_dialog.rs
@@ -37,11 +37,13 @@ pub struct ExportDialogFilter {
 /// # Arguments
 /// * `default_name` - Suggested file name pre-filled in the dialog.
 /// * `filters` - File type filters shown in the dialog.
+/// * `title` - Optional title shown on the native save dialog.
 #[tauri::command]
 #[specta::specta]
 pub async fn pick_export_destination(
     default_name: String,
     filters: Vec<ExportDialogFilter>,
+    title: Option<String>,
     app_handle: AppHandle,
 ) -> Result<Option<String>, String> {
     // Run the native save dialog off the async runtime via its callback API,
@@ -51,6 +53,11 @@ pub async fn pick_export_destination(
     let mut builder = app_handle.dialog().file();
     if !default_name.trim().is_empty() {
         builder = builder.set_file_name(default_name);
+    }
+    if let Some(dialog_title) = title {
+        if !dialog_title.trim().is_empty() {
+            builder = builder.set_title(dialog_title);
+        }
     }
     for filter in &filters {
         let extension_refs: Vec<&str> = filter.extensions.iter().map(|s| s.as_str()).collect();
@@ -78,7 +85,12 @@ pub async fn pick_export_destination(
 
     let parent = path
         .parent()
-        .ok_or_else(|| format!("Selected export path has no parent directory: {}", path.display()))?
+        .ok_or_else(|| {
+            format!(
+                "Selected export path has no parent directory: {}",
+                path.display()
+            )
+        })?
         .to_path_buf();
 
     // Normalize the parent directory before approving it. Canonicalization resolves

--- a/src-tauri/src/ipc/commands/export_dialog.rs
+++ b/src-tauri/src/ipc/commands/export_dialog.rs
@@ -1,0 +1,103 @@
+//! Export destination picker command.
+//!
+//! Exposes a native save dialog to the frontend and records the chosen parent
+//! directory in a session-scoped allow-list (`AppState::approved_export_dirs`).
+//!
+//! Security rationale:
+//! - IPC is a trust boundary; a compromised renderer (webview) could forge output
+//!   paths. Export commands therefore restrict writes to `default_export_allowed_roots`
+//!   plus the directories the user explicitly confirmed here.
+//! - The allow-list can ONLY be widened through this command, which requires a real
+//!   user interaction (the native dialog). The renderer cannot inject a path argument
+//!   that bypasses validation: the approved directory is derived from the dialog
+//!   result, not from any renderer-supplied value.
+
+use specta::Type;
+use tauri::AppHandle;
+use tauri_plugin_dialog::DialogExt;
+
+use crate::AppState;
+use tauri::Manager;
+
+/// A file type filter for the native save dialog (IPC DTO).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Type)]
+pub struct ExportDialogFilter {
+    /// Human-readable filter name (e.g., "Video").
+    pub name: String,
+    /// File extensions associated with the filter, without the leading dot (e.g., ["mp4"]).
+    pub extensions: Vec<String>,
+}
+
+/// Opens a native save dialog for an export destination.
+///
+/// On confirmation, the parent directory of the chosen path is normalized and added
+/// to the session-scoped approved-export allow-list, then the absolute path is
+/// returned. On cancel, returns `Ok(None)`.
+///
+/// # Arguments
+/// * `default_name` - Suggested file name pre-filled in the dialog.
+/// * `filters` - File type filters shown in the dialog.
+#[tauri::command]
+#[specta::specta]
+pub async fn pick_export_destination(
+    default_name: String,
+    filters: Vec<ExportDialogFilter>,
+    app_handle: AppHandle,
+) -> Result<Option<String>, String> {
+    // Run the native save dialog off the async runtime via its callback API,
+    // bridging the result back with a oneshot channel so we never block a runtime worker.
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let mut builder = app_handle.dialog().file();
+    if !default_name.trim().is_empty() {
+        builder = builder.set_file_name(default_name);
+    }
+    for filter in &filters {
+        let extension_refs: Vec<&str> = filter.extensions.iter().map(|s| s.as_str()).collect();
+        builder = builder.add_filter(filter.name.clone(), &extension_refs);
+    }
+
+    builder.save_file(move |file_path| {
+        // Ignore send errors: the receiver is only dropped if the command future was
+        // cancelled, in which case there is nothing left to deliver the result to.
+        let _ = tx.send(file_path);
+    });
+
+    let selected = rx
+        .await
+        .map_err(|_| "Export dialog was closed unexpectedly".to_string())?;
+
+    let Some(file_path) = selected else {
+        // User cancelled the dialog.
+        return Ok(None);
+    };
+
+    let path = file_path
+        .into_path()
+        .map_err(|e| format!("Failed to resolve selected export path: {e}"))?;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Selected export path has no parent directory: {}", path.display()))?
+        .to_path_buf();
+
+    // Normalize the parent directory before approving it. Canonicalization resolves
+    // symlinks and `..` segments so the later scope check in `validate_scoped_output_path`
+    // matches; fall back to the lexical parent if canonicalization fails (best-effort).
+    let approved_dir = match std::fs::canonicalize(&parent) {
+        Ok(canonical) => canonical,
+        Err(error) => {
+            tracing::warn!(
+                "Failed to canonicalize approved export directory '{}' (using as-is): {}",
+                parent.display(),
+                error
+            );
+            parent
+        }
+    };
+
+    let state = app_handle.state::<AppState>();
+    state.approve_export_dir(approved_dir).await;
+
+    Ok(Some(path.to_string_lossy().to_string()))
+}

--- a/src-tauri/src/ipc/commands/interchange.rs
+++ b/src-tauri/src/ipc/commands/interchange.rs
@@ -5,9 +5,7 @@
 use tauri::State;
 
 use crate::core::{
-    fs::{
-        default_export_allowed_roots, validate_scoped_output_path, write_bytes_atomic_no_symlink,
-    },
+    fs::{export_allowed_roots, validate_scoped_output_path, write_bytes_atomic_no_symlink},
     interchange::{edl, models::InterchangeExportResult, xml},
     CoreError,
 };
@@ -56,7 +54,8 @@ pub async fn export_edl(
     };
 
     // Validate output path
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_path = validate_scoped_output_path(&output_path, "EDL output path", &root_refs)?;
 
@@ -128,7 +127,8 @@ pub async fn export_fcpxml(
     };
 
     // Validate output path
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_path =
         validate_scoped_output_path(&output_path, "FCPXML output path", &root_refs)?;

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -75,6 +75,9 @@ pub mod terminal;
 // Interchange commands (EDL/FCPXML export)
 pub mod interchange;
 
+// Export destination picker (native save dialog + session-scoped allow-list)
+pub mod export_dialog;
+
 // Transcript-based editing commands (S35-001)
 pub mod transcript_editing;
 
@@ -118,6 +121,9 @@ pub use terminal::*;
 
 // Re-export interchange commands
 pub use interchange::*;
+
+// Re-export export destination picker
+pub use export_dialog::*;
 
 // Re-export transcript editing commands
 pub use transcript_editing::*;

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -7,7 +7,7 @@ use specta::Type;
 use tauri::State;
 
 use crate::core::{
-    fs::{default_export_allowed_roots, validate_local_input_path, validate_scoped_output_path},
+    fs::{export_allowed_roots, validate_local_input_path, validate_scoped_output_path},
     render::{
         cancel_render_job, register_render_job, unregister_render_job, AudioExportFormat,
         ExportError, ExportPreset, ImageFormat, VideoExportRequest,
@@ -380,7 +380,8 @@ pub async fn start_render(
     };
 
     // Validate output path within allowed roots (defense-in-depth for compromised renderer).
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_output_path =
         validate_scoped_output_path(&output_path, "Output path", &root_refs)?;
@@ -645,7 +646,8 @@ pub async fn render_range(
     };
 
     // Validate output path
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_output_path =
         validate_scoped_output_path(&output_path, "Output path", &root_refs)?;
@@ -882,7 +884,8 @@ pub async fn batch_render(
     };
 
     // Validate all output paths upfront before starting any renders
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
 
     let mut validated_items: Vec<(ExportSettings, String)> = Vec::with_capacity(items.len());
@@ -1212,7 +1215,8 @@ pub async fn export_frame(
 
         (sequence, assets, project_path)
     };
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_output_path =
         validate_scoped_output_path(&output_path, "Output path", &root_refs)?;
@@ -1324,7 +1328,8 @@ pub async fn export_audio_only(
     };
 
     // Validate output path
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_output_path =
         validate_scoped_output_path(&output_path, "Output path", &root_refs)?;

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -7,7 +7,7 @@ use tauri::{Emitter, State};
 
 use crate::core::{
     fs::{
-        default_export_allowed_roots, validate_path_id_component, validate_scoped_output_path,
+        export_allowed_roots, validate_path_id_component, validate_scoped_output_path,
         write_bytes_atomic_no_symlink,
     },
     jobs::{Job, JobType, Priority},
@@ -809,7 +809,8 @@ pub async fn export_captions(
         ));
     }
 
-    let roots = default_export_allowed_roots(&project_path);
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
     let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
     let validated_output_path =
         validate_scoped_output_path(output_path_trimmed, "outputPath", &root_refs)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -940,6 +940,17 @@ pub struct AppState {
     /// Runtime-only approval tokens issued for external agent mutation windows.
     pub external_agent_approval_tokens:
         Mutex<crate::core::external_agent::ExternalAgentApprovalTokenStore>,
+
+    /// Session-scoped allow-list of directories the user confirmed via the native
+    /// save dialog (`pick_export_destination`).
+    ///
+    /// Security model:
+    /// - IPC is a trust boundary; the renderer (webview) could be compromised.
+    /// - Export commands restrict writes to `default_export_allowed_roots` plus this set.
+    /// - This set is populated ONLY from the parent directory of a path the user picked
+    ///   in the native dialog, never from a path argument supplied by the renderer.
+    /// - It is intentionally runtime-only (never persisted to disk) and reset per session.
+    pub approved_export_dirs: Mutex<std::collections::HashSet<PathBuf>>,
 }
 
 /// Runtime source monitor state for dual-viewer workflow.
@@ -1075,12 +1086,31 @@ impl AppState {
             external_agent_approval_tokens: Mutex::new(
                 crate::core::external_agent::ExternalAgentApprovalTokenStore::default(),
             ),
+            approved_export_dirs: Mutex::new(std::collections::HashSet::new()),
         }
     }
 
     /// Stores the app handle for later use (best-effort, idempotent).
     pub fn set_app_handle(&self, handle: tauri::AppHandle) {
         let _ = self.app_handle.set(handle);
+    }
+
+    /// Returns a snapshot of the session-scoped, user-approved export directories.
+    ///
+    /// Call sites combine this with `default_export_allowed_roots` to build the
+    /// allowed roots passed to `validate_scoped_output_path`. Returning a clone keeps
+    /// the lock scope short and avoids holding the mutex across path validation I/O.
+    pub async fn approved_export_dirs_snapshot(&self) -> std::collections::HashSet<PathBuf> {
+        self.approved_export_dirs.lock().await.clone()
+    }
+
+    /// Records the parent directory of a user-confirmed export path as approved.
+    ///
+    /// This is the ONLY way the approved set grows. The input must originate from the
+    /// native save dialog (`pick_export_destination`), never from a renderer-supplied
+    /// argument, so a compromised webview cannot widen the export allow-list.
+    pub async fn approve_export_dir(&self, dir: PathBuf) {
+        self.approved_export_dirs.lock().await.insert(dir);
     }
 
     /// Allowlist a directory for the asset protocol (best-effort).
@@ -1336,6 +1366,8 @@ mod tauri_app {
                 // Interchange export commands (EDL, FCPXML)
                 $crate::ipc::export_edl,
                 $crate::ipc::export_fcpxml,
+                // Export destination picker (native save dialog + allow-list)
+                $crate::ipc::pick_export_destination,
                 // AI commands
                 $crate::ipc::analyze_intent,
                 $crate::ipc::create_proposal,
@@ -1835,6 +1867,8 @@ mod tauri_app {
             // Interchange export commands (EDL, FCPXML)
             ipc::export_edl,
             ipc::export_fcpxml,
+            // Export destination picker (native save dialog + allow-list)
+            ipc::pick_export_destination,
             // AI commands
             ipc::analyze_intent,
             ipc::create_proposal,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,6 +62,10 @@
       "certificateThumbprint": null,
       "timestampUrl": "http://timestamp.digicert.com",
       "digestAlgorithm": "sha256",
+      "webviewInstallMode": {
+        "type": "offlineInstaller",
+        "silent": true
+      },
       "wix": null,
       "nsis": {
         "compression": "lzma",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -752,6 +752,25 @@ async exportFcpxml(sequenceId: string, outputPath: string) : Promise<Result<Inte
 }
 },
 /**
+ * Opens a native save dialog for an export destination.
+ * 
+ * On confirmation, the parent directory of the chosen path is normalized and added
+ * to the session-scoped approved-export allow-list, then the absolute path is
+ * returned. On cancel, returns `Ok(None)`.
+ * 
+ * # Arguments
+ * * `default_name` - Suggested file name pre-filled in the dialog.
+ * * `filters` - File type filters shown in the dialog.
+ * * `title` - Optional title shown on the native save dialog.
+ */
+async pickExportDestination(defaultName: string, filters: ExportDialogFilter[], title: string | null) : Promise<Result<string | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("pick_export_destination", { defaultName, filters, title }) };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
+/**
  * Analyzes user intent and generates an EditScript
  */
 async analyzeIntent(intent: string, context: AIContextDto) : Promise<Result<EditScriptDto, string>> {
@@ -4738,6 +4757,18 @@ tempoClassification: TempoClassification }
  * Response for estimate_generation_cost
  */
 export type EstimateGenerationCostResponse = { estimatedCents: number; quality: string; durationSec: number }
+/**
+ * A file type filter for the native save dialog (IPC DTO).
+ */
+export type ExportDialogFilter = { 
+/**
+ * Human-readable filter name (e.g., "Video").
+ */
+name: string; 
+/**
+ * File extensions associated with the filter, without the leading dot (e.g., ["mp4"]).
+ */
+extensions: string[] }
 /**
  * User-facing quality tier that maps to concrete encoder settings.
  */

--- a/src/hooks/useCaptionExport.ts
+++ b/src/hooks/useCaptionExport.ts
@@ -162,6 +162,7 @@ export function useCaptionExport(): UseCaptionExportReturn {
               extensions: [format],
             },
           ],
+          title: `Export Captions as ${format.toUpperCase()}`,
         });
 
         if (!filePath) {

--- a/src/hooks/useCaptionExport.ts
+++ b/src/hooks/useCaptionExport.ts
@@ -6,7 +6,7 @@
 
 import { useState, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { save } from '@tauri-apps/plugin-dialog';
+import { pickExportDestination } from '@/services/exportDestination';
 import type { Caption } from '@/types';
 import { createLogger } from '@/services/logger';
 
@@ -154,15 +154,14 @@ export function useCaptionExport(): UseCaptionExportReturn {
         const safeName = sanitizeFilename(defaultName);
 
         // Show save dialog
-        const filePath = await save({
-          defaultPath: `${safeName}${getExtension(format)}`,
+        const filePath = await pickExportDestination({
+          defaultName: `${safeName}${getExtension(format)}`,
           filters: [
             {
               name: format === 'srt' ? 'SubRip Subtitle' : 'WebVTT',
               extensions: [format],
             },
           ],
-          title: `Export Captions as ${format.toUpperCase()}`,
         });
 
         if (!filePath) {

--- a/src/hooks/useExportDialog.test.ts
+++ b/src/hooks/useExportDialog.test.ts
@@ -372,6 +372,7 @@ describe('useExportDialog', () => {
     expect(invoke).toHaveBeenCalledWith('pick_export_destination', {
       defaultName: 'Sequence.ogg',
       filters: [{ name: 'Ogg Audio', extensions: ['ogg'] }],
+      title: 'Export Audio',
     });
     expect(result.current.outputPath).toBe('/tmp/out.ogg');
   });

--- a/src/hooks/useExportDialog.test.ts
+++ b/src/hooks/useExportDialog.test.ts
@@ -9,12 +9,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import { save } from '@tauri-apps/plugin-dialog';
 import { useExportDialog } from './useExportDialog';
-
-vi.mock('@tauri-apps/plugin-dialog', () => ({
-  save: vi.fn(),
-}));
 
 describe('useExportDialog', () => {
   beforeEach(() => {
@@ -355,7 +350,7 @@ describe('useExportDialog', () => {
   });
 
   it('should browse with audio-specific filters when audio export is selected', async () => {
-    vi.mocked(save).mockResolvedValue('/tmp/out.ogg');
+    vi.mocked(invoke).mockResolvedValue('/tmp/out.ogg');
 
     const { result } = renderHook(() =>
       useExportDialog({
@@ -374,13 +369,10 @@ describe('useExportDialog', () => {
       await result.current.handleBrowse();
     });
 
-    expect(save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        defaultPath: 'Sequence.ogg',
-        title: 'Export Audio',
-        filters: [{ name: 'Ogg Audio', extensions: ['ogg'] }],
-      }),
-    );
+    expect(invoke).toHaveBeenCalledWith('pick_export_destination', {
+      defaultName: 'Sequence.ogg',
+      filters: [{ name: 'Ogg Audio', extensions: ['ogg'] }],
+    });
     expect(result.current.outputPath).toBe('/tmp/out.ogg');
   });
 

--- a/src/hooks/useExportDialog.ts
+++ b/src/hooks/useExportDialog.ts
@@ -270,6 +270,7 @@ export function useExportDialog({
       const selected = await pickExportDestination({
         defaultName: `${sequenceName}.${extension}`,
         filters: [{ name: option.name, extensions: [extension] }],
+        title: 'Export Audio',
       });
 
       if (selected) {

--- a/src/hooks/useExportDialog.ts
+++ b/src/hooks/useExportDialog.ts
@@ -6,8 +6,8 @@
  */
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { save } from '@tauri-apps/plugin-dialog';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { pickExportDestination } from '@/services/exportDestination';
 import { commands } from '@/bindings';
 import type {
   AudioExportFormat,
@@ -267,10 +267,9 @@ export function useExportDialog({
       const option = getAudioFormatOption(selectedAudioFormat);
       const extension = getAudioFormatExtension(selectedAudioFormat);
 
-      const selected = await save({
-        defaultPath: `${sequenceName}.${extension}`,
+      const selected = await pickExportDestination({
+        defaultName: `${sequenceName}.${extension}`,
         filters: [{ name: option.name, extensions: [extension] }],
-        title: 'Export Audio',
       });
 
       if (selected) {
@@ -284,10 +283,9 @@ export function useExportDialog({
       const option = getTimelineFormatOption(selectedTimelineFormat);
       const extension = getTimelineFormatExtension(selectedTimelineFormat);
 
-      const selected = await save({
-        defaultPath: `${sequenceName}.${extension}`,
+      const selected = await pickExportDestination({
+        defaultName: `${sequenceName}.${extension}`,
         filters: [{ name: option.name, extensions: [extension] }],
-        title: 'Export Editable Timeline',
       });
 
       if (selected) {
@@ -299,10 +297,9 @@ export function useExportDialog({
 
     const extension = getPresetExtension(selectedPreset);
 
-    const selected = await save({
-      defaultPath: `${sequenceName}.${extension}`,
+    const selected = await pickExportDestination({
+      defaultName: `${sequenceName}.${extension}`,
       filters: [{ name: 'Video', extensions: [extension] }],
-      title: 'Export Video',
     });
 
     if (selected) {

--- a/src/hooks/useInterchangeExport.test.ts
+++ b/src/hooks/useInterchangeExport.test.ts
@@ -26,6 +26,7 @@ describe('useInterchangeExport', () => {
     expect(invoke).toHaveBeenCalledWith('pick_export_destination', {
       defaultName: 'My_Sequence.edl',
       filters: [{ name: 'Edit Decision List', extensions: ['edl'] }],
+      title: 'Export as EDL',
     });
     expect(result.current.status).toEqual({ type: 'idle' });
   });

--- a/src/hooks/useInterchangeExport.test.ts
+++ b/src/hooks/useInterchangeExport.test.ts
@@ -7,12 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { invoke } from '@tauri-apps/api/core';
-import { save } from '@tauri-apps/plugin-dialog';
 import { useInterchangeExport } from './useInterchangeExport';
-
-vi.mock('@tauri-apps/plugin-dialog', () => ({
-  save: vi.fn(),
-}));
 
 describe('useInterchangeExport', () => {
   beforeEach(() => {
@@ -20,7 +15,7 @@ describe('useInterchangeExport', () => {
   });
 
   it('should sanitize the default filename before opening the save dialog', async () => {
-    vi.mocked(save).mockResolvedValue(null);
+    vi.mocked(invoke).mockResolvedValue(null);
 
     const { result } = renderHook(() => useInterchangeExport());
 
@@ -28,11 +23,10 @@ describe('useInterchangeExport', () => {
       await result.current.exportEdl('sequence-1', 'My:Sequence');
     });
 
-    expect(save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        defaultPath: 'My_Sequence.edl',
-      }),
-    );
+    expect(invoke).toHaveBeenCalledWith('pick_export_destination', {
+      defaultName: 'My_Sequence.edl',
+      filters: [{ name: 'Edit Decision List', extensions: ['edl'] }],
+    });
     expect(result.current.status).toEqual({ type: 'idle' });
   });
 
@@ -44,9 +38,13 @@ describe('useInterchangeExport', () => {
       trackCount: 2,
       durationSec: 12.5,
     };
-    vi.mocked(save).mockResolvedValue('/tmp/sequence.edl');
-    // Mock invoke which backs commands.exportEdl via the Result wrapper
-    vi.mocked(invoke).mockResolvedValue(exportResult);
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'pick_export_destination') {
+        return '/tmp/sequence.edl';
+      }
+      // export_edl backs commands.exportEdl via the Result wrapper
+      return exportResult;
+    });
 
     const { result } = renderHook(() => useInterchangeExport());
 
@@ -66,9 +64,13 @@ describe('useInterchangeExport', () => {
   });
 
   it('should update status to failed when the backend returns an error', async () => {
-    vi.mocked(save).mockResolvedValue('/tmp/sequence.edl');
-    // Simulate a backend error — invoke throws, bindings catch and wrap as { status: "error" }
-    vi.mocked(invoke).mockRejectedValue('Sequence not found: seq-1');
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'pick_export_destination') {
+        return '/tmp/sequence.edl';
+      }
+      // Simulate a backend error — invoke throws, bindings catch and wrap as { status: "error" }
+      throw 'Sequence not found: seq-1';
+    });
 
     const { result } = renderHook(() => useInterchangeExport());
 
@@ -83,7 +85,12 @@ describe('useInterchangeExport', () => {
   });
 
   it('should update status to failed when the save dialog throws', async () => {
-    vi.mocked(save).mockRejectedValue(new Error('Dialog unavailable'));
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'pick_export_destination') {
+        throw new Error('Dialog unavailable');
+      }
+      return undefined;
+    });
 
     const { result } = renderHook(() => useInterchangeExport());
 
@@ -91,7 +98,7 @@ describe('useInterchangeExport', () => {
       await result.current.exportFcpxml('sequence-1', 'Sequence');
     });
 
-    expect(invoke).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalledWith('export_fcpxml', expect.anything());
     expect(result.current.status).toEqual({
       type: 'failed',
       error: 'Dialog unavailable',

--- a/src/hooks/useInterchangeExport.ts
+++ b/src/hooks/useInterchangeExport.ts
@@ -86,6 +86,7 @@ export function useInterchangeExport(): UseInterchangeExportReturn {
         const outputPath = await pickExportDestination({
           defaultName: `${safeName}.${config.extension}`,
           filters: [{ name: config.filterName, extensions: [config.extension] }],
+          title: `Export as ${config.label}`,
         });
 
         if (!outputPath) {

--- a/src/hooks/useInterchangeExport.ts
+++ b/src/hooks/useInterchangeExport.ts
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useState } from 'react';
-import { save } from '@tauri-apps/plugin-dialog';
+import { pickExportDestination } from '@/services/exportDestination';
 import { commands } from '@/bindings';
 import type { InterchangeExportResult, InterchangeFormat } from '@/bindings';
 import { createLogger } from '@/services/logger';
@@ -83,10 +83,9 @@ export function useInterchangeExport(): UseInterchangeExportReturn {
 
       try {
         const safeName = sanitizeFilename(sequenceName);
-        const outputPath = await save({
-          defaultPath: `${safeName}.${config.extension}`,
+        const outputPath = await pickExportDestination({
+          defaultName: `${safeName}.${config.extension}`,
           filters: [{ name: config.filterName, extensions: [config.extension] }],
-          title: `Export as ${config.label}`,
         });
 
         if (!outputPath) {

--- a/src/hooks/useRenderQueue.test.ts
+++ b/src/hooks/useRenderQueue.test.ts
@@ -9,15 +9,27 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import { save } from '@tauri-apps/plugin-dialog';
 import { useRenderQueue } from './useRenderQueue';
 import { DESKTOP_RUNTIME_TEST_FLAG } from '@/services/runtimeEnvironment';
 
-vi.mock('@tauri-apps/plugin-dialog', () => ({
-  save: vi.fn(),
-}));
-
 type EventHandler = (event: { payload: unknown }) => void;
+
+/**
+ * Wraps a backend invoke mock so the native export-destination picker
+ * (`pick_export_destination`) always resolves to a fixed path, while every other
+ * command is delegated to the provided handler.
+ */
+function withExportPicker(
+  picked: string | null,
+  backend: (command: string) => unknown,
+): (command: string) => Promise<unknown> {
+  return async (command: string) => {
+    if (command === 'pick_export_destination') {
+      return picked;
+    }
+    return backend(command);
+  };
+}
 
 describe('useRenderQueue', () => {
   const handlers = new Map<string, EventHandler>();
@@ -26,7 +38,7 @@ describe('useRenderQueue', () => {
     handlers.clear();
     vi.clearAllMocks();
     globalThis[DESKTOP_RUNTIME_TEST_FLAG] = true;
-    vi.mocked(save).mockResolvedValue('/tmp/out.mp4');
+    vi.mocked(invoke).mockImplementation(withExportPicker('/tmp/out.mp4', () => undefined));
     vi.mocked(listen).mockImplementation(async (event, handler) => {
       handlers.set(String(event), handler as EventHandler);
       return () => {
@@ -55,12 +67,14 @@ describe('useRenderQueue', () => {
   });
 
   it('should process an immediate batch completion event after startBatchRender', async () => {
-    vi.mocked(invoke).mockResolvedValue({
-      batchId: 'batch-1',
-      jobIds: ['job-1'],
-      totalItems: 1,
-      status: 'started',
-    });
+    vi.mocked(invoke).mockImplementation(
+      withExportPicker('/tmp/out.mp4', () => ({
+        batchId: 'batch-1',
+        jobIds: ['job-1'],
+        totalItems: 1,
+        status: 'started',
+      })),
+    );
 
     const { result } = renderHook(() =>
       useRenderQueue({
@@ -96,13 +110,17 @@ describe('useRenderQueue', () => {
   });
 
   it('should not mark a job as cancelled when the backend reports not found', async () => {
-    vi.mocked(save).mockResolvedValue('/tmp/out.mp4');
-    vi.mocked(invoke).mockResolvedValueOnce({
-      batchId: 'batch-1',
-      jobIds: ['job-1'],
-      totalItems: 1,
-      status: 'started',
-    });
+    const backendQueue: unknown[] = [
+      {
+        batchId: 'batch-1',
+        jobIds: ['job-1'],
+        totalItems: 1,
+        status: 'started',
+      },
+    ];
+    vi.mocked(invoke).mockImplementation(
+      withExportPicker('/tmp/out.mp4', () => backendQueue.shift()),
+    );
 
     const { result } = renderHook(() =>
       useRenderQueue({
@@ -123,10 +141,7 @@ describe('useRenderQueue', () => {
       expect(result.current.queue[0]?.status).toBe('rendering');
     });
 
-    vi.mocked(invoke).mockResolvedValueOnce({
-      jobId: 'job-1',
-      cancelled: false,
-    });
+    backendQueue.push({ jobId: 'job-1', cancelled: false });
 
     await act(async () => {
       await result.current.cancelJob('job-1');
@@ -136,12 +151,14 @@ describe('useRenderQueue', () => {
   });
 
   it('should start a queued batch even when the current range inputs become invalid later', async () => {
-    vi.mocked(invoke).mockResolvedValue({
-      batchId: 'batch-1',
-      jobIds: ['job-1'],
-      totalItems: 1,
-      status: 'started',
-    });
+    vi.mocked(invoke).mockImplementation(
+      withExportPicker('/tmp/out.mp4', () => ({
+        batchId: 'batch-1',
+        jobIds: ['job-1'],
+        totalItems: 1,
+        status: 'started',
+      })),
+    );
 
     const { result } = renderHook(() =>
       useRenderQueue({
@@ -188,12 +205,14 @@ describe('useRenderQueue', () => {
   });
 
   it('should preserve the full structured request when adding high quality exports to the queue', async () => {
-    vi.mocked(invoke).mockResolvedValue({
-      batchId: 'batch-1',
-      jobIds: ['job-1'],
-      totalItems: 1,
-      status: 'started',
-    });
+    vi.mocked(invoke).mockImplementation(
+      withExportPicker('/tmp/out.mp4', () => ({
+        batchId: 'batch-1',
+        jobIds: ['job-1'],
+        totalItems: 1,
+        status: 'started',
+      })),
+    );
 
     const { result } = renderHook(() =>
       useRenderQueue({

--- a/src/hooks/useRenderQueue.ts
+++ b/src/hooks/useRenderQueue.ts
@@ -218,6 +218,7 @@ export function useRenderQueue({
       const selected = await pickExportDestination({
         defaultName: `${sequenceName}_${preset.name.replace(/\s+/g, '_')}.${extension}`,
         filters: [{ name: 'Video', extensions: [extension] }],
+        title: `Export - ${preset.name}`,
       });
 
       if (!selected) return;

--- a/src/hooks/useRenderQueue.ts
+++ b/src/hooks/useRenderQueue.ts
@@ -10,7 +10,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { commands } from '@/bindings';
 import type { BatchRenderItemDto } from '@/bindings';
-import { save } from '@tauri-apps/plugin-dialog';
+import { pickExportDestination } from '@/services/exportDestination';
 import {
   EXPORT_PRESETS,
   getPresetExtension,
@@ -215,10 +215,9 @@ export function useRenderQueue({
       if (!preset) return;
 
       const extension = getPresetExtension(presetId);
-      const selected = await save({
-        defaultPath: `${sequenceName}_${preset.name.replace(/\s+/g, '_')}.${extension}`,
+      const selected = await pickExportDestination({
+        defaultName: `${sequenceName}_${preset.name.replace(/\s+/g, '_')}.${extension}`,
         filters: [{ name: 'Video', extensions: [extension] }],
-        title: `Export - ${preset.name}`,
       });
 
       if (!selected) return;

--- a/src/services/exportDestination.ts
+++ b/src/services/exportDestination.ts
@@ -25,6 +25,8 @@ export interface PickExportDestinationArgs {
   defaultName: string;
   /** File type filters shown in the dialog. */
   filters: ExportDestinationFilter[];
+  /** Optional title shown on the native save dialog. */
+  title?: string;
 }
 
 /**
@@ -36,6 +38,7 @@ export async function pickExportDestination(args: PickExportDestinationArgs): Pr
   const selected = await invoke<string | null>('pick_export_destination', {
     defaultName: args.defaultName,
     filters: args.filters,
+    title: args.title,
   });
   return selected ?? null;
 }

--- a/src/services/exportDestination.ts
+++ b/src/services/exportDestination.ts
@@ -1,0 +1,41 @@
+/**
+ * Export destination service.
+ *
+ * Wraps the `pick_export_destination` Tauri command, which opens a native save
+ * dialog in the Rust backend and records the chosen parent directory in a
+ * session-scoped allow-list. Using this command (instead of the frontend
+ * `@tauri-apps/plugin-dialog` `save()`) is what lets the backend accept exports
+ * to user-chosen locations outside the default allowed roots, without weakening
+ * the IPC trust boundary: only directories the user confirms here become writable.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+/** A file type filter shown in the native save dialog. */
+export interface ExportDestinationFilter {
+  /** Human-readable filter name (e.g., "Video"). */
+  name: string;
+  /** File extensions without the leading dot (e.g., ["mp4"]). */
+  extensions: string[];
+}
+
+/** Arguments for {@link pickExportDestination}. */
+export interface PickExportDestinationArgs {
+  /** Suggested file name pre-filled in the dialog. */
+  defaultName: string;
+  /** File type filters shown in the dialog. */
+  filters: ExportDestinationFilter[];
+}
+
+/**
+ * Opens the native save dialog for an export destination.
+ *
+ * @returns The absolute path the user selected, or `null` if the dialog was cancelled.
+ */
+export async function pickExportDestination(args: PickExportDestinationArgs): Promise<string | null> {
+  const selected = await invoke<string | null>('pick_export_destination', {
+    defaultName: args.defaultName,
+    filters: args.filters,
+  });
+  return selected ?? null;
+}


### PR DESCRIPTION
### **User description**
## Description

Adds a native export destination picker and a backend-enforced, session-scoped write allow-list for exports. The renderer resolves the output path through a native save dialog; the backend records the confirmed directory and validates every export write against the default roots plus the user-approved directories. Also carries related packaging tweaks that were part of the same work.

## Related Issue

Closes #743

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `pick_export_destination` IPC command (`src-tauri/src/ipc/commands/export_dialog.rs`) that opens a native save dialog and records the chosen parent directory in a session-scoped approved-export allow-list (`AppState::approve_export_dir` / `approved_export_dirs`); the allow-list can only widen through a real dialog result.
- Introduce `export_allowed_roots(project, approved_dirs)` (`src-tauri/src/core/fs/mod.rs`) and apply it across `start_render`, `render_range`, `batch_render`, `export_frame`, `export_audio_only`, and `export_captions`, replacing `default_export_allowed_roots`.
- Add the frontend `exportDestination` service (`src/services/exportDestination.ts`) and route the export hooks (`useExportDialog`, `useInterchangeExport`, `useRenderQueue`, `useCaptionExport`) through the native picker.
- Packaging: switch the Windows WebView2 bootstrapper to the offline installer (`tauri.conf.json`) and add a GitHub-hosted fallback source for the bundled FFmpeg/FFprobe download (`scripts/prepare-bundled-ffmpeg.mjs`).

## Screenshots / Videos

N/A — the only user-visible change is the native OS "Save As" dialog; no in-app UI layout changes.

## Testing

Local static checks were run; full unit/integration suites run in CI (`.github/workflows/ci.yml`).

### Test Environment

- OS: Windows 11
- Node.js version: v22.19.0
- Rust version: 1.92.0

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [ ] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

The export-hook test files (`useExportDialog.test.ts`, `useInterchangeExport.test.ts`, `useRenderQueue.test.ts`) are updated alongside the change. Local `cargo check --features gui` and `cargo clippy -D warnings` pass; TypeScript type-check and ESLint pass via the pre-commit hook. The full `pnpm test` / `cargo test` suites are left to CI. A follow-up security-hardening PR is stacked on this branch.


___

### **PR Type**
Enhancement


___

### **Description**
- Implements a native save dialog for export destination selection.

- Establishes a backend-enforced, session-scoped allow-list for export directories.

- Integrates the new export destination picker across all frontend export flows.

- Updates backend export commands to validate paths against the approved list.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Frontend Export Hooks] -- "Call pickExportDestination" --> B(Export Destination Service);
  B -- "Invoke pick_export_destination" --> C{Tauri Backend};
  C -- "Open Native Save Dialog" --> D[User Interaction];
  D -- "Selected Path" --> C;
  C -- "Approve Parent Dir" --> E[AppState::approved_export_dirs];
  C -- "Return Selected Path" --> B;
  B -- "Return Path" --> A;
  A -- "Invoke Backend Export Command" --> C;
  C -- "Validate Path with export_allowed_roots" --> E;
  E -- "Allowed Roots" --> C;
  C -- "Proceed with Export" --> F[File System Write];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>useCaptionExport.ts</strong><dd><code>Switches caption export to use native destination picker</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-3789288b72793749cd6e02840e32c2c4952a5b70c0970895dba66c19ab4b493b">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useExportDialog.ts</strong><dd><code>Migrates export dialog to use native destination picker for all </code><br><code>formats</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-100a1cde52e3715f4addc673c125cd63085a97836165b45cc23bd47bbf36c4ed">+7/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useInterchangeExport.ts</strong><dd><code>Adopts native destination picker for interchange format exports</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-b65b55877a41f97da95b8b66d67fc6c602eb241d335b02809638e14067936d52">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRenderQueue.ts</strong><dd><code>Integrates native destination picker for adding items to render queue</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-3716c1fdec2c95cbfbd5cd196cedf6eea71fc6a02e889970153b34e3933115eb">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Adds <code>export_allowed_roots</code> and related tests for export path validation</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-ee66fa1da6146df4d95e808d678b6225815dbfaa120f3407e29f92d40676a71b">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>worker.rs</strong><dd><code>Updates render worker to use <code>export_allowed_roots</code> for path validation</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-698f85a82a42a143fbeb1e262f70ca49bd20962595288210b54b7e84602ad6b3">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>interchange.rs</strong><dd><code>Updates interchange export commands to use `export_allowed_roots`</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-d3f9e5fdd27a7c6faf81afd836f05aa26e533330025b9f5d93df8794a5f8f8b0">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong><dd><code>Updates render commands to use <code>export_allowed_roots</code> for path <br>validation</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.rs</strong><dd><code>Updates caption export to use <code>export_allowed_roots</code> for path validation</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-8f3bc0f34153988c4c381f436da7aaa711daad3d84418067f3505cfb3055b5cc">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Adds <code>approved_export_dirs</code> to <code>AppState</code> and registers new IPC command</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>useExportDialog.test.ts</strong><dd><code>Updates export dialog tests to mock native destination picker</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-3796e2cd9baf4a19931f854a9170f2434b76d91307d7579e9ed1028ded66abf4">+5/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useInterchangeExport.test.ts</strong><dd><code>Adjusts interchange export tests for native destination picker</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-721c340f9b206bf1c10d069cbe297d58bd4bfb3b2595b3acf34b152182d98dc8">+26/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useRenderQueue.test.ts</strong><dd><code>Updates render queue tests to support native destination picker</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-bf71c4f20a26dc188429ae72348eac1945b5c594bb2fbf9b3ebe98006b6a731e">+54/-35</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>New feature</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>exportDestination.ts</strong><dd><code>Introduces frontend service for native export destination picking</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-fcab17bb5fae1dde2fb312b7a040c5ea54d220c5400c4621489a8b357b9cf0b0">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export_dialog.rs</strong><dd><code>Implements `pick_export_destination` command for native save dialog</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-44e10fe25d292865a412c4ddf4377ac359d23be8e938d9e724bd5de231ed97c6">+103/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Registers new `export_dialog` module and commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-8de5687a2d5c74f0cb806414ab85c74e1ad3d290ab3750d2ab020e5a9fb7233c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prepare-bundled-ffmpeg.mjs</strong><dd><code>Adds GitHub fallback URL for bundled FFmpeg/FFprobe download</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-129c13839a37e3dd4539c987702b7ddb827e4425f74c534ca549deb8fb483645">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tauri.conf.json</strong><dd><code>Configures Windows WebView2 bootstrapper to use offline installer</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/744/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a native export destination picker with format-specific file filters and smarter default filenames.
  - Export destinations can now be chosen from approved folders during rendering, caption export, and interchange export.

- **Bug Fixes**
  - Improved export path validation so valid output locations are accepted more reliably.
  - Added alternate download locations for bundled FFmpeg on Windows when the primary source is unavailable.

- **Chores**
  - Updated Windows app installation behavior to use a silent offline WebView installer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->