### PR TITLE
fix(commands): persist motion keyframes through replay

### DIFF
--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -135,6 +135,7 @@ impl CommandExecutor {
         // Capture command metadata for persistence.
         // NOTE: ops.jsonl must contain replayable operations, not just the input command payload.
         let type_name = command.type_name().to_string();
+        let op_kind = Self::type_name_to_op_kind(&type_name)?;
         let command_json = command.to_json();
         let prev_op_id = state.last_op_id.clone();
 
@@ -151,7 +152,6 @@ impl CommandExecutor {
         // Build replayable operation payload AFTER executing.
         // Many commands generate IDs at runtime (clips/tracks/sequences), so the operation
         // payload must include the realized entities/fields.
-        let op_kind = Self::type_name_to_op_kind(&type_name);
         let op_payload = Self::build_operation_payload(
             &type_name,
             op_kind.clone(),
@@ -1405,6 +1405,14 @@ impl CommandExecutor {
                     payload.insert("transform".to_string(), to_value(&clip.transform)?);
                 }
 
+                if type_name == "SetClipMotionKeyframes" {
+                    payload.remove("keyframes");
+                    payload.insert(
+                        "motionKeyframes".to_string(),
+                        to_value(&clip.motion_keyframes)?,
+                    );
+                }
+
                 if type_name == "SetClipBlendMode" {
                     payload.insert("blendMode".to_string(), to_value(&clip.blend_mode)?);
                 }
@@ -2037,8 +2045,8 @@ impl CommandExecutor {
     }
 
     /// Converts command type name to OpKind
-    fn type_name_to_op_kind(type_name: &str) -> OpKind {
-        match type_name {
+    fn type_name_to_op_kind(type_name: &str) -> CoreResult<OpKind> {
+        let op_kind = match type_name {
             "InsertClip" | "AddClip" => OpKind::ClipAdd,
             "InsertEdit" | "OverwriteEdit" | "RippleDelete" | "CloseGap" | "CloseAllGaps"
             | "Lift" | "ExtractEdit" | "InsertMedia" => OpKind::Batch,
@@ -2047,6 +2055,7 @@ impl CommandExecutor {
             "TrimClip" => OpKind::ClipTrim,
             "SetClipMute"
             | "SetClipTransform"
+            | "SetClipMotionKeyframes"
             | "SetClipAudio"
             | "SetClipSpeed"
             | "SetClipSlowMotionInterpolation"
@@ -2111,8 +2120,14 @@ impl CommandExecutor {
             "RenameFile" => OpKind::FileRename,
             "MoveFile" => OpKind::FileMove,
             "DeleteFile" => OpKind::FileDelete,
-            _ => OpKind::Batch, // Default to batch for unknown types
-        }
+            _ => {
+                return Err(CoreError::NotSupported(format!(
+                    "Unregistered command type: {type_name}"
+                )))
+            }
+        };
+
+        Ok(op_kind)
     }
 
     /// Returns summary info for all entries in the undo stack (oldest first)
@@ -2247,14 +2262,16 @@ mod tests {
         ImportGeneratedCaptionsCommand, InsertClipCommand, InsertEditCommand, LiftCommand,
         LinkClipsCommand, MoveClipCommand, OverwriteEditCommand, RippleDeleteCommand,
         SetAudioFadeInCommand, SetAudioFadeOutCommand, SetClipBlendModeCommand,
-        SetMasterVolumeCommand, SetTrackBlendModeCommand, SplitClipCommand, StateChange,
-        TrimClipCommand, UngroupClipsCommand, UnlinkClipsCommand, UnnestCompoundClipCommand,
+        SetClipMotionKeyframesCommand, SetMasterVolumeCommand, SetTrackBlendModeCommand,
+        SplitClipCommand, StateChange, TrimClipCommand, UngroupClipsCommand, UnlinkClipsCommand,
+        UnnestCompoundClipCommand,
     };
     use crate::core::effects::{EffectType, ParamValue};
     use crate::core::masks::{MaskShape, RectMask};
     use crate::core::project::{OpKind, Operation, OpsLog, ProjectMeta, ProjectState};
     use crate::core::timeline::{
-        BlendMode, Clip, FadeType, Sequence, SequenceFormat, Track, TrackKind,
+        BlendMode, Clip, FadeType, KeyframeInterpolation, Sequence, SequenceFormat, Track,
+        TrackKind, Transform, TransformKeyframe,
     };
     use tempfile::TempDir;
 
@@ -2337,6 +2354,32 @@ mod tests {
 
         fn to_json(&self) -> serde_json::Value {
             serde_json::json!({ "assetId": self.asset_id })
+        }
+    }
+
+    struct TestUnknownCommand {
+        asset: Asset,
+    }
+
+    impl Command for TestUnknownCommand {
+        fn execute(&mut self, state: &mut ProjectState) -> CoreResult<CommandResult> {
+            state
+                .assets
+                .insert(self.asset.id.clone(), self.asset.clone());
+            Ok(CommandResult::new(&ulid::Ulid::new().to_string()))
+        }
+
+        fn undo(&self, state: &mut ProjectState) -> CoreResult<()> {
+            state.assets.remove(&self.asset.id);
+            Ok(())
+        }
+
+        fn type_name(&self) -> &'static str {
+            "UnknownCommand"
+        }
+
+        fn to_json(&self) -> serde_json::Value {
+            serde_json::json!({ "assetId": self.asset.id })
         }
     }
 
@@ -3711,91 +3754,138 @@ mod tests {
 
     #[test]
     fn test_type_name_to_op_kind() {
+        let assert_kind = |type_name, expected| {
+            assert_eq!(
+                CommandExecutor::type_name_to_op_kind(type_name).unwrap(),
+                expected
+            );
+        };
+
+        assert_kind("InsertClip", OpKind::ClipAdd);
+        assert_kind("InsertEdit", OpKind::Batch);
+        assert_kind("OverwriteEdit", OpKind::Batch);
+        assert_kind("RippleDelete", OpKind::Batch);
+        assert_kind("CloseGap", OpKind::Batch);
+        assert_kind("CloseAllGaps", OpKind::Batch);
+        assert_kind("Lift", OpKind::Batch);
+        assert_kind("ExtractEdit", OpKind::Batch);
+        assert_kind("ImportGeneratedCaptions", OpKind::Batch);
+        assert_kind("SplitClip", OpKind::ClipSplit);
+        assert_kind("ImportAsset", OpKind::AssetImport);
+        assert_kind("AddAudioKeyframe", OpKind::ClipUpdate);
+        assert_kind("SetAudioFadeIn", OpKind::ClipUpdate);
+        assert_kind("SetClipMotionKeyframes", OpKind::ClipUpdate);
+        assert_kind("SetMasterVolume", OpKind::SequenceUpdate);
+        assert_kind("CreateCompoundClip", OpKind::CompoundClipCreate);
+        assert_kind("UnnestCompoundClip", OpKind::CompoundClipUnnest);
+        assert_kind("GroupClips", OpKind::ClipGroup);
+        assert_kind("UngroupClips", OpKind::ClipUngroup);
+        assert_kind("LinkClips", OpKind::ClipLink);
+        assert_kind("UnlinkClips", OpKind::ClipUnlink);
+        assert_kind("CreateAdjustmentLayer", OpKind::ClipAdd);
+
+        let error = CommandExecutor::type_name_to_op_kind("UnknownCommand").unwrap_err();
         assert_eq!(
-            CommandExecutor::type_name_to_op_kind("InsertClip"),
-            OpKind::ClipAdd
+            error.to_string(),
+            "Not supported: Unregistered command type: UnknownCommand"
         );
+    }
+
+    #[test]
+    fn test_executor_rejects_unregistered_command_before_state_mutation() {
+        let mut executor = CommandExecutor::new();
+        let mut state = ProjectState::new("Test");
+        let asset = Asset::new_video("unknown.mp4", "/unknown.mp4", VideoInfo::default());
+
+        let error = executor
+            .execute(Box::new(TestUnknownCommand { asset }), &mut state)
+            .unwrap_err();
+
         assert_eq!(
-            CommandExecutor::type_name_to_op_kind("InsertEdit"),
-            OpKind::Batch
+            error.to_string(),
+            "Not supported: Unregistered command type: UnknownCommand"
         );
+        assert!(state.assets.is_empty());
+        assert_eq!(executor.undo_count(), 0);
+        assert!(!state.is_dirty);
+    }
+
+    #[test]
+    fn test_executor_persists_and_replays_realized_motion_keyframes() {
+        let temp_dir = TempDir::new().unwrap();
+        let ops_path = temp_dir.path().join("ops.jsonl");
+        let ops_log = OpsLog::new(&ops_path);
+        let mut state = ProjectState::new_empty("Test");
+        let (sequence_id, track_id, clip_ids) =
+            seed_replayable_video_track_with_clips(&ops_log, &mut state, &[(0.0, 5.0)]);
+        let clip_id = &clip_ids[0];
+        let mut executor = CommandExecutor::with_ops_log(ops_log);
+
+        let mut late_transform = Transform::default();
+        late_transform.position.x = 2.0;
+        late_transform.scale.x = 0.0;
+        let keyframes = vec![
+            TransformKeyframe {
+                time_offset: 4.0,
+                transform: late_transform,
+                interpolation: KeyframeInterpolation::Hold,
+            },
+            TransformKeyframe {
+                time_offset: -1.0,
+                transform: Transform::default(),
+                interpolation: KeyframeInterpolation::Linear,
+            },
+            TransformKeyframe {
+                time_offset: 0.0,
+                transform: Transform::default(),
+                interpolation: KeyframeInterpolation::Linear,
+            },
+        ];
+
+        executor
+            .execute(
+                Box::new(SetClipMotionKeyframesCommand::new(
+                    &sequence_id,
+                    &track_id,
+                    clip_id,
+                    keyframes,
+                )),
+                &mut state,
+            )
+            .unwrap();
+
+        let realized_keyframes = state.sequences[&sequence_id].tracks[0].clips[0]
+            .motion_keyframes
+            .clone();
+        assert_eq!(realized_keyframes.len(), 2);
+        assert_eq!(realized_keyframes[0].time_offset, 0.0);
+        assert_eq!(realized_keyframes[1].time_offset, 4.0);
+        assert_eq!(realized_keyframes[1].transform.position.x, 1.0);
+        assert_eq!(realized_keyframes[1].transform.scale.x, 0.01);
+
+        executor.undo(&mut state).unwrap();
+        assert!(state.sequences[&sequence_id].tracks[0].clips[0]
+            .motion_keyframes
+            .is_empty());
+        executor.redo(&mut state).unwrap();
         assert_eq!(
-            CommandExecutor::type_name_to_op_kind("OverwriteEdit"),
-            OpKind::Batch
+            state.sequences[&sequence_id].tracks[0].clips[0].motion_keyframes,
+            realized_keyframes
         );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("RippleDelete"),
-            OpKind::Batch
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("CloseGap"),
-            OpKind::Batch
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("CloseAllGaps"),
-            OpKind::Batch
-        );
-        assert_eq!(CommandExecutor::type_name_to_op_kind("Lift"), OpKind::Batch);
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("ExtractEdit"),
-            OpKind::Batch
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("ImportGeneratedCaptions"),
-            OpKind::Batch
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("SplitClip"),
-            OpKind::ClipSplit
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("ImportAsset"),
-            OpKind::AssetImport
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("AddAudioKeyframe"),
-            OpKind::ClipUpdate
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("SetAudioFadeIn"),
-            OpKind::ClipUpdate
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("SetMasterVolume"),
-            OpKind::SequenceUpdate
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("CreateCompoundClip"),
-            OpKind::CompoundClipCreate
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("UnnestCompoundClip"),
-            OpKind::CompoundClipUnnest
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("GroupClips"),
-            OpKind::ClipGroup
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("UngroupClips"),
-            OpKind::ClipUngroup
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("LinkClips"),
-            OpKind::ClipLink
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("UnlinkClips"),
-            OpKind::ClipUnlink
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("CreateAdjustmentLayer"),
-            OpKind::ClipAdd
-        );
-        assert_eq!(
-            CommandExecutor::type_name_to_op_kind("UnknownCommand"),
-            OpKind::Batch
-        );
+
+        let read = OpsLog::new(&ops_path).read_all().unwrap();
+        let persisted = read.operations.last().unwrap();
+        assert_eq!(persisted.kind, OpKind::ClipUpdate);
+        assert!(persisted.payload.get("keyframes").is_none());
+        let persisted_keyframes: Vec<TransformKeyframe> =
+            serde_json::from_value(persisted.payload["motionKeyframes"].clone()).unwrap();
+        assert_eq!(persisted_keyframes, realized_keyframes);
+
+        let replayed =
+            ProjectState::from_operations(read.operations, ProjectMeta::new("Replay")).unwrap();
+        let replayed_keyframes =
+            &replayed.sequences[&sequence_id].tracks[0].clips[0].motion_keyframes;
+        assert_eq!(replayed_keyframes, &realized_keyframes);
     }
 
     // =========================================================================

--- a/src-tauri/src/core/project/state.rs
+++ b/src-tauri/src/core/project/state.rs
@@ -15,7 +15,10 @@ use crate::core::{
     effects::Effect,
     masks::MaskGroup,
     project::{OpKind, Operation, OpsLog},
-    timeline::{AudioSettings, BlendMode, Clip, Marker, Sequence, SequenceHdrSettings, Track},
+    timeline::{
+        AudioSettings, BlendMode, Clip, Marker, Sequence, SequenceHdrSettings, Track,
+        TransformKeyframe,
+    },
     AssetId, CoreError, CoreResult, EffectId, SequenceId,
 };
 
@@ -1253,6 +1256,23 @@ impl ProjectState {
                         None
                     };
 
+                let parsed_motion_keyframes: Option<Vec<TransformKeyframe>> =
+                    if let Some(keyframes_value) = op.payload.get("motionKeyframes") {
+                        if keyframes_value.is_null() {
+                            None
+                        } else {
+                            Some(
+                                serde_json::from_value(keyframes_value.clone()).map_err(|e| {
+                                    CoreError::InvalidCommand(format!(
+                                        "Invalid motionKeyframes payload: {e}"
+                                    ))
+                                })?,
+                            )
+                        }
+                    } else {
+                        None
+                    };
+
                 // ── Phase 2: Apply all mutations (validation already passed) ──
 
                 let has_full_audio_payload = parsed_audio.is_some();
@@ -1305,6 +1325,9 @@ impl ProjectState {
                     // Transform was pre-validated before any mutation.
                     if let Some(transform) = parsed_transform {
                         clip.transform = transform;
+                    }
+                    if let Some(motion_keyframes) = parsed_motion_keyframes {
+                        clip.motion_keyframes = motion_keyframes;
                     }
                     return Ok(());
                 }
@@ -1372,6 +1395,9 @@ impl ProjectState {
                             })?;
                         clip.transform = transform;
                     }
+                }
+                if let Some(motion_keyframes) = parsed_motion_keyframes {
+                    clip.motion_keyframes = motion_keyframes;
                 }
                 return Ok(());
             }
@@ -2328,7 +2354,9 @@ mod tests {
     use super::*;
     use crate::core::{
         assets::{Asset, VideoInfo},
-        timeline::{Clip, Sequence, SequenceFormat, Track, TrackKind},
+        timeline::{
+            Clip, KeyframeInterpolation, Sequence, SequenceFormat, Track, TrackKind, Transform,
+        },
     };
     use tempfile::TempDir;
 
@@ -3740,6 +3768,141 @@ mod tests {
             .get_clip(&clip_id)
             .unwrap();
         assert_eq!(updated_clip.blend_mode, BlendMode::Screen);
+    }
+
+    #[test]
+    fn test_clip_update_motion_keyframes_replays_canonical_payload() {
+        let mut state = ProjectState::new("Test Project");
+        let seq_id = state.active_sequence_id.clone().unwrap();
+        let video_track = state
+            .sequences
+            .get_mut(&seq_id)
+            .unwrap()
+            .tracks
+            .get_mut(0)
+            .unwrap();
+
+        let clip = Clip::new("asset_video")
+            .with_source_range(0.0, 5.0)
+            .place_at(0.0);
+        let clip_id = clip.id.clone();
+        video_track.add_clip(clip);
+
+        let mut end_transform = Transform::default();
+        end_transform.scale.x = 1.25;
+        end_transform.scale.y = 1.25;
+        let keyframes = vec![
+            TransformKeyframe {
+                time_offset: 0.0,
+                transform: Transform::default(),
+                interpolation: KeyframeInterpolation::Linear,
+            },
+            TransformKeyframe {
+                time_offset: 4.0,
+                transform: end_transform,
+                interpolation: KeyframeInterpolation::Linear,
+            },
+        ];
+
+        state
+            .apply_operation(&Operation::new(
+                OpKind::ClipUpdate,
+                serde_json::json!({
+                    "sequenceId": seq_id,
+                    "clipId": clip_id,
+                    "motionKeyframes": keyframes,
+                }),
+            ))
+            .unwrap();
+
+        let updated_clip = state.sequences[&seq_id].tracks[0]
+            .get_clip(&clip_id)
+            .unwrap();
+        assert_eq!(updated_clip.motion_keyframes, keyframes);
+    }
+
+    #[test]
+    fn test_clip_update_invalid_motion_keyframes_is_atomic() {
+        let mut state = ProjectState::new("Test Project");
+        let seq_id = state.active_sequence_id.clone().unwrap();
+        let video_track = state
+            .sequences
+            .get_mut(&seq_id)
+            .unwrap()
+            .tracks
+            .get_mut(0)
+            .unwrap();
+
+        let mut clip = Clip::new("asset_video")
+            .with_source_range(0.0, 5.0)
+            .place_at(0.0);
+        clip.motion_keyframes = vec![TransformKeyframe {
+            time_offset: 1.0,
+            transform: Transform::default(),
+            interpolation: KeyframeInterpolation::Hold,
+        }];
+        let original_keyframes = clip.motion_keyframes.clone();
+        let clip_id = clip.id.clone();
+        video_track.add_clip(clip);
+
+        let result = state.apply_operation(&Operation::new(
+            OpKind::ClipUpdate,
+            serde_json::json!({
+                "sequenceId": seq_id,
+                "clipId": clip_id,
+                "blendMode": "screen",
+                "motionKeyframes": { "not": "an array" },
+            }),
+        ));
+
+        assert!(matches!(result, Err(CoreError::InvalidCommand(_))));
+        let unchanged_clip = state.sequences[&seq_id].tracks[0]
+            .get_clip(&clip_id)
+            .unwrap();
+        assert_eq!(unchanged_clip.blend_mode, BlendMode::Normal);
+        assert_eq!(unchanged_clip.motion_keyframes, original_keyframes);
+    }
+
+    #[test]
+    fn test_clip_update_motion_keyframes_applies_with_full_audio_payload() {
+        let mut state = ProjectState::new("Test Project");
+        let seq_id = state.active_sequence_id.clone().unwrap();
+        let video_track = state
+            .sequences
+            .get_mut(&seq_id)
+            .unwrap()
+            .tracks
+            .get_mut(0)
+            .unwrap();
+
+        let clip = Clip::new("asset_video")
+            .with_source_range(0.0, 5.0)
+            .place_at(0.0);
+        let clip_id = clip.id.clone();
+        video_track.add_clip(clip);
+
+        let keyframes = vec![TransformKeyframe {
+            time_offset: 0.0,
+            transform: Transform::default(),
+            interpolation: KeyframeInterpolation::Linear,
+        }];
+
+        state
+            .apply_operation(&Operation::new(
+                OpKind::ClipUpdate,
+                serde_json::json!({
+                    "sequenceId": seq_id,
+                    "clipId": clip_id,
+                    "audio": AudioSettings::default(),
+                    "motionKeyframes": keyframes,
+                }),
+            ))
+            .unwrap();
+
+        let updated_clip = state.sequences[&seq_id].tracks[0]
+            .get_clip(&clip_id)
+            .unwrap();
+        assert_eq!(updated_clip.motion_keyframes, keyframes);
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## Description

Fix the runtime execution and event-log replay path for `SetClipMotionKeyframes`. The command is now classified before execution, persisted using canonical `motionKeyframes`, and restored during replay. Unregistered command types are rejected before they can mutate project state.

## Related Issue

Closes #762

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Classify `SetClipMotionKeyframes` as a replayable `ClipUpdate` before command execution.
- Persist only the realized and normalized `motionKeyframes` payload and restore it during operation-log replay.
- Reject unregistered command types before state mutation and add regression coverage for persistence, replay, undo/redo, and malformed payloads.

## Screenshots / Videos

Not applicable. This is a backend command execution and persistence fix with no UI changes.

## Testing

### Test Environment

- OS: Microsoft Windows 11 Pro (build 26200)
- Node.js version: v22.19.0
- Rust version: rustc 1.92.0 (ded5c06cf 2025-12-08)

### Tests Performed

- [x] Unit tests pass (`npm run test:run` — 8,096 passed)
- [x] Rust tests pass (`cargo test -p openreelio --lib` — 3,293 passed, 2 ignored)
- [ ] Manual testing performed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- No documentation changes are required because this fixes an internal command classification and replay defect without changing the public API.
- This change has no dependent PRs or packages.
- Additional verification passed: `cargo fmt --all -- --check`, `cargo clippy -p openreelio --lib -- -D warnings`, and `cargo check -p openreelio --features gui`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enable `SetClipMotionKeyframes` command execution.

- Persist normalized motion keyframes for replay.

- Reject unregistered commands before state mutation.

- Add comprehensive tests for command persistence and error handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Command Input] --> B{Determine OpKind};
  B -- "Unregistered Type" --> C{Error: Not Supported};
  B -- "SetClipMotionKeyframes" --> D[Normalize Motion Keyframes Payload];
  B -- "Other Valid Type" --> E[Execute Command];
  D --> E;
  E --> F[Persist Operation to OpsLog];
  F --> G[ProjectState (Replay)];
  G -- "Apply motionKeyframes" --> H[Clip State Updated];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Enhance command classification and SetClipMotionKeyframes persistence</code></dd></summary>
<hr>

src-tauri/src/core/commands/executor.rs

<ul><li>Modified <code>type_name_to_op_kind</code> to return <code>CoreResult<OpKind></code>, explicitly <br>rejecting unregistered command types with a <code>CoreError::NotSupported</code> <br>error instead of defaulting to <code>OpKind::Batch</code>.<br> <li> Moved the <code>op_kind</code> determination to occur *before* command execution, <br>enabling early rejection of unsupported commands.<br> <li> Added specific logic to <code>build_operation_payload</code> for <br><code>SetClipMotionKeyframes</code> to remove the raw <code>keyframes</code> and persist the <br>*realized and normalized* <code>motionKeyframes</code> from the clip.<br> <li> Included <code>SetClipMotionKeyframes</code> in the <code>ClipUpdate</code> category within <br><code>type_name_to_op_kind</code>.<br> <li> Added new test cases to verify that unregistered commands are rejected <br>before state mutation and that <code>SetClipMotionKeyframes</code> correctly <br>persists and replays realized keyframes, including undo/redo <br>functionality.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/763/files#diff-ef781f77e71d37b770c063002c84fcc01b122dc1b694a44036f644fa4106d946">+177/-87</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>state.rs</strong><dd><code>Enable motion keyframe replay and ensure atomic updates</code>&nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/project/state.rs

<ul><li>Added <code>TransformKeyframe</code> to imports for handling motion keyframes.<br> <li> Implemented logic within <code>apply_operation</code> to parse and apply <br><code>motionKeyframes</code> from the operation payload during project replay.<br> <li> Ensured <code>motionKeyframes</code> are correctly applied when a full audio <br>payload is present, covering different update paths.<br> <li> Added new test cases to confirm that <code>motionKeyframes</code> are replayed <br>correctly and that invalid <code>motionKeyframes</code> payloads result in atomic <br>failures, preventing partial state updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/763/files#diff-0fc2d8061589576bbb640630c10ba515b1532fafe1de0524754a126d0f551b0e">+165/-2</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown commands are now rejected safely before they can modify project state.
  * Clip motion keyframes now persist and replay correctly, including through undo and redo.
  * Invalid keyframe updates no longer partially change clip data.
  * Motion keyframes are correctly applied alongside full audio updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->