### PR TITLE
fix: IPC boundary input-validation and output-encoding hardening

### DIFF
--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -132,10 +132,19 @@ fn escape_ffmpeg_filter_value(raw: &str) -> String {
     // FFmpeg filtergraphs treat `:` and `,` as separators and `\` as an escape character.
     // Windows paths also contain `\` and `:` (drive letter), so we must escape them to
     // keep filter strings replayable and safe against filtergraph injection.
+    //
+    // Values produced here are always emitted inside a single-quoted region
+    // (e.g. `subtitles='<value>'`). Inside single quotes FFmpeg treats every
+    // character literally, including `\`, so a bare `\'` does NOT escape a quote —
+    // it terminates the quoted region and lets subsequent `;`/`[`/`]` inject new
+    // filter nodes (arbitrary file read/write via `movie=`/output filters). The
+    // only safe way to embed a literal `'` is to close the quote, emit an escaped
+    // quote, and reopen: `'\''`. This keeps parsing inside the quoted region for
+    // every possible input, so no other character can break out.
     raw.replace('\\', r"\\")
         .replace(':', r"\:")
         .replace(',', r"\,")
-        .replace('\'', r"\'")
+        .replace('\'', r"'\''")
 }
 
 fn escape_drawtext_value(raw: &str) -> String {
@@ -1386,10 +1395,13 @@ impl Effect {
 
         let zoom = self.get_float("zoom").unwrap_or(0.0).clamp(-100.0, 100.0);
 
+        // Emitted inside a single-quoted region (`input='<path>'`); a literal `'`
+        // must be closed-escaped-reopened as `'\''` so it cannot terminate the
+        // quote and inject additional filter nodes. See escape_ffmpeg_filter_value.
         let escaped_path = analysis_path
             .replace('\\', "/")
             .replace(':', "\\:")
-            .replace('\'', "\\'");
+            .replace('\'', "'\\''");
 
         format!(
             "vidstabtransform=input='{}':smoothing={}:crop={}:optzoom={}:zoom={:.1}:interpol=bilinear",
@@ -2578,9 +2590,41 @@ mod tests {
         );
 
         let filter = effect.to_filter_string("in", "out");
+        // A literal single quote is emitted as the FFmpeg close-escape-reopen
+        // sequence `'\''` so it cannot terminate the surrounding single-quoted
+        // region; `'q'` therefore becomes `'\''q'\''`.
         assert!(
-            filter.contains("text='100\\% C\\:\\\\tmp\\\\foo\\:bar\\,baz \\'q\\''"),
+            filter.contains("text='100\\% C\\:\\\\tmp\\\\foo\\:bar\\,baz '\\''q'\\'''"),
             "Unexpected drawtext escaping: {}",
+            filter
+        );
+    }
+
+    #[test]
+    fn test_subtitles_single_quote_cannot_break_out_of_filter() {
+        // A crafted subtitles path with a single quote plus filtergraph separators
+        // must NOT be able to close the quoted region and inject a new filter node
+        // (e.g. `movie=` for arbitrary file read/write). Every literal quote is
+        // rewritten to `'\''`, so the injected `;`/`[`/`]` stay inside the quotes.
+        let mut effect = Effect::new(EffectType::Subtitle);
+        effect.set_param(
+            "file",
+            ParamValue::String("x';[in]movie=filename=/etc/passwd[out];[out]".to_string()),
+        );
+
+        let filter = effect.to_filter_string("in", "out");
+        // The raw breakout sequence `x';` must never survive: an unescaped `'`
+        // followed by `;` would close the quote and make `;` a filtergraph
+        // separator. Correct escaping turns it into `x'\'';`, where the reopened
+        // quote keeps the following `;`/`[`/`]`/`movie=` inside the filename value.
+        assert!(
+            !filter.contains("x';"),
+            "Single quote must not terminate the quoted region: {}",
+            filter
+        );
+        assert!(
+            filter.contains("subtitles='x'\\'';[in]movie=filename=/etc/passwd[out];[out]'"),
+            "Expected close-escape-reopen quoting of the injected value, got: {}",
             filter
         );
     }

--- a/src-tauri/src/ipc/commands/ai_legacy.rs
+++ b/src-tauri/src/ipc/commands/ai_legacy.rs
@@ -2257,6 +2257,55 @@ pub async fn configure_ai_provider(
 ) -> Result<ProviderStatusDto, String> {
     use crate::core::ai::{create_provider, ProviderConfig, ProviderRuntimeStatus, ProviderType};
 
+    // Returns true if `host` (already lowercased, brackets trimmed) refers to a
+    // loopback, private, link-local, or otherwise internal address. Mirrors the
+    // rejection set used by validate_stock_download_url so a caller-supplied cloud
+    // base URL cannot forward the API key to an internal service (SSRF).
+    fn base_url_host_is_internal(host: &str) -> bool {
+        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+            return match ip {
+                std::net::IpAddr::V4(ip) => {
+                    let octets = ip.octets();
+                    ip.is_private()
+                        || ip.is_loopback()
+                        || ip.is_link_local()
+                        || ip.is_unspecified()
+                        || ip.is_broadcast()
+                        || octets[0] == 0
+                        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+                }
+                std::net::IpAddr::V6(ip) => {
+                    ip.is_loopback()
+                        || ip.is_unspecified()
+                        || ip.is_unique_local()
+                        || ip.is_unicast_link_local()
+                }
+            };
+        }
+
+        if host == "localhost"
+            || host.ends_with(".localhost")
+            || host.ends_with(".local")
+            || host == "0.0.0.0"
+            || host.starts_with("0.")
+            || host.starts_with("127.")
+            || host.starts_with("10.")
+            || host.starts_with("100.64.")
+            || host.starts_with("169.254.")
+            || host.starts_with("192.168.")
+            || host == "::1"
+        {
+            return true;
+        }
+
+        matches!(
+            host.strip_prefix("172.")
+                .and_then(|rest| rest.split('.').next())
+                .and_then(|octet| octet.parse::<u8>().ok()),
+            Some(second_octet) if (16..=31).contains(&second_octet)
+        )
+    }
+
     fn validate_base_url(url: &str, allow_http: bool) -> Result<(), String> {
         let url = url.trim();
         if url.is_empty() {
@@ -2274,6 +2323,22 @@ pub async fn configure_ai_provider(
         }
         if is_http && !allow_http {
             return Err("Base URL must use https:// for cloud providers".to_string());
+        }
+
+        // For cloud providers (`allow_http == false`) the API key is sent to this
+        // host in an auth header, so a caller-supplied base URL must not target an
+        // internal/private address. Local providers intentionally use localhost and
+        // are exempt.
+        if !allow_http {
+            let parsed = reqwest::Url::parse(url).map_err(|e| format!("Invalid base URL: {e}"))?;
+            let host = parsed
+                .host_str()
+                .ok_or_else(|| "Base URL must include a host".to_string())?
+                .trim_matches(|ch| ch == '[' || ch == ']')
+                .to_ascii_lowercase();
+            if base_url_host_is_internal(&host) {
+                return Err("Base URL must not target local/private hosts".to_string());
+            }
         }
 
         Ok(())
@@ -2338,6 +2403,30 @@ pub async fn configure_ai_provider(
             cfg
         }
     };
+
+    // Warn when a cloud provider is pointed at a non-default endpoint: the API key
+    // is sent to this host in the auth header. Internal/private hosts are already
+    // rejected by validate_base_url; this surfaces use of any external custom
+    // endpoint for auditability. (Logging the URL is safe; the key is never logged.)
+    if !matches!(provider_type, ProviderType::Local) {
+        if let Some(custom_base) = requested_base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let provider_label = match provider_type {
+                ProviderType::OpenAI => "openai",
+                ProviderType::Anthropic => "anthropic",
+                ProviderType::Gemini => "gemini",
+                ProviderType::Local => "local",
+            };
+            tracing::warn!(
+                provider = provider_label,
+                base_url = %custom_base,
+                "Cloud AI provider configured with a custom base URL; the API key will be sent to this host"
+            );
+        }
+    }
 
     // Create the provider
     let provider = create_provider(provider_config).map_err(|e| e.to_ipc_error())?;

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -883,11 +883,22 @@ pub async fn import_diarization_json(
         }
     };
 
-    let json = tokio::fs::read_to_string(&resolved_input_path)
+    // Security: `input_path` is caller-supplied and reaches the filesystem directly.
+    // Validate it (rejects `..` traversal, URL/protocol strings, and non-regular
+    // files) so a compromised renderer cannot coerce reads of arbitrary locations,
+    // and map IO/parse failures to generic messages so the target file's contents
+    // are never reflected back to the caller via error strings.
+    let validated_input_path = crate::core::fs::validate_local_input_path(
+        &resolved_input_path.to_string_lossy(),
+        "diarization inputPath",
+    )
+    .map_err(|_| "Invalid diarization input path".to_string())?;
+
+    let json = tokio::fs::read_to_string(&validated_input_path)
         .await
-        .map_err(|e| format!("Failed to read diarization JSON: {}", e))?;
-    let diarization_segments =
-        parse_imported_diarization_json(&json).map_err(|e| e.to_ipc_error())?;
+        .map_err(|_| "Failed to read diarization JSON file".to_string())?;
+    let diarization_segments = parse_imported_diarization_json(&json)
+        .map_err(|_| "Failed to parse diarization JSON: invalid format".to_string())?;
 
     let runner = AnalysisJobRunner::new(&project_path);
     let mut bundle = runner

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -1617,6 +1617,15 @@ pub async fn stabilize_clip(
         (asset.uri.clone(), project.path.clone())
     };
 
+    // Security: the asset URI can be set via UpdateAsset without validation, so
+    // re-validate before handing it to ffmpeg. This rejects `..`/URL/protocol
+    // strings and non-existent files, preventing path traversal, ffmpeg-protocol
+    // SSRF, and argument injection at the input arg.
+    let source_path = validate_local_input_path(&source_path, "stabilize source")
+        .map_err(|e| format!("Invalid source media path: {}", e))?
+        .to_string_lossy()
+        .to_string();
+
     // Get FFmpeg runner
     let ffmpeg_guard = ffmpeg_state.read().await;
     let ffmpeg = ffmpeg_guard.runner().ok_or_else(|| {
@@ -1854,6 +1863,17 @@ pub async fn smart_reframe(
 
         asset.uri.clone()
     };
+
+    // Security: the asset URI can be set via UpdateAsset without validation, so
+    // re-validate before handing it to ffprobe/ffmpeg. This rejects `..`/URL/
+    // protocol strings and non-existent files, preventing path traversal,
+    // ffmpeg-protocol SSRF, and ffprobe argument injection (the URI is passed as a
+    // bare positional arg below, so a leading `-` would otherwise be parsed as an
+    // option; an absolute validated path cannot).
+    let source_path = validate_local_input_path(&source_path, "reframe source")
+        .map_err(|e| format!("Invalid source media path: {}", e))?
+        .to_string_lossy()
+        .to_string();
 
     // Get FFmpeg runner (for ffprobe access)
     let ffmpeg_guard = ffmpeg_state.read().await;

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -466,7 +466,17 @@ pub async fn transcribe_asset(
             .get(&asset_id)
             .ok_or_else(|| format!("Asset not found: {}", asset_id))?;
 
-        (PathBuf::from(&asset.uri), asset.name.clone())
+        // Security: the asset URI can be set via UpdateAsset without validation, and
+        // this synchronous path feeds it straight to ffmpeg. Re-validate to reject
+        // `..`/URL/protocol strings and non-existent files, preventing path traversal
+        // and ffmpeg-protocol handling of a caller-controlled input.
+        let validated = crate::core::fs::validate_local_input_path(
+            &asset.uri,
+            "transcription source",
+        )
+        .map_err(|e| format!("Invalid source media path: {}", e))?;
+
+        (validated, asset.name.clone())
     };
 
     tracing::info!(

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -470,11 +470,9 @@ pub async fn transcribe_asset(
         // this synchronous path feeds it straight to ffmpeg. Re-validate to reject
         // `..`/URL/protocol strings and non-existent files, preventing path traversal
         // and ffmpeg-protocol handling of a caller-controlled input.
-        let validated = crate::core::fs::validate_local_input_path(
-            &asset.uri,
-            "transcription source",
-        )
-        .map_err(|e| format!("Invalid source media path: {}", e))?;
+        let validated =
+            crate::core::fs::validate_local_input_path(&asset.uri, "transcription source")
+                .map_err(|e| format!("Invalid source media path: {}", e))?;
 
         (validated, asset.name.clone())
     };


### PR DESCRIPTION
### **User description**
## Description

Input-validation and output-encoding hardening for the IPC / renderer trust boundary across the effects, render/transcription, analysis, and AI-provider command paths. Details are intentionally kept high-level here in line with the project's private security-disclosure policy (`.github/ISSUE_TEMPLATE/config.yml`).

## Related Issue

N/A — security hardening. Per the project's security policy these are handled through the private disclosure channel rather than public issues, so there is no public issue to close.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- effects: correct the single-quoted FFmpeg filter-value encoding so effect string parameters cannot alter the surrounding filtergraph structure.
- render/transcription: validate media source paths before they are handed to ffmpeg/ffprobe in `stabilize_clip`, `smart_reframe`, and `transcribe_asset`.
- analysis: scope the diarization-import path and return generic error messages instead of reflecting file contents.
- ai: reject internal/private hosts for custom cloud-provider base URLs (local providers, which use localhost, remain exempt) and log when a custom endpoint is configured.

## Screenshots / Videos

N/A — backend-only changes.

## Testing

### Test Environment

- OS: Windows 11
- Node.js version: v22.19.0
- Rust version: 1.92.0

### Tests Performed

- [ ] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The export feature this was stacked on (#744) is merged, so this PR now targets `main` directly and contains only the security-hardening commits (plus a merge of `main` to stay current). Local verification: `cargo fmt --all --check`, `cargo clippy --features gui -D warnings`, and the generated-bindings sync check are clean; the `effects::filter_builder` module tests (207) pass, including a new regression test for the filter-value encoding. The full `pnpm test` / `cargo test` suites run in CI (`.github/workflows/ci.yml`). Detailed vulnerability analysis was performed separately and is intentionally not reproduced here per the private security-disclosure policy.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent FFmpeg filtergraph injection via effect parameters.

- Validate AI provider base URLs to prevent SSRF.

- Scope diarization import paths and hide error details.

- Re-validate asset URIs before FFmpeg/FFprobe processing.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter_builder.rs</strong><dd><code>Fix FFmpeg filtergraph injection via effect parameters</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/effects/filter_builder.rs

<ul><li>Corrected FFmpeg filter value escaping to prevent filtergraph <br>injection.<br> <li> Changed single quote escaping from <code>\'</code> to <code>'\''</code> to ensure quotes are <br>properly embedded within single-quoted regions.<br> <li> Updated <code>vidstabtransform</code> path escaping to use the new <code>'\''</code> sequence <br>for single quotes.<br> <li> Added a new test case <br><code>test_subtitles_single_quote_cannot_break_out_of_filter</code> to verify the <br>fix.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/745/files#diff-86aaa5bbc7d4304dce89d4a4bb017d4044971db7e1ef672b58072d452c2ab8de">+47/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai_legacy.rs</strong><dd><code>Prevent SSRF by validating AI provider base URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/ai_legacy.rs

<ul><li>Introduced <code>base_url_host_is_internal</code> function to identify loopback, <br>private, and link-local IP addresses/hostnames.<br> <li> Modified <code>validate_base_url</code> to reject internal/private hosts for cloud <br>AI provider base URLs, preventing SSRF.<br> <li> Added a warning log when a cloud AI provider is configured with a <br>custom base URL for auditability.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/745/files#diff-845d6b859f348138f8dfb2cd2ddca34ee0cd7284e6f2e34350cf24495507ee05">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>analysis.rs</strong><dd><code>Scope diarization import path and hide error details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/analysis.rs

<ul><li>Implemented <code>validate_local_input_path</code> for the <code>input_path</code> in <br><code>import_diarization_json</code>.<br> <li> Rejected path traversal (<code>..</code>), URL/protocol strings, and non-regular <br>files for diarization input.<br> <li> Replaced detailed error messages with generic ones to prevent <br>information leakage about file contents.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/745/files#diff-27ee8d77b931eb5265b4548b8b912173ea914870e28c0a6e0ecba9a971e37f5f">+15/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>render.rs</strong><dd><code>Validate asset URIs before FFmpeg/FFprobe processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/render.rs

<ul><li>Added <code>validate_local_input_path</code> for <code>source_path</code> in <code>stabilize_clip</code> and <br><code>smart_reframe</code>.<br> <li> Ensured asset URIs are re-validated before being passed to <br>FFmpeg/FFprobe.<br> <li> Prevented path traversal, ffmpeg-protocol SSRF, and argument injection <br>vulnerabilities.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/745/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transcription.rs</strong><dd><code>Validate asset URIs before transcription</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/transcription.rs

<ul><li>Applied <code>validate_local_input_path</code> to <code>asset.uri</code> in <code>transcribe_asset</code>.<br> <li> Re-validated the asset URI to prevent path traversal and <br>ffmpeg-protocol handling of caller-controlled inputs.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/745/files#diff-8f3bc0f34153988c4c381f436da7aaa711daad3d84418067f3505cfb3055b5cc">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

