### PR TITLE
feat(core): unify FFmpeg dependency management with in-app installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,8 +353,9 @@ jobs:
 
       - name: Prepare FFmpeg binaries for target platform
         env:
-          # Current upstream FFmpeg URLs are mutable. Keep this explicit so the
-          # release job does not pretend these downloads are checksum-pinned.
+          # Sources come from scripts/ffmpeg-sources.json. Primary URLs are
+          # verified against provider-published SHA-256 sidecars; this flag
+          # keeps fallback URLs without published checksums usable.
           OPENREELIO_ALLOW_UNVERIFIED_FFMPEG: '1'
         run: node scripts/prepare-bundled-ffmpeg.mjs ${{ matrix.target }}
         timeout-minutes: 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -975,36 +975,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad3e7d446bbdc05f33371b17aae2857e2c5f1dd6750848f555c129c5060725f"
+checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ee145f9cbf7474350ee48e5c33ec2312177fa32c07e4eb395727250892a201"
+checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7025668e34c499fd0960dfaf68bc1689c961002fb67227f3dd262535c4118e52"
+checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad0b552e9b906fee4416b68664463e80f9024215da2cebd4065eee99d5d3008"
+checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87371fa1b0e21dc0a7943f372ce5a308c7d6b26ef8c9982a8a063218fe101ae"
+checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ef297d4dd3af3e571691568958ceea1d3e723bb24eef4e934bbd569c93ef6"
+checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1052,24 +1052,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65396f589d1f746f52db7370372bc8611aa7a5bc0b0322f77deaa1b62e12287"
+checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5731530f81a1566057f9475639f34463e723210ef2484fe9f087e03d79e879a"
+checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3437f152d3766d07420956f4eabaa6f89fa98543e53d387dd1e395980441c68d"
+checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dbb5c65123d9bd76a701523d72f78e1f9b754321caa7767a70ea9304f49be1"
+checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1090,15 +1090,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a493c7a6e01f9c6e9b5468faa7f13a06d6d882f92942f8042a0fd0a8e3e8bc2c"
+checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bd8bd6a0a5bce75e9b24b4e9578114ef6be94795956c4d19aeaa1da607abfd"
+checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.11"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c33438ba0b8ba75137bd45eb0d36a319efe90cf145f9fd5773b84f0b89f0edc"
+checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
 
 [[package]]
 name = "crc"
@@ -1694,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1723,7 +1723,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1862,7 +1862,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2631,7 +2631,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -2845,7 +2845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4488,9 +4488,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae33db3d81aa92ead4ba06f7f9bbf32b2d8ff4132a00df5fa0913fd03dfa33c"
+checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4500,9 +4500,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
+checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4570,7 +4570,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5051,7 +5051,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5118,7 +5118,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5937,7 +5937,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -6378,7 +6378,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7334,9 +7334,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319b720df5e1c49b5dbc916d28a386aad3f03ed96fa3cebe2c6270eb11b6baf3"
+checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -7389,9 +7389,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc2633f356486b8c5917e2aad7aca2b5b54f0f674a8f384a166e34d48101893"
+checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7416,18 +7416,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e647efa7382e8cc8b668ee871af1da0f097d5f12ba2242ac865107c30996e8"
+checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd2f0ea194190ae3d89e7d3f7a9bf95ccf7decdcb27ddef8418f7e03f5aeed5"
+checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7445,9 +7445,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13915309c8ac371ce8aaadf856aad7a7685e390fdf158df1d35c3b0b7a320c44"
+checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7460,15 +7460,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08935e3f35beb765593e42432b6f97fd6df16f1c9aa629a79137a04d30a168f4"
+checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd24355be6b01300639f3fd2e83dfbb75efc18a3d3386e955e87415c96fc105d"
+checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7493,9 +7493,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d322d8644a6057b221215ca579c40e4bdf90146119d4dc5172d2b37b1a0e3bb9"
+checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
 dependencies = [
  "anyhow",
  "cc",
@@ -7509,9 +7509,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307cef37d6c5563e0a408e24ab983b06ebe3ec27dd01675c7e7b12133205484c"
+checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
 dependencies = [
  "cc",
  "object",
@@ -7521,9 +7521,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2e02bd5006f643d8787a33c71e8fb401f029a35df25cd237d25d6d2ddc1c07"
+checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7533,24 +7533,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b0166bd79eb87e2e2e9d6ed7bc6c593428cadfd82cbc94fd113268c29d36a"
+checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3295d1f1de2f3769b749a15e8f64341c38da6faa7fcd737ed485eb3fa40158"
+checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34055eb99cdff44ddd277e3b3baec670ef0302c847465c894f1118d4e7b1e3d"
+checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7561,9 +7561,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
+checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7572,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08a4d8a3501080d3707f845acfcd2fedec9bb91dad3fd9078b7a17e8c8a0884"
+checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7589,9 +7589,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc86f7cc67cafad52959bc1b91176d73e1ed6dbcc00c7a31b3c0a30ac32e881a"
+checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -7602,9 +7602,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53a8072429ae61b472280b33b61dc0d21173b2b21b68a18bb9cc2024d18414d"
+checksum = "82e4772f39340104c70837d421c71c50364c185936f07eaee19e46cb0754c9e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7633,9 +7633,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bd4ac921831465ff97529a528e93f786095adf748d03736e2bd7fb3b0f5623"
+checksum = "b1267c55a52d9ce27da6ff522ddb5b847e811cf477b0ef4c7c1155dd544c25ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7827,9 +7827,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7406efc093a6a31c9a48fb7346e721088a6c9426056217012f1c31e206d07d4e"
+checksum = "3185c97adf4d5f4c0d2abfea7f0bdeb21b486970acd2cf19c7a7fd95308f1764"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7842,9 +7842,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57eb5ff74b0b8b35b22a484a340732dce2f6f2ebb1e54aae0bb2a7f6e72e4285"
+checksum = "13a019367ecff91d714d8f6cba589c36d7b16195eff0598236f9ce5aaf8b811d"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -7856,9 +7856,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba7d2d428b0753e045dd2144b02cb96e0ae7e4f17965905025391ea6810fb5e"
+checksum = "5e2f5a33059321aee91888c331b45de1d6e9f9d0f89ab88398ef1fda2d3ee1fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7888,7 +7888,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7899,9 +7899,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.11"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33afb2737056d7162813a167fc53b8d986e725724a4e6c76ca9910952bb94b5"
+checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
@@ -8495,7 +8495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Prerequisites:
 
 - [Rust](https://rustup.rs/) 1.88+
 - [Node.js](https://nodejs.org/) 20+
-- [FFmpeg](https://ffmpeg.org/) 6+ or bundled FFmpeg binaries in `src-tauri/binaries`
+- [FFmpeg](https://ffmpeg.org/) 6+ (optional): a system FFmpeg/FFprobe on PATH is used if present; otherwise the first debug build automatically downloads bundled binaries into `src-tauri/binaries` (sources pinned in `scripts/ffmpeg-sources.json`; opt out with `SKIP_FFMPEG_DOWNLOAD=1`)
 - (Optional) LLVM/Clang for Whisper: building with `--features whisper` requires `libclang` (bindgen). On Windows, install LLVM and set `LIBCLANG_PATH` to the folder containing `libclang.dll`.
 
 ```bash

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -2,7 +2,9 @@
 
 use crate::output;
 use clap::Subcommand;
-use openreelio_core::ffmpeg::{detect_bundled_at_path, detect_system_ffmpeg, FFmpegRunner};
+use openreelio_core::ffmpeg::{
+    detect_bundled_at_path, detect_system_ffmpeg, set_resolved_paths, FFmpegRunner,
+};
 use openreelio_core::render::{
     build_render_graph, build_render_plan, validate_export_settings, AudioCodec, ExportEngine,
     ExportPreset, ExportSettings, HdrMode, VideoCodec,
@@ -209,12 +211,19 @@ fn detect_cli_ffmpeg() -> anyhow::Result<openreelio_core::ffmpeg::FFmpegInfo> {
             .and_then(|path| path.parent().map(|parent| parent.to_path_buf())),
     ];
 
-    for root in candidate_roots.into_iter().flatten() {
-        if let Ok(info) = detect_bundled_at_path(&root) {
-            return Ok(info);
-        }
-    }
+    let info = candidate_roots
+        .into_iter()
+        .flatten()
+        .find_map(|root| detect_bundled_at_path(&root).ok())
+        .map(Ok)
+        .unwrap_or_else(|| {
+            detect_system_ffmpeg()
+                .map_err(|error| anyhow::anyhow!("FFmpeg initialization failed: {}", error))
+        })?;
 
-    detect_system_ffmpeg()
-        .map_err(|error| anyhow::anyhow!("FFmpeg initialization failed: {}", error))
+    // Publish the detected paths so core modules that spawn ffmpeg/ffprobe
+    // directly resolve the same binaries instead of relying on PATH.
+    set_resolved_paths(info.ffmpeg_path.clone(), info.ffprobe_path.clone());
+
+    Ok(info)
 }

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -51,6 +51,17 @@ Codex CLI is not bundled as a guaranteed runtime dependency. If a feature requir
 
 Release CI prepares FFmpeg/FFprobe with `scripts/prepare-bundled-ffmpeg.mjs` before the Tauri bundle step, then verifies each binary. This avoids requiring users to install FFmpeg separately and avoids a duplicate Rust release build just to fetch runtime tools.
 
+FFmpeg download sources live in a single manifest, `scripts/ffmpeg-sources.json`, shared by the release script and the `src-tauri/build.rs` dev auto-download path. Per target triple:
+
+| Target                     | Provider                        | Fallback                | Checksum                    |
+| -------------------------- | ------------------------------- | ----------------------- | --------------------------- |
+| `x86_64-pc-windows-msvc`   | gyan.dev (release essentials)   | BtbN GitHub builds      | SHA-256 sidecar (both)      |
+| `x86_64-apple-darwin`      | martin-riedl.de (amd64 release) | evermeet.cx             | SHA-256 sidecar (primary)   |
+| `aarch64-apple-darwin`     | martin-riedl.de (arm64 release) | osxexperts.net          | SHA-256 sidecar (primary)   |
+| `x86_64-unknown-linux-gnu` | johnvansickle.com (static)      | BtbN GitHub builds      | SHA-256 sidecar (fallback)  |
+
+macOS installers ship architecture-native binaries: the `aarch64-apple-darwin` build bundles native arm64 FFmpeg/FFprobe instead of x86_64 builds running under Rosetta. Downloads with a checksum source are verified; URLs without one require `OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1` (set in the release workflow).
+
 ---
 
 ## User Installation Guide

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,13 +92,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -117,21 +117,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -148,14 +148,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -165,14 +165,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -192,29 +192,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -264,27 +264,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -336,33 +336,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -370,14 +370,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2672,9 +2672,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3512,9 +3512,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4047,10 +4047,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4369,9 +4379,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -4683,9 +4693,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4703,7 +4713,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4976,9 +4986,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4998,12 +5008,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5951,13 +5961,13 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/scripts/ffmpeg-sources.json
+++ b/scripts/ffmpeg-sources.json
@@ -1,0 +1,138 @@
+{
+  "comment": "Single source of truth for bundled FFmpeg/FFprobe download sources. Consumed by scripts/prepare-bundled-ffmpeg.mjs and src-tauri/build.rs. Each archive lists candidate URLs in priority order; later entries are fallbacks. Checksum fields per URL: 'sha256' pins a hex digest, 'sha256Url' points to a checksum sidecar file (bare digest or 'digest  filename' lines), 'sha256Sidecar' is a suffix appended to the redirect-resolved download URL to locate the provider's sidecar. URLs without any checksum source require OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 (or the build.rs dev auto-download path, which warns instead).",
+  "version": "latest",
+  "targets": {
+    "x86_64-pc-windows-msvc": {
+      "platform": "windows",
+      "archives": [
+        {
+          "name": "ffmpeg",
+          "format": "zip",
+          "filename": "ffmpeg-release-essentials.zip",
+          "binaries": ["ffmpeg.exe", "ffprobe.exe"],
+          "urls": [
+            {
+              "url": "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip",
+              "sha256": null,
+              "sha256Url": "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip.sha256"
+            },
+            {
+              "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
+              "sha256": null,
+              "sha256Url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256"
+            }
+          ]
+        }
+      ]
+    },
+    "x86_64-apple-darwin": {
+      "platform": "macos",
+      "archives": [
+        {
+          "name": "ffmpeg",
+          "format": "zip",
+          "filename": "ffmpeg.zip",
+          "binaries": ["ffmpeg"],
+          "urls": [
+            {
+              "url": "https://ffmpeg.martin-riedl.de/redirect/latest/macos/amd64/release/ffmpeg.zip",
+              "sha256": null,
+              "sha256Url": null,
+              "sha256Sidecar": ".sha256"
+            },
+            {
+              "url": "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip",
+              "sha256": null,
+              "sha256Url": null
+            }
+          ]
+        },
+        {
+          "name": "ffprobe",
+          "format": "zip",
+          "filename": "ffprobe.zip",
+          "binaries": ["ffprobe"],
+          "urls": [
+            {
+              "url": "https://ffmpeg.martin-riedl.de/redirect/latest/macos/amd64/release/ffprobe.zip",
+              "sha256": null,
+              "sha256Url": null,
+              "sha256Sidecar": ".sha256"
+            },
+            {
+              "url": "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip",
+              "sha256": null,
+              "sha256Url": null
+            }
+          ]
+        }
+      ]
+    },
+    "aarch64-apple-darwin": {
+      "platform": "macos",
+      "archives": [
+        {
+          "name": "ffmpeg",
+          "format": "zip",
+          "filename": "ffmpeg.zip",
+          "binaries": ["ffmpeg"],
+          "urls": [
+            {
+              "url": "https://ffmpeg.martin-riedl.de/redirect/latest/macos/arm64/release/ffmpeg.zip",
+              "sha256": null,
+              "sha256Url": null,
+              "sha256Sidecar": ".sha256"
+            },
+            {
+              "url": "https://www.osxexperts.net/ffmpeg9arm.zip",
+              "sha256": null,
+              "sha256Url": null
+            }
+          ]
+        },
+        {
+          "name": "ffprobe",
+          "format": "zip",
+          "filename": "ffprobe.zip",
+          "binaries": ["ffprobe"],
+          "urls": [
+            {
+              "url": "https://ffmpeg.martin-riedl.de/redirect/latest/macos/arm64/release/ffprobe.zip",
+              "sha256": null,
+              "sha256Url": null,
+              "sha256Sidecar": ".sha256"
+            },
+            {
+              "url": "https://www.osxexperts.net/ffprobe9arm.zip",
+              "sha256": null,
+              "sha256Url": null
+            }
+          ]
+        }
+      ]
+    },
+    "x86_64-unknown-linux-gnu": {
+      "platform": "linux",
+      "archives": [
+        {
+          "name": "ffmpeg",
+          "format": "tar.xz",
+          "filename": "ffmpeg-release-amd64-static.tar.xz",
+          "binaries": ["ffmpeg", "ffprobe"],
+          "urls": [
+            {
+              "url": "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz",
+              "sha256": null,
+              "sha256Url": null
+            },
+            {
+              "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
+              "sha256": null,
+              "sha256Url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/prepare-bundled-ffmpeg.mjs
+++ b/scripts/prepare-bundled-ffmpeg.mjs
@@ -49,7 +49,14 @@ function loadTargetConfig(sourceManifest, releaseTarget) {
     process.exit(1);
   }
 
-  for (const archive of targetConfig.archives ?? []) {
+  if (!Array.isArray(targetConfig.archives) || targetConfig.archives.length === 0) {
+    console.error(
+      `Invalid manifest entry for ${releaseTarget}: "archives" must be a non-empty array.`,
+    );
+    process.exit(1);
+  }
+
+  for (const archive of targetConfig.archives) {
     if (
       !archive.name ||
       !archive.format ||
@@ -244,16 +251,25 @@ async function resolveExpectedSha256(source, resolvedUrl) {
     return null;
   }
 
-  const response = await fetch(sidecarUrl, {
-    headers: { 'User-Agent': 'OpenReelio release asset downloader' },
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch checksum sidecar ${sidecarUrl}: HTTP ${response.status}`,
-    );
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  let sidecarText;
+  try {
+    const response = await fetch(sidecarUrl, {
+      headers: { 'User-Agent': 'OpenReelio release asset downloader' },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch checksum sidecar ${sidecarUrl}: HTTP ${response.status}`,
+      );
+    }
+    sidecarText = await response.text();
+  } finally {
+    clearTimeout(timeout);
   }
 
-  const digest = parseSha256Sidecar(await response.text(), source.url);
+  const digest = parseSha256Sidecar(sidecarText, source.url);
   if (!digest) {
     throw new Error(`No matching SHA-256 digest found in ${sidecarUrl}`);
   }

--- a/scripts/prepare-bundled-ffmpeg.mjs
+++ b/scripts/prepare-bundled-ffmpeg.mjs
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
-import { chmod, copyFile, mkdir, readdir, rm } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, readdir, readFile, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { Readable } from 'node:stream';
@@ -7,100 +8,84 @@ import { pipeline } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
 
 const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
-
-const targets = {
-  'x86_64-pc-windows-msvc': {
-    platform: 'windows',
-    sources: [
-      {
-        name: 'ffmpeg',
-        format: 'zip',
-        url: 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip',
-        fallbackUrls: [
-          'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip',
-        ],
-        filename: 'ffmpeg-release-essentials.zip',
-        binaries: ['ffmpeg.exe', 'ffprobe.exe'],
-      },
-    ],
-  },
-  'x86_64-apple-darwin': {
-    platform: 'macos',
-    sources: [
-      {
-        name: 'ffmpeg',
-        format: 'zip',
-        url: 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip',
-        filename: 'ffmpeg.zip',
-        binaries: ['ffmpeg'],
-      },
-      {
-        name: 'ffprobe',
-        format: 'zip',
-        url: 'https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip',
-        filename: 'ffprobe.zip',
-        binaries: ['ffprobe'],
-      },
-    ],
-  },
-  'aarch64-apple-darwin': {
-    platform: 'macos',
-    sources: [
-      {
-        name: 'ffmpeg',
-        format: 'zip',
-        url: 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip',
-        filename: 'ffmpeg.zip',
-        binaries: ['ffmpeg'],
-      },
-      {
-        name: 'ffprobe',
-        format: 'zip',
-        url: 'https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip',
-        filename: 'ffprobe.zip',
-        binaries: ['ffprobe'],
-      },
-    ],
-  },
-  'x86_64-unknown-linux-gnu': {
-    platform: 'linux',
-    sources: [
-      {
-        name: 'ffmpeg',
-        format: 'tar.xz',
-        url: 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz',
-        fallbackUrls: [
-          'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz',
-        ],
-        filename: 'ffmpeg-release-amd64-static.tar.xz',
-        binaries: ['ffmpeg', 'ffprobe'],
-      },
-    ],
-  },
-};
+const DOWNLOAD_ATTEMPTS_PER_URL = 3;
+const DOWNLOAD_RETRY_DELAY_MS = 2000;
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
+const manifestPath = path.join(scriptDir, 'ffmpeg-sources.json');
 const binariesDir = path.join(repoRoot, 'src-tauri', 'binaries');
 
-const target = process.argv[2] ?? process.env.OPENREELIO_RELEASE_TARGET;
-const config = targets[target];
+const args = process.argv.slice(2).filter((arg) => arg !== '--dry-run');
+const dryRun = process.argv.includes('--dry-run');
+const target = args[0] ?? process.env.OPENREELIO_RELEASE_TARGET;
 
-if (!config) {
-  console.error(
-    `Unsupported release target "${target ?? ''}". Expected one of: ${Object.keys(targets).join(', ')}`,
-  );
-  process.exit(1);
-}
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+const config = loadTargetConfig(manifest, target);
 
-if (process.env.OPENREELIO_ALLOW_UNVERIFIED_FFMPEG !== '1') {
-  console.error(
-    'FFmpeg release downloads are not checksum-pinned yet. Set OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 only in the controlled release workflow.',
-  );
-  process.exit(1);
+if (dryRun) {
+  console.log(`Manifest entry for ${target} is valid:`);
+  for (const archive of config.archives) {
+    console.log(
+      `  ${archive.name} (${archive.format}) -> ${archive.binaries.join(', ')}`,
+    );
+    for (const source of archive.urls) {
+      console.log(`    ${source.url} [${describeChecksum(source)}]`);
+    }
+  }
+  process.exit(0);
 }
 
 await prepareBundledFfmpeg(target, config);
+
+function loadTargetConfig(sourceManifest, releaseTarget) {
+  const targets = sourceManifest.targets ?? {};
+  const targetConfig = targets[releaseTarget];
+
+  if (!targetConfig) {
+    console.error(
+      `Unsupported release target "${releaseTarget ?? ''}". Expected one of: ${Object.keys(targets).join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  for (const archive of targetConfig.archives ?? []) {
+    if (
+      !archive.name ||
+      !archive.format ||
+      !archive.filename ||
+      !Array.isArray(archive.binaries) ||
+      archive.binaries.length === 0 ||
+      !Array.isArray(archive.urls) ||
+      archive.urls.length === 0 ||
+      archive.urls.some((source) => typeof source.url !== 'string')
+    ) {
+      console.error(
+        `Invalid manifest entry for ${releaseTarget}: archive "${archive.name ?? '?'}" is missing required fields.`,
+      );
+      process.exit(1);
+    }
+  }
+
+  return targetConfig;
+}
+
+function describeChecksum(source) {
+  if (source.sha256) {
+    return 'pinned sha256';
+  }
+  if (source.sha256Url) {
+    return 'sha256 sidecar url';
+  }
+  if (source.sha256Sidecar) {
+    return `sha256 sidecar suffix ${source.sha256Sidecar}`;
+  }
+  return 'unverified';
+}
+
+function hasChecksumSource(source) {
+  return Boolean(source.sha256 || source.sha256Url || source.sha256Sidecar);
+}
 
 async function prepareBundledFfmpeg(releaseTarget, releaseConfig) {
   const downloadRoot = path.join(
@@ -110,28 +95,29 @@ async function prepareBundledFfmpeg(releaseTarget, releaseConfig) {
     `ffmpeg-download-${releaseTarget}`,
   );
   const stagedBinaries = new Map();
+  const allowUnverified = process.env.OPENREELIO_ALLOW_UNVERIFIED_FFMPEG === '1';
 
   await rm(downloadRoot, { recursive: true, force: true });
   await mkdir(downloadRoot, { recursive: true });
   await mkdir(binariesDir, { recursive: true });
 
   try {
-    for (const source of releaseConfig.sources) {
-      const archivePath = path.join(downloadRoot, source.filename);
-      const extractDir = path.join(downloadRoot, `${source.name}-extracted`);
+    for (const archive of releaseConfig.archives) {
+      const archivePath = path.join(downloadRoot, archive.filename);
+      const extractDir = path.join(downloadRoot, `${archive.name}-extracted`);
 
       await mkdir(extractDir, { recursive: true });
-      await downloadFile(source, archivePath);
-      await extractArchive(source.format, archivePath, extractDir);
+      await downloadArchive(archive, archivePath, allowUnverified);
+      await extractArchive(archive.format, archivePath, extractDir);
 
-      for (const binaryName of source.binaries) {
+      for (const binaryName of archive.binaries) {
         const binaryPath = await findBinary(extractDir, binaryName);
         stagedBinaries.set(binaryName, binaryPath);
       }
     }
 
     const expectedBinaries = [
-      ...new Set(releaseConfig.sources.flatMap((source) => source.binaries)),
+      ...new Set(releaseConfig.archives.flatMap((archive) => archive.binaries)),
     ];
     for (const binaryName of expectedBinaries) {
       const sourcePath = stagedBinaries.get(binaryName);
@@ -154,45 +140,156 @@ async function prepareBundledFfmpeg(releaseTarget, releaseConfig) {
   }
 }
 
-async function downloadFile(source, outputPath) {
-  const urls = [source.url, ...(source.fallbackUrls ?? [])];
-  let lastError;
+async function downloadArchive(archive, outputPath, allowUnverified) {
+  const errors = [];
 
-  for (const url of urls) {
+  for (const source of archive.urls) {
+    if (!hasChecksumSource(source) && !allowUnverified) {
+      errors.push(
+        `${source.url}: no checksum source in manifest and OPENREELIO_ALLOW_UNVERIFIED_FFMPEG is not set to 1`,
+      );
+      continue;
+    }
+
     try {
-      await downloadUrl(url, outputPath);
+      const resolvedUrl = await downloadUrl(source.url, outputPath);
+      await verifyDownload(source, outputPath, resolvedUrl);
       return;
     } catch (error) {
-      lastError = error;
-      console.warn(`Download failed for ${url}: ${error.message}`);
+      errors.push(`${source.url}: ${error.message}`);
+      console.warn(`Download failed for ${source.url}: ${error.message}`);
     }
   }
 
-  throw lastError ?? new Error(`No download URLs configured for ${source.name}`);
+  throw new Error(
+    `All download URLs failed for ${archive.name}: ${errors.join('; ')}`,
+  );
 }
 
 async function downloadUrl(url, outputPath) {
-  console.log(`Downloading ${url}`);
+  let lastError;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  for (let attempt = 1; attempt <= DOWNLOAD_ATTEMPTS_PER_URL; attempt += 1) {
+    console.log(
+      `Downloading ${url}${attempt > 1 ? ` (attempt ${attempt}/${DOWNLOAD_ATTEMPTS_PER_URL})` : ''}`,
+    );
 
-  try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        Accept: 'application/octet-stream, application/x-xz, application/zip, */*',
-        'User-Agent': 'OpenReelio release asset downloader',
-      },
-    });
-    if (!response.ok || !response.body) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/octet-stream, application/x-xz, application/zip, */*',
+          'User-Agent': 'OpenReelio release asset downloader',
+        },
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      await pipeline(Readable.fromWeb(response.body), createWriteStream(outputPath));
+      return response.url || url;
+    } catch (error) {
+      lastError = error;
+      console.warn(`Attempt ${attempt} failed for ${url}: ${error.message}`);
+      if (attempt < DOWNLOAD_ATTEMPTS_PER_URL) {
+        await new Promise((resolve) => setTimeout(resolve, DOWNLOAD_RETRY_DELAY_MS));
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw lastError ?? new Error(`Download failed: ${url}`);
+}
+
+async function verifyDownload(source, archivePath, resolvedUrl) {
+  const expected = await resolveExpectedSha256(source, resolvedUrl);
+
+  if (!expected) {
+    console.warn(
+      `No checksum source for ${source.url}; accepting unverified download (OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1).`,
+    );
+    return;
+  }
+
+  const actual = createHash('sha256')
+    .update(await readFile(archivePath))
+    .digest('hex');
+
+  if (actual.toLowerCase() !== expected.toLowerCase()) {
+    throw new Error(
+      `SHA-256 mismatch for ${path.basename(archivePath)}: expected ${expected}, got ${actual}`,
+    );
+  }
+
+  console.log(`Verified SHA-256 for ${path.basename(archivePath)}: ${actual}`);
+}
+
+async function resolveExpectedSha256(source, resolvedUrl) {
+  if (source.sha256) {
+    return source.sha256;
+  }
+
+  let sidecarUrl = null;
+  if (source.sha256Url) {
+    sidecarUrl = source.sha256Url;
+  } else if (source.sha256Sidecar) {
+    sidecarUrl = `${resolvedUrl}${source.sha256Sidecar}`;
+  }
+
+  if (!sidecarUrl) {
+    return null;
+  }
+
+  const response = await fetch(sidecarUrl, {
+    headers: { 'User-Agent': 'OpenReelio release asset downloader' },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch checksum sidecar ${sidecarUrl}: HTTP ${response.status}`,
+    );
+  }
+
+  const digest = parseSha256Sidecar(await response.text(), source.url);
+  if (!digest) {
+    throw new Error(`No matching SHA-256 digest found in ${sidecarUrl}`);
+  }
+
+  return digest;
+}
+
+function parseSha256Sidecar(sidecarText, sourceUrl) {
+  // Match against the manifest URL basename: redirect targets (for example
+  // GitHub release assets) often resolve to opaque object-storage paths.
+  const downloadBasename = path.posix
+    .basename(new URL(sourceUrl).pathname)
+    .toLowerCase();
+  const digestPattern = /^[0-9a-f]{64}$/i;
+  const digests = [];
+
+  for (const line of sidecarText.split(/\r?\n/)) {
+    const tokens = line.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0 || !digestPattern.test(tokens[0])) {
+      continue;
     }
 
-    await pipeline(Readable.fromWeb(response.body), createWriteStream(outputPath));
-  } finally {
-    clearTimeout(timeout);
+    // Match "digest  filename" lines against the downloaded file first.
+    const fileToken = tokens[tokens.length - 1].replace(/^\*/, '');
+    if (
+      tokens.length > 1 &&
+      path.posix.basename(fileToken).toLowerCase() === downloadBasename
+    ) {
+      return tokens[0];
+    }
+
+    digests.push(tokens[0]);
   }
+
+  // A bare-digest sidecar (single digest, no filename) applies to the download.
+  return digests.length === 1 ? digests[0] : null;
 }
 
 async function extractArchive(format, archivePath, outputDir) {
@@ -208,6 +305,11 @@ async function extractArchive(format, archivePath, outputDir) {
 
   if (format === 'tar.xz') {
     await run('tar', ['-xJf', archivePath, '-C', outputDir]);
+    return;
+  }
+
+  if (format === 'tar.gz') {
+    await run('tar', ['-xzf', archivePath, '-C', outputDir]);
     return;
   }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,8 @@ required-features = ["gui"]
 [build-dependencies]
 tauri-build = { version = "2", features = [], optional = true }
 # FFmpeg bundler build dependencies
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking"] }
 sha2 = "0.10"
 zip = "2.2"
@@ -168,6 +170,9 @@ gui = [
     "dep:sha2",
     "dep:tar",
     "dep:flate2",
+    # In-app FFmpeg installer: zip (Windows/macOS archives) + tar.xz (Linux archives).
+    "dep:zip",
+    "dep:xz2",
     # Browser launcher for the in-app Claude sign-in flow.
     "dep:open",
 ]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -4,8 +4,15 @@
 //! 1. Standard Tauri build process
 //! 2. Automatic FFmpeg binary download for bundling
 //!
-//! FFmpeg is automatically downloaded if binaries don't exist.
-//! Set SKIP_FFMPEG_DOWNLOAD=1 to disable automatic download.
+//! Download sources come from `scripts/ffmpeg-sources.json`, the single
+//! manifest shared with `scripts/prepare-bundled-ffmpeg.mjs`.
+//!
+//! Download policy:
+//! - `SKIP_FFMPEG_DOWNLOAD=1` disables all automatic downloads.
+//! - `OPENREELIO_DOWNLOAD_FFMPEG=1` or the `bundled-ffmpeg` feature opts in
+//!   explicitly (release-style, checksum-strict).
+//! - Debug, non-CI builds auto-download when neither bundled binaries nor a
+//!   system FFmpeg/FFprobe on PATH are available (best-effort verification).
 
 use std::env;
 use std::path::PathBuf;
@@ -26,6 +33,7 @@ fn configure_build_command(command: &mut std::process::Command) {
 fn main() {
     println!("cargo:rerun-if-changed=icons");
     println!("cargo:rerun-if-changed=tauri.conf.json");
+    println!("cargo:rerun-if-changed={FFMPEG_SOURCES_MANIFEST_PATH}");
 
     // Standard Tauri build (only when GUI feature is enabled)
     #[cfg(feature = "gui")]
@@ -50,9 +58,9 @@ fn main() {
     emit_windows_test_manifest_if_requested();
 
     // Download FFmpeg binaries if needed
-    if should_download_ffmpeg() {
+    if let Some(mode) = should_download_ffmpeg() {
         println!("cargo:warning=FFmpeg binaries not found, downloading...");
-        match download_ffmpeg_for_build() {
+        match download_ffmpeg_for_build(mode) {
             Ok(paths) => {
                 println!("cargo:warning=FFmpeg downloaded successfully");
                 println!("cargo:warning=  ffmpeg: {}", paths.ffmpeg.display());
@@ -111,33 +119,78 @@ fn emit_windows_test_manifest_if_requested() {
     );
 }
 
-/// Determine if FFmpeg should be downloaded during build
-fn should_download_ffmpeg() -> bool {
-    // Require explicit opt-in to avoid non-reproducible builds and supply-chain surprises.
-    // Enable by setting `OPENREELIO_DOWNLOAD_FFMPEG=1` after pinned checksums are configured,
-    // or by building with the `bundled-ffmpeg` feature.
-    let opted_in = env::var("OPENREELIO_DOWNLOAD_FFMPEG").ok().as_deref() == Some("1")
-        || env::var("CARGO_FEATURE_BUNDLED_FFMPEG").is_ok();
-    if !opted_in {
-        return false;
-    }
+/// How a build-time FFmpeg download was requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownloadMode {
+    /// Explicit opt-in via `OPENREELIO_DOWNLOAD_FFMPEG=1` or the
+    /// `bundled-ffmpeg` feature. Unverified sources hard-fail unless
+    /// `OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1` is set.
+    Explicit,
+    /// Automatic developer convenience download for debug, non-CI builds.
+    /// Unverified sources emit a warning instead of failing the build.
+    DevAuto,
+}
 
+/// Determine if FFmpeg should be downloaded during build, and in which mode
+fn should_download_ffmpeg() -> Option<DownloadMode> {
     // Skip if explicitly disabled
     if env::var("SKIP_FFMPEG_DOWNLOAD").is_ok() {
-        return false;
+        return None;
     }
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
     let binaries_dir = PathBuf::from(&manifest_dir).join("binaries");
 
+    // Explicit opt-in via env var or the `bundled-ffmpeg` feature.
+    let opted_in = env::var("OPENREELIO_DOWNLOAD_FFMPEG").ok().as_deref() == Some("1")
+        || env::var("CARGO_FEATURE_BUNDLED_FFMPEG").is_ok();
+    if opted_in {
+        if bundled_ffmpeg_binaries_are_usable(&binaries_dir) {
+            return None;
+        }
+
+        println!(
+            "cargo:warning=Bundled FFmpeg binaries are missing or not executable for this platform; downloading replacements."
+        );
+        return Some(DownloadMode::Explicit);
+    }
+
+    // Dev convenience: debug, non-CI builds fetch FFmpeg automatically when
+    // neither bundled binaries nor a system FFmpeg on PATH are available.
+    let is_debug_build = env::var("PROFILE").ok().as_deref() == Some("debug");
+    if !is_debug_build || env::var("CI").is_ok() {
+        return None;
+    }
+
     if bundled_ffmpeg_binaries_are_usable(&binaries_dir) {
-        return false;
+        return None;
+    }
+
+    if system_ffmpeg_available() {
+        return None;
     }
 
     println!(
-        "cargo:warning=Bundled FFmpeg binaries are missing or not executable for this platform; downloading replacements."
+        "cargo:warning=No bundled FFmpeg binaries and no system ffmpeg/ffprobe on PATH; downloading FFmpeg for this debug build (sources: scripts/ffmpeg-sources.json). Set SKIP_FFMPEG_DOWNLOAD=1 to opt out."
     );
-    true
+    Some(DownloadMode::DevAuto)
+}
+
+/// Check whether both `ffmpeg` and `ffprobe` are resolvable on PATH
+fn system_ffmpeg_available() -> bool {
+    let locator = if cfg!(windows) { "where" } else { "which" };
+
+    ["ffmpeg", "ffprobe"].iter().all(|tool| {
+        let mut command = std::process::Command::new(locator);
+        configure_build_command(&mut command);
+        command
+            .arg(tool)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    })
 }
 
 fn bundled_ffmpeg_binaries_are_usable(binaries_dir: &Path) -> bool {
@@ -170,17 +223,17 @@ fn bundled_ffmpeg_binaries_are_usable(binaries_dir: &Path) -> bool {
 }
 
 /// Download FFmpeg binaries to OUT_DIR
-fn download_ffmpeg_for_build() -> Result<FFmpegPaths, String> {
+fn download_ffmpeg_for_build(mode: DownloadMode) -> Result<FFmpegPaths, String> {
     let out_dir = env::var("OUT_DIR").map_err(|e| format!("OUT_DIR not set: {e}"))?;
     let output_dir = PathBuf::from(out_dir);
 
     let config = BundlerConfig {
-        verify_checksums: env::var("OPENREELIO_REQUIRE_FFMPEG_CHECKSUMS")
+        mode,
+        require_checksums: env::var("OPENREELIO_REQUIRE_FFMPEG_CHECKSUMS")
             .ok()
             .as_deref()
             == Some("1"),
         timeout_seconds: 600, // 10 minutes timeout for CI
-        cache_dir: None,
     };
 
     download_ffmpeg(&output_dir, &config).map_err(|e| e.to_string())
@@ -243,9 +296,9 @@ pub enum Arch {
 
 #[derive(Debug)]
 pub struct BundlerConfig {
-    pub verify_checksums: bool,
-    pub timeout_seconds: u64,
-    pub cache_dir: Option<PathBuf>,
+    mode: DownloadMode,
+    require_checksums: bool,
+    timeout_seconds: u64,
 }
 
 #[derive(Debug)]
@@ -308,59 +361,71 @@ pub fn get_binary_names(platform: Platform) -> (&'static str, &'static str) {
     }
 }
 
-struct DownloadSource {
-    url: String,
-    fallback_urls: Vec<String>,
-    filename: String,
-    sha256: Option<String>,
+/// Relative path (from `CARGO_MANIFEST_DIR`) to the shared FFmpeg source manifest
+const FFMPEG_SOURCES_MANIFEST_PATH: &str = "../scripts/ffmpeg-sources.json";
+
+/// Attempts per download URL before falling through to the next candidate
+const DOWNLOAD_ATTEMPTS_PER_URL: u32 = 3;
+
+/// Shared FFmpeg source manifest (`scripts/ffmpeg-sources.json`)
+#[derive(Debug, serde::Deserialize)]
+struct SourceManifest {
+    targets: std::collections::HashMap<String, TargetSources>,
 }
 
-fn get_ffmpeg_download_url(platform: Platform, arch: Arch) -> BundlerResult<DownloadSource> {
+/// Download sources for a single target triple
+#[derive(Debug, serde::Deserialize)]
+struct TargetSources {
+    archives: Vec<ArchiveSource>,
+}
+
+/// One downloadable archive and the binaries it provides
+#[derive(Debug, serde::Deserialize)]
+struct ArchiveSource {
+    name: String,
+    filename: String,
+    binaries: Vec<String>,
+    urls: Vec<UrlSource>,
+}
+
+/// A candidate download URL with optional checksum sources
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UrlSource {
+    url: String,
+    #[serde(default)]
+    sha256: Option<String>,
+    #[serde(default)]
+    sha256_url: Option<String>,
+    #[serde(default)]
+    sha256_sidecar: Option<String>,
+}
+
+fn load_source_manifest() -> BundlerResult<SourceManifest> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")
+        .map_err(|e| BundlerError::DownloadFailed(format!("CARGO_MANIFEST_DIR not set: {e}")))?;
+    let manifest_path = PathBuf::from(manifest_dir).join(FFMPEG_SOURCES_MANIFEST_PATH);
+    let contents = std::fs::read_to_string(&manifest_path)?;
+
+    serde_json::from_str(&contents).map_err(|e| {
+        BundlerError::DownloadFailed(format!("Failed to parse {}: {e}", manifest_path.display()))
+    })
+}
+
+/// Map the build platform/arch to a manifest target-triple key
+fn manifest_target_key(platform: Platform, arch: Arch) -> BundlerResult<&'static str> {
     match (platform, arch) {
-        (Platform::Windows, Arch::X64) => Ok(DownloadSource {
-            url: "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip".to_string(),
-            fallback_urls: Vec::new(),
-            filename: "ffmpeg-release-essentials.zip".to_string(),
-            sha256: None,
-        }),
-        (Platform::MacOS, Arch::X64) | (Platform::MacOS, Arch::Arm64) => Ok(DownloadSource {
-            url: "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip".to_string(),
-            fallback_urls: Vec::new(),
-            filename: "ffmpeg.zip".to_string(),
-            sha256: None,
-        }),
-        (Platform::Linux, Arch::X64) => Ok(DownloadSource {
-            url: "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
-                .to_string(),
-            fallback_urls: vec![
-                "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
-                    .to_string(),
-            ],
-            filename: "ffmpeg-release-amd64-static.tar.xz".to_string(),
-            sha256: None,
-        }),
+        (Platform::Windows, Arch::X64) => Ok("x86_64-pc-windows-msvc"),
+        (Platform::MacOS, Arch::X64) => Ok("x86_64-apple-darwin"),
+        (Platform::MacOS, Arch::Arm64) => Ok("aarch64-apple-darwin"),
+        (Platform::Linux, Arch::X64) => Ok("x86_64-unknown-linux-gnu"),
         _ => Err(BundlerError::UnsupportedPlatform(format!(
             "{platform:?} {arch:?}"
         ))),
     }
 }
 
-fn get_ffprobe_download_url(
-    platform: Platform,
-    arch: Arch,
-) -> BundlerResult<Option<DownloadSource>> {
-    match (platform, arch) {
-        (Platform::MacOS, Arch::X64) | (Platform::MacOS, Arch::Arm64) => Ok(Some(DownloadSource {
-            url: "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip".to_string(),
-            fallback_urls: Vec::new(),
-            filename: "ffprobe.zip".to_string(),
-            sha256: None,
-        })),
-        _ => Ok(None),
-    }
-}
-
-fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> BundlerResult<()> {
+fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> BundlerResult<String> {
     use reqwest::header::{ACCEPT, USER_AGENT};
     use std::time::Duration;
 
@@ -386,6 +451,7 @@ fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> Bundle
         )));
     }
 
+    let final_url = response.url().to_string();
     let bytes = response
         .bytes()
         .map_err(|e| BundlerError::DownloadFailed(format!("Failed to read response: {e}")))?;
@@ -399,63 +465,215 @@ fn download_file_blocking(url: &str, output: &Path, timeout_secs: u64) -> Bundle
         output.display()
     );
 
-    Ok(())
+    Ok(final_url)
 }
 
-fn download_source_blocking(
-    source: &DownloadSource,
+/// Download one manifest archive, trying each candidate URL with retries and
+/// verifying checksums per the bundler config policy
+fn download_archive_blocking(
+    archive: &ArchiveSource,
     output: &Path,
-    timeout_secs: u64,
+    config: &BundlerConfig,
 ) -> BundlerResult<()> {
     let mut errors = Vec::new();
 
-    for url in std::iter::once(&source.url).chain(source.fallback_urls.iter()) {
-        match download_file_blocking(url, output, timeout_secs) {
-            Ok(()) => return Ok(()),
-            Err(error) => errors.push(format!("{url}: {error}")),
+    for source in &archive.urls {
+        let mut download_result = Err(BundlerError::DownloadFailed(format!(
+            "No download attempted for {}",
+            source.url
+        )));
+        for attempt in 1..=DOWNLOAD_ATTEMPTS_PER_URL {
+            download_result = download_file_blocking(&source.url, output, config.timeout_seconds);
+            match &download_result {
+                Ok(_) => break,
+                Err(error) if attempt < DOWNLOAD_ATTEMPTS_PER_URL => {
+                    println!(
+                        "cargo:warning=Attempt {attempt}/{DOWNLOAD_ATTEMPTS_PER_URL} failed for {}: {error}",
+                        source.url
+                    );
+                }
+                Err(_) => {}
+            }
+        }
+
+        match download_result {
+            Ok(final_url) => match verify_downloaded_archive(source, output, &final_url, config) {
+                Ok(()) => return Ok(()),
+                Err(error) => errors.push(format!("{}: {error}", source.url)),
+            },
+            Err(error) => errors.push(format!("{}: {error}", source.url)),
         }
     }
 
     Err(BundlerError::DownloadFailed(format!(
-        "All FFmpeg download URLs failed: {}",
+        "All download URLs failed for {}: {}",
+        archive.name,
         errors.join("; ")
     )))
 }
 
-fn verify_archive_checksum(path: &Path, expected_sha256: Option<&str>) -> BundlerResult<()> {
+/// Verify a downloaded archive against the manifest checksum sources
+fn verify_downloaded_archive(
+    source: &UrlSource,
+    path: &Path,
+    final_url: &str,
+    config: &BundlerConfig,
+) -> BundlerResult<()> {
     use sha2::{Digest, Sha256};
 
-    let Some(expected_sha256) = expected_sha256 else {
-        if std::env::var("OPENREELIO_ALLOW_UNVERIFIED_FFMPEG")
-            .ok()
-            .as_deref()
-            == Some("1")
-        {
+    let expected = match resolve_expected_sha256(source, final_url, config.timeout_seconds) {
+        Ok(expected) => expected,
+        Err(error) => {
             println!(
-                "cargo:warning=OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 set; skipping checksum for {}",
-                path.display()
+                "cargo:warning=Failed to resolve checksum for {}: {error}",
+                source.url
             );
-            return Ok(());
+            None
         }
+    };
 
-        return Err(BundlerError::VerificationFailed(format!(
-            "Missing pinned SHA-256 for downloaded FFmpeg archive: {}",
-            path.display()
-        )));
+    let Some(expected) = expected else {
+        return handle_unverified_download(source, path, config);
     };
 
     let bytes = std::fs::read(path)?;
     let actual = format!("{:x}", Sha256::digest(&bytes));
-    if !actual.eq_ignore_ascii_case(expected_sha256) {
+    if !actual.eq_ignore_ascii_case(&expected) {
         return Err(BundlerError::VerificationFailed(format!(
             "Checksum mismatch for {}: expected {}, got {}",
             path.display(),
-            expected_sha256,
+            expected,
             actual
         )));
     }
 
+    println!(
+        "cargo:warning=Verified SHA-256 for {}: {actual}",
+        path.display()
+    );
     Ok(())
+}
+
+/// Decide whether an archive without a verifiable checksum may be used
+fn handle_unverified_download(
+    source: &UrlSource,
+    path: &Path,
+    config: &BundlerConfig,
+) -> BundlerResult<()> {
+    let allow_unverified = env::var("OPENREELIO_ALLOW_UNVERIFIED_FFMPEG")
+        .ok()
+        .as_deref()
+        == Some("1");
+
+    if allow_unverified {
+        println!(
+            "cargo:warning=OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 set; skipping checksum for {}",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    if config.mode == DownloadMode::DevAuto && !config.require_checksums {
+        println!(
+            "cargo:warning=No verifiable SHA-256 for {}; accepting unverified download in dev auto-download mode.",
+            source.url
+        );
+        return Ok(());
+    }
+
+    Err(BundlerError::VerificationFailed(format!(
+        "Missing pinned SHA-256 for downloaded FFmpeg archive: {} (set OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1 to override)",
+        path.display()
+    )))
+}
+
+/// Resolve the expected SHA-256 digest from the manifest entry, fetching a
+/// checksum sidecar when one is configured
+fn resolve_expected_sha256(
+    source: &UrlSource,
+    final_url: &str,
+    timeout_secs: u64,
+) -> BundlerResult<Option<String>> {
+    if let Some(sha256) = &source.sha256 {
+        return Ok(Some(sha256.clone()));
+    }
+
+    let sidecar_url = if let Some(sha256_url) = &source.sha256_url {
+        sha256_url.clone()
+    } else if let Some(suffix) = &source.sha256_sidecar {
+        format!("{final_url}{suffix}")
+    } else {
+        return Ok(None);
+    };
+
+    use reqwest::header::USER_AGENT;
+    use std::time::Duration;
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|e| BundlerError::DownloadFailed(e.to_string()))?;
+
+    let response = client
+        .get(&sidecar_url)
+        .header(USER_AGENT, "OpenReelio release asset downloader")
+        .send()
+        .map_err(|e| BundlerError::DownloadFailed(format!("Sidecar request failed: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(BundlerError::DownloadFailed(format!(
+            "HTTP {}: {sidecar_url}",
+            response.status()
+        )));
+    }
+
+    let sidecar_text = response
+        .text()
+        .map_err(|e| BundlerError::DownloadFailed(format!("Failed to read sidecar: {e}")))?;
+
+    match parse_sha256_sidecar(&sidecar_text, &source.url) {
+        Some(digest) => Ok(Some(digest)),
+        None => Err(BundlerError::VerificationFailed(format!(
+            "No matching SHA-256 digest found in {sidecar_url}"
+        ))),
+    }
+}
+
+/// Parse a checksum sidecar (bare digest, or `digest  filename` lines) and
+/// return the digest matching the manifest URL's basename
+fn parse_sha256_sidecar(sidecar_text: &str, source_url: &str) -> Option<String> {
+    // Match against the manifest URL basename: redirect targets (for example
+    // GitHub release assets) often resolve to opaque object-storage paths.
+    let url_path = source_url.split('?').next().unwrap_or(source_url);
+    let download_basename = url_path.rsplit('/').next().unwrap_or(url_path);
+    let mut digests = Vec::new();
+
+    for line in sidecar_text.lines() {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        let Some(digest) = tokens.first() else {
+            continue;
+        };
+        if digest.len() != 64 || !digest.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+
+        if tokens.len() > 1 {
+            let file_token = tokens[tokens.len() - 1].trim_start_matches('*');
+            let file_basename = file_token.rsplit('/').next().unwrap_or(file_token);
+            if file_basename.eq_ignore_ascii_case(download_basename) {
+                return Some((*digest).to_string());
+            }
+        }
+
+        digests.push((*digest).to_string());
+    }
+
+    // A bare-digest sidecar (single digest, no filename) applies to the download.
+    if digests.len() == 1 {
+        return digests.pop();
+    }
+
+    None
 }
 
 fn extract_archive(archive_path: &Path, output_dir: &Path) -> BundlerResult<()> {
@@ -718,8 +936,13 @@ fn verify_binary(path: &Path) -> BundlerResult<()> {
 pub fn download_ffmpeg(output_dir: &Path, config: &BundlerConfig) -> BundlerResult<FFmpegPaths> {
     let platform = detect_platform();
     let arch = detect_arch();
-    let source = get_ffmpeg_download_url(platform, arch)?;
-    let ffprobe_source = get_ffprobe_download_url(platform, arch)?;
+    let manifest = load_source_manifest()?;
+    let target_key = manifest_target_key(platform, arch)?;
+    let target = manifest.targets.get(target_key).ok_or_else(|| {
+        BundlerError::UnsupportedPlatform(format!(
+            "No entry for {target_key} in {FFMPEG_SOURCES_MANIFEST_PATH}"
+        ))
+    })?;
     let (ffmpeg_name, ffprobe_name) = get_binary_names(platform);
 
     // Create directories
@@ -731,44 +954,40 @@ pub fn download_ffmpeg(output_dir: &Path, config: &BundlerConfig) -> BundlerResu
     let binaries_dir = output_dir.join("binaries");
     std::fs::create_dir_all(&binaries_dir)?;
 
-    // Download main FFmpeg archive
-    let archive_path = temp_dir.join(&source.filename);
-    download_source_blocking(&source, &archive_path, config.timeout_seconds)?;
-    if config.verify_checksums {
-        verify_archive_checksum(&archive_path, source.sha256.as_deref())?;
-    }
+    // Download and extract every archive listed for this target, then stage
+    // the binaries each archive provides.
+    let mut staged_binaries: std::collections::HashMap<String, PathBuf> =
+        std::collections::HashMap::new();
 
-    // Extract main archive
-    println!("cargo:warning=Extracting FFmpeg archive...");
-    extract_archive(&archive_path, &extract_dir)?;
+    for archive in &target.archives {
+        let archive_path = temp_dir.join(&archive.filename);
+        let archive_extract_dir = extract_dir.join(format!("{}-extracted", archive.name));
+        std::fs::create_dir_all(&archive_extract_dir)?;
 
-    // Find and copy ffmpeg binary
-    let ffmpeg_found = find_binary_in_dir(&extract_dir, ffmpeg_name)?;
-    let final_ffmpeg = binaries_dir.join(ffmpeg_name);
-    std::fs::copy(&ffmpeg_found, &final_ffmpeg)?;
+        download_archive_blocking(archive, &archive_path, config)?;
 
-    // Handle ffprobe
-    let final_ffprobe = binaries_dir.join(ffprobe_name);
+        println!("cargo:warning=Extracting {} archive...", archive.name);
+        extract_archive(&archive_path, &archive_extract_dir)?;
 
-    if let Some(ffprobe_src) = ffprobe_source {
-        // macOS: Download separate ffprobe
-        let ffprobe_archive = temp_dir.join(&ffprobe_src.filename);
-        download_source_blocking(&ffprobe_src, &ffprobe_archive, config.timeout_seconds)?;
-        if config.verify_checksums {
-            verify_archive_checksum(&ffprobe_archive, ffprobe_src.sha256.as_deref())?;
+        for binary_name in &archive.binaries {
+            let found = find_binary_in_dir(&archive_extract_dir, binary_name)?;
+            staged_binaries.insert(binary_name.clone(), found);
         }
-
-        let ffprobe_extract_dir = extract_dir.join("ffprobe_extracted");
-        std::fs::create_dir_all(&ffprobe_extract_dir)?;
-        extract_archive(&ffprobe_archive, &ffprobe_extract_dir)?;
-
-        let ffprobe_found = find_binary_in_dir(&ffprobe_extract_dir, ffprobe_name)?;
-        std::fs::copy(&ffprobe_found, &final_ffprobe)?;
-    } else {
-        // Windows/Linux: ffprobe is in main archive
-        let ffprobe_found = find_binary_in_dir(&extract_dir, ffprobe_name)?;
-        std::fs::copy(&ffprobe_found, &final_ffprobe)?;
     }
+
+    let copy_staged = |binary_name: &str| -> BundlerResult<PathBuf> {
+        let source_path = staged_binaries.get(binary_name).ok_or_else(|| {
+            BundlerError::BinaryNotFound(format!(
+                "{binary_name} is not provided by any archive for {target_key}"
+            ))
+        })?;
+        let destination = binaries_dir.join(binary_name);
+        std::fs::copy(source_path, &destination)?;
+        Ok(destination)
+    };
+
+    let final_ffmpeg = copy_staged(ffmpeg_name)?;
+    let final_ffprobe = copy_staged(ffprobe_name)?;
 
     // Set executable permissions on Unix
     #[cfg(unix)]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -521,16 +521,11 @@ fn verify_downloaded_archive(
 ) -> BundlerResult<()> {
     use sha2::{Digest, Sha256};
 
-    let expected = match resolve_expected_sha256(source, final_url, config.timeout_seconds) {
-        Ok(expected) => expected,
-        Err(error) => {
-            println!(
-                "cargo:warning=Failed to resolve checksum for {}: {error}",
-                source.url
-            );
-            None
-        }
-    };
+    // A candidate URL whose DECLARED checksum source fails to resolve is
+    // rejected (the caller moves on to the next URL) instead of silently
+    // falling through to the unverified-download path. `Ok(None)` still means
+    // the manifest declares no checksum source for this URL at all.
+    let expected = resolve_expected_sha256(source, final_url, config.timeout_seconds)?;
 
     let Some(expected) = expected else {
         return handle_unverified_download(source, path, config);

--- a/src-tauri/src/core/analysis/mod.rs
+++ b/src-tauri/src/core/analysis/mod.rs
@@ -81,9 +81,9 @@ const CONTACT_SHEET_FILENAME: &str = "contact-sheet.jpg";
 pub struct AnalysisJobRunner {
     /// Project root directory
     project_dir: PathBuf,
-    /// Path to FFmpeg binary (uses PATH if not set)
+    /// Path to FFmpeg binary (globally resolved by default)
     ffmpeg_path: PathBuf,
-    /// Path to FFprobe binary (uses PATH if not set)
+    /// Path to FFprobe binary (globally resolved by default)
     ffprobe_path: PathBuf,
 }
 
@@ -92,8 +92,8 @@ impl AnalysisJobRunner {
     pub fn new(project_dir: &Path) -> Self {
         Self {
             project_dir: project_dir.to_path_buf(),
-            ffmpeg_path: PathBuf::from("ffmpeg"),
-            ffprobe_path: PathBuf::from("ffprobe"),
+            ffmpeg_path: crate::core::ffmpeg::resolved_ffmpeg_path(),
+            ffprobe_path: crate::core::ffmpeg::resolved_ffprobe_path(),
         }
     }
 

--- a/src-tauri/src/core/annotations/providers/local.rs
+++ b/src-tauri/src/core/annotations/providers/local.rs
@@ -18,6 +18,7 @@ use crate::core::annotations::{
     AnalysisProvider as ProviderType, AnalysisProviderTrait, AnalysisRequest, AnalysisResponse,
     AnalysisResult, AnalysisType, CostEstimate, ProviderCapabilities, ShotResult,
 };
+use crate::core::ffmpeg::{resolved_ffmpeg_path, resolved_ffprobe_path};
 use crate::core::indexing::shots::{ShotDetector, ShotDetectorConfig};
 use crate::core::{CoreError, CoreResult};
 
@@ -30,18 +31,19 @@ use crate::core::{CoreError, CoreResult};
 /// This provider is free and works offline, but only supports shot detection.
 /// It wraps the existing `ShotDetector` from the indexing module.
 pub struct LocalAnalysisProvider {
-    /// FFmpeg binary path (optional, uses PATH if not set)
+    /// FFmpeg binary path (falls back to the global resolver if not set)
     ffmpeg_path: Option<PathBuf>,
-    /// FFprobe binary path (optional, uses PATH if not set)
+    /// FFprobe binary path (falls back to the global resolver if not set)
     ffprobe_path: Option<PathBuf>,
 }
 
 impl LocalAnalysisProvider {
-    /// Creates a new local analysis provider
+    /// Creates a new local analysis provider using the globally resolved
+    /// FFmpeg/FFprobe paths (bundled, dev-mode, or system PATH)
     pub fn new() -> Self {
         Self {
-            ffmpeg_path: None,
-            ffprobe_path: None,
+            ffmpeg_path: Some(resolved_ffmpeg_path()),
+            ffprobe_path: Some(resolved_ffprobe_path()),
         }
     }
 
@@ -179,7 +181,7 @@ impl AnalysisProviderTrait for LocalAnalysisProvider {
             Ok(())
         } else {
             Err(CoreError::NotSupported(
-                "FFmpeg not found in PATH".to_string(),
+                "FFmpeg not found (bundled, dev, or system PATH)".to_string(),
             ))
         }
     }
@@ -237,8 +239,9 @@ mod tests {
     #[test]
     fn test_local_provider_default() {
         let provider = LocalAnalysisProvider::default();
-        assert!(provider.ffmpeg_path.is_none());
-        assert!(provider.ffprobe_path.is_none());
+        // Default construction resolves paths through the global resolver.
+        assert!(provider.ffmpeg_path.is_some());
+        assert!(provider.ffprobe_path.is_some());
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/annotations/providers/local.rs
+++ b/src-tauri/src/core/annotations/providers/local.rs
@@ -18,7 +18,6 @@ use crate::core::annotations::{
     AnalysisProvider as ProviderType, AnalysisProviderTrait, AnalysisRequest, AnalysisResponse,
     AnalysisResult, AnalysisType, CostEstimate, ProviderCapabilities, ShotResult,
 };
-use crate::core::ffmpeg::{resolved_ffmpeg_path, resolved_ffprobe_path};
 use crate::core::indexing::shots::{ShotDetector, ShotDetectorConfig};
 use crate::core::{CoreError, CoreResult};
 
@@ -38,12 +37,16 @@ pub struct LocalAnalysisProvider {
 }
 
 impl LocalAnalysisProvider {
-    /// Creates a new local analysis provider using the globally resolved
-    /// FFmpeg/FFprobe paths (bundled, dev-mode, or system PATH)
+    /// Creates a new local analysis provider that resolves FFmpeg/FFprobe
+    /// paths lazily at point of use via the global resolver.
+    ///
+    /// Storing `None` here (instead of snapshotting the resolver at
+    /// construction) ensures a provider created before a managed FFmpeg
+    /// install completes still picks up the freshly registered paths.
     pub fn new() -> Self {
         Self {
-            ffmpeg_path: Some(resolved_ffmpeg_path()),
-            ffprobe_path: Some(resolved_ffprobe_path()),
+            ffmpeg_path: None,
+            ffprobe_path: None,
         }
     }
 
@@ -67,6 +70,9 @@ impl LocalAnalysisProvider {
             min_shot_duration: config.map(|c| c.min_duration_sec).unwrap_or(0.5),
             generate_keyframes: config.map(|c| c.generate_keyframes).unwrap_or(false),
             keyframe_dir: None,
+            // `None` makes the detector fall back to the global resolver at
+            // spawn time, so late registrations (e.g. an in-app FFmpeg
+            // install) are always honored.
             ffmpeg_path: self.ffmpeg_path.clone(),
             ffprobe_path: self.ffprobe_path.clone(),
             ..Default::default()
@@ -239,9 +245,11 @@ mod tests {
     #[test]
     fn test_local_provider_default() {
         let provider = LocalAnalysisProvider::default();
-        // Default construction resolves paths through the global resolver.
-        assert!(provider.ffmpeg_path.is_some());
-        assert!(provider.ffprobe_path.is_some());
+        // Default construction stores no paths: they are resolved lazily via
+        // the global resolver at point of use, so a provider created before a
+        // managed FFmpeg install still picks up the fresh paths.
+        assert!(provider.ffmpeg_path.is_none());
+        assert!(provider.ffprobe_path.is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/assets/metadata.rs
+++ b/src-tauri/src/core/assets/metadata.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::core::assets::{AudioInfo, VideoInfo};
+use crate::core::ffmpeg::resolved_ffprobe_path;
 use crate::core::process::configure_std_command;
 use crate::core::{CoreError, CoreResult, Ratio};
 
@@ -98,7 +99,7 @@ impl MetadataExtractor {
         }
 
         // Run FFprobe
-        let mut command = Command::new("ffprobe");
+        let mut command = Command::new(resolved_ffprobe_path());
         configure_std_command(&mut command);
         let output = command
             .args([
@@ -230,7 +231,7 @@ impl MetadataExtractor {
 
     /// Check if FFprobe is available on the system
     pub fn is_available() -> bool {
-        let mut command = Command::new("ffprobe");
+        let mut command = Command::new(resolved_ffprobe_path());
         configure_std_command(&mut command);
         command
             .arg("-version")

--- a/src-tauri/src/core/captions/audio.rs
+++ b/src-tauri/src/core/captions/audio.rs
@@ -3,10 +3,11 @@
 //! Provides audio extraction functionality for transcription using FFmpeg.
 //! Extracts audio as 16kHz mono WAV format suitable for Whisper.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use thiserror::Error;
 
+use crate::core::ffmpeg::resolved_ffmpeg_path;
 use crate::core::process::configure_std_command;
 use crate::core::project::ProjectState;
 use crate::core::render::build_render_graph;
@@ -61,7 +62,7 @@ pub struct SequenceAudioMixdownResult {
 ///
 /// * `input_path` - Path to the input video/audio file
 /// * `output_path` - Path where the WAV file should be saved
-/// * `ffmpeg_path` - Optional path to FFmpeg binary (defaults to "ffmpeg")
+/// * `ffmpeg_path` - Optional path to FFmpeg binary (defaults to the globally resolved path)
 ///
 /// # Returns
 ///
@@ -100,7 +101,9 @@ pub fn extract_audio_for_transcription(
     }
 
     // Build FFmpeg command
-    let ffmpeg = ffmpeg_path.unwrap_or("ffmpeg");
+    let ffmpeg = ffmpeg_path
+        .map(PathBuf::from)
+        .unwrap_or_else(resolved_ffmpeg_path);
     let mut cmd = Command::new(ffmpeg);
     configure_std_command(&mut cmd);
     let output = cmd
@@ -175,7 +178,9 @@ pub fn mix_sequence_audio_for_transcription(
         ));
     }
 
-    let ffmpeg = ffmpeg_path.unwrap_or("ffmpeg");
+    let ffmpeg = ffmpeg_path
+        .map(PathBuf::from)
+        .unwrap_or_else(resolved_ffmpeg_path);
     let mut cmd = Command::new(ffmpeg);
     configure_std_command(&mut cmd);
     cmd.arg("-y").arg("-hide_banner");

--- a/src-tauri/src/core/ffmpeg/commands.rs
+++ b/src-tauri/src/core/ffmpeg/commands.rs
@@ -6,12 +6,20 @@
 use std::path::PathBuf;
 
 use specta::Type;
+use tauri::Emitter;
 use tauri::Manager;
 use tauri::State;
 
-use super::{MediaInfo, SharedFFmpegState};
+use super::{FFmpegState, MediaInfo, SharedFFmpegState};
+use crate::core::ffmpeg::installer;
 use crate::core::fs::{validate_local_input_path, validate_scoped_output_path};
 use crate::AppState;
+
+/// Tauri event name for in-app FFmpeg install progress.
+pub const FFMPEG_INSTALL_PROGRESS_EVENT: &str = "ffmpeg-install-progress";
+
+/// Lock id inside [`AppState::runtime_install_locks`] for the FFmpeg installer.
+const FFMPEG_INSTALL_LOCK_ID: &str = "ffmpeg";
 
 async fn build_allowed_output_roots(
     state: &State<'_, AppState>,
@@ -54,33 +62,157 @@ pub struct FFmpegStatus {
     pub ffmpeg_path: Option<String>,
     /// Path to ffprobe executable
     pub ffprobe_path: Option<String>,
+    /// Where the binaries came from (`bundled`/`managed`/`dev`/`system`)
+    pub source: Option<String>,
 }
 
-/// Check if FFmpeg is available and return its status
-#[tauri::command]
-#[specta::specta]
-pub async fn check_ffmpeg(
-    ffmpeg_state: tauri::State<'_, SharedFFmpegState>,
-) -> Result<FFmpegStatus, String> {
-    let state = ffmpeg_state.read().await;
-
+/// Builds the IPC status payload from the shared FFmpeg state.
+fn build_ffmpeg_status(state: &FFmpegState) -> FFmpegStatus {
     if let Some(info) = state.info() {
-        Ok(FFmpegStatus {
+        FFmpegStatus {
             available: true,
             version: Some(info.version.clone()),
             is_bundled: info.is_bundled,
             ffmpeg_path: Some(info.ffmpeg_path.to_string_lossy().to_string()),
             ffprobe_path: Some(info.ffprobe_path.to_string_lossy().to_string()),
-        })
+            source: Some(info.source.as_str().to_string()),
+        }
     } else {
-        Ok(FFmpegStatus {
+        FFmpegStatus {
             available: false,
             version: None,
             is_bundled: false,
             ffmpeg_path: None,
             ffprobe_path: None,
-        })
+            source: None,
+        }
     }
+}
+
+/// Check if FFmpeg is available and return its status
+///
+/// When the shared state reports FFmpeg as unavailable, this re-attempts
+/// initialization so a freshly installed (or slow-to-initialize) FFmpeg is
+/// picked up without restarting the app.
+#[tauri::command]
+#[specta::specta]
+pub async fn check_ffmpeg(
+    app: tauri::AppHandle,
+    ffmpeg_state: tauri::State<'_, SharedFFmpegState>,
+) -> Result<FFmpegStatus, String> {
+    {
+        let state = ffmpeg_state.read().await;
+        if state.is_available() {
+            return Ok(build_ffmpeg_status(&state));
+        }
+    }
+
+    // Not available yet: retry initialization (lazy re-init, mirrors the
+    // transcription command path). Failure is not an error here — the status
+    // simply reports unavailable.
+    let mut state = ffmpeg_state.write().await;
+    if !state.is_available() {
+        let _ = state.initialize(Some(&app));
+    }
+    Ok(build_ffmpeg_status(&state))
+}
+
+/// Progress payload emitted on [`FFMPEG_INSTALL_PROGRESS_EVENT`].
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FFmpegInstallProgressPayload {
+    /// Install stage (`downloading|verifying|extracting|installing|done`).
+    stage: String,
+    /// Logical binary/archive name the stage applies to.
+    binary: String,
+    /// Bytes downloaded so far for the current archive.
+    downloaded_bytes: u64,
+    /// Total bytes for the current archive, when known.
+    total_bytes: Option<u64>,
+}
+
+/// RAII guard ensuring only one FFmpeg install runs at a time.
+///
+/// Mirrors `RuntimeInstallGuard` in `ipc::commands::external_agent`, sharing
+/// [`AppState::runtime_install_locks`] so `Drop` releases the lock on every
+/// exit path.
+struct FFmpegInstallGuard<'a> {
+    state: &'a AppState,
+}
+
+impl<'a> FFmpegInstallGuard<'a> {
+    fn acquire(state: &'a AppState) -> Result<Self, String> {
+        let mut locks = state
+            .runtime_install_locks
+            .lock()
+            .map_err(|_| "FFmpeg install lock is poisoned".to_string())?;
+        if !locks.insert(FFMPEG_INSTALL_LOCK_ID) {
+            return Err(
+                "An FFmpeg installation is already in progress. Wait for it to finish.".to_string(),
+            );
+        }
+        Ok(Self { state })
+    }
+}
+
+impl Drop for FFmpegInstallGuard<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut locks) = self.state.runtime_install_locks.lock() {
+            locks.remove(FFMPEG_INSTALL_LOCK_ID);
+        }
+    }
+}
+
+/// Download and install FFmpeg/FFprobe into the managed install directory.
+///
+/// Emits [`FFMPEG_INSTALL_PROGRESS_EVENT`] while running, then re-initializes
+/// the shared FFmpeg state (publishing resolved paths) and returns the fresh
+/// status. Concurrent installs are rejected.
+#[tauri::command]
+#[specta::specta]
+pub async fn install_ffmpeg(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    ffmpeg_state: tauri::State<'_, SharedFFmpegState>,
+) -> Result<FFmpegStatus, String> {
+    let _guard = FFmpegInstallGuard::acquire(&state)?;
+
+    let progress_app = app.clone();
+    let install = tokio::task::spawn_blocking(move || {
+        installer::install_managed_ffmpeg(move |progress| {
+            let payload = FFmpegInstallProgressPayload {
+                stage: progress.stage.as_str().to_string(),
+                binary: progress.binary,
+                downloaded_bytes: progress.downloaded_bytes,
+                total_bytes: progress.total_bytes,
+            };
+            if let Err(error) = progress_app.emit(FFMPEG_INSTALL_PROGRESS_EVENT, payload) {
+                tracing::debug!("Failed to emit FFmpeg install progress: {error}");
+            }
+        })
+    })
+    .await
+    .map_err(|error| format!("FFmpeg install task failed: {error}"))??;
+
+    if !install.verified {
+        tracing::warn!(
+            "FFmpeg was installed without checksum verification (no checksum source in manifest)"
+        );
+    }
+    tracing::info!(
+        ffmpeg = %install.ffmpeg_path.display(),
+        ffprobe = %install.ffprobe_path.display(),
+        "Managed FFmpeg install completed"
+    );
+
+    // Re-run state initialization so the fresh install is detected and the
+    // globally resolved paths are published (`set_resolved_paths` runs inside
+    // `FFmpegState::initialize` via `apply_info`).
+    let mut ffmpeg = ffmpeg_state.write().await;
+    ffmpeg
+        .initialize(Some(&app))
+        .map_err(|error| format!("FFmpeg was installed but initialization failed: {error}"))?;
+    Ok(build_ffmpeg_status(&ffmpeg))
 }
 
 /// Extract a single frame from a video
@@ -217,6 +349,7 @@ mod tests {
             is_bundled: false,
             ffmpeg_path: Some("/usr/bin/ffmpeg".to_string()),
             ffprobe_path: Some("/usr/bin/ffprobe".to_string()),
+            source: Some("system".to_string()),
         };
 
         let json = serde_json::to_string(&status).unwrap();

--- a/src-tauri/src/core/ffmpeg/commands.rs
+++ b/src-tauri/src/core/ffmpeg/commands.rs
@@ -108,12 +108,11 @@ pub async fn check_ffmpeg(
     }
 
     // Not available yet: retry initialization (lazy re-init, mirrors the
-    // transcription command path). Failure is not an error here — the status
-    // simply reports unavailable.
-    let mut state = ffmpeg_state.write().await;
-    if !state.is_available() {
-        let _ = state.initialize(Some(&app));
-    }
+    // transcription command path). Detection runs on the blocking pool without
+    // holding the state lock. Failure is not an error here — the status simply
+    // reports unavailable.
+    let _ = super::initialize_shared_ffmpeg(ffmpeg_state.inner(), Some(app)).await;
+    let state = ffmpeg_state.read().await;
     Ok(build_ffmpeg_status(&state))
 }
 
@@ -206,12 +205,13 @@ pub async fn install_ffmpeg(
     );
 
     // Re-run state initialization so the fresh install is detected and the
-    // globally resolved paths are published (`set_resolved_paths` runs inside
-    // `FFmpegState::initialize` via `apply_info`).
-    let mut ffmpeg = ffmpeg_state.write().await;
-    ffmpeg
-        .initialize(Some(&app))
+    // globally resolved paths are published (`set_resolved_paths` runs when
+    // the detected info is applied). Detection runs on the blocking pool
+    // without holding the state lock.
+    super::initialize_shared_ffmpeg(ffmpeg_state.inner(), Some(app))
+        .await
         .map_err(|error| format!("FFmpeg was installed but initialization failed: {error}"))?;
+    let ffmpeg = ffmpeg_state.read().await;
     Ok(build_ffmpeg_status(&ffmpeg))
 }
 

--- a/src-tauri/src/core/ffmpeg/detection.rs
+++ b/src-tauri/src/core/ffmpeg/detection.rs
@@ -9,6 +9,31 @@ use std::process::Command;
 use super::{FFmpegError, FFmpegResult};
 use crate::core::process::configure_std_command;
 
+/// Where a detected FFmpeg installation came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FFmpegSource {
+    /// Bundled with the application (resource directory).
+    Bundled,
+    /// Installed by the in-app managed installer.
+    Managed,
+    /// Development-mode binaries under `src-tauri/binaries/`.
+    Dev,
+    /// System-installed FFmpeg (PATH or common locations).
+    System,
+}
+
+impl FFmpegSource {
+    /// Stable lowercase identifier surfaced to the frontend.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FFmpegSource::Bundled => "bundled",
+            FFmpegSource::Managed => "managed",
+            FFmpegSource::Dev => "dev",
+            FFmpegSource::System => "system",
+        }
+    }
+}
+
 /// Information about detected FFmpeg installation
 #[derive(Debug, Clone)]
 pub struct FFmpegInfo {
@@ -20,6 +45,8 @@ pub struct FFmpegInfo {
     pub version: String,
     /// Whether this is a bundled (sidecar) installation
     pub is_bundled: bool,
+    /// Where the installation was detected from
+    pub source: FFmpegSource,
 }
 
 /// Detect FFmpeg from bundled sidecar binaries
@@ -31,22 +58,8 @@ pub struct FFmpegInfo {
 /// are downloaded during the build process.
 #[cfg(feature = "gui")]
 pub fn detect_bundled_ffmpeg(app_handle: &tauri::AppHandle) -> FFmpegResult<FFmpegInfo> {
-    use tauri::Manager;
-
-    // Get the resource directory (works in production)
-    let resource_dir = app_handle
-        .path()
-        .resource_dir()
-        .map_err(|_| FFmpegError::NotFound)?;
-
-    tracing::debug!("Checking resource directory: {:?}", resource_dir);
-
     // Try resource directory first (production path)
-    if let Ok(info) = detect_bundled_at_path(&resource_dir) {
-        tracing::info!(
-            "Found bundled FFmpeg at resource directory: {:?}",
-            info.ffmpeg_path
-        );
+    if let Ok(info) = detect_bundled_resources(app_handle) {
         return Ok(info);
     }
 
@@ -63,12 +76,57 @@ pub fn detect_bundled_ffmpeg(app_handle: &tauri::AppHandle) -> FFmpegResult<FFmp
     Err(FFmpegError::NotFound)
 }
 
+/// Detect FFmpeg from the application resource directory only (no dev-mode
+/// fallback), so callers can interleave other sources in the resolution order.
+#[cfg(feature = "gui")]
+pub fn detect_bundled_resources(app_handle: &tauri::AppHandle) -> FFmpegResult<FFmpegInfo> {
+    use tauri::Manager;
+
+    // Get the resource directory (works in production)
+    let resource_dir = app_handle
+        .path()
+        .resource_dir()
+        .map_err(|_| FFmpegError::NotFound)?;
+
+    tracing::debug!("Checking resource directory: {:?}", resource_dir);
+
+    let info = detect_bundled_at_path(&resource_dir)?;
+    tracing::info!(
+        "Found bundled FFmpeg at resource directory: {:?}",
+        info.ffmpeg_path
+    );
+    Ok(info)
+}
+
+/// Detect FFmpeg binaries installed by the in-app managed installer.
+///
+/// Looks in `{data_local}/openreelio/ffmpeg/bin/` (see
+/// [`super::installer::managed_install_dir`]).
+pub fn detect_managed_ffmpeg() -> FFmpegResult<FFmpegInfo> {
+    let install_dir = super::installer::managed_install_dir();
+    let (ffmpeg_name, ffprobe_name) = get_bundled_binary_names();
+    let ffmpeg_path = install_dir.join(ffmpeg_name);
+    let ffprobe_path = install_dir.join(ffprobe_name);
+
+    if !ffmpeg_path.exists() || !ffprobe_path.exists() {
+        return Err(FFmpegError::NotFound);
+    }
+
+    let version = get_ffmpeg_version(&ffmpeg_path)?;
+    Ok(FFmpegInfo {
+        ffmpeg_path,
+        ffprobe_path,
+        version,
+        is_bundled: false,
+        source: FFmpegSource::Managed,
+    })
+}
+
 /// Detect FFmpeg binaries in development mode
 ///
 /// During development (`npm run tauri dev`), binaries are in `src-tauri/binaries/`
 /// which is not the same as the resource directory. This function checks that path.
-#[cfg(any(test, feature = "gui"))]
-fn detect_dev_mode_binaries() -> FFmpegResult<FFmpegInfo> {
+pub(crate) fn detect_dev_mode_binaries() -> FFmpegResult<FFmpegInfo> {
     // Get the path to src-tauri/binaries from CARGO_MANIFEST_DIR or relative to executable
     let dev_binaries_paths = get_dev_mode_paths();
 
@@ -107,6 +165,7 @@ fn detect_dev_mode_binaries() -> FFmpegResult<FFmpegInfo> {
                         ffprobe_path,
                         version,
                         is_bundled: true,
+                        source: FFmpegSource::Dev,
                     });
                 }
             }
@@ -117,7 +176,6 @@ fn detect_dev_mode_binaries() -> FFmpegResult<FFmpegInfo> {
 }
 
 /// Get possible paths where dev mode binaries might be located
-#[cfg(any(test, feature = "gui"))]
 fn get_dev_mode_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
@@ -184,6 +242,7 @@ pub fn detect_bundled_at_path(resource_dir: &Path) -> FFmpegResult<FFmpegInfo> {
         ffprobe_path,
         version,
         is_bundled: true,
+        source: FFmpegSource::Bundled,
     })
 }
 
@@ -211,6 +270,7 @@ pub fn detect_system_ffmpeg() -> FFmpegResult<FFmpegInfo> {
         ffprobe_path,
         version,
         is_bundled: false,
+        source: FFmpegSource::System,
     })
 }
 
@@ -542,6 +602,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "6.0".to_string(),
             is_bundled: false,
+            source: FFmpegSource::System,
         };
 
         let cloned = info.clone();
@@ -558,6 +619,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "6.0".to_string(),
             is_bundled: true,
+            source: FFmpegSource::Bundled,
         };
 
         let debug_str = format!("{:?}", info);

--- a/src-tauri/src/core/ffmpeg/installer.rs
+++ b/src-tauri/src/core/ffmpeg/installer.rs
@@ -459,11 +459,16 @@ where
             },
             Ok(None) => {
                 tracing::warn!(
+                    archive = archive.name,
                     url = source.url,
-                    "No checksum source in manifest; accepting unverified FFmpeg download"
+                    "FFmpeg archive download could not be checksum-verified: \
+                     the manifest declares no checksum source for this URL"
                 );
                 false
             }
+            // A DECLARED checksum source that fails to resolve rejects this
+            // candidate URL (move on to the next one) instead of silently
+            // downgrading the download to unverified.
             Err(error) => {
                 errors.push(format!("{}: {error}", source.url));
                 let _ = std::fs::remove_file(&part_path);

--- a/src-tauri/src/core/ffmpeg/installer.rs
+++ b/src-tauri/src/core/ffmpeg/installer.rs
@@ -1,0 +1,885 @@
+//! In-app FFmpeg installer (managed install).
+//!
+//! Downloads platform-specific FFmpeg/FFprobe archives described by the
+//! compile-time embedded `scripts/ffmpeg-sources.json` manifest, verifies
+//! checksums when the manifest provides a checksum source, extracts the
+//! binaries, sanity-runs them, and atomically installs them into the managed
+//! install directory:
+//!
+//! ```text
+//! {data_local}/openreelio/ffmpeg/bin/ffmpeg[.exe]
+//! {data_local}/openreelio/ffmpeg/bin/ffprobe[.exe]
+//! ```
+//!
+//! The directory derivation intentionally avoids the Tauri path API (mirroring
+//! the whisper model directory in `captions::whisper::default_models_dir`) so
+//! the CLI can reuse the same managed install later.
+//!
+//! Failure at any point leaves a previous managed install intact: all work
+//! happens in a temporary staging directory that is removed on drop, and the
+//! final placement is a per-file atomic rename.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+#[cfg(feature = "gui")]
+use std::path::Path;
+
+/// Embedded FFmpeg download-source manifest (single source of truth shared
+/// with `scripts/prepare-bundled-ffmpeg.mjs` and `build.rs`).
+const FFMPEG_SOURCES_MANIFEST: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../scripts/ffmpeg-sources.json"
+));
+
+/// Number of download attempts per URL before falling through to the next URL.
+#[cfg(feature = "gui")]
+const DOWNLOAD_ATTEMPTS_PER_URL: usize = 3;
+/// Delay between download retries of the same URL.
+#[cfg(feature = "gui")]
+const DOWNLOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+/// Total timeout for a single archive download (connect + headers + body).
+#[cfg(feature = "gui")]
+const DOWNLOAD_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+/// Read/download buffer size (1 MiB), matching the managed runtime installer.
+#[cfg(feature = "gui")]
+const DOWNLOAD_BUFFER_BYTES: usize = 1024 * 1024;
+
+// =============================================================================
+// Manifest model
+// =============================================================================
+
+/// Parsed `ffmpeg-sources.json` manifest.
+#[derive(Debug, Deserialize)]
+struct SourcesManifest {
+    /// Download sources keyed by Rust target triple.
+    targets: HashMap<String, TargetSources>,
+}
+
+/// Download sources for one target triple.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TargetSources {
+    /// Archives to download for this target.
+    archives: Vec<ArchiveSource>,
+}
+
+/// One downloadable archive and the binaries it provides.
+#[derive(Debug, Clone, Deserialize)]
+struct ArchiveSource {
+    /// Logical archive name (`ffmpeg` / `ffprobe`), used for progress labels.
+    name: String,
+    /// Archive format: `zip` or `tar.xz`.
+    format: String,
+    /// Local filename to store the download as.
+    filename: String,
+    /// Binary file names expected inside the archive.
+    binaries: Vec<String>,
+    /// Candidate download URLs in priority order (later entries are fallbacks).
+    urls: Vec<DownloadSource>,
+}
+
+/// One candidate URL with its checksum source.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DownloadSource {
+    /// Absolute download URL.
+    url: String,
+    /// Pinned lowercase-hex SHA-256 digest, when known ahead of time.
+    #[serde(default)]
+    sha256: Option<String>,
+    /// URL of a checksum sidecar file (bare digest or `digest  filename` lines).
+    #[serde(default)]
+    sha256_url: Option<String>,
+    /// Suffix appended to the redirect-resolved final URL to locate the
+    /// provider's checksum sidecar.
+    #[serde(default)]
+    sha256_sidecar: Option<String>,
+}
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/// Stage of an in-progress FFmpeg install, surfaced to the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FFmpegInstallStage {
+    /// Streaming an archive to disk.
+    Downloading,
+    /// Verifying the archive checksum.
+    Verifying,
+    /// Extracting binaries from the archive.
+    Extracting,
+    /// Staging, sanity-running, and swapping binaries into place.
+    Installing,
+    /// Install finished successfully.
+    Done,
+}
+
+impl FFmpegInstallStage {
+    /// Stable lowercase identifier used in the Tauri progress payload.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FFmpegInstallStage::Downloading => "downloading",
+            FFmpegInstallStage::Verifying => "verifying",
+            FFmpegInstallStage::Extracting => "extracting",
+            FFmpegInstallStage::Installing => "installing",
+            FFmpegInstallStage::Done => "done",
+        }
+    }
+}
+
+/// Progress update emitted while installing FFmpeg.
+#[derive(Debug, Clone)]
+pub struct FFmpegInstallProgress {
+    /// Current install stage.
+    pub stage: FFmpegInstallStage,
+    /// Logical binary/archive name the stage applies to (`ffmpeg` / `ffprobe`).
+    pub binary: String,
+    /// Bytes downloaded so far for the current archive.
+    pub downloaded_bytes: u64,
+    /// Total bytes for the current archive, when the server advertised one.
+    pub total_bytes: Option<u64>,
+}
+
+/// Outcome of a successful managed FFmpeg install.
+#[derive(Debug, Clone)]
+pub struct ManagedFFmpegInstall {
+    /// Installed ffmpeg binary path.
+    pub ffmpeg_path: PathBuf,
+    /// Installed ffprobe binary path.
+    pub ffprobe_path: PathBuf,
+    /// Whether every downloaded archive passed SHA-256 verification.
+    pub verified: bool,
+}
+
+// =============================================================================
+// Platform mapping and directories
+// =============================================================================
+
+/// Maps the compile-time platform to the manifest's target-triple key.
+pub fn current_target_triple() -> Result<&'static str, String> {
+    if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        return Ok("x86_64-pc-windows-msvc");
+    }
+    if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        return Ok("x86_64-apple-darwin");
+    }
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        return Ok("aarch64-apple-darwin");
+    }
+    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        return Ok("x86_64-unknown-linux-gnu");
+    }
+    Err(format!(
+        "Automatic FFmpeg installation is not supported on this platform ({}-{}). \
+         Please install FFmpeg manually.",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    ))
+}
+
+/// Base directory for the managed FFmpeg install.
+///
+/// Uses the same `{data_local}/openreelio/...` convention as the whisper model
+/// directory so the CLI can derive the identical path without an AppHandle.
+pub fn managed_ffmpeg_root() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("openreelio")
+        .join("ffmpeg")
+}
+
+/// Directory that holds the managed ffmpeg/ffprobe binaries.
+pub fn managed_install_dir() -> PathBuf {
+    managed_ffmpeg_root().join("bin")
+}
+
+/// Loads and parses the embedded manifest, selecting the given target triple.
+fn load_target_sources(target: &str) -> Result<TargetSources, String> {
+    let manifest: SourcesManifest = serde_json::from_str(FFMPEG_SOURCES_MANIFEST)
+        .map_err(|error| format!("Failed to parse embedded FFmpeg source manifest: {error}"))?;
+    let sources =
+        manifest.targets.get(target).cloned().ok_or_else(|| {
+            format!("The FFmpeg source manifest has no entry for target '{target}'.")
+        })?;
+    if sources.archives.is_empty() {
+        return Err(format!(
+            "The FFmpeg source manifest entry for '{target}' lists no archives."
+        ));
+    }
+    for archive in &sources.archives {
+        if archive.binaries.is_empty() || archive.urls.is_empty() {
+            return Err(format!(
+                "The FFmpeg source manifest archive '{}' is missing binaries or URLs.",
+                archive.name
+            ));
+        }
+    }
+    Ok(sources)
+}
+
+/// Parses a checksum sidecar body into the digest for `source_url`.
+///
+/// Mirrors `parseSha256Sidecar` in `scripts/prepare-bundled-ffmpeg.mjs`:
+/// `digest  filename` lines are matched against the manifest URL basename
+/// (redirect targets often resolve to opaque object-storage paths), and a
+/// bare single-digest sidecar applies to the download as a whole.
+fn parse_sha256_sidecar(sidecar_text: &str, source_url: &str) -> Option<String> {
+    let download_basename = source_url
+        .split('?')
+        .next()
+        .unwrap_or(source_url)
+        .rsplit('/')
+        .next()
+        .unwrap_or(source_url)
+        .to_ascii_lowercase();
+
+    let is_digest = |token: &str| token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit());
+
+    let mut digests: Vec<String> = Vec::new();
+    for line in sidecar_text.lines() {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        let Some(first) = tokens.first() else {
+            continue;
+        };
+        if !is_digest(first) {
+            continue;
+        }
+
+        // Match "digest  filename" lines against the downloaded file first.
+        if tokens.len() > 1 {
+            let file_token = tokens[tokens.len() - 1].trim_start_matches('*');
+            let file_basename = file_token
+                .rsplit('/')
+                .next()
+                .unwrap_or(file_token)
+                .to_ascii_lowercase();
+            if file_basename == download_basename {
+                return Some((*first).to_ascii_lowercase());
+            }
+        }
+
+        digests.push((*first).to_ascii_lowercase());
+    }
+
+    // A bare-digest sidecar (single digest, no matching filename) applies to
+    // the download.
+    if digests.len() == 1 {
+        digests.pop()
+    } else {
+        None
+    }
+}
+
+// =============================================================================
+// Install flow (GUI builds only: requires reqwest/zip/xz2)
+// =============================================================================
+
+/// Downloads, verifies, extracts, and atomically installs FFmpeg + FFprobe
+/// into [`managed_install_dir`], reporting progress via `on_progress`.
+///
+/// Returns the installed binary paths and whether every archive passed
+/// checksum verification. On any failure the previous managed install (if
+/// any) is left untouched and all partial downloads are cleaned up.
+#[cfg(feature = "gui")]
+pub fn install_managed_ffmpeg<F>(mut on_progress: F) -> Result<ManagedFFmpegInstall, String>
+where
+    F: FnMut(FFmpegInstallProgress),
+{
+    use crate::core::artifact;
+
+    let target = current_target_triple()?;
+    let sources = load_target_sources(target)?;
+
+    let root = managed_ffmpeg_root();
+    std::fs::create_dir_all(&root)
+        .map_err(|error| format!("Failed to create FFmpeg install directory: {error}"))?;
+
+    // Staging lives next to the final bin dir (same filesystem) so the final
+    // placement can be an atomic rename. TempDir removes everything on drop,
+    // which covers partial downloads on every failure path.
+    let staging = tempfile::Builder::new()
+        .prefix(".install-")
+        .tempdir_in(&root)
+        .map_err(|error| format!("Failed to create FFmpeg staging directory: {error}"))?;
+    let stage_bin_dir = staging.path().join("bin");
+    std::fs::create_dir_all(&stage_bin_dir)
+        .map_err(|error| format!("Failed to create FFmpeg staging directory: {error}"))?;
+
+    let client = artifact::blocking_http_client(DOWNLOAD_TOTAL_TIMEOUT)?;
+
+    let mut all_verified = true;
+    let mut staged: HashMap<String, PathBuf> = HashMap::new();
+
+    for archive in &sources.archives {
+        let archive_path = staging.path().join(&archive.filename);
+        let (verified, downloaded_bytes, total_bytes) =
+            download_and_verify_archive(&client, archive, &archive_path, &mut on_progress)?;
+        all_verified = all_verified && verified;
+
+        on_progress(FFmpegInstallProgress {
+            stage: FFmpegInstallStage::Extracting,
+            binary: archive.name.clone(),
+            downloaded_bytes,
+            total_bytes,
+        });
+        let extract_dir = staging.path().join(format!("{}-extracted", archive.name));
+        extract_archive(&archive.format, &archive_path, &extract_dir)?;
+        // The consumed archive is no longer needed; free the space early.
+        let _ = std::fs::remove_file(&archive_path);
+
+        on_progress(FFmpegInstallProgress {
+            stage: FFmpegInstallStage::Installing,
+            binary: archive.name.clone(),
+            downloaded_bytes,
+            total_bytes,
+        });
+        for binary_name in &archive.binaries {
+            let found = find_binary_recursive(&extract_dir, binary_name).ok_or_else(|| {
+                format!("Binary '{binary_name}' was not found in the downloaded archive.")
+            })?;
+            let staged_path = stage_bin_dir.join(binary_name);
+            std::fs::rename(&found, &staged_path).or_else(|_| {
+                std::fs::copy(&found, &staged_path)
+                    .map(|_| ())
+                    .map_err(|error| {
+                        format!("Failed to stage FFmpeg binary '{binary_name}': {error}")
+                    })
+            })?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&staged_path, std::fs::Permissions::from_mode(0o755))
+                    .map_err(|error| {
+                        format!("Failed to mark '{binary_name}' executable: {error}")
+                    })?;
+            }
+
+            // FFmpeg binaries use the single-dash `-version` flag.
+            crate::core::managed_runtime::verify_runnable_with_arg(&staged_path, "-version")?;
+            staged.insert(binary_name.clone(), staged_path);
+        }
+        let _ = std::fs::remove_dir_all(&extract_dir);
+    }
+
+    // All archives are staged and sanity-checked; swap into the final bin dir.
+    let (ffmpeg_name, ffprobe_name) = super::get_bundled_binary_names();
+    for required in [ffmpeg_name, ffprobe_name] {
+        if !staged.contains_key(required) {
+            return Err(format!(
+                "The downloaded FFmpeg archives did not provide '{required}'."
+            ));
+        }
+    }
+
+    let install_dir = managed_install_dir();
+    std::fs::create_dir_all(&install_dir)
+        .map_err(|error| format!("Failed to create FFmpeg install directory: {error}"))?;
+    for (binary_name, staged_path) in &staged {
+        let destination = install_dir.join(binary_name);
+        // `rename` replaces the destination atomically on unix; on Windows a
+        // live destination must be removed first (mirrors managed_runtime).
+        if cfg!(windows) && destination.exists() {
+            std::fs::remove_file(&destination)
+                .map_err(|error| format!("Failed to replace existing '{binary_name}': {error}"))?;
+        }
+        std::fs::rename(staged_path, &destination)
+            .map_err(|error| format!("Failed to install FFmpeg binary '{binary_name}': {error}"))?;
+    }
+
+    on_progress(FFmpegInstallProgress {
+        stage: FFmpegInstallStage::Done,
+        binary: "ffmpeg".to_string(),
+        downloaded_bytes: 0,
+        total_bytes: None,
+    });
+
+    Ok(ManagedFFmpegInstall {
+        ffmpeg_path: install_dir.join(ffmpeg_name),
+        ffprobe_path: install_dir.join(ffprobe_name),
+        verified: all_verified,
+    })
+}
+
+/// Downloads one archive, trying each URL (with per-URL retries) until one
+/// downloads and verifies. Returns `(verified, downloaded_bytes, total_bytes)`.
+#[cfg(feature = "gui")]
+fn download_and_verify_archive<F>(
+    client: &reqwest::blocking::Client,
+    archive: &ArchiveSource,
+    destination: &Path,
+    on_progress: &mut F,
+) -> Result<(bool, u64, Option<u64>), String>
+where
+    F: FnMut(FFmpegInstallProgress),
+{
+    use crate::core::artifact;
+
+    let part_path = destination.with_extension("part");
+    let mut errors: Vec<String> = Vec::new();
+
+    for source in &archive.urls {
+        let download =
+            download_url_with_retries(client, &source.url, &part_path, &archive.name, on_progress);
+        let (final_url, downloaded_bytes, total_bytes) = match download {
+            Ok(result) => result,
+            Err(error) => {
+                errors.push(format!("{}: {error}", source.url));
+                let _ = std::fs::remove_file(&part_path);
+                continue;
+            }
+        };
+
+        on_progress(FFmpegInstallProgress {
+            stage: FFmpegInstallStage::Verifying,
+            binary: archive.name.clone(),
+            downloaded_bytes,
+            total_bytes,
+        });
+
+        let verified = match resolve_expected_sha256(client, source, &final_url) {
+            Ok(Some(expected)) => match artifact::verify_sha256(&part_path, &expected) {
+                Ok(true) => true,
+                Ok(false) => {
+                    errors.push(format!("{}: SHA-256 checksum mismatch", source.url));
+                    let _ = std::fs::remove_file(&part_path);
+                    continue;
+                }
+                Err(error) => {
+                    errors.push(format!(
+                        "{}: checksum computation failed: {error}",
+                        source.url
+                    ));
+                    let _ = std::fs::remove_file(&part_path);
+                    continue;
+                }
+            },
+            Ok(None) => {
+                tracing::warn!(
+                    url = source.url,
+                    "No checksum source in manifest; accepting unverified FFmpeg download"
+                );
+                false
+            }
+            Err(error) => {
+                errors.push(format!("{}: {error}", source.url));
+                let _ = std::fs::remove_file(&part_path);
+                continue;
+            }
+        };
+
+        std::fs::rename(&part_path, destination)
+            .map_err(|error| format!("Failed to finalize downloaded archive: {error}"))?;
+        return Ok((verified, downloaded_bytes, total_bytes));
+    }
+
+    Err(format!(
+        "All download URLs failed for {}: {}",
+        archive.name,
+        errors.join("; ")
+    ))
+}
+
+/// Streams one URL to `part_path` with up to [`DOWNLOAD_ATTEMPTS_PER_URL`]
+/// attempts. Returns `(redirect_resolved_url, downloaded_bytes, total_bytes)`.
+#[cfg(feature = "gui")]
+fn download_url_with_retries<F>(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    part_path: &Path,
+    binary_label: &str,
+    on_progress: &mut F,
+) -> Result<(String, u64, Option<u64>), String>
+where
+    F: FnMut(FFmpegInstallProgress),
+{
+    let mut last_error = String::new();
+    for attempt in 1..=DOWNLOAD_ATTEMPTS_PER_URL {
+        match stream_download(client, url, part_path, binary_label, on_progress) {
+            Ok(result) => return Ok(result),
+            Err(error) => {
+                tracing::warn!(
+                    url,
+                    attempt,
+                    error,
+                    "FFmpeg archive download attempt failed"
+                );
+                last_error = error;
+                let _ = std::fs::remove_file(part_path);
+                if attempt < DOWNLOAD_ATTEMPTS_PER_URL {
+                    std::thread::sleep(DOWNLOAD_RETRY_DELAY);
+                }
+            }
+        }
+    }
+    Err(last_error)
+}
+
+/// Streams a single download attempt to `part_path`, reporting progress.
+#[cfg(feature = "gui")]
+fn stream_download<F>(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    part_path: &Path,
+    binary_label: &str,
+    on_progress: &mut F,
+) -> Result<(String, u64, Option<u64>), String>
+where
+    F: FnMut(FFmpegInstallProgress),
+{
+    use std::io::{Read, Write};
+
+    let mut response = client
+        .get(url)
+        .send()
+        .map_err(|error| format!("Download request failed: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Download request failed with HTTP status {}",
+            response.status()
+        ));
+    }
+
+    let final_url = response.url().to_string();
+    let total_bytes = response.content_length();
+    let mut output = std::fs::File::create(part_path)
+        .map_err(|error| format!("Failed to create partial download file: {error}"))?;
+    let mut downloaded_bytes = 0_u64;
+    let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
+    loop {
+        let read = response
+            .read(&mut buffer)
+            .map_err(|error| format!("Download failed: {error}"))?;
+        if read == 0 {
+            break;
+        }
+        output
+            .write_all(&buffer[..read])
+            .map_err(|error| format!("Failed to write download: {error}"))?;
+        downloaded_bytes += read as u64;
+        on_progress(FFmpegInstallProgress {
+            stage: FFmpegInstallStage::Downloading,
+            binary: binary_label.to_string(),
+            downloaded_bytes,
+            total_bytes,
+        });
+    }
+
+    if downloaded_bytes == 0 {
+        return Err("Downloaded archive is empty.".to_string());
+    }
+    if let Some(expected) = total_bytes {
+        if downloaded_bytes != expected {
+            return Err(format!(
+                "Downloaded {downloaded_bytes} bytes but expected {expected} bytes."
+            ));
+        }
+    }
+    output
+        .sync_all()
+        .map_err(|error| format!("Failed to flush download: {error}"))?;
+
+    Ok((final_url, downloaded_bytes, total_bytes))
+}
+
+/// Resolves the expected SHA-256 digest for a download source, if any.
+///
+/// Returns `Ok(None)` when the manifest provides no checksum source at all
+/// (the caller marks the install unverified instead of failing).
+#[cfg(feature = "gui")]
+fn resolve_expected_sha256(
+    client: &reqwest::blocking::Client,
+    source: &DownloadSource,
+    final_url: &str,
+) -> Result<Option<String>, String> {
+    if let Some(pinned) = &source.sha256 {
+        return Ok(Some(pinned.clone()));
+    }
+
+    let sidecar_url = if let Some(url) = &source.sha256_url {
+        url.clone()
+    } else if let Some(suffix) = &source.sha256_sidecar {
+        format!("{final_url}{suffix}")
+    } else {
+        return Ok(None);
+    };
+
+    let response = client
+        .get(&sidecar_url)
+        .send()
+        .map_err(|error| format!("Failed to fetch checksum sidecar {sidecar_url}: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Failed to fetch checksum sidecar {sidecar_url}: HTTP {}",
+            response.status()
+        ));
+    }
+    let body = response
+        .text()
+        .map_err(|error| format!("Failed to read checksum sidecar {sidecar_url}: {error}"))?;
+
+    parse_sha256_sidecar(&body, &source.url)
+        .map(Some)
+        .ok_or_else(|| format!("No matching SHA-256 digest found in {sidecar_url}"))
+}
+
+/// Extracts an archive by manifest format (`zip` or `tar.xz`).
+#[cfg(feature = "gui")]
+fn extract_archive(format: &str, archive_path: &Path, output_dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(output_dir)
+        .map_err(|error| format!("Failed to create extraction directory: {error}"))?;
+    match format {
+        "zip" => extract_zip(archive_path, output_dir),
+        "tar.xz" => extract_tar_xz(archive_path, output_dir),
+        other => Err(format!("Unsupported archive format: {other}")),
+    }
+}
+
+/// Safely extracts a zip archive (rejects symlinks and path traversal).
+#[cfg(feature = "gui")]
+fn extract_zip(archive_path: &Path, output_dir: &Path) -> Result<(), String> {
+    use crate::core::artifact::{
+        archive_entry_destination, ensure_no_existing_symlink_in_destination,
+    };
+
+    let file = std::fs::File::open(archive_path)
+        .map_err(|error| format!("Failed to open archive: {error}"))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|error| format!("Failed to open zip archive: {error}"))?;
+    let output_root = output_dir
+        .canonicalize()
+        .map_err(|error| format!("Failed to resolve extraction directory: {error}"))?;
+
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| format!("Failed to read zip entry: {error}"))?;
+
+        if entry.is_symlink() {
+            return Err(format!(
+                "Archive symlink entries are not allowed: {}",
+                entry.name()
+            ));
+        }
+
+        let entry_name = entry.enclosed_name().ok_or_else(|| {
+            format!(
+                "Archive entry escapes extraction directory: {}",
+                entry.name()
+            )
+        })?;
+        let destination = archive_entry_destination(&output_root, &entry_name)
+            .map_err(|error| error.to_string())?;
+        ensure_no_existing_symlink_in_destination(&output_root, &destination)
+            .map_err(|error| error.to_string())?;
+
+        if entry.is_dir() {
+            std::fs::create_dir_all(&destination)
+                .map_err(|error| format!("Failed to create directory: {error}"))?;
+            continue;
+        }
+
+        if let Some(parent) = destination.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("Failed to create directory: {error}"))?;
+        }
+        let mut output_file = std::fs::File::create(&destination)
+            .map_err(|error| format!("Failed to create extracted file: {error}"))?;
+        std::io::copy(&mut entry, &mut output_file)
+            .map_err(|error| format!("Failed to extract zip entry: {error}"))?;
+
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(mode));
+        }
+    }
+
+    Ok(())
+}
+
+/// Safely extracts a `.tar.xz` archive via the shared tar extraction helper.
+#[cfg(feature = "gui")]
+fn extract_tar_xz(archive_path: &Path, output_dir: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(archive_path)
+        .map_err(|error| format!("Failed to open archive: {error}"))?;
+    let decompressor = xz2::read::XzDecoder::new(file);
+    crate::core::artifact::extract_tar_entries(
+        tar::Archive::new(decompressor),
+        output_dir,
+        "tar.xz",
+    )
+    .map_err(|error| error.to_string())
+}
+
+/// Recursively finds the first regular file whose name case-insensitively
+/// matches `binary_name` (mirrors `findBinary` in the prepare script).
+#[cfg(feature = "gui")]
+fn find_binary_recursive(dir: &Path, binary_name: &str) -> Option<PathBuf> {
+    for entry in walkdir::WalkDir::new(dir).follow_links(false) {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if entry.file_type().is_file()
+            && entry
+                .file_name()
+                .to_string_lossy()
+                .eq_ignore_ascii_case(binary_name)
+        {
+            return Some(entry.path().to_path_buf());
+        }
+    }
+    None
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_manifest_parses_and_covers_all_release_targets() {
+        let manifest: SourcesManifest =
+            serde_json::from_str(FFMPEG_SOURCES_MANIFEST).expect("manifest parses");
+
+        for target in [
+            "x86_64-pc-windows-msvc",
+            "x86_64-apple-darwin",
+            "aarch64-apple-darwin",
+            "x86_64-unknown-linux-gnu",
+        ] {
+            let sources = manifest.targets.get(target).expect("target present");
+            assert!(!sources.archives.is_empty(), "{target} has archives");
+            for archive in &sources.archives {
+                assert!(!archive.name.is_empty());
+                assert!(matches!(archive.format.as_str(), "zip" | "tar.xz"));
+                assert!(!archive.filename.is_empty());
+                assert!(!archive.binaries.is_empty());
+                assert!(!archive.urls.is_empty());
+                for url in &archive.urls {
+                    assert!(url.url.starts_with("https://"));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn manifest_checksum_fields_deserialize_camel_case() {
+        let source: DownloadSource = serde_json::from_str(
+            r#"{"url":"https://example.com/a.zip","sha256":null,"sha256Url":"https://example.com/a.zip.sha256","sha256Sidecar":".sha256"}"#,
+        )
+        .expect("source parses");
+        assert!(source.sha256.is_none());
+        assert_eq!(
+            source.sha256_url.as_deref(),
+            Some("https://example.com/a.zip.sha256")
+        );
+        assert_eq!(source.sha256_sidecar.as_deref(), Some(".sha256"));
+    }
+
+    #[test]
+    fn current_target_triple_maps_to_a_manifest_entry() {
+        // Development and CI hosts are always one of the supported targets;
+        // the mapped triple must exist in the manifest.
+        let target = current_target_triple().expect("supported platform");
+        let sources = load_target_sources(target).expect("manifest entry");
+        assert!(!sources.archives.is_empty());
+    }
+
+    #[test]
+    fn load_target_sources_rejects_unknown_target() {
+        let error = load_target_sources("aarch64-unknown-linux-gnu").unwrap_err();
+        assert!(error.contains("no entry"));
+    }
+
+    #[test]
+    fn managed_install_dir_uses_data_local_convention() {
+        let dir = managed_install_dir();
+        let path = dir.to_string_lossy().replace('\\', "/");
+        assert!(
+            path.ends_with("openreelio/ffmpeg/bin"),
+            "unexpected managed install dir: {path}"
+        );
+    }
+
+    #[test]
+    fn sidecar_parser_accepts_bare_digest() {
+        let digest = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72";
+        assert_eq!(
+            parse_sha256_sidecar(&format!("{digest}\n"), "https://example.com/ffmpeg.zip"),
+            Some(digest.to_string())
+        );
+    }
+
+    #[test]
+    fn sidecar_parser_matches_filename_lines() {
+        let expected = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72";
+        let other = "0000000000000000000000000000000000000000000000000000000000000000";
+        let sidecar =
+            format!("{other}  other-file.zip\n{expected}  ffmpeg-release-essentials.zip\n");
+        assert_eq!(
+            parse_sha256_sidecar(
+                &sidecar,
+                "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
+            ),
+            Some(expected.to_string())
+        );
+    }
+
+    #[test]
+    fn sidecar_parser_rejects_ambiguous_content() {
+        let sidecar = "0000000000000000000000000000000000000000000000000000000000000000  a.zip\n\
+                       1111111111111111111111111111111111111111111111111111111111111111  b.zip\n";
+        assert_eq!(
+            parse_sha256_sidecar(sidecar, "https://example.com/c.zip"),
+            None
+        );
+        assert_eq!(
+            parse_sha256_sidecar("not a digest", "https://example.com/c.zip"),
+            None
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "gui")]
+    fn finds_binary_case_insensitively_in_nested_dirs() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let nested = temp.path().join("pkg").join("bin");
+        std::fs::create_dir_all(&nested).expect("dirs");
+        std::fs::write(temp.path().join("README"), b"x").expect("sibling");
+        let target = nested.join("FFmpeg.exe");
+        std::fs::write(&target, b"bin").expect("binary");
+
+        assert_eq!(
+            find_binary_recursive(temp.path(), "ffmpeg.exe"),
+            Some(target)
+        );
+        assert_eq!(find_binary_recursive(temp.path(), "ffprobe"), None);
+    }
+
+    /// Real end-to-end download install. Requires network; run manually with
+    /// `cargo test -p openreelio --lib installer -- --ignored`.
+    #[test]
+    #[cfg(feature = "gui")]
+    #[ignore = "downloads FFmpeg archives from the network"]
+    fn real_install_downloads_and_installs_ffmpeg() {
+        let result = install_managed_ffmpeg(|progress| {
+            println!(
+                "{} {} {}/{:?}",
+                progress.stage.as_str(),
+                progress.binary,
+                progress.downloaded_bytes,
+                progress.total_bytes
+            );
+        })
+        .expect("install succeeds");
+        assert!(result.ffmpeg_path.exists());
+        assert!(result.ffprobe_path.exists());
+    }
+}

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -21,6 +21,8 @@ pub mod bundler;
 #[cfg(all(not(test), feature = "gui"))]
 mod commands;
 mod detection;
+pub mod installer;
+mod resolver;
 mod runner;
 mod state;
 
@@ -30,6 +32,9 @@ pub use bundler::{
 #[cfg(all(not(test), feature = "gui"))]
 pub use commands::*;
 pub use detection::*;
+pub use resolver::{
+    resolved_ffmpeg_path, resolved_ffprobe_path, set_resolved_paths, ResolvedFFmpeg,
+};
 pub use runner::{
     AudioStreamInfo, FFmpegProgress, FFmpegRunner, MediaInfo, RenderSettings, VideoStreamInfo,
     WaveformData,

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -40,6 +40,8 @@ pub use runner::{
     WaveformData,
 };
 pub use state::{create_ffmpeg_state, FFmpegState, SharedFFmpegState};
+#[cfg(all(not(test), feature = "gui"))]
+pub use state::{detect_ffmpeg, initialize_shared_ffmpeg};
 
 /// FFmpeg-related error types
 #[derive(Debug, thiserror::Error)]

--- a/src-tauri/src/core/ffmpeg/resolver.rs
+++ b/src-tauri/src/core/ffmpeg/resolver.rs
@@ -1,0 +1,114 @@
+//! Global FFmpeg/FFprobe path resolver
+//!
+//! Modules that spawn ffmpeg/ffprobe directly (metadata extraction, shot
+//! detection, audio extraction, ...) must not assume the binaries are on the
+//! system PATH: on installs where FFmpeg is only bundled, bare "ffmpeg"
+//! invocations silently fail. This module stores the paths resolved by
+//! `FFmpegState::initialize` (GUI) or `detect_cli_ffmpeg` (CLI) and exposes
+//! them process-wide. If nothing has been registered yet, a one-time lazy
+//! detection runs (dev-mode binaries, then system PATH), falling back to the
+//! bare binary name as the last resort so behavior never regresses.
+
+use std::path::PathBuf;
+use std::sync::{OnceLock, RwLock};
+
+use super::detection::{detect_dev_mode_binaries, detect_system_ffmpeg};
+
+/// Globally resolved FFmpeg/FFprobe binary paths.
+#[derive(Clone, Debug)]
+pub struct ResolvedFFmpeg {
+    /// Path to the ffmpeg binary
+    pub ffmpeg: PathBuf,
+    /// Path to the ffprobe binary
+    pub ffprobe: PathBuf,
+}
+
+static RESOLVED: OnceLock<RwLock<Option<ResolvedFFmpeg>>> = OnceLock::new();
+
+fn resolved_cell() -> &'static RwLock<Option<ResolvedFFmpeg>> {
+    RESOLVED.get_or_init(|| RwLock::new(None))
+}
+
+/// Registers the globally resolved FFmpeg/FFprobe paths.
+///
+/// Called by `FFmpegState::initialize` (GUI) and `detect_cli_ffmpeg` (CLI)
+/// once detection succeeds. Overwrites any previously cached paths.
+pub fn set_resolved_paths(ffmpeg: PathBuf, ffprobe: PathBuf) {
+    // A poisoned lock only means another thread panicked mid-write; the
+    // stored Option is still valid, so recover the guard instead of panicking.
+    let mut guard = resolved_cell()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(ResolvedFFmpeg { ffmpeg, ffprobe });
+}
+
+/// Returns the globally resolved paths, running lazy detection if needed.
+fn resolved_paths() -> ResolvedFFmpeg {
+    if let Some(resolved) = resolved_cell()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+    {
+        return resolved;
+    }
+
+    // No registration yet: detect once (dev-mode binaries, then system PATH)
+    // and fall back to bare names so PATH-based lookup keeps working.
+    let detected = detect_dev_mode_binaries()
+        .or_else(|_| detect_system_ffmpeg())
+        .map(|info| ResolvedFFmpeg {
+            ffmpeg: info.ffmpeg_path,
+            ffprobe: info.ffprobe_path,
+        })
+        .unwrap_or_else(|_| ResolvedFFmpeg {
+            ffmpeg: PathBuf::from("ffmpeg"),
+            ffprobe: PathBuf::from("ffprobe"),
+        });
+
+    let mut guard = resolved_cell()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Another thread (or an explicit registration) may have won the race.
+    match guard.as_ref() {
+        Some(existing) => existing.clone(),
+        None => {
+            *guard = Some(detected.clone());
+            detected
+        }
+    }
+}
+
+/// Returns the globally resolved ffmpeg path (lazy detection on first use).
+pub fn resolved_ffmpeg_path() -> PathBuf {
+    resolved_paths().ffmpeg
+}
+
+/// Returns the globally resolved ffprobe path (lazy detection on first use).
+pub fn resolved_ffprobe_path() -> PathBuf {
+    resolved_paths().ffprobe
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The resolver caches into process-global state shared by every test in
+    // this binary, so all assertions live in a single test to keep ordering
+    // deterministic.
+    #[test]
+    fn test_resolver_lazy_fallback_then_explicit_registration() {
+        // Lazy path: with or without prior registration, the resolver must
+        // always return a non-empty path for both binaries.
+        let lazy_ffmpeg = resolved_ffmpeg_path();
+        let lazy_ffprobe = resolved_ffprobe_path();
+        assert!(!lazy_ffmpeg.as_os_str().is_empty());
+        assert!(!lazy_ffprobe.as_os_str().is_empty());
+
+        // Explicit registration overrides whatever was cached.
+        let custom_ffmpeg = PathBuf::from("/custom/bin/ffmpeg");
+        let custom_ffprobe = PathBuf::from("/custom/bin/ffprobe");
+        set_resolved_paths(custom_ffmpeg.clone(), custom_ffprobe.clone());
+        assert_eq!(resolved_ffmpeg_path(), custom_ffmpeg);
+        assert_eq!(resolved_ffprobe_path(), custom_ffprobe);
+    }
+}

--- a/src-tauri/src/core/ffmpeg/resolver.rs
+++ b/src-tauri/src/core/ffmpeg/resolver.rs
@@ -110,5 +110,9 @@ mod tests {
         set_resolved_paths(custom_ffmpeg.clone(), custom_ffprobe.clone());
         assert_eq!(resolved_ffmpeg_path(), custom_ffmpeg);
         assert_eq!(resolved_ffprobe_path(), custom_ffprobe);
+
+        // Restore the initially resolved paths so later tests in this binary
+        // never observe the synthetic /custom registration.
+        set_resolved_paths(lazy_ffmpeg, lazy_ffprobe);
     }
 }

--- a/src-tauri/src/core/ffmpeg/state.rs
+++ b/src-tauri/src/core/ffmpeg/state.rs
@@ -33,30 +33,12 @@ impl FFmpegState {
     ///
     /// Resolution order: bundled resources → managed install → dev-mode
     /// binaries → system PATH.
+    ///
+    /// This runs blocking process probes; async callers must use
+    /// [`initialize_shared_ffmpeg`] instead so the async runtime never blocks.
     #[cfg(all(not(test), feature = "gui"))]
     pub fn initialize(&mut self, app_handle: Option<&tauri::AppHandle>) -> Result<(), FFmpegError> {
-        // Try bundled resources first (if app_handle provided)
-        if let Some(handle) = app_handle {
-            if let Ok(info) = super::detect_bundled_resources(handle) {
-                self.apply_info(info);
-                return Ok(());
-            }
-        }
-
-        // Managed install (in-app FFmpeg installer)
-        if let Ok(info) = super::detect_managed_ffmpeg() {
-            self.apply_info(info);
-            return Ok(());
-        }
-
-        // Dev-mode binaries (src-tauri/binaries during `npm run tauri dev`)
-        if let Ok(info) = super::detection::detect_dev_mode_binaries() {
-            self.apply_info(info);
-            return Ok(());
-        }
-
-        // Fall back to system FFmpeg
-        let info = detect_system_ffmpeg()?;
+        let info = detect_ffmpeg(app_handle)?;
         self.apply_info(info);
         Ok(())
     }
@@ -101,8 +83,60 @@ impl Default for FFmpegState {
     }
 }
 
+/// Detects an FFmpeg installation without touching any shared state.
+///
+/// Resolution order: bundled resources → managed install → dev-mode
+/// binaries → system PATH. This spawns blocking `ffmpeg -version` process
+/// probes, so async callers must run it inside `spawn_blocking` (see
+/// [`initialize_shared_ffmpeg`]).
+#[cfg(all(not(test), feature = "gui"))]
+pub fn detect_ffmpeg(app_handle: Option<&tauri::AppHandle>) -> Result<FFmpegInfo, FFmpegError> {
+    // Try bundled resources first (if app_handle provided)
+    if let Some(handle) = app_handle {
+        if let Ok(info) = super::detect_bundled_resources(handle) {
+            return Ok(info);
+        }
+    }
+
+    // Managed install (in-app FFmpeg installer)
+    if let Ok(info) = super::detect_managed_ffmpeg() {
+        return Ok(info);
+    }
+
+    // Dev-mode binaries (src-tauri/binaries during `npm run tauri dev`)
+    if let Ok(info) = super::detection::detect_dev_mode_binaries() {
+        return Ok(info);
+    }
+
+    // Fall back to system FFmpeg
+    detect_system_ffmpeg()
+}
+
 /// Shared FFmpeg state for the async runtime.
 pub type SharedFFmpegState = Arc<RwLock<FFmpegState>>;
+
+/// Initializes the shared FFmpeg state without blocking the async runtime.
+///
+/// Detection (which spawns `ffmpeg -version` process probes) runs on the
+/// blocking thread pool while no lock is held; the write lock is taken only
+/// to apply the detected info and publish the resolved paths. If concurrent
+/// initializations race, the last writer wins, which is acceptable because
+/// they detect the same installation.
+#[cfg(all(not(test), feature = "gui"))]
+pub async fn initialize_shared_ffmpeg(
+    state: &SharedFFmpegState,
+    app_handle: Option<tauri::AppHandle>,
+) -> Result<(), FFmpegError> {
+    let info = tokio::task::spawn_blocking(move || detect_ffmpeg(app_handle.as_ref()))
+        .await
+        .map_err(|error| {
+            FFmpegError::ExecutionFailed(format!("FFmpeg detection task failed: {error}"))
+        })??;
+
+    let mut guard = state.write().await;
+    guard.apply_info(info);
+    Ok(())
+}
 
 /// Create a new shared FFmpeg state.
 pub fn create_ffmpeg_state() -> SharedFFmpegState {

--- a/src-tauri/src/core/ffmpeg/state.rs
+++ b/src-tauri/src/core/ffmpeg/state.rs
@@ -31,22 +31,33 @@ impl FFmpegState {
 
     /// Initialize FFmpeg by detecting installation.
     ///
-    /// In non-test builds, this optionally attempts bundled FFmpeg detection first.
+    /// Resolution order: bundled resources → managed install → dev-mode
+    /// binaries → system PATH.
     #[cfg(all(not(test), feature = "gui"))]
     pub fn initialize(&mut self, app_handle: Option<&tauri::AppHandle>) -> Result<(), FFmpegError> {
-        // Try bundled first (if app_handle provided)
+        // Try bundled resources first (if app_handle provided)
         if let Some(handle) = app_handle {
-            if let Ok(info) = super::detect_bundled_ffmpeg(handle) {
-                self.info = Some(info.clone());
-                self.runner = Some(FFmpegRunner::new(info));
+            if let Ok(info) = super::detect_bundled_resources(handle) {
+                self.apply_info(info);
                 return Ok(());
             }
         }
 
+        // Managed install (in-app FFmpeg installer)
+        if let Ok(info) = super::detect_managed_ffmpeg() {
+            self.apply_info(info);
+            return Ok(());
+        }
+
+        // Dev-mode binaries (src-tauri/binaries during `npm run tauri dev`)
+        if let Ok(info) = super::detection::detect_dev_mode_binaries() {
+            self.apply_info(info);
+            return Ok(());
+        }
+
         // Fall back to system FFmpeg
         let info = detect_system_ffmpeg()?;
-        self.info = Some(info.clone());
-        self.runner = Some(FFmpegRunner::new(info));
+        self.apply_info(info);
         Ok(())
     }
 
@@ -56,9 +67,16 @@ impl FFmpegState {
     #[cfg(test)]
     pub fn initialize(&mut self) -> Result<(), FFmpegError> {
         let info = detect_system_ffmpeg()?;
+        self.apply_info(info);
+        Ok(())
+    }
+
+    /// Store detected info and publish the paths to the global resolver.
+    #[cfg(any(test, feature = "gui"))]
+    fn apply_info(&mut self, info: FFmpegInfo) {
+        super::set_resolved_paths(info.ffmpeg_path.clone(), info.ffprobe_path.clone());
         self.info = Some(info.clone());
         self.runner = Some(FFmpegRunner::new(info));
-        Ok(())
     }
 
     /// Get the FFmpeg runner.

--- a/src-tauri/src/core/indexing/shots.rs
+++ b/src-tauri/src/core/indexing/shots.rs
@@ -11,6 +11,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use super::db::IndexDb;
+use crate::core::ffmpeg::{resolved_ffmpeg_path, resolved_ffprobe_path};
 use crate::core::process::{configure_std_command, configure_tokio_command};
 use crate::core::{AssetId, CoreError, CoreResult};
 
@@ -261,8 +262,8 @@ impl ShotDetector {
         let ffprobe_bin = self
             .config
             .ffprobe_path
-            .as_deref()
-            .unwrap_or_else(|| Path::new("ffprobe"));
+            .clone()
+            .unwrap_or_else(resolved_ffprobe_path);
 
         let mut cmd = Command::new(ffprobe_bin);
         configure_tokio_command(&mut cmd);
@@ -324,8 +325,8 @@ impl ShotDetector {
         let ffmpeg_bin = self
             .config
             .ffmpeg_path
-            .as_deref()
-            .unwrap_or_else(|| Path::new("ffmpeg"));
+            .clone()
+            .unwrap_or_else(resolved_ffmpeg_path);
 
         let filter = format!("select='gt(scene,{})',showinfo", self.config.threshold);
 
@@ -633,9 +634,9 @@ impl ShotDetector {
         Ok(shots)
     }
 
-    /// Checks if FFmpeg is available on the system
+    /// Checks if FFmpeg is available (bundled, dev-mode, or system PATH)
     pub fn is_ffmpeg_available() -> bool {
-        let mut command = std::process::Command::new("ffmpeg");
+        let mut command = std::process::Command::new(resolved_ffmpeg_path());
         configure_std_command(&mut command);
         command
             .arg("-version")

--- a/src-tauri/src/core/managed_runtime.rs
+++ b/src-tauri/src/core/managed_runtime.rs
@@ -465,12 +465,18 @@ where
 }
 
 /// Runs `<binary> --version` to confirm the freshly installed file is runnable.
+fn verify_runnable(path: &Path) -> Result<(), String> {
+    verify_runnable_with_arg(path, "--version")
+}
+
+/// Runs `<binary> <version_arg>` to confirm a freshly installed file is runnable.
 ///
 /// This is blocking code, so the wait is bounded by [`VERIFY_RUNNABLE_TIMEOUT`]:
 /// the child is spawned, polled with `try_wait`, and killed if it does not exit
-/// in time. Without this, a hung `<bin> --version` would block the install (and
-/// its `RuntimeInstallGuard`) forever.
-fn verify_runnable(path: &Path) -> Result<(), String> {
+/// in time. Without this, a hung version probe would block the install (and its
+/// install guard) forever. Shared with the FFmpeg installer, whose binaries use
+/// the single-dash `-version` flag.
+pub(crate) fn verify_runnable_with_arg(path: &Path, version_arg: &str) -> Result<(), String> {
     if !path.exists() {
         return Err(format!(
             "Installed runtime binary does not exist: {}",
@@ -483,7 +489,7 @@ fn verify_runnable(path: &Path) -> Result<(), String> {
     // Output is discarded (only the exit status matters); null'ing the pipes also
     // avoids any chance of a full-pipe deadlock during the bounded wait.
     let mut child = command
-        .arg("--version")
+        .arg(version_arg)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -4925,10 +4925,11 @@ pub fn build_complex_filter_args_with_audio_info(
 ) -> Result<Vec<String>, ExportError> {
     let engine = ExportEngine::new(crate::core::ffmpeg::FFmpegRunner::new(
         crate::core::ffmpeg::FFmpegInfo {
-            ffmpeg_path: PathBuf::from("ffmpeg"),
-            ffprobe_path: PathBuf::from("ffprobe"),
+            ffmpeg_path: crate::core::ffmpeg::resolved_ffmpeg_path(),
+            ffprobe_path: crate::core::ffmpeg::resolved_ffprobe_path(),
             version: "test-builder".to_string(),
             is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
         },
     ));
 
@@ -5195,6 +5196,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "test".to_string(),
             is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
         }));
         let ass_path = PathBuf::from("/tmp/openreelio:text,overlay.ass");
 
@@ -6734,6 +6736,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "test".to_string(),
             is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
         }));
         let settings =
             ExportSettings::from_preset(ExportPreset::WebmVp9, PathBuf::from("output.webm"));
@@ -7173,6 +7176,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "test".to_string(),
             is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
         }));
         let settings = AudioExportSettings {
             format: AudioExportFormat::Mp3,
@@ -7259,6 +7263,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "test".to_string(),
             is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
         }));
         let settings = AudioExportSettings {
             format: AudioExportFormat::Wav,
@@ -9008,6 +9013,7 @@ mod tests {
             ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
             version: "test".to_string(),
             is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
         }));
 
         let (clip, asset) = engine

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -320,16 +320,20 @@ async fn resolve_transcription_ffmpeg_path(
     }
 
     {
-        let mut guard = ffmpeg_state.write().await;
         #[cfg(test)]
         {
+            let mut guard = ffmpeg_state.write().await;
             let _ = guard.initialize();
         }
         #[cfg(all(not(test), feature = "gui"))]
         {
-            let _ = guard.initialize(app);
+            // Detection runs on the blocking pool without holding the lock.
+            let _ =
+                crate::core::ffmpeg::initialize_shared_ffmpeg(ffmpeg_state.inner(), app.cloned())
+                    .await;
         }
 
+        let guard = ffmpeg_state.read().await;
         if let Some(info) = guard.info() {
             return Ok(info.ffmpeg_path.to_string_lossy().into_owned());
         }
@@ -910,10 +914,11 @@ pub async fn detect_shots(
     let ffmpeg_info = match ffmpeg_info {
         Some(info) => info,
         None => {
-            // Best-effort initialization (system FFmpeg only) in case the command
-            // is called before app startup initialization completes.
-            let mut guard = ffmpeg_state.write().await;
-            let _ = guard.initialize(None);
+            // Best-effort initialization (no app handle) in case the command
+            // is called before app startup initialization completes. Detection
+            // runs on the blocking pool without holding the state lock.
+            let _ = crate::core::ffmpeg::initialize_shared_ffmpeg(ffmpeg_state.inner(), None).await;
+            let guard = ffmpeg_state.read().await;
             guard
                 .info()
                 .cloned()
@@ -1103,8 +1108,9 @@ pub async fn is_shot_detection_available(
         }
     }
 
-    let mut guard = ffmpeg_state.write().await;
-    let _ = guard.initialize(None);
+    // Detection runs on the blocking pool without holding the state lock.
+    let _ = crate::core::ffmpeg::initialize_shared_ffmpeg(ffmpeg_state.inner(), None).await;
+    let guard = ffmpeg_state.read().await;
     Ok(guard.is_available())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1477,6 +1477,7 @@ mod tauri_app {
                 $crate::core::ai::streaming::abort_ai_stream,
                 // FFmpeg commands
                 $crate::core::ffmpeg::check_ffmpeg,
+                $crate::core::ffmpeg::install_ffmpeg,
                 $crate::core::ffmpeg::extract_frame,
                 $crate::core::ffmpeg::generate_thumbnail,
                 $crate::core::ffmpeg::probe_media,
@@ -2004,6 +2005,7 @@ mod tauri_app {
             crate::core::ai::streaming::abort_ai_stream,
             // FFmpeg commands
             crate::core::ffmpeg::check_ffmpeg,
+            crate::core::ffmpeg::install_ffmpeg,
             crate::core::ffmpeg::extract_frame,
             crate::core::ffmpeg::generate_thumbnail,
             crate::core::ffmpeg::probe_media,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1706,13 +1706,14 @@ mod tauri_app {
                 }
             }
 
-            // Initialize FFmpeg
+            // Initialize FFmpeg (detection probes run on the blocking pool so
+            // the async runtime is never blocked while holding the state lock)
             let ffmpeg = ffmpeg_state.clone();
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
-                let mut state = ffmpeg.write().await;
-                match state.initialize(Some(&handle)) {
+                match crate::core::ffmpeg::initialize_shared_ffmpeg(&ffmpeg, Some(handle)).await {
                     Ok(()) => {
+                        let state = ffmpeg.read().await;
                         if let Some(info) = state.info() {
                             tracing::info!(
                                 "FFmpeg initialized: version {} (bundled: {})",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,11 @@ function App(): JSX.Element {
   const { general, isLoaded: settingsLoaded } = useSettings();
 
   // FFmpeg status check
-  const { isAvailable: isFFmpegAvailable, isLoading: isFFmpegLoading } = useFFmpegStatus();
+  const {
+    isAvailable: isFFmpegAvailable,
+    isLoading: isFFmpegLoading,
+    recheck: recheckFFmpeg,
+  } = useFFmpegStatus();
   const [showFFmpegWarning, setShowFFmpegWarning] = useState(false);
   const [ffmpegWarningDismissed, setFFmpegWarningDismissed] = useState(false);
 
@@ -102,9 +106,15 @@ function App(): JSX.Element {
   // Application lifecycle management (close handlers)
   useAppLifecycle();
 
-  // Show FFmpeg warning when check completes and FFmpeg is not available
+  // Show FFmpeg warning when check completes and FFmpeg is not available;
+  // hide it as soon as FFmpeg becomes available (e.g. after auto-install).
   useEffect(() => {
-    if (!isFFmpegLoading && !isFFmpegAvailable && !ffmpegWarningDismissed) {
+    if (isFFmpegLoading) {
+      return;
+    }
+    if (isFFmpegAvailable) {
+      setShowFFmpegWarning(false);
+    } else if (!ffmpegWarningDismissed) {
       setShowFFmpegWarning(true);
     }
   }, [isFFmpegLoading, isFFmpegAvailable, ffmpegWarningDismissed]);
@@ -221,6 +231,7 @@ function App(): JSX.Element {
           isOpen={showFFmpegWarning}
           onDismiss={handleDismissFFmpegWarning}
           allowDismiss={true}
+          onRecheck={recheckFFmpeg}
         />
         <ToastContainer toasts={toasts} onClose={dismissToast} />
       </>
@@ -277,6 +288,7 @@ function App(): JSX.Element {
         isOpen={showFFmpegWarning}
         onDismiss={handleDismissFFmpegWarning}
         allowDismiss={true}
+        onRecheck={recheckFFmpeg}
       />
       <ToastContainer toasts={toasts} onClose={dismissToast} />
     </>

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1550,10 +1550,28 @@ async abortAiStream(streamId: string) : Promise<Result<null, string>> {
 },
 /**
  * Check if FFmpeg is available and return its status
+ * 
+ * When the shared state reports FFmpeg as unavailable, this re-attempts
+ * initialization so a freshly installed (or slow-to-initialize) FFmpeg is
+ * picked up without restarting the app.
  */
 async checkFfmpeg() : Promise<Result<FFmpegStatus, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("check_ffmpeg") };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
+/**
+ * Download and install FFmpeg/FFprobe into the managed install directory.
+ * 
+ * Emits [`FFMPEG_INSTALL_PROGRESS_EVENT`] while running, then re-initializes
+ * the shared FFmpeg state (publishing resolved paths) and returns the fresh
+ * status. Concurrent installs are rejected.
+ */
+async installFfmpeg() : Promise<Result<FFmpegStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("install_ffmpeg") };
 } catch (e) {
     return { status: "error", error: e  as any };
 }
@@ -5302,7 +5320,11 @@ ffmpegPath: string | null;
 /**
  * Path to ffprobe executable
  */
-ffprobePath: string | null }
+ffprobePath: string | null; 
+/**
+ * Where the binaries came from (`bundled`/`managed`/`dev`/`system`)
+ */
+source: string | null }
 /**
  * A detected face in a frame
  */

--- a/src/components/features/setup/SetupWizard.tsx
+++ b/src/components/features/setup/SetupWizard.tsx
@@ -20,6 +20,8 @@ import {
   ArrowLeft,
 } from 'lucide-react';
 import { useFFmpegStatus } from '@/hooks/useFFmpegStatus';
+import { useFFmpegInstaller } from '@/hooks/useFFmpegInstaller';
+import { FFmpegInstallProgress } from '@/components/ui/FFmpegInstallProgress';
 import { useSettings } from '@/hooks/useSettings';
 import { createLogger } from '@/services/logger';
 
@@ -102,6 +104,14 @@ function WelcomeStep({ onNext, onSkip }: StepProps & { version?: string }): JSX.
 /** FFmpeg check step */
 function FFmpegStep({ onNext, onBack }: StepProps): JSX.Element {
   const { isAvailable, isLoading, error, recheck } = useFFmpegStatus();
+  const {
+    install,
+    isInstalling,
+    progress,
+    error: installError,
+  } = useFFmpegInstaller({
+    onInstalled: () => void recheck(),
+  });
 
   return (
     <div className="flex flex-col items-center text-center p-8">
@@ -161,6 +171,21 @@ function FFmpegStep({ onNext, onBack }: StepProps): JSX.Element {
                 </li>
               </ul>
             </div>
+
+            {isInstalling ? (
+              <FFmpegInstallProgress progress={progress} />
+            ) : (
+              <button
+                onClick={() => void install()}
+                data-testid="setup-ffmpeg-install"
+                className="w-full py-2 bg-primary-600 hover:bg-primary-500 text-white rounded-lg text-sm font-medium transition-colors"
+              >
+                Install FFmpeg Automatically
+              </button>
+            )}
+            {installError && (
+              <p className="text-xs text-status-error">Installation failed: {installError}</p>
+            )}
 
             <button
               onClick={() => void recheck()}

--- a/src/components/shared/ErrorOverlay.test.tsx
+++ b/src/components/shared/ErrorOverlay.test.tsx
@@ -229,6 +229,29 @@ describe('ErrorOverlay', () => {
   });
 
   // ===========================================================================
+  // Recovery Suggestions
+  // ===========================================================================
+
+  describe('recovery suggestions', () => {
+    it('should suggest installing FFmpeg when the binary is missing', () => {
+      render(<ErrorOverlay error={new Error('FFmpeg not found')} onDismiss={vi.fn()} />);
+      expect(screen.getByText(/Install FFmpeg Automatically/)).toBeInTheDocument();
+    });
+
+    it('should suggest installing FFmpeg when the binary is unavailable', () => {
+      render(<ErrorOverlay error={new Error('FFmpeg not available')} onDismiss={vi.fn()} />);
+      expect(screen.getByText(/Install FFmpeg Automatically/)).toBeInTheDocument();
+    });
+
+    it('should keep the codec suggestion for FFmpeg processing failures', () => {
+      render(
+        <ErrorOverlay error={new Error('FFmpeg encoder failed: bad codec')} onDismiss={vi.fn()} />,
+      );
+      expect(screen.getByText(/Try a different format or codec/)).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
   // useErrorOverlay Hook
   // ===========================================================================
 

--- a/src/components/shared/ErrorOverlay.tsx
+++ b/src/components/shared/ErrorOverlay.tsx
@@ -247,7 +247,7 @@ export function ErrorOverlay({
   // Categorize error
   const category = categorizeError(error);
   const displayTitle = title ?? getErrorTitle(category);
-  const suggestion = getRecoverySuggestion(category);
+  const suggestion = getRecoverySuggestion(category, error.message);
 
   return (
     <div style={styles.overlay}>

--- a/src/components/shared/errorOverlayModel.ts
+++ b/src/components/shared/errorOverlayModel.ts
@@ -89,8 +89,15 @@ export function getErrorTitle(category: ErrorCategory): string {
 
 /**
  * Get recovery suggestion based on error category.
+ *
+ * When the FFmpeg category stems from a missing binary (rather than a
+ * processing failure), suggest installing FFmpeg instead of changing codecs.
  */
-export function getRecoverySuggestion(category: ErrorCategory): string {
+export function getRecoverySuggestion(category: ErrorCategory, message?: string): string {
+  if (category === 'ffmpeg' && message && /not (found|available)/i.test(message)) {
+    return 'FFmpeg is not installed. Use "Install FFmpeg Automatically" in the FFmpeg warning dialog (or Setup wizard), or install it manually and check again.';
+  }
+
   switch (category) {
     case 'network':
       return 'Please check your internet connection and try again.';

--- a/src/components/ui/FFmpegInstallProgress.tsx
+++ b/src/components/ui/FFmpegInstallProgress.tsx
@@ -1,0 +1,83 @@
+/**
+ * FFmpegInstallProgress Component
+ *
+ * Progress bar for the in-app FFmpeg installer: shows a percentage bar when
+ * the total download size is known, otherwise an indeterminate bar, plus the
+ * current stage and binary being processed.
+ */
+
+import type { FFmpegInstallProgress as InstallProgress } from '@/hooks/useFFmpegInstaller';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface FFmpegInstallProgressProps {
+  /** Latest progress event (null before the first event arrives) */
+  progress: InstallProgress | null;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const STAGE_LABELS: Record<string, string> = {
+  downloading: 'Downloading',
+  verifying: 'Verifying checksum',
+  extracting: 'Extracting',
+  installing: 'Installing',
+  done: 'Finishing up',
+};
+
+function formatBytes(bytes: number): string {
+  const megabytes = bytes / (1024 * 1024);
+  return `${megabytes.toFixed(1)} MB`;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function FFmpegInstallProgress({ progress }: FFmpegInstallProgressProps): JSX.Element {
+  const stageLabel = progress ? (STAGE_LABELS[progress.stage] ?? progress.stage) : 'Starting…';
+  const percent =
+    progress && progress.totalBytes && progress.totalBytes > 0
+      ? Math.min(100, (progress.downloadedBytes / progress.totalBytes) * 100)
+      : null;
+
+  const detail =
+    progress && progress.stage === 'downloading'
+      ? percent !== null
+        ? `${formatBytes(progress.downloadedBytes)} / ${formatBytes(progress.totalBytes ?? 0)}`
+        : formatBytes(progress.downloadedBytes)
+      : null;
+
+  return (
+    <div data-testid="ffmpeg-install-progress" className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-text-secondary">
+        <span>
+          {stageLabel}
+          {progress ? ` ${progress.binary}` : ''}
+        </span>
+        {detail && <span>{detail}</span>}
+      </div>
+      <div
+        role="progressbar"
+        aria-label="FFmpeg installation progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent !== null ? Math.round(percent) : undefined}
+        className="h-2 w-full overflow-hidden rounded-full bg-surface-active"
+      >
+        {percent !== null ? (
+          <div
+            className="h-full rounded-full bg-primary-500 transition-[width] duration-200"
+            style={{ width: `${percent}%` }}
+          />
+        ) : (
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-primary-500" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/FFmpegManualInstructions.tsx
+++ b/src/components/ui/FFmpegManualInstructions.tsx
@@ -1,0 +1,84 @@
+/**
+ * FFmpegManualInstructions Component
+ *
+ * Collapsible manual installation instructions for FFmpeg, shown as a
+ * secondary path below the automatic installer.
+ */
+
+import { useCallback } from 'react';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const FFMPEG_DOWNLOAD_URL = 'https://ffmpeg.org/download.html';
+const FFMPEG_WINDOWS_URL = 'https://www.gyan.dev/ffmpeg/builds/';
+const FFMPEG_MAC_HOMEBREW = 'brew install ffmpeg';
+const FFMPEG_LINUX_APT = 'sudo apt install ffmpeg';
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function FFmpegManualInstructions(): JSX.Element {
+  const handleOpenLink = useCallback((url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  return (
+    <details data-testid="ffmpeg-manual-instructions" className="rounded-lg bg-surface-base">
+      <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium text-text-secondary hover:text-text-primary">
+        Manual installation
+      </summary>
+      <div className="px-4 pb-4">
+        <div className="mb-3 min-w-0">
+          <div className="mb-1 flex items-center gap-2 text-sm text-text-secondary">
+            <span className="font-medium text-text-primary">Windows:</span>
+          </div>
+          <ol className="ml-2 list-inside list-decimal space-y-1 text-xs text-text-secondary">
+            <li>
+              Download from{' '}
+              <button
+                type="button"
+                className="break-all text-primary-400 underline hover:text-primary-300"
+                onClick={() => handleOpenLink(FFMPEG_WINDOWS_URL)}
+              >
+                gyan.dev/ffmpeg/builds
+              </button>
+            </li>
+            <li>Extract to a folder (e.g., C:\ffmpeg)</li>
+            <li>Add the bin folder to your system PATH</li>
+          </ol>
+        </div>
+
+        <div className="mb-3">
+          <div className="mb-1 flex items-center gap-2 text-sm text-text-secondary">
+            <span className="font-medium text-text-primary">macOS:</span>
+          </div>
+          <code className="ml-2 block whitespace-pre-wrap break-all rounded bg-surface-active px-2 py-1 font-mono text-xs text-status-success">
+            {FFMPEG_MAC_HOMEBREW}
+          </code>
+        </div>
+
+        <div>
+          <div className="mb-1 flex items-center gap-2 text-sm text-text-secondary">
+            <span className="font-medium text-text-primary">Linux (Debian/Ubuntu):</span>
+          </div>
+          <code className="ml-2 block whitespace-pre-wrap break-all rounded bg-surface-active px-2 py-1 font-mono text-xs text-status-success">
+            {FFMPEG_LINUX_APT}
+          </code>
+        </div>
+
+        <div className="mt-3">
+          <button
+            type="button"
+            className="text-xs text-primary-400 underline hover:text-primary-300"
+            onClick={() => handleOpenLink(FFMPEG_DOWNLOAD_URL)}
+          >
+            Official Download
+          </button>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/components/ui/FFmpegWarning.test.tsx
+++ b/src/components/ui/FFmpegWarning.test.tsx
@@ -1,16 +1,32 @@
 /**
  * FFmpegWarning Component Tests
+ *
+ * Integration-style tests: only the Tauri IPC boundary (`@tauri-apps/api/*`)
+ * is mocked (globally, in src/test/setup.ts).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { FFmpegWarning } from './FFmpegWarning';
+import type { FFmpegInstallProgress } from '@/hooks/useFFmpegInstaller';
+
+const INSTALLED_STATUS = {
+  available: true,
+  version: '7.1',
+  isBundled: false,
+  ffmpegPath: '/managed/bin/ffmpeg',
+  ffprobePath: '/managed/bin/ffprobe',
+  source: 'managed',
+};
 
 describe('FFmpegWarning', () => {
   const mockOnDismiss = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listen).mockResolvedValue(() => {});
   });
 
   // ===========================================================================
@@ -111,10 +127,106 @@ describe('FFmpegWarning', () => {
     expect(mockOpen).toHaveBeenCalledWith(
       'https://ffmpeg.org/download.html',
       '_blank',
-      'noopener,noreferrer'
+      'noopener,noreferrer',
     );
 
     vi.unstubAllGlobals();
+  });
+
+  // ===========================================================================
+  // Automatic Install Flow Tests
+  // ===========================================================================
+
+  it('should show progress while installing and success plus recheck when install completes', async () => {
+    const mockOnRecheck = vi.fn();
+
+    // Capture the progress-event handler the hook subscribes with.
+    let progressHandler: ((event: { payload: FFmpegInstallProgress }) => void) | null = null;
+    vi.mocked(listen).mockImplementation((eventName, handler) => {
+      if (eventName === 'ffmpeg-install-progress') {
+        progressHandler = handler as (event: { payload: FFmpegInstallProgress }) => void;
+      }
+      return Promise.resolve(() => {});
+    });
+
+    // Keep the install command pending until we resolve it manually.
+    let resolveInstall: (value: unknown) => void = () => {};
+    vi.mocked(invoke).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveInstall = resolve;
+        }),
+    );
+
+    render(<FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} onRecheck={mockOnRecheck} />);
+
+    fireEvent.click(screen.getByTestId('ffmpeg-warning-install'));
+
+    // Progress UI appears while the install is running.
+    await waitFor(() => {
+      expect(screen.getByTestId('ffmpeg-install-progress')).toBeInTheDocument();
+    });
+
+    // A streamed progress event updates the visible stage.
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+    act(() => {
+      progressHandler?.({
+        payload: {
+          stage: 'downloading',
+          binary: 'ffmpeg',
+          downloadedBytes: 50 * 1024 * 1024,
+          totalBytes: 100 * 1024 * 1024,
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Downloading ffmpeg/)).toBeInTheDocument();
+    });
+
+    // Completing the command shows the success state and triggers a recheck.
+    await act(async () => {
+      resolveInstall(INSTALLED_STATUS);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('ffmpeg-install-success')).toBeInTheDocument();
+    });
+    expect(mockOnRecheck).toHaveBeenCalled();
+  });
+
+  it('should show an error message when the install fails', async () => {
+    const mockOnRecheck = vi.fn();
+    vi.mocked(invoke).mockRejectedValue('All download URLs failed for ffmpeg');
+
+    render(<FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} onRecheck={mockOnRecheck} />);
+
+    fireEvent.click(screen.getByTestId('ffmpeg-warning-install'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ffmpeg-install-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/All download URLs failed/)).toBeInTheDocument();
+    expect(mockOnRecheck).not.toHaveBeenCalled();
+    // The install button returns so the user can retry.
+    expect(screen.getByTestId('ffmpeg-warning-install')).toBeInTheDocument();
+  });
+
+  it('should call onRecheck when Check Again is clicked', () => {
+    const mockOnRecheck = vi.fn();
+    render(<FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} onRecheck={mockOnRecheck} />);
+
+    fireEvent.click(screen.getByTestId('ffmpeg-warning-recheck'));
+    expect(mockOnRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  it('should hide Check Again when no onRecheck handler is provided', () => {
+    render(<FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} />);
+    expect(screen.queryByTestId('ffmpeg-warning-recheck')).not.toBeInTheDocument();
+  });
+
+  it('should keep manual instructions available behind an accordion', () => {
+    render(<FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} />);
+    expect(screen.getByTestId('ffmpeg-manual-instructions')).toBeInTheDocument();
+    expect(screen.getByText('Manual installation')).toBeInTheDocument();
   });
 
   // ===========================================================================

--- a/src/components/ui/FFmpegWarning.test.tsx
+++ b/src/components/ui/FFmpegWarning.test.tsx
@@ -193,6 +193,28 @@ describe('FFmpegWarning', () => {
     expect(mockOnRecheck).toHaveBeenCalled();
   });
 
+  it('should clear the stale success state when the dialog reopens', async () => {
+    vi.mocked(invoke).mockResolvedValue(INSTALLED_STATUS);
+
+    const { rerender } = render(
+      <FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} onRecheck={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByTestId('ffmpeg-warning-install'));
+    await waitFor(() => {
+      expect(screen.getByTestId('ffmpeg-install-success')).toBeInTheDocument();
+    });
+
+    // Close, then reopen: the status check found no usable FFmpeg after all,
+    // so the dialog must offer the install button again instead of the stale
+    // success message.
+    rerender(<FFmpegWarning isOpen={false} onDismiss={mockOnDismiss} onRecheck={vi.fn()} />);
+    rerender(<FFmpegWarning isOpen={true} onDismiss={mockOnDismiss} onRecheck={vi.fn()} />);
+
+    expect(screen.queryByTestId('ffmpeg-install-success')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ffmpeg-warning-install')).toBeInTheDocument();
+  });
+
   it('should show an error message when the install fails', async () => {
     const mockOnRecheck = vi.fn();
     vi.mocked(invoke).mockRejectedValue('All download URLs failed for ffmpeg');

--- a/src/components/ui/FFmpegWarning.tsx
+++ b/src/components/ui/FFmpegWarning.tsx
@@ -72,9 +72,13 @@ export function FFmpegWarning({
   // ===========================================================================
 
   useEffect(() => {
-    if (isOpen && installButtonRef.current) {
-      installButtonRef.current.focus();
+    if (!isOpen) {
+      return;
     }
+    // A reopen means the follow-up status check still found no usable FFmpeg,
+    // so stale success state must not hide the install/manual options.
+    setInstallSucceeded(false);
+    installButtonRef.current?.focus();
   }, [isOpen]);
 
   // ===========================================================================

--- a/src/components/ui/FFmpegWarning.tsx
+++ b/src/components/ui/FFmpegWarning.tsx
@@ -2,11 +2,15 @@
  * FFmpegWarning Component
  *
  * Displays a warning modal when FFmpeg is not available on the system.
- * Provides installation instructions and links.
+ * Offers a one-click automatic installation (primary) and manual
+ * installation instructions (collapsed, secondary).
  */
 
-import { useCallback, useId, useRef, useEffect, type KeyboardEvent } from 'react';
+import { useCallback, useId, useRef, useEffect, useState, type KeyboardEvent } from 'react';
+import { useFFmpegInstaller } from '@/hooks/useFFmpegInstaller';
 import { ModalShell } from './ModalShell';
+import { FFmpegInstallProgress } from './FFmpegInstallProgress';
+import { FFmpegManualInstructions } from './FFmpegManualInstructions';
 
 // =============================================================================
 // Types
@@ -19,16 +23,9 @@ export interface FFmpegWarningProps {
   onDismiss: () => void;
   /** Whether to allow dismissing (user may want to force install) */
   allowDismiss?: boolean;
+  /** Re-checks FFmpeg status (after install or manual installation) */
+  onRecheck?: () => void | Promise<void>;
 }
-
-// =============================================================================
-// Constants
-// =============================================================================
-
-const FFMPEG_DOWNLOAD_URL = 'https://ffmpeg.org/download.html';
-const FFMPEG_WINDOWS_URL = 'https://www.gyan.dev/ffmpeg/builds/';
-const FFMPEG_MAC_HOMEBREW = 'brew install ffmpeg';
-const FFMPEG_LINUX_APT = 'sudo apt install ffmpeg';
 
 // =============================================================================
 // Component
@@ -38,9 +35,18 @@ export function FFmpegWarning({
   isOpen,
   onDismiss,
   allowDismiss = true,
+  onRecheck,
 }: FFmpegWarningProps): JSX.Element | null {
   const titleId = useId();
-  const dismissButtonRef = useRef<HTMLButtonElement>(null);
+  const installButtonRef = useRef<HTMLButtonElement>(null);
+  const [installSucceeded, setInstallSucceeded] = useState(false);
+
+  const { install, isInstalling, progress, error } = useFFmpegInstaller({
+    onInstalled: () => {
+      setInstallSucceeded(true);
+      void onRecheck?.();
+    },
+  });
 
   // ===========================================================================
   // Handlers
@@ -61,17 +67,13 @@ export function FFmpegWarning({
     }
   }, [allowDismiss, onDismiss]);
 
-  const handleOpenLink = useCallback((url: string) => {
-    window.open(url, '_blank', 'noopener,noreferrer');
-  }, []);
-
   // ===========================================================================
   // Effects
   // ===========================================================================
 
   useEffect(() => {
-    if (isOpen && dismissButtonRef.current) {
-      dismissButtonRef.current.focus();
+    if (isOpen && installButtonRef.current) {
+      installButtonRef.current.focus();
     }
   }, [isOpen]);
 
@@ -124,16 +126,18 @@ export function FFmpegWarning({
       }
       footer={
         <div className="flex flex-col-reverse gap-2 px-6 pb-6 sm:flex-row sm:justify-end sm:gap-3">
-          <button
-            type="button"
-            className="rounded bg-surface-active px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-highest"
-            onClick={() => handleOpenLink(FFMPEG_DOWNLOAD_URL)}
-          >
-            Official Download
-          </button>
+          {onRecheck && (
+            <button
+              type="button"
+              data-testid="ffmpeg-warning-recheck"
+              className="rounded bg-surface-active px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-highest"
+              onClick={() => void onRecheck()}
+            >
+              Check Again
+            </button>
+          )}
           {allowDismiss && (
             <button
-              ref={dismissButtonRef}
               data-testid="ffmpeg-warning-dismiss"
               type="button"
               className="rounded bg-status-warning px-4 py-2 text-sm font-medium text-white transition-colors hover:brightness-110"
@@ -145,54 +149,41 @@ export function FFmpegWarning({
         </div>
       }
     >
-      <div className="break-words px-6 py-4 [overflow-wrap:anywhere]">
-        <div className="rounded-lg bg-surface-base p-4">
-          <h3 className="mb-3 text-sm font-medium text-text-secondary">
-            Installation Instructions
-          </h3>
-
-          <div className="mb-3 min-w-0">
-            <div className="mb-1 flex items-center gap-2 text-sm text-text-secondary">
-              <span className="font-medium text-text-primary">Windows:</span>
-            </div>
-            <ol className="ml-2 list-inside list-decimal space-y-1 text-xs text-text-secondary">
-              <li>
-                Download from{' '}
-                <button
-                  type="button"
-                  className="break-all text-primary-400 underline hover:text-primary-300"
-                  onClick={() => handleOpenLink(FFMPEG_WINDOWS_URL)}
-                >
-                  gyan.dev/ffmpeg/builds
-                </button>
-              </li>
-              <li>Extract to a folder (e.g., C:\ffmpeg)</li>
-              <li>Add the bin folder to your system PATH</li>
-            </ol>
+      <div className="space-y-4 break-words px-6 py-4 [overflow-wrap:anywhere]">
+        {installSucceeded ? (
+          <div
+            data-testid="ffmpeg-install-success"
+            className="rounded-lg bg-status-success/10 p-4 text-sm text-status-success"
+          >
+            FFmpeg was installed successfully. Video processing is ready to use.
           </div>
-
-          <div className="mb-3">
-            <div className="mb-1 flex items-center gap-2 text-sm text-text-secondary">
-              <span className="font-medium text-text-primary">macOS:</span>
-            </div>
-            <code className="ml-2 block whitespace-pre-wrap break-all rounded bg-surface-active px-2 py-1 font-mono text-xs text-status-success">
-              {FFMPEG_MAC_HOMEBREW}
-            </code>
+        ) : (
+          <div className="space-y-3">
+            {isInstalling ? (
+              <FFmpegInstallProgress progress={progress} />
+            ) : (
+              <button
+                ref={installButtonRef}
+                type="button"
+                data-testid="ffmpeg-warning-install"
+                className="w-full rounded bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-500"
+                onClick={() => void install()}
+              >
+                Install FFmpeg Automatically
+              </button>
+            )}
+            {error && (
+              <p data-testid="ffmpeg-install-error" className="text-xs text-status-error">
+                Installation failed: {error}
+              </p>
+            )}
+            <FFmpegManualInstructions />
+            <p className="text-xs text-text-muted">
+              After installing FFmpeg manually, click &quot;Check Again&quot; to detect it — no
+              restart needed.
+            </p>
           </div>
-
-          <div>
-            <div className="mb-1 flex items-center gap-2 text-sm text-text-secondary">
-              <span className="font-medium text-text-primary">Linux (Debian/Ubuntu):</span>
-            </div>
-            <code className="ml-2 block whitespace-pre-wrap break-all rounded bg-surface-active px-2 py-1 font-mono text-xs text-status-success">
-              {FFMPEG_LINUX_APT}
-            </code>
-          </div>
-        </div>
-
-        <p className="mt-4 text-xs text-text-muted">
-          After installing FFmpeg, restart OpenReelio for changes to take effect.
-        </p>
+        )}
       </div>
     </ModalShell>
   );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -14,6 +14,8 @@ export {
   type MenuItemOrDivider,
 } from './ContextMenu';
 export { FFmpegWarning, type FFmpegWarningProps } from './FFmpegWarning';
+export { FFmpegInstallProgress, type FFmpegInstallProgressProps } from './FFmpegInstallProgress';
+export { FFmpegManualInstructions } from './FFmpegManualInstructions';
 export {
   Skeleton,
   SkeletonText,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -58,6 +58,14 @@ export type { UseWaveformPeaksOptions, UseWaveformPeaksReturn } from './useWavef
 export { useFFmpegStatus } from './useFFmpegStatus';
 export type { FFmpegStatus, UseFFmpegStatusResult } from './useFFmpegStatus';
 
+export { useFFmpegInstaller } from './useFFmpegInstaller';
+export type {
+  FFmpegInstallProgress,
+  FFmpegInstallStage,
+  UseFFmpegInstallerOptions,
+  UseFFmpegInstallerResult,
+} from './useFFmpegInstaller';
+
 export { useAutoSave } from './useAutoSave';
 export type { UseAutoSaveOptions, UseAutoSaveReturn } from './useAutoSave';
 

--- a/src/hooks/useFFmpegInstaller.ts
+++ b/src/hooks/useFFmpegInstaller.ts
@@ -1,0 +1,110 @@
+/**
+ * useFFmpegInstaller Hook
+ *
+ * Runs the in-app FFmpeg installer via the `install_ffmpeg` Tauri command and
+ * streams progress from the `ffmpeg-install-progress` event.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { FFmpegStatus } from './useFFmpegStatus';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type FFmpegInstallStage = 'downloading' | 'verifying' | 'extracting' | 'installing' | 'done';
+
+export interface FFmpegInstallProgress {
+  /** Current install stage */
+  stage: FFmpegInstallStage;
+  /** Binary/archive the stage applies to (e.g. "ffmpeg", "ffprobe") */
+  binary: string;
+  /** Bytes downloaded so far for the current archive */
+  downloadedBytes: number;
+  /** Total bytes for the current archive, when known */
+  totalBytes: number | null;
+}
+
+export interface UseFFmpegInstallerOptions {
+  /** Called after a successful install with the fresh FFmpeg status */
+  onInstalled?: (status: FFmpegStatus) => void;
+}
+
+export interface UseFFmpegInstallerResult {
+  /** Start the installation (no-op while one is already running) */
+  install: () => Promise<void>;
+  /** Whether an installation is in progress */
+  isInstalling: boolean;
+  /** Latest progress event, or null before the first one */
+  progress: FFmpegInstallProgress | null;
+  /** Error message if the install failed */
+  error: string | null;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const FFMPEG_INSTALL_PROGRESS_EVENT = 'ffmpeg-install-progress';
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+export function useFFmpegInstaller(
+  options: UseFFmpegInstallerOptions = {},
+): UseFFmpegInstallerResult {
+  const [isInstalling, setIsInstalling] = useState(false);
+  const [progress, setProgress] = useState<FFmpegInstallProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onInstalledRef = useRef(options.onInstalled);
+  onInstalledRef.current = options.onInstalled;
+
+  const isMountedRef = useRef(true);
+  const isInstallingRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const install = useCallback(async () => {
+    if (isInstallingRef.current) {
+      return;
+    }
+    isInstallingRef.current = true;
+    setIsInstalling(true);
+    setProgress(null);
+    setError(null);
+
+    let unlisten: UnlistenFn | null = null;
+    try {
+      unlisten = await listen<FFmpegInstallProgress>(FFMPEG_INSTALL_PROGRESS_EVENT, (event) => {
+        if (isMountedRef.current) {
+          setProgress(event.payload);
+        }
+      });
+
+      const status = await invoke<FFmpegStatus>('install_ffmpeg');
+      onInstalledRef.current?.(status);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (isMountedRef.current) {
+        setError(message);
+      }
+    } finally {
+      unlisten?.();
+      isInstallingRef.current = false;
+      if (isMountedRef.current) {
+        setIsInstalling(false);
+      }
+    }
+  }, []);
+
+  return { install, isInstalling, progress, error };
+}

--- a/src/hooks/useFFmpegInstaller.ts
+++ b/src/hooks/useFFmpegInstaller.ts
@@ -61,7 +61,9 @@ export function useFFmpegInstaller(
   const [error, setError] = useState<string | null>(null);
 
   const onInstalledRef = useRef(options.onInstalled);
-  onInstalledRef.current = options.onInstalled;
+  useEffect(() => {
+    onInstalledRef.current = options.onInstalled;
+  }, [options.onInstalled]);
 
   const isMountedRef = useRef(true);
   const isInstallingRef = useRef(false);
@@ -91,7 +93,9 @@ export function useFFmpegInstaller(
       });
 
       const status = await invoke<FFmpegStatus>('install_ffmpeg');
-      onInstalledRef.current?.(status);
+      if (isMountedRef.current) {
+        onInstalledRef.current?.(status);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (isMountedRef.current) {

--- a/src/hooks/useFFmpegStatus.ts
+++ b/src/hooks/useFFmpegStatus.ts
@@ -17,6 +17,8 @@ export interface FFmpegStatus {
   isBundled: boolean;
   ffmpegPath: string | null;
   ffprobePath: string | null;
+  /** Where the binaries came from: 'bundled' | 'managed' | 'dev' | 'system' */
+  source: string | null;
 }
 
 export interface UseFFmpegStatusResult {
@@ -42,6 +44,7 @@ const INITIAL_STATUS: FFmpegStatus = {
   isBundled: false,
   ffmpegPath: null,
   ffprobePath: null,
+  source: null,
 };
 
 // =============================================================================
@@ -65,6 +68,7 @@ export function useFFmpegStatus(): UseFFmpegStatusResult {
         isBundled: result.isBundled,
         ffmpegPath: result.ffmpegPath ?? null,
         ffprobePath: result.ffprobePath ?? null,
+        source: result.source ?? null,
       });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
### **User description**
## Description

<!-- Provide a brief description of the changes in this PR -->

Overhauls how OpenReelio acquires and resolves its FFmpeg/FFprobe dependency so that all video features work out of the box on every platform. Adds a one-click in-app FFmpeg installer with download progress, routes all previously PATH-bypassing call sites through the resolved binaries, bundles native arm64 FFmpeg for Apple Silicon releases, unifies the three divergent download implementations behind a single checksum-verified source manifest, and auto-downloads FFmpeg for debug builds when it is missing.

## Related Issue

<!-- Link to the related issue (if applicable) -->
Closes #780
Closes #781
Closes #782
Closes #783

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Added `scripts/ffmpeg-sources.json` as the single source of truth for FFmpeg/FFprobe downloads (per target triple, with per-URL SHA-256 pinning/sidecar verification, retries, and ordered fallbacks), consumed by `scripts/prepare-bundled-ffmpeg.mjs` and `src-tauri/build.rs`; `aarch64-apple-darwin` releases now bundle native arm64 binaries (martin-riedl.de) instead of the x86_64 evermeet build
- Debug builds auto-download FFmpeg when neither usable bundled binaries nor system FFmpeg are present (opt out with `SKIP_FFMPEG_DOWNLOAD=1`; disabled on CI); README and `docs/DISTRIBUTION.md` updated
- New `core/ffmpeg/installer.rs` + `install_ffmpeg` Tauri command: streaming download to `{data_local}/openreelio/ffmpeg/bin` with `ffmpeg-install-progress` events, SHA-256 verification, safe zip/tar.xz extraction, `-version` sanity run, atomic install, and a concurrency guard
- New `core/ffmpeg/resolver.rs` global resolved-path registry; asset metadata, shot detection, caption audio extraction, local analysis provider, analysis runner, and one export arg-builder path no longer spawn bare `ffmpeg`/`ffprobe` from PATH
- Detection order extended to bundled → managed → dev → system (reported via a new `source` field on `FFmpegStatus`); `check_ffmpeg` now lazily re-initializes, fixing a startup race that showed a false "FFmpeg Not Found" warning
- FFmpegWarning dialog rewritten: primary "Install FFmpeg Automatically" action with progress bar (`FFmpegInstallProgress`), "Check Again" button (no restart needed), manual instructions collapsed into `FFmpegManualInstructions`; setup wizard FFmpeg step gains the same auto-install flow; error overlay suggestions for missing-FFmpeg errors now point to the installer instead of "try a different format or codec"

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

Not included — UI changes are the FFmpeg warning dialog (install button + progress bar + collapsible manual instructions) and the setup wizard FFmpeg step.

## Testing

<!-- Describe how you tested your changes -->

### Test Environment

- OS: macOS (Apple Silicon, Darwin 25.5.0)
- Node.js version: v24.18.0
- Rust version: rustc 1.97.1

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [x] Manual testing performed
- [x] New tests added for changes

Details: full frontend suites green including 20 new FFmpegWarning install-flow tests and 3 new ErrorOverlay suggestion tests (only `@tauri-apps/api/*` mocked, per repo mock policy); Rust ffmpeg module suite 66 passed with 9 new installer unit tests; `cargo fmt --check`, `cargo check` (gui / openreelio-core / openreelio-cli), clippy clean on touched files; `npm run type-check` and lint clean. Manual/empirical verification on this machine: a gated real-download integration test ran the full install pipeline end to end (download → verify → extract → install in 15 s), and the installed managed binaries execute natively (`Mach-O 64-bit executable arm64`, FFmpeg 9.0); `node scripts/prepare-bundled-ffmpeg.mjs aarch64-apple-darwin` produced verified native arm64 binaries; the build.rs dev auto-download path was exercised by removing `src-tauri/binaries/` and observing restoration during `cargo check`, and `SKIP_FFMPEG_DOWNLOAD=1` suppresses it.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->

- Linux (johnvansickle.com) publishes only MD5 upstream, so its primary source remains unverified with a SHA-256-verified BtbN fallback; all Windows/macOS sources are verified
- `src/bindings.ts` is regenerated output (`export_bindings`) for the new `install_ffmpeg` command and `FFmpegStatus.source` field
- Release CI still sets `OPENREELIO_ALLOW_UNVERIFIED_FFMPEG=1` as an escape hatch, but with manifest checksums present it is no longer required for the verified targets
- Known follow-ups tracked separately (not in this PR): SHA-256 verification for Whisper model downloads, resolving the un-bundled Meilisearch sidecar, and auditing credential storage vs the unused stronghold plugin
- Recommend verifying the next release's `aarch64-apple-darwin` artifact contains arm64 FFmpeg (`file Contents/Resources/binaries/ffmpeg`)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Adds one-click in-app FFmpeg installation with progress.

- Unifies FFmpeg sources into a single manifest.

- Routes all modules through a global path resolver.

- Enables automatic FFmpeg download for debug builds.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Manifest["ffmpeg-sources.json"] -- "Defines URLs" --> Build["build.rs / CI"]
  Manifest -- "Embedded in" --> Installer["core/ffmpeg/installer.rs"]
  Installer -- "Downloads to" --> ManagedDir["Managed App Data"]
  Resolver["core/ffmpeg/resolver.rs"] -- "Prioritizes" --> ManagedDir
  Resolver -- "Provides paths to" --> Modules["Metadata / Export / AI"]
  UI["FFmpegWarning UI"] -- "Triggers" --> Installer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>installer.rs</strong><dd><code>Implements managed FFmpeg installation with checksum verification</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-0c102c9456665c032bea3d6d13710496662a77caa91adc39aa1d12e79fce158b">+885/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>resolver.rs</strong><dd><code>Global registry for resolved FFmpeg and FFprobe paths</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-e37ea6968de71807aca33a46fddb1a88c7e1bdd563def433082ae43894dfcc4e">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>detection.rs</strong><dd><code>Extends detection logic to support managed and dev sources</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-0cb454d500c76c6c39a98864a5e353cabf625c2adddfb404f211622b2e338397">+80/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Adds Tauri commands for FFmpeg status and installation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-dbe076a2842e359032df96c3691ae2df69ec9a760d542e5776f604d4f27cd7b8">+145/-12</a></td>

</tr>

<tr>
  <td><strong>FFmpegWarning.tsx</strong><dd><code>Updates warning modal to support automatic installation flow</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-6dedf14ed17c159d0f87b751bc38a65f26750666eda44073bdefb8b06a69e94f">+63/-72</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useFFmpegInstaller.ts</strong><dd><code>React hook for managing FFmpeg installation state and progress</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-407f1aa7a2c414f90b446e7b22c7a55cfd659d9a65bfa8dc7e6ae557ea0f4add">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>FFmpegInstallProgress.tsx</strong><dd><code>New component for displaying installation progress bar</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-48055a9137a54fecc7020fc9384ca727e3716a43512193e89113520d8321eb27">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Integrates FFmpeg recheck logic into main application lifecycle</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SetupWizard.tsx</strong><dd><code>Adds automatic FFmpeg installation to the setup wizard</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-5e1ddd0deeb06e7da69c924467112070ae2e592b80ab5a3ea096ab23271152cd">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>errorOverlayModel.ts</strong><dd><code>Updates error suggestions to point to automatic installer</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-839cbcf6f3945bd2f856db26062ac569542619056ee27a4e1c253a28f2195a43">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useFFmpegStatus.ts</strong><dd><code>Exposes FFmpeg source information to the frontend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-0810285c316c8ab0c48a5737cb1f2dadbc0a2dd30a0e2a75cf37fb43626c4101">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>build.rs</strong><dd><code>Automates FFmpeg download for dev builds using manifest</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-7d1ef5b0b986fee369d8f5fa4361f21fa3075601e5416738ba4f4d1ea5dfb2ed">+344/-125</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>audio.rs</strong><dd><code>Routes audio extraction through the global FFmpeg resolver</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-c98a36028001dacf84d67a63f54b501767c167d5f3ef29929cc3f171af8d11c8">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>local.rs</strong><dd><code>Ensures local analysis uses resolved FFmpeg paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-073f3da82c26e935baf452914e235af2c38a26068d9e108ee9f1a7056abd90e2">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.rs</strong><dd><code>Updates export engine to use resolved binary paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>FFmpegManualInstructions.tsx</strong><dd><code>Refactors manual instructions into a collapsible component</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-6c11efd024319062a644f709fc620c7fd84af14794bbd4fba6c7464b6a0359d5">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Updates TypeScript bindings for new FFmpeg commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>FFmpegWarning.test.tsx</strong><dd><code>Tests for the new automatic installation UI flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-c2fb28006cbfd291462585b93aac09c243e1dad4ed377790f866f1322efcd745">+114/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ErrorOverlay.test.tsx</strong><dd><code>Tests for FFmpeg recovery suggestions in error overlay</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-31de4a8f00b0308d7edde490de4c0a34de1f6c8b5cecac354718f70cff7092e2">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Exports new FFmpeg installer hooks and types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-b96dae4653c651669a3c7a95ddf01ed8823a967561b1a74951e2640b2bcbc174">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>release.yml</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-280e1b2f4fcfd0aff373db2f4103f98a471444033d18d9ad282608a80355019f">+18/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DISTRIBUTION.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-9be3330c309d8e0483351ebde7db2ffa3e0106e0cd9bc245ada40a06dc69261c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ffmpeg-sources.json</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-ca5e707b70d3aaf3484efc04e293b396d5799e0b4dc17a82a6f8dc64b8b61a0d">+138/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>prepare-bundled-ffmpeg.mjs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-129c13839a37e3dd4539c987702b7ddb827e4425f74c534ca549deb8fb483645">+218/-116</a></td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-ee1ec68a6c16498846fbdeed6ee57a511828e681c5493aee1cd5b746fbfe8312">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metadata.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-f92f01c44c85ff6773b02ad6ee5a319c6137723869c318812765f636253545b4">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-9ae7a973de71a367eeff8df45197b3e3c27b6d1fc78c4f1b2629b32cf05ad346">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>state.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-49c644ec9f655fd0d830f3f1be3de67d941d833fac6d70c5b2a3b1f8dd46f9f0">+26/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shots.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-b4bb34737d2a0ca75c02ba72c4a93615516c943401223439932b4807057c810b">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>managed_runtime.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-156c75fc3e75ebeed59c6bca2625b7ee30d1d8008490c4c047a48bbe037b259c">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ErrorOverlay.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-f15c90bfeb4abb49f4d3ee6724fb0ba759877b7c84a0525f3c14a065381ace7e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/784/files#diff-eadb6fcb2aedeca64e3744e1a577995c25f33bb3496cd357ad01681dceb0c587">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic FFmpeg installation with live download and installation progress.
  * Added platform-specific manual installation instructions and clearer recovery guidance.
  * FFmpeg detection now supports bundled, managed, development, and system installations.
  * Added “Check Again” functionality when FFmpeg is unavailable.
  * Added support for native Apple Silicon FFmpeg and FFprobe binaries.

* **Bug Fixes**
  * Improved FFmpeg and FFprobe path resolution across rendering, analysis, metadata, captions, and indexing.
  * Improved download reliability and checksum verification for bundled binaries.

* **Documentation**
  * Updated setup and distribution documentation for optional system FFmpeg, bundled downloads, sources, checksums, and opt-out settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->