### PR TITLE
feat(api): headless perception and verification primitives for external agents

### DIFF
--- a/crates/openreelio-cli/Cargo.toml
+++ b/crates/openreelio-cli/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "signal", "macros"] }
 
 # Scratch directories for composited frame renders and contact-sheet cells
 tempfile = "3"

--- a/crates/openreelio-cli/Cargo.toml
+++ b/crates/openreelio-cli/Cargo.toml
@@ -27,11 +27,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
+# Scratch directories for composited frame renders and contact-sheet cells
+tempfile = "3"
+
 # Error handling
 anyhow = "1"
-
-[dev-dependencies]
-tempfile = "3"
 
 [features]
 default = ["whisper"]

--- a/crates/openreelio-cli/src/commands/analysis.rs
+++ b/crates/openreelio-cli/src/commands/analysis.rs
@@ -1,5 +1,11 @@
-//! Analysis inspection commands: cached source analysis reporting.
+//! Analysis commands: local perception generation and cached source analysis
+//! reporting.
+//!
+//! The perception verbs (`shots`, `silence`, `audio`, `run`) produce the
+//! artifacts that the reporting verbs read; their implementations live in
+//! [`super::perception`].
 
+use super::perception::{AudioArgs, RunArgs, ShotsArgs, SilenceArgs};
 use crate::output;
 use chrono::Utc;
 use clap::Subcommand;
@@ -13,6 +19,18 @@ use std::path::{Path, PathBuf};
 
 #[derive(Subcommand)]
 pub enum AnalysisAction {
+    /// Detect shot boundaries with FFmpeg and cache them for the app and reports
+    Shots(ShotsArgs),
+
+    /// Detect silence regions with FFmpeg
+    Silence(SilenceArgs),
+
+    /// Profile the audio track (silence, loudness, BPM, speech regions)
+    Audio(AudioArgs),
+
+    /// Run the local analysis pipeline and cache the resulting bundle
+    Run(RunArgs),
+
     /// Build a source analysis report for an asset from cached analysis artifacts
     Report {
         /// Project directory path
@@ -346,6 +364,10 @@ struct CachedAnalysisBundle {
 
 pub fn execute(action: AnalysisAction) -> anyhow::Result<()> {
     match action {
+        AnalysisAction::Shots(args) => super::perception::shots(args),
+        AnalysisAction::Silence(args) => super::perception::silence(args),
+        AnalysisAction::Audio(args) => super::perception::audio(args),
+        AnalysisAction::Run(args) => super::perception::run(args),
         AnalysisAction::Report { path, id } => {
             let project_dir = std::fs::canonicalize(&path).map_err(|e| {
                 anyhow::anyhow!("Project path '{}' not found: {}", path.display(), e)

--- a/crates/openreelio-cli/src/commands/asset.rs
+++ b/crates/openreelio-cli/src/commands/asset.rs
@@ -1,5 +1,6 @@
 //! Asset management commands: import, list, info, remove.
 
+use crate::ffmpeg_env::ensure_ffmpeg_optional;
 use crate::output;
 use clap::Subcommand;
 use openreelio_core::commands::ImportAssetCommand;
@@ -59,6 +60,11 @@ pub enum AssetAction {
 pub fn execute(action: AssetAction) -> anyhow::Result<()> {
     match action {
         AssetAction::Import { path, file, name } => {
+            // Import probes media metadata with ffprobe when the container is
+            // ambiguous. Register the binaries first, but keep importing when
+            // FFmpeg is absent: metadata probing only enriches the asset.
+            ensure_ffmpeg_optional();
+
             let mut project = super::load_project(&path)?;
             let file_path = std::fs::canonicalize(&file)
                 .map_err(|e| anyhow::anyhow!("File '{}' not found: {}", file.display(), e))?;

--- a/crates/openreelio-cli/src/commands/ffmpeg.rs
+++ b/crates/openreelio-cli/src/commands/ffmpeg.rs
@@ -1,0 +1,27 @@
+//! FFmpeg toolchain inspection commands.
+
+use crate::ffmpeg_env::ensure_ffmpeg;
+use crate::output;
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum FfmpegAction {
+    /// Resolve the FFmpeg/FFprobe binaries this CLI will use
+    Info,
+}
+
+pub fn execute(action: FfmpegAction) -> anyhow::Result<()> {
+    match action {
+        FfmpegAction::Info => {
+            let info = ensure_ffmpeg()?;
+
+            output::print_json_pretty(&serde_json::json!({
+                "status": "ok",
+                "ffmpegPath": info.ffmpeg_path.display().to_string(),
+                "ffprobePath": info.ffprobe_path.display().to_string(),
+                "version": info.version,
+                "source": info.source.as_str(),
+            }))
+        }
+    }
+}

--- a/crates/openreelio-cli/src/commands/frame.rs
+++ b/crates/openreelio-cli/src/commands/frame.rs
@@ -496,7 +496,7 @@ impl TimelineFrameContext<'_> {
                 };
                 let result = self
                     .engine
-                    .export_frame(self.sequence, self.assets(), &settings)
+                    .export_frame(self.sequence, self.assets(), &self.project.path, &settings)
                     .await
                     .map_err(|error| anyhow::anyhow!("Frame export failed: {}", error))?;
 

--- a/crates/openreelio-cli/src/commands/frame.rs
+++ b/crates/openreelio-cli/src/commands/frame.rs
@@ -29,6 +29,12 @@ use std::path::{Path, PathBuf};
 /// while staying well under typical image-token limits.
 const DEFAULT_MAX_WIDTH: u32 = 1280;
 
+/// Largest contact sheet accepted, in cells.
+///
+/// Every cell costs one FFmpeg extraction, so an unbounded grid would turn a
+/// single command into thousands of process spawns.
+const MAX_GRID_CELLS: usize = 100;
+
 /// Shortest composited window that FFmpeg can still render.
 ///
 /// `normalize_output_time_range` rejects zero-length ranges, so a single
@@ -145,6 +151,8 @@ enum Selection {
     /// A contact sheet sampled over a timeline range.
     Grid {
         columns: usize,
+        /// Rows the samples fill, which is fewer than `--grid` asked for when
+        /// `--count` does not fill the layout.
         rows: usize,
         times: Vec<f64>,
     },
@@ -162,7 +170,22 @@ fn resolve_selection(args: &ExtractArgs) -> anyhow::Result<Selection> {
         }
         validate::time_range_ordered(range[0], range[1], "between START", "between END")?;
 
-        let capacity = columns * rows;
+        let capacity = columns.checked_mul(rows).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invalid value for --grid: {}x{} is too large",
+                columns,
+                rows
+            )
+        })?;
+        if capacity > MAX_GRID_CELLS {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --grid: {}x{} needs {} cells, more than the maximum of {}",
+                columns,
+                rows,
+                capacity,
+                MAX_GRID_CELLS
+            ));
+        }
         let count = args.count.unwrap_or(capacity);
         if count < 1 {
             return Err(anyhow::anyhow!("Invalid value for --count: must be >= 1"));
@@ -177,10 +200,15 @@ fn resolve_selection(args: &ExtractArgs) -> anyhow::Result<Selection> {
             ));
         }
 
+        let times = sample_times(range[0], range[1], count);
+
         return Ok(Selection::Grid {
             columns,
-            rows,
-            times: sample_times(range[0], range[1], count),
+            // FFmpeg's `tile` filter fills unused cells with black, so a sheet
+            // built from fewer samples than the requested capacity would carry
+            // dead rows. Keep only the rows the samples reach.
+            rows: times.len().div_ceil(columns),
+            times,
         });
     }
 
@@ -777,6 +805,53 @@ mod tests {
         assert!(parse_grid_spec("0x2").is_err());
         assert!(parse_grid_spec("2x0").is_err());
         assert!(parse_grid_spec("ax2").is_err());
+    }
+
+    fn grid_args(grid: &str, count: Option<usize>) -> ExtractArgs {
+        ExtractArgs {
+            path: PathBuf::from("."),
+            out: PathBuf::from("sheet.jpg"),
+            asset: None,
+            source_time: None,
+            time: None,
+            times: None,
+            sequence: None,
+            mode: "fast".to_string(),
+            max_width: None,
+            format: "jpeg".to_string(),
+            grid: Some(grid.to_string()),
+            between: Some(vec![0.0, 4.0]),
+            count,
+        }
+    }
+
+    #[test]
+    fn resolve_selection_should_reject_grids_beyond_the_cell_budget() {
+        assert!(resolve_selection(&grid_args("11x11", None)).is_err());
+    }
+
+    #[test]
+    fn resolve_selection_should_reject_a_grid_whose_capacity_overflows() {
+        let spec = format!("{}x2", usize::MAX);
+
+        assert!(resolve_selection(&grid_args(&spec, None)).is_err());
+    }
+
+    #[test]
+    fn resolve_selection_should_drop_rows_no_sample_reaches() {
+        let selection = resolve_selection(&grid_args("3x3", Some(5))).expect("selection resolves");
+
+        let Selection::Grid {
+            columns,
+            rows,
+            times,
+        } = selection
+        else {
+            panic!("Expected a grid selection");
+        };
+        assert_eq!(columns, 3);
+        assert_eq!(rows, 2, "Five samples over three columns fill two rows");
+        assert_eq!(times.len(), 5);
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/frame.rs
+++ b/crates/openreelio-cli/src/commands/frame.rs
@@ -1,0 +1,852 @@
+//! Frame extraction commands.
+//!
+//! Gives agents a way to *see* the project: single stills from a source asset
+//! or a timeline position, batches of stills, and contact sheets that map grid
+//! cells back to timeline timecodes.
+
+use crate::ffmpeg_env::ensure_ffmpeg;
+use crate::output;
+use crate::validate;
+use clap::{Args, Subcommand};
+use openreelio_core::analysis::visual::{
+    VisualAnalyzer, CONTACT_SHEET_CELL_HEIGHT, CONTACT_SHEET_CELL_WIDTH,
+};
+use openreelio_core::assets::Asset;
+use openreelio_core::effects::Effect;
+use openreelio_core::ffmpeg::{FFmpegRunner, FrameExtractOptions};
+use openreelio_core::render::{
+    build_render_graph, build_render_plan, clip_source_time_at, probed_image_dimensions,
+    scaled_frame_dimensions, validate_export_settings, ExportEngine, ExportSettings,
+    FrameExportSettings, ImageFormat,
+};
+use openreelio_core::timeline::Sequence;
+use openreelio_core::ActiveProject;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Default maximum still width. 1280px keeps frames readable for vision models
+/// while staying well under typical image-token limits.
+const DEFAULT_MAX_WIDTH: u32 = 1280;
+
+/// Shortest composited window that FFmpeg can still render.
+///
+/// `normalize_output_time_range` rejects zero-length ranges, so a single
+/// composited frame is rendered as a tiny non-zero window.
+const MIN_COMPOSITE_WINDOW_SEC: f64 = 0.05;
+
+#[derive(Subcommand)]
+pub enum FrameAction {
+    /// Extract still frames from an asset, a timeline position, or a grid of timeline positions
+    Extract(ExtractArgs),
+}
+
+/// Arguments for `frame extract`.
+#[derive(Args)]
+pub struct ExtractArgs {
+    /// Project directory path
+    #[arg(long)]
+    pub path: PathBuf,
+
+    /// Output image file, or output directory for --times
+    #[arg(long)]
+    pub out: PathBuf,
+
+    /// Asset ID to extract from (requires --source-time)
+    #[arg(long, requires = "source_time", conflicts_with_all = ["time", "times", "grid"])]
+    pub asset: Option<String>,
+
+    /// Time in seconds inside the asset's own media (requires --asset)
+    #[arg(long, requires = "asset")]
+    pub source_time: Option<f64>,
+
+    /// Timeline time in seconds
+    #[arg(long, conflicts_with_all = ["times", "grid"])]
+    pub time: Option<f64>,
+
+    /// Comma-separated timeline times in seconds; --out must be a directory
+    #[arg(long, value_delimiter = ',', conflicts_with = "grid")]
+    pub times: Option<Vec<f64>>,
+
+    /// Sequence ID (defaults to active)
+    #[arg(long)]
+    pub sequence: Option<String>,
+
+    /// Timeline extraction mode: fast (topmost clip only) or composite (full render)
+    #[arg(long, default_value = "fast")]
+    pub mode: String,
+
+    /// Maximum output width in pixels (aspect ratio preserved, never upscaled)
+    #[arg(long)]
+    pub max_width: Option<u32>,
+
+    /// Output image format
+    #[arg(long, default_value = "png")]
+    pub format: String,
+
+    /// Contact sheet grid as COLSxROWS (requires --between)
+    #[arg(long, requires = "between")]
+    pub grid: Option<String>,
+
+    /// Timeline range to sample for --grid
+    #[arg(long, num_args = 2, value_names = ["START", "END"])]
+    pub between: Option<Vec<f64>>,
+
+    /// Number of grid samples (defaults to columns * rows)
+    #[arg(long, requires = "grid")]
+    pub count: Option<usize>,
+}
+
+pub fn execute(action: FrameAction) -> anyhow::Result<()> {
+    match action {
+        FrameAction::Extract(args) => extract(args),
+    }
+}
+
+// ── Selection ───────────────────────────────────────────────────────────
+
+/// Timeline extraction strategy.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TimelineMode {
+    /// Topmost file-backed clip only; no effects, text, or compositing.
+    Fast,
+    /// Full composited render of a minimal window around the requested time.
+    Composite,
+}
+
+impl TimelineMode {
+    fn parse(raw: &str) -> anyhow::Result<Self> {
+        match raw.trim().to_lowercase().as_str() {
+            "fast" => Ok(Self::Fast),
+            "composite" => Ok(Self::Composite),
+            other => Err(anyhow::anyhow!(
+                "Invalid value for --mode: expected 'fast' or 'composite' (got '{}')",
+                other
+            )),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Fast => "fast",
+            Self::Composite => "composite",
+        }
+    }
+}
+
+/// What the caller asked for, after argument validation.
+enum Selection {
+    /// A single frame from an asset's own media timebase.
+    AssetTime { asset_id: String, source_time: f64 },
+    /// One timeline still written to `--out`.
+    SingleTime(f64),
+    /// Several timeline stills written into the `--out` directory.
+    BatchTimes(Vec<f64>),
+    /// A contact sheet sampled over a timeline range.
+    Grid {
+        columns: usize,
+        rows: usize,
+        times: Vec<f64>,
+    },
+}
+
+fn resolve_selection(args: &ExtractArgs) -> anyhow::Result<Selection> {
+    if let Some(grid) = &args.grid {
+        let (columns, rows) = parse_grid_spec(grid)?;
+        let range = args
+            .between
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("--grid requires --between <START> <END>"))?;
+        if range.len() != 2 {
+            return Err(anyhow::anyhow!("--between takes exactly two values"));
+        }
+        validate::time_range_ordered(range[0], range[1], "between START", "between END")?;
+
+        let capacity = columns * rows;
+        let count = args.count.unwrap_or(capacity);
+        if count < 1 {
+            return Err(anyhow::anyhow!("Invalid value for --count: must be >= 1"));
+        }
+        if count > capacity {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --count: {} exceeds the {}x{} grid capacity of {}",
+                count,
+                columns,
+                rows,
+                capacity
+            ));
+        }
+
+        return Ok(Selection::Grid {
+            columns,
+            rows,
+            times: sample_times(range[0], range[1], count),
+        });
+    }
+
+    if let Some(asset_id) = &args.asset {
+        validate::non_empty(asset_id, "asset")?;
+        let source_time = args
+            .source_time
+            .ok_or_else(|| anyhow::anyhow!("--asset requires --source-time <SEC>"))?;
+        validate::time_non_negative(source_time, "source-time")?;
+        return Ok(Selection::AssetTime {
+            asset_id: asset_id.clone(),
+            source_time,
+        });
+    }
+
+    if let Some(times) = &args.times {
+        if times.is_empty() {
+            return Err(anyhow::anyhow!("--times requires at least one value"));
+        }
+        for time in times {
+            validate::time_non_negative(*time, "times")?;
+        }
+        return Ok(Selection::BatchTimes(times.clone()));
+    }
+
+    if let Some(time) = args.time {
+        validate::time_non_negative(time, "time")?;
+        return Ok(Selection::SingleTime(time));
+    }
+
+    Err(anyhow::anyhow!(
+        "Nothing to extract: pass --time, --times, --grid, or --asset with --source-time"
+    ))
+}
+
+// ── Execution ───────────────────────────────────────────────────────────
+
+fn extract(args: ExtractArgs) -> anyhow::Result<()> {
+    let selection = resolve_selection(&args)?;
+    let format = parse_image_format(&args.format)?;
+    let mode = TimelineMode::parse(&args.mode)?;
+    if let Some(max_width) = args.max_width {
+        if max_width == 0 {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --max-width: must be >= 1"
+            ));
+        }
+    }
+
+    let ffmpeg_info = ensure_ffmpeg()?;
+    let project = super::load_project(&args.path)?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))?;
+    let runner = FFmpegRunner::new(ffmpeg_info);
+
+    let result = match selection {
+        Selection::AssetTime {
+            asset_id,
+            source_time,
+        } => runtime.block_on(run_asset_mode(
+            &project,
+            &runner,
+            &asset_id,
+            source_time,
+            &args.out,
+            format,
+            args.max_width,
+        ))?,
+        Selection::SingleTime(time) => runtime.block_on(run_timeline_mode(
+            &project,
+            &runner,
+            &args,
+            format,
+            mode,
+            &[time],
+            false,
+        ))?,
+        Selection::BatchTimes(times) => runtime.block_on(run_timeline_mode(
+            &project, &runner, &args, format, mode, &times, true,
+        ))?,
+        Selection::Grid {
+            columns,
+            rows,
+            times,
+        } => runtime.block_on(run_grid_mode(
+            &project, &runner, &args, format, mode, columns, rows, &times,
+        ))?,
+    };
+
+    output::print_json_pretty(&result)
+}
+
+async fn run_asset_mode(
+    project: &ActiveProject,
+    runner: &FFmpegRunner,
+    asset_id: &str,
+    source_time: f64,
+    out: &Path,
+    format: ImageFormat,
+    max_width: Option<u32>,
+) -> anyhow::Result<serde_json::Value> {
+    let asset = project
+        .state
+        .assets
+        .get(asset_id)
+        .ok_or_else(|| anyhow::anyhow!("Asset '{}' not found", asset_id))?;
+    let media_path = asset.resolved_path(&project.path);
+
+    let output_path = resolve_single_output_path(out, source_time, format)?;
+    runner
+        .extract_frame_with_options(
+            &media_path,
+            source_time,
+            &output_path,
+            &FrameExtractOptions {
+                overwrite: true,
+                max_width,
+                quality: None,
+            },
+        )
+        .await
+        .map_err(|error| anyhow::anyhow!("Frame extraction failed: {}", error))?;
+
+    let (width, height) = probed_image_dimensions(runner, &output_path)
+        .await
+        .unwrap_or_else(|| {
+            asset
+                .video
+                .as_ref()
+                .map(|video| scaled_frame_dimensions(video.width, video.height, max_width))
+                .unwrap_or((0, 0))
+        });
+
+    let frame = FrameEntry {
+        index: 0,
+        time_sec: source_time,
+        source_time_sec: Some(source_time),
+        clip_id: None,
+        asset_id: Some(asset_id.to_string()),
+        path: output_path.display().to_string(),
+        width,
+        height,
+        fell_back_to_composite: None,
+    };
+
+    Ok(serde_json::json!({
+        "status": "ok",
+        "mode": "asset",
+        "frames": [frame],
+        "count": 1,
+    }))
+}
+
+async fn run_timeline_mode(
+    project: &ActiveProject,
+    runner: &FFmpegRunner,
+    args: &ExtractArgs,
+    format: ImageFormat,
+    mode: TimelineMode,
+    times: &[f64],
+    batch: bool,
+) -> anyhow::Result<serde_json::Value> {
+    let (sequence_id, sequence) = resolve_sequence(project, args.sequence.clone())?;
+    let context = TimelineFrameContext {
+        engine: ExportEngine::new(runner.clone()),
+        runner,
+        project,
+        sequence,
+        sequence_id: &sequence_id,
+        format: format.clone(),
+        max_width: args.max_width.unwrap_or(DEFAULT_MAX_WIDTH),
+        mode,
+    };
+
+    if batch {
+        std::fs::create_dir_all(&args.out).map_err(|error| {
+            anyhow::anyhow!(
+                "Failed to create output directory '{}': {}",
+                args.out.display(),
+                error
+            )
+        })?;
+    }
+
+    let mut frames = Vec::with_capacity(times.len());
+    for (index, time) in times.iter().enumerate() {
+        let output_path = if batch {
+            args.out.join(batch_frame_name(*time, &format))
+        } else {
+            resolve_single_output_path(&args.out, *time, format.clone())?
+        };
+        frames.push(context.extract(index, *time, &output_path).await?);
+    }
+
+    Ok(serde_json::json!({
+        "status": "ok",
+        "mode": mode.label(),
+        "frames": frames,
+        "count": frames.len(),
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_grid_mode(
+    project: &ActiveProject,
+    runner: &FFmpegRunner,
+    args: &ExtractArgs,
+    format: ImageFormat,
+    mode: TimelineMode,
+    columns: usize,
+    rows: usize,
+    times: &[f64],
+) -> anyhow::Result<serde_json::Value> {
+    let (sequence_id, sequence) = resolve_sequence(project, args.sequence.clone())?;
+    let context = TimelineFrameContext {
+        engine: ExportEngine::new(runner.clone()),
+        runner,
+        project,
+        sequence,
+        sequence_id: &sequence_id,
+        // Contact sheet cells are always JPEG: FFmpeg reads them back as a
+        // `%d.jpg` image sequence.
+        format: ImageFormat::Jpeg,
+        max_width: args.max_width.unwrap_or(DEFAULT_MAX_WIDTH),
+        mode,
+    };
+
+    let cell_dir = tempfile::tempdir()
+        .map_err(|error| anyhow::anyhow!("Failed to create temporary cell directory: {error}"))?;
+
+    let mut cell_paths = Vec::with_capacity(times.len());
+    let mut cells = Vec::with_capacity(times.len());
+    for (index, time) in times.iter().enumerate() {
+        // The contact-sheet input pattern is a zero-based `%d.jpg` sequence.
+        let cell_path = cell_dir.path().join(format!("{}.jpg", index));
+        context.extract(index, *time, &cell_path).await?;
+        cell_paths.push(cell_path);
+        cells.push(GridCell {
+            index,
+            row: index / columns,
+            col: index % columns,
+            timeline_sec: *time,
+        });
+    }
+
+    let sheet_path = normalize_extension(args.out.clone(), &format);
+    let analyzer = VisualAnalyzer::new(runner.info().ffmpeg_path.clone());
+    let artifact = analyzer
+        .generate_contact_sheet_with_layout(&cell_paths, &sheet_path, Some((columns, rows)))
+        .await
+        .map_err(|error| anyhow::anyhow!("Contact sheet generation failed: {}", error))?
+        .ok_or_else(|| anyhow::anyhow!("Contact sheet generation produced no output"))?;
+
+    Ok(serde_json::json!({
+        "status": "ok",
+        "mode": "grid",
+        "sheet": {
+            "path": artifact.path,
+            "cols": artifact.columns,
+            "rows": artifact.rows,
+            "cellWidth": CONTACT_SHEET_CELL_WIDTH,
+            "cellHeight": CONTACT_SHEET_CELL_HEIGHT,
+            "cells": cells,
+        },
+    }))
+}
+
+// ── Timeline frame extraction ───────────────────────────────────────────
+
+/// Everything needed to turn a timeline time into a still image.
+struct TimelineFrameContext<'a> {
+    engine: ExportEngine,
+    runner: &'a FFmpegRunner,
+    project: &'a ActiveProject,
+    sequence: &'a Sequence,
+    sequence_id: &'a str,
+    format: ImageFormat,
+    max_width: u32,
+    mode: TimelineMode,
+}
+
+impl TimelineFrameContext<'_> {
+    fn assets(&self) -> &HashMap<String, Asset> {
+        &self.project.state.assets
+    }
+
+    fn effects(&self) -> &HashMap<String, Effect> {
+        &self.project.state.effects
+    }
+
+    /// Extracts one timeline still, falling back to a composited render when
+    /// fast mode cannot serve the requested time (title cards, gaps).
+    async fn extract(
+        &self,
+        index: usize,
+        time_sec: f64,
+        output_path: &Path,
+    ) -> anyhow::Result<FrameEntry> {
+        if self.mode == TimelineMode::Fast {
+            if let Some((clip, _)) =
+                self.engine
+                    .find_topmost_clip_at_time(self.sequence, self.assets(), time_sec)
+            {
+                let settings = FrameExportSettings {
+                    time_sec,
+                    format: self.format.clone(),
+                    output_path: output_path.to_path_buf(),
+                    quality: None,
+                    max_width: Some(self.max_width),
+                };
+                let result = self
+                    .engine
+                    .export_frame(self.sequence, self.assets(), &settings)
+                    .await
+                    .map_err(|error| anyhow::anyhow!("Frame export failed: {}", error))?;
+
+                return Ok(FrameEntry {
+                    index,
+                    time_sec,
+                    source_time_sec: Some(clip_source_time_at(clip, time_sec)),
+                    clip_id: Some(clip.id.clone()),
+                    asset_id: Some(clip.asset_id.clone()),
+                    path: result.output_path.display().to_string(),
+                    width: result.width,
+                    height: result.height,
+                    fell_back_to_composite: None,
+                });
+            }
+        }
+
+        let fell_back = self.mode == TimelineMode::Fast;
+        let (width, height) = self.render_composite(time_sec, output_path).await?;
+
+        Ok(FrameEntry {
+            index,
+            time_sec,
+            source_time_sec: None,
+            clip_id: None,
+            asset_id: None,
+            path: output_path.display().to_string(),
+            width,
+            height,
+            fell_back_to_composite: fell_back.then_some(true),
+        })
+    }
+
+    /// Renders a minimal composited window around `time_sec` and grabs its
+    /// first frame.
+    ///
+    /// Range renders decode from timeline zero, so the cost grows with
+    /// `time_sec` — this is the accurate but slow path.
+    async fn render_composite(
+        &self,
+        time_sec: f64,
+        output_path: &Path,
+    ) -> anyhow::Result<(u32, u32)> {
+        let fps = self.sequence.format.fps.as_f64();
+        let window = if fps > 0.0 {
+            (2.0 / fps).max(MIN_COMPOSITE_WINDOW_SEC)
+        } else {
+            MIN_COMPOSITE_WINDOW_SEC
+        };
+
+        let temp_dir = tempfile::tempdir().map_err(|error| {
+            anyhow::anyhow!("Failed to create temporary render directory: {error}")
+        })?;
+        let temp_render = temp_dir.path().join("composite.mp4");
+
+        let canvas = &self.sequence.format.canvas;
+        let (width, height) =
+            scaled_frame_dimensions(canvas.width, canvas.height, Some(self.max_width));
+
+        let mut settings =
+            ExportSettings::preview(temp_render.clone(), Some(time_sec), Some(time_sec + window));
+        settings.width = Some(width);
+        settings.height = Some(height);
+
+        let validation =
+            validate_export_settings(self.sequence, self.assets(), self.effects(), &settings);
+        if !validation.is_valid {
+            return Err(anyhow::anyhow!(
+                "Composite render validation failed: {}",
+                validation.errors.join("; ")
+            ));
+        }
+
+        let graph = build_render_graph(&self.project.state, self.sequence_id)
+            .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
+        let render_plan = build_render_plan(&graph, self.assets(), self.effects(), &settings);
+        if !render_plan.validation.is_valid {
+            return Err(anyhow::anyhow!(
+                "Composite render plan validation failed: {}",
+                render_plan.validation.errors.join("; ")
+            ));
+        }
+
+        self.engine
+            .export_sequence_with_effects_for_plan(
+                self.sequence,
+                self.assets(),
+                self.effects(),
+                &settings,
+                &render_plan,
+                None,
+                None,
+            )
+            .await
+            .map_err(|error| anyhow::anyhow!("Composite render failed: {}", error))?;
+
+        self.runner
+            .extract_frame_with_options(
+                &temp_render,
+                0.0,
+                output_path,
+                &FrameExtractOptions {
+                    overwrite: true,
+                    max_width: None,
+                    quality: None,
+                },
+            )
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("Frame extraction from composite render failed: {}", error)
+            })?;
+
+        Ok(probed_image_dimensions(self.runner, output_path)
+            .await
+            .unwrap_or((width, height)))
+    }
+}
+
+// ── Output payloads ─────────────────────────────────────────────────────
+
+/// One extracted still in the JSON payload.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FrameEntry {
+    index: usize,
+    time_sec: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_time_sec: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    clip_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    asset_id: Option<String>,
+    path: String,
+    width: u32,
+    height: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fell_back_to_composite: Option<bool>,
+}
+
+/// One contact-sheet cell, mapping a grid position back to a timeline time.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GridCell {
+    index: usize,
+    row: usize,
+    col: usize,
+    timeline_sec: f64,
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Resolves the target sequence, defaulting to the project's active sequence.
+fn resolve_sequence(
+    project: &ActiveProject,
+    sequence: Option<String>,
+) -> anyhow::Result<(String, &Sequence)> {
+    let sequence_id = super::resolve_sequence_id(project, sequence)?;
+    let sequence = project
+        .state
+        .sequences
+        .get(&sequence_id)
+        .ok_or_else(|| anyhow::anyhow!("Sequence '{}' not found", sequence_id))?;
+
+    Ok((sequence_id, sequence))
+}
+
+fn parse_image_format(raw: &str) -> anyhow::Result<ImageFormat> {
+    match raw.trim().to_lowercase().as_str() {
+        "png" => Ok(ImageFormat::Png),
+        "jpeg" | "jpg" => Ok(ImageFormat::Jpeg),
+        other => Err(anyhow::anyhow!(
+            "Invalid value for --format: expected 'png' or 'jpeg' (got '{}')",
+            other
+        )),
+    }
+}
+
+/// Parses a `COLSxROWS` grid specification.
+fn parse_grid_spec(raw: &str) -> anyhow::Result<(usize, usize)> {
+    let normalized = raw.trim().to_lowercase();
+    let (columns, rows) = normalized.split_once('x').ok_or_else(|| {
+        anyhow::anyhow!("Invalid value for --grid: expected COLSxROWS (e.g. 3x2)")
+    })?;
+
+    let parse_part = |value: &str, name: &str| -> anyhow::Result<usize> {
+        let parsed: usize = value.trim().parse().map_err(|_| {
+            anyhow::anyhow!(
+                "Invalid value for --grid: {} must be a positive integer (got '{}')",
+                name,
+                value
+            )
+        })?;
+        if parsed == 0 {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --grid: {} must be >= 1",
+                name
+            ));
+        }
+        Ok(parsed)
+    };
+
+    Ok((parse_part(columns, "columns")?, parse_part(rows, "rows")?))
+}
+
+/// Samples `count` evenly spaced times inside `[start, end]`.
+///
+/// Samples sit at the centre of `count` equal sub-intervals so neither
+/// boundary is hit exactly — timeline edges are frequently outside any clip.
+fn sample_times(start: f64, end: f64, count: usize) -> Vec<f64> {
+    if count == 0 {
+        return Vec::new();
+    }
+    let span = end - start;
+    (0..count)
+        .map(|index| start + span * (index as f64 + 0.5) / count as f64)
+        .collect()
+}
+
+/// Builds the file name used for `--times` batch output.
+fn batch_frame_name(time_sec: f64, format: &ImageFormat) -> String {
+    let millis = (time_sec * 1000.0).round().max(0.0) as u64;
+    format!("frame_{}.{}", millis, format.extension())
+}
+
+/// Resolves `--out` for a single still: an existing directory receives a
+/// generated file name, otherwise the path is used as-is.
+fn resolve_single_output_path(
+    out: &Path,
+    time_sec: f64,
+    format: ImageFormat,
+) -> anyhow::Result<PathBuf> {
+    if out.is_dir() {
+        return Ok(out.join(batch_frame_name(time_sec, &format)));
+    }
+    if out.as_os_str().is_empty() {
+        return Err(anyhow::anyhow!("Invalid value for --out: cannot be empty"));
+    }
+    Ok(normalize_extension(out.to_path_buf(), &format))
+}
+
+/// Forces the output extension to match the requested format so the encoder
+/// FFmpeg picks always agrees with `--format`.
+fn normalize_extension(path: PathBuf, format: &ImageFormat) -> PathBuf {
+    let matches = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| {
+            let ext = ext.to_lowercase();
+            match format {
+                ImageFormat::Png => ext == "png",
+                ImageFormat::Jpeg => ext == "jpg" || ext == "jpeg",
+                ImageFormat::Tiff => ext == "tif" || ext == "tiff",
+            }
+        })
+        .unwrap_or(false);
+
+    if matches {
+        path
+    } else {
+        path.with_extension(format.extension())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_grid_spec_should_accept_cols_by_rows() {
+        assert_eq!(parse_grid_spec("3x2").unwrap(), (3, 2));
+        assert_eq!(parse_grid_spec(" 4X4 ").unwrap(), (4, 4));
+    }
+
+    #[test]
+    fn parse_grid_spec_should_reject_malformed_input() {
+        assert!(parse_grid_spec("3").is_err());
+        assert!(parse_grid_spec("3x").is_err());
+        assert!(parse_grid_spec("0x2").is_err());
+        assert!(parse_grid_spec("2x0").is_err());
+        assert!(parse_grid_spec("ax2").is_err());
+    }
+
+    #[test]
+    fn sample_times_should_space_samples_evenly_inside_the_range() {
+        assert_eq!(sample_times(0.0, 4.0, 4), vec![0.5, 1.5, 2.5, 3.5]);
+    }
+
+    #[test]
+    fn sample_times_should_return_the_midpoint_for_a_single_sample() {
+        assert_eq!(sample_times(2.0, 6.0, 1), vec![4.0]);
+    }
+
+    #[test]
+    fn sample_times_should_stay_inside_the_range_and_ascend() {
+        let samples = sample_times(1.0, 3.0, 5);
+        assert_eq!(samples.len(), 5);
+        assert!(samples.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(samples.iter().all(|time| *time > 1.0 && *time < 3.0));
+    }
+
+    #[test]
+    fn sample_times_should_return_nothing_for_zero_count() {
+        assert!(sample_times(0.0, 4.0, 0).is_empty());
+    }
+
+    #[test]
+    fn batch_frame_name_should_encode_milliseconds_and_format() {
+        assert_eq!(batch_frame_name(1.25, &ImageFormat::Png), "frame_1250.png");
+        assert_eq!(batch_frame_name(0.0, &ImageFormat::Jpeg), "frame_0.jpg");
+        assert_eq!(
+            batch_frame_name(12.3456, &ImageFormat::Png),
+            "frame_12346.png"
+        );
+    }
+
+    #[test]
+    fn normalize_extension_should_keep_matching_extensions() {
+        assert_eq!(
+            normalize_extension(PathBuf::from("a/b.png"), &ImageFormat::Png),
+            PathBuf::from("a/b.png")
+        );
+        assert_eq!(
+            normalize_extension(PathBuf::from("a/b.JPEG"), &ImageFormat::Jpeg),
+            PathBuf::from("a/b.JPEG")
+        );
+    }
+
+    #[test]
+    fn normalize_extension_should_replace_mismatched_extensions() {
+        assert_eq!(
+            normalize_extension(PathBuf::from("a/b.jpg"), &ImageFormat::Png),
+            PathBuf::from("a/b.png")
+        );
+        assert_eq!(
+            normalize_extension(PathBuf::from("a/b"), &ImageFormat::Jpeg),
+            PathBuf::from("a/b.jpg")
+        );
+    }
+
+    #[test]
+    fn timeline_mode_should_parse_known_values() {
+        assert!(TimelineMode::parse("fast").is_ok());
+        assert!(TimelineMode::parse("COMPOSITE").is_ok());
+        assert!(TimelineMode::parse("turbo").is_err());
+    }
+
+    #[test]
+    fn parse_image_format_should_accept_png_and_jpeg_aliases() {
+        assert_eq!(parse_image_format("png").unwrap(), ImageFormat::Png);
+        assert_eq!(parse_image_format("JPG").unwrap(), ImageFormat::Jpeg);
+        assert!(parse_image_format("gif").is_err());
+    }
+}

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -576,6 +576,25 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "params": {},
                 "example": "openreelio-cli ffmpeg info"
             },
+            "frame.extract": {
+                "description": "Extract still frames for visual inspection: one asset-time frame, one or many timeline-time frames, or a contact sheet grid. Timeline 'fast' mode captures the topmost file-backed clip only (no effects, text, or compositing) and falls back to 'composite' automatically when no such clip covers the requested time.",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "out": { "type": "string", "required": true, "desc": "Output image file; must be a directory when --times is used. The extension is normalized to match --format." },
+                    "asset": { "type": "string", "required": false, "desc": "Asset ID to extract from; requires --source-time and cannot be combined with timeline selectors" },
+                    "source-time": { "type": "number", "required": false, "desc": "Time in seconds inside the asset's own media; requires --asset" },
+                    "time": { "type": "number", "required": false, "desc": "Timeline time in seconds for a single still" },
+                    "times": { "type": "string", "required": false, "desc": "Comma-separated timeline times in seconds; --out must be a directory and files are named frame_<ms>.<ext>" },
+                    "sequence": { "type": "string", "required": false, "desc": "Sequence ID (defaults to active)" },
+                    "mode": { "type": "string", "required": false, "desc": "Timeline extraction mode: fast (default, topmost clip only) or composite (full render of a minimal window; decodes from timeline zero so cost grows with the timestamp)" },
+                    "max-width": { "type": "number", "required": false, "desc": "Maximum output width in pixels, aspect ratio preserved and never upscaled (default: 1280 for timeline modes, native for --asset)" },
+                    "format": { "type": "string", "required": false, "desc": "Output image format: png (default) or jpeg. Grid cells are always JPEG; the sheet itself uses this format." },
+                    "grid": { "type": "string", "required": false, "desc": "Contact sheet layout as COLSxROWS (e.g. 3x2); requires --between" },
+                    "between": { "type": "string", "required": false, "desc": "Timeline range sampled by --grid, given as two values: START END" },
+                    "count": { "type": "number", "required": false, "desc": "Number of grid samples (default: columns * rows; must not exceed the grid capacity)" }
+                },
+                "example": "openreelio-cli frame extract --path ./project --time 12.5 --out frame.png"
+            },
             "mcp": {
                 "description": "Serve read-only OpenReelio MCP tools for external AI agents",
                 "params": {

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -76,6 +76,51 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 },
                 "example": "openreelio-cli asset remove --path ./project --id asset_001"
             },
+            "analysis.shots": {
+                "description": "Detect shot boundaries with FFmpeg scene detection and cache them in index.db, the analysis bundle, and the asset annotation",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "id": { "type": "string", "required": true, "desc": "Asset ID" },
+                    "threshold": { "type": "number", "required": false, "desc": "Scene change threshold 0.0-1.0; lower detects more cuts (default: 0.3)" },
+                    "min-shot-duration": { "type": "number", "required": false, "desc": "Minimum shot duration in seconds; shorter shots are merged (default: 0.5)" },
+                    "timeout-sec": { "type": "number", "required": false, "desc": "FFmpeg scene-detection timeout in seconds (default: 600)" },
+                    "no-persist": { "type": "boolean", "required": false, "desc": "Detect only: skip the index.db, bundle, and annotation writes" }
+                },
+                "example": "openreelio-cli analysis shots --path ./project --id asset_001 --threshold 0.3 --min-shot-duration 0.5"
+            },
+            "analysis.silence": {
+                "description": "Detect silence regions with FFmpeg; results are cached only at the shared -40dB / 0.5s contract, otherwise they are output-only",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "id": { "type": "string", "required": true, "desc": "Asset ID" },
+                    "threshold-db": { "type": "number", "required": false, "desc": "Silence threshold in dB (default: -40)" },
+                    "min-duration": { "type": "number", "required": false, "desc": "Minimum silence duration in seconds (default: 0.5)" }
+                },
+                "example": "openreelio-cli analysis silence --path ./project --id asset_001 --threshold-db -40 --min-duration 0.5"
+            },
+            "analysis.audio": {
+                "description": "Profile the audio track (silence regions, loudness curve, peak, BPM, speech regions) and cache it in the analysis bundle",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "id": { "type": "string", "required": true, "desc": "Asset ID" }
+                },
+                "example": "openreelio-cli analysis audio --path ./project --id asset_001"
+            },
+            "analysis.run": {
+                "description": "Run the local analysis pipeline (shots, audio, segments, optional transcript and visual) and cache the resulting bundle; exits non-zero only when every enabled sub-job fails",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "id": { "type": "string", "required": true, "desc": "Asset ID" },
+                    "shots": { "type": "boolean", "required": false, "desc": "Run shot detection" },
+                    "audio": { "type": "boolean", "required": false, "desc": "Run audio profiling" },
+                    "segments": { "type": "boolean", "required": false, "desc": "Run content segmentation (requires shots and audio)" },
+                    "transcript": { "type": "boolean", "required": false, "desc": "Run transcription (requires an installed Whisper model)" },
+                    "visual": { "type": "boolean", "required": false, "desc": "Run local visual frame analysis" },
+                    "all": { "type": "boolean", "required": false, "desc": "Run every local sub-job; transcription stays off unless --transcript is given" },
+                    "progress": { "type": "boolean", "required": false, "desc": "Stream NDJSON sub-job progress to stderr" }
+                },
+                "example": "openreelio-cli analysis run --path ./project --id asset_001 --all --progress"
+            },
             "analysis.report": {
                 "description": "Build a cached source analysis report for one asset as structured JSON plus embedded Markdown, including moments, chapters, and candidate highlights",
                 "params": {
@@ -676,6 +721,13 @@ mod tests {
         assert!(commands["text.add"]["params"]["font-weight"].is_object());
         assert!(commands["text.update"]["params"]["duration"].is_object());
         assert!(commands["text.transform"]["params"]["scale-x"].is_object());
+        assert!(commands.contains_key("analysis.shots"));
+        assert!(commands.contains_key("analysis.silence"));
+        assert!(commands.contains_key("analysis.audio"));
+        assert!(commands.contains_key("analysis.run"));
+        assert!(commands["analysis.shots"]["params"]["no-persist"].is_object());
+        assert!(commands["analysis.silence"]["params"]["threshold-db"].is_object());
+        assert!(commands["analysis.run"]["params"]["progress"].is_object());
         assert!(commands.contains_key("analysis.report"));
         assert!(commands.contains_key("analysis.search"));
         assert!(commands.contains_key("analysis.search-library"));

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -567,9 +567,13 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "output": { "type": "string", "required": true, "desc": "Output file path" },
                     "preset": { "type": "string", "required": false, "desc": "Render preset name (default: mp4_h264_1080p). Use render.presets for the supported list." },
-                    "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
+                    "proxy": { "type": "boolean", "required": false, "desc": "Render a fast 480p proxy for inspection (shorthand for --preset proxy_480p); conflicts with --preset and defaults the output extension to .mp4" },
+                    "sequence": { "type": "string", "required": false, "desc": "Sequence ID" },
+                    "start": { "type": "number", "required": false, "desc": "Start of the rendered range in timeline seconds (default: 0)" },
+                    "end": { "type": "number", "required": false, "desc": "End of the rendered range in timeline seconds (default: sequence duration); must be greater than --start" },
+                    "progress": { "type": "boolean", "required": false, "desc": "Stream NDJSON encode progress to stderr as {\"type\":\"progress\",\"percent\":..,\"frame\":..,\"totalFrames\":..,\"fps\":..,\"etaSeconds\":..}" }
                 },
-                "example": "openreelio-cli render start --path ./project --output output.mp4"
+                "example": "openreelio-cli render start --path ./project --proxy --start 0 --end 5 --progress --output proxy.mp4"
             },
             "ffmpeg.info": {
                 "description": "Resolve the FFmpeg/FFprobe binaries this CLI will use and report their version and source (explicit, env, bundled, managed, dev, or system)",

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -644,6 +644,23 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 },
                 "example": "openreelio-cli frame extract --path ./project --time 12.5 --out frame.png"
             },
+            "verify": {
+                "description": "Run deterministic quality control over a sequence and, with --file, over a rendered export. Emits one entry per check — including the ones that passed or were skipped — so an agent can tell 'checked and clean' from 'never checked'. Exit codes: 0 = ran without breaching --fail-on, 1 = threshold breached, 2 = tool failure (bad arguments, unreadable file, FFmpeg failure, or a check that errored).",
+                "params": {
+                    "path": { "type": "string", "required": true, "desc": "Project directory path" },
+                    "sequence": { "type": "string", "required": false, "desc": "Sequence ID (defaults to active)" },
+                    "file": { "type": "string", "required": false, "desc": "Rendered file to measure (black/freeze/silence detection, EBU R128 loudness, peaks). Without it only structural checks run and FFmpeg is never invoked. Measured times are file-relative and are compared against timeline times, so pass a full-sequence render rather than a partial one." },
+                    "structural-only": { "type": "boolean", "required": false, "desc": "Run structural checks only and never touch FFmpeg; conflicts with --file" },
+                    "checks": { "type": "string", "required": false, "desc": "Comma-separated check IDs to run exclusively: timeline.gap, clip.orphan, clip.missing_asset, audio.silent_clip, caption.overlap, caption.reading_rate, caption.out_of_bounds, caption.safe_area, shot.length_stats, shot.cut_rhythm, clip.aspect_ratio, asset.license, sequence.duration, render.black_frames, audio.peak, audio.loudness. asset.license and sequence.duration are opt-in and only run when named here." },
+                    "skip": { "type": "string", "required": false, "desc": "Comma-separated check IDs to disable" },
+                    "target-lufs": { "type": "number", "required": false, "desc": "Integrated loudness target in LUFS (default -14). Deviation over 1 LU warns, over 3 LU errors." },
+                    "max-true-peak": { "type": "number", "required": false, "desc": "Maximum acceptable true peak in dBTP (default -1). Sample peak is used when the encoder reports no true peak." },
+                    "fail-on": { "type": "string", "required": false, "desc": "Lowest severity that exits 1: info, warning, error (default), critical" },
+                    "timeout-sec": { "type": "number", "required": false, "desc": "Timeout for the rendered-file measurement pass in seconds (default: 600)" },
+                    "json-pretty": { "type": "boolean", "required": false, "desc": "Pretty-print the JSON output" }
+                },
+                "example": "openreelio-cli verify --path ./project --file proxy.mp4 --target-lufs -14 --fail-on error"
+            },
             "mcp": {
                 "description": "Serve read-only OpenReelio MCP tools for external AI agents",
                 "params": {

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -638,9 +638,9 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "mode": { "type": "string", "required": false, "desc": "Timeline extraction mode: fast (default, topmost clip only) or composite (full render of a minimal window; decodes from timeline zero so cost grows with the timestamp)" },
                     "max-width": { "type": "number", "required": false, "desc": "Maximum output width in pixels, aspect ratio preserved and never upscaled (default: 1280 for timeline modes, native for --asset)" },
                     "format": { "type": "string", "required": false, "desc": "Output image format: png (default) or jpeg. Grid cells are always JPEG; the sheet itself uses this format." },
-                    "grid": { "type": "string", "required": false, "desc": "Contact sheet layout as COLSxROWS (e.g. 3x2); requires --between" },
+                    "grid": { "type": "string", "required": false, "desc": "Contact sheet layout as COLSxROWS (e.g. 3x2), at most 100 cells; requires --between" },
                     "between": { "type": "string", "required": false, "desc": "Timeline range sampled by --grid, given as two values: START END" },
-                    "count": { "type": "number", "required": false, "desc": "Number of grid samples (default: columns * rows; must not exceed the grid capacity)" }
+                    "count": { "type": "number", "required": false, "desc": "Number of grid samples (default: columns * rows; must not exceed the grid capacity). Rows no sample reaches are dropped, so the reported rows can be fewer than --grid asked for." }
                 },
                 "example": "openreelio-cli frame extract --path ./project --time 12.5 --out frame.png"
             },
@@ -651,7 +651,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID (defaults to active)" },
                     "file": { "type": "string", "required": false, "desc": "Rendered file to measure (black/freeze/silence detection, EBU R128 loudness, peaks). Without it only structural checks run and FFmpeg is never invoked. Measured times are file-relative and are compared against timeline times, so pass a full-sequence render rather than a partial one." },
                     "structural-only": { "type": "boolean", "required": false, "desc": "Run structural checks only and never touch FFmpeg; conflicts with --file" },
-                    "checks": { "type": "string", "required": false, "desc": "Comma-separated check IDs to run exclusively: timeline.gap, clip.orphan, clip.missing_asset, audio.silent_clip, caption.overlap, caption.reading_rate, caption.out_of_bounds, caption.safe_area, shot.length_stats, shot.cut_rhythm, clip.aspect_ratio, asset.license, sequence.duration, render.black_frames, audio.peak, audio.loudness. asset.license and sequence.duration are opt-in and only run when named here." },
+                    "checks": { "type": "string", "required": false, "desc": "Comma-separated check IDs to run exclusively (asset.license and sequence.duration are opt-in and only run when named here): timeline.gap, clip.orphan, clip.missing_asset, audio.silent_clip, caption.overlap, caption.reading_rate, caption.out_of_bounds, caption.safe_area, shot.length_stats, shot.cut_rhythm, clip.aspect_ratio, asset.license, sequence.duration, render.black_frames, audio.peak, audio.loudness" },
                     "skip": { "type": "string", "required": false, "desc": "Comma-separated check IDs to disable" },
                     "target-lufs": { "type": "number", "required": false, "desc": "Integrated loudness target in LUFS (default -14). Deviation over 1 LU warns, over 3 LU errors." },
                     "max-true-peak": { "type": "number", "required": false, "desc": "Maximum acceptable true peak in dBTP (default -1). Sample peak is used when the encoder reports no true peak." },

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -571,6 +571,11 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 },
                 "example": "openreelio-cli render start --path ./project --output output.mp4"
             },
+            "ffmpeg.info": {
+                "description": "Resolve the FFmpeg/FFprobe binaries this CLI will use and report their version and source (explicit, env, bundled, managed, dev, or system)",
+                "params": {},
+                "example": "openreelio-cli ffmpeg info"
+            },
             "mcp": {
                 "description": "Serve read-only OpenReelio MCP tools for external AI agents",
                 "params": {

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod ffmpeg;
 mod frame;
 mod help_json;
 mod mcp;
+mod perception;
 mod plan;
 mod project;
 mod render;

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod asset;
 mod caption;
 mod command;
 mod ffmpeg;
+mod frame;
 mod help_json;
 mod mcp;
 mod plan;
@@ -97,6 +98,12 @@ pub enum Commands {
         action: ffmpeg::FfmpegAction,
     },
 
+    /// Still frame extraction for visual inspection
+    Frame {
+        #[command(subcommand)]
+        action: frame::FrameAction,
+    },
+
     /// Batch plan execution (atomic multi-step edits)
     Plan {
         #[command(subcommand)]
@@ -134,6 +141,7 @@ pub fn execute(cli: Cli) -> anyhow::Result<()> {
         Commands::Text { action } => text::execute(action),
         Commands::Render { action } => render::execute(action),
         Commands::Ffmpeg { action } => ffmpeg::execute(action),
+        Commands::Frame { action } => frame::execute(action),
         Commands::Plan { action } => plan::execute(action),
         Commands::Command { action } => command::execute(action),
         Commands::State { action } => state::execute(action),

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod analysis;
 mod asset;
 mod caption;
 mod command;
+mod ffmpeg;
 mod help_json;
 mod mcp;
 mod plan;
@@ -90,6 +91,12 @@ pub enum Commands {
         action: render::RenderAction,
     },
 
+    /// FFmpeg toolchain inspection
+    Ffmpeg {
+        #[command(subcommand)]
+        action: ffmpeg::FfmpegAction,
+    },
+
     /// Batch plan execution (atomic multi-step edits)
     Plan {
         #[command(subcommand)]
@@ -126,6 +133,7 @@ pub fn execute(cli: Cli) -> anyhow::Result<()> {
         Commands::Transcription { action } => transcription::execute(action),
         Commands::Text { action } => text::execute(action),
         Commands::Render { action } => render::execute(action),
+        Commands::Ffmpeg { action } => ffmpeg::execute(action),
         Commands::Plan { action } => plan::execute(action),
         Commands::Command { action } => command::execute(action),
         Commands::State { action } => state::execute(action),

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ mod state;
 mod text;
 mod timeline;
 mod transcription;
+mod verify;
 
 use clap::{Parser, Subcommand};
 
@@ -123,6 +124,9 @@ pub enum Commands {
         action: state::StateAction,
     },
 
+    /// Deterministic quality control for a sequence and its rendered output
+    Verify(verify::VerifyArgs),
+
     /// Model Context Protocol server for external AI agents
     Mcp(mcp::McpAction),
 
@@ -146,6 +150,7 @@ pub fn execute(cli: Cli) -> anyhow::Result<()> {
         Commands::Plan { action } => plan::execute(action),
         Commands::Command { action } => command::execute(action),
         Commands::State { action } => state::execute(action),
+        Commands::Verify(args) => verify::execute(args),
         Commands::Mcp(action) => mcp::execute(action),
         Commands::HelpJson => help_json::execute(),
     }

--- a/crates/openreelio-cli/src/commands/perception.rs
+++ b/crates/openreelio-cli/src/commands/perception.rs
@@ -1,0 +1,966 @@
+//! Headless perception verbs.
+//!
+//! These commands let an agent *generate* the analysis artifacts that
+//! `analysis report` / `analysis search` only read: shot boundaries, silence
+//! regions, audio profiles, and full analysis bundles. Everything runs
+//! locally through FFmpeg — no network calls and no API keys.
+//!
+//! Persistence targets mirror what the GUI writes, so artifacts produced
+//! headlessly show up in the app:
+//!
+//! - `{project}/index.db` `shots` table — the only source the GUI shot markers read
+//! - `{project}/.openreelio/analysis/{asset_id}/bundle.json` — the analysis cache
+//! - `{project}/.openreelio/annotations/{asset_id}.json` — the annotation store
+
+use crate::ffmpeg_env::ensure_ffmpeg;
+use crate::output;
+use crate::validate;
+use clap::Args;
+use openreelio_core::analysis::audio::AudioProfiler;
+use openreelio_core::analysis::cleanup::{
+    DEFAULT_SILENCE_MIN_DURATION_SEC, DEFAULT_SILENCE_THRESHOLD_DB,
+};
+use openreelio_core::analysis::{
+    AnalysisBundle, AnalysisJobRunner, AnalysisOptions, AudioProfile, VideoMetadata,
+    SILENCE_FLOOR_DB,
+};
+use openreelio_core::annotations::{
+    AnalysisProvider, AnalysisResult, AnnotationStore, AssetAnnotation, ShotResult,
+};
+use openreelio_core::assets::Asset;
+use openreelio_core::ffmpeg::{FFmpegInfo, FFmpegRunner};
+use openreelio_core::indexing::shots::{
+    Shot, DEFAULT_FFMPEG_TIMEOUT_SECS, DEFAULT_MIN_SHOT_DURATION, DEFAULT_SCENE_THRESHOLD,
+};
+use openreelio_core::indexing::{IndexDb, ShotDetector, ShotDetectorConfig};
+use openreelio_core::{ActiveProject, CoreError};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Attempts made when writing shots into `index.db`.
+///
+/// A GUI instance may hold the same SQLite file, so a transient `SQLITE_BUSY`
+/// must not be reported as a failed detection.
+const INDEX_DB_WRITE_ATTEMPTS: u32 = 3;
+
+/// Base backoff between `index.db` write attempts.
+const INDEX_DB_RETRY_BACKOFF: Duration = Duration::from_millis(50);
+
+/// Tolerance used when comparing requested silence parameters with the cached
+/// contract. Mirrors the tolerance `cleanup::can_reuse_cached_silence_regions`
+/// applies on the read side.
+const SILENCE_PARAMETER_EPSILON: f64 = 0.001;
+
+/// Provider label recorded on annotations written by `analysis shots`.
+const SHOT_DETECTOR_NAME: &str = "ffmpeg-scenedetect";
+
+// ── Arguments ───────────────────────────────────────────────────────────
+
+/// Arguments for `analysis shots`.
+#[derive(Args)]
+pub struct ShotsArgs {
+    /// Project directory path
+    #[arg(long)]
+    pub path: PathBuf,
+
+    /// Asset ID
+    #[arg(long)]
+    pub id: String,
+
+    /// Scene change threshold (0.0 - 1.0); lower values detect more cuts
+    #[arg(long, default_value_t = DEFAULT_SCENE_THRESHOLD)]
+    pub threshold: f64,
+
+    /// Minimum shot duration in seconds; shorter shots are merged
+    #[arg(long, default_value_t = DEFAULT_MIN_SHOT_DURATION)]
+    pub min_shot_duration: f64,
+
+    /// FFmpeg scene-detection timeout in seconds
+    #[arg(long, default_value_t = DEFAULT_FFMPEG_TIMEOUT_SECS)]
+    pub timeout_sec: u64,
+
+    /// Detect only: skip the index.db, bundle, and annotation writes
+    #[arg(long)]
+    pub no_persist: bool,
+}
+
+/// Arguments for `analysis silence`.
+#[derive(Args)]
+pub struct SilenceArgs {
+    /// Project directory path
+    #[arg(long)]
+    pub path: PathBuf,
+
+    /// Asset ID
+    #[arg(long)]
+    pub id: String,
+
+    /// Silence threshold in dB (negative values are expected, e.g. -40)
+    #[arg(long, allow_hyphen_values = true, default_value_t = DEFAULT_SILENCE_THRESHOLD_DB)]
+    pub threshold_db: f64,
+
+    /// Minimum silence duration in seconds
+    #[arg(long, default_value_t = DEFAULT_SILENCE_MIN_DURATION_SEC)]
+    pub min_duration: f64,
+}
+
+/// Arguments for `analysis audio`.
+#[derive(Args)]
+pub struct AudioArgs {
+    /// Project directory path
+    #[arg(long)]
+    pub path: PathBuf,
+
+    /// Asset ID
+    #[arg(long)]
+    pub id: String,
+}
+
+/// Arguments for `analysis run`.
+#[derive(Args)]
+pub struct RunArgs {
+    /// Project directory path
+    #[arg(long)]
+    pub path: PathBuf,
+
+    /// Asset ID
+    #[arg(long)]
+    pub id: String,
+
+    /// Run shot detection
+    #[arg(long)]
+    pub shots: bool,
+
+    /// Run audio profiling (silence, loudness, BPM, speech regions)
+    #[arg(long)]
+    pub audio: bool,
+
+    /// Run content segmentation (requires shots and audio)
+    #[arg(long)]
+    pub segments: bool,
+
+    /// Run speech-to-text transcription (requires an installed Whisper model)
+    #[arg(long)]
+    pub transcript: bool,
+
+    /// Run local visual frame analysis
+    #[arg(long)]
+    pub visual: bool,
+
+    /// Run every local sub-job; transcription stays off unless --transcript is given
+    #[arg(long)]
+    pub all: bool,
+
+    /// Stream NDJSON sub-job progress to stderr
+    #[arg(long)]
+    pub progress: bool,
+}
+
+// ── Verb entry points ───────────────────────────────────────────────────
+
+/// Detects shot boundaries and persists them for the GUI and the analysis cache.
+pub fn shots(args: ShotsArgs) -> anyhow::Result<()> {
+    validate::non_empty(&args.id, "id")?;
+    validate::time_non_negative(args.min_shot_duration, "min-shot-duration")?;
+    if !args.threshold.is_finite() || !(0.0..=1.0).contains(&args.threshold) {
+        return Err(anyhow::anyhow!(
+            "Invalid value for --threshold: must be between 0.0 and 1.0 (got {})",
+            args.threshold
+        ));
+    }
+    if args.timeout_sec == 0 {
+        return Err(anyhow::anyhow!(
+            "Invalid value for --timeout-sec: must be >= 1"
+        ));
+    }
+
+    let project = super::load_project(&args.path)?;
+    let asset = resolve_asset(&project, &args.id)?;
+    let media_path = asset.resolved_path(&project.path);
+    let ffmpeg_info = ensure_ffmpeg()?;
+
+    let detector = ShotDetector::with_config(ShotDetectorConfig {
+        threshold: args.threshold,
+        min_shot_duration: args.min_shot_duration,
+        ffmpeg_path: Some(ffmpeg_info.ffmpeg_path.clone()),
+        ffprobe_path: Some(ffmpeg_info.ffprobe_path.clone()),
+        ffmpeg_timeout: Duration::from_secs(args.timeout_sec),
+        ..ShotDetectorConfig::default()
+    });
+
+    let runtime = build_runtime()?;
+    let detected = runtime
+        .block_on(detector.detect(&media_path, &args.id))
+        .map_err(|error| describe_shot_error(error, args.timeout_sec))?;
+
+    let mut persisted: Vec<&str> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    if !args.no_persist {
+        match runtime.block_on(save_shots_to_index_db(&project.path, &detector, &detected)) {
+            Ok(()) => persisted.push("indexDb"),
+            Err(error) => warnings.push(format!("index.db write skipped: {}", error)),
+        }
+
+        let shot_results = to_shot_results(&detected);
+        let metadata =
+            runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
+
+        AnalysisJobRunner::new(&project.path)
+            .merge_bundle_shots(&args.id, &metadata, shot_results.clone())
+            .map_err(|error| anyhow::anyhow!("Failed to update the analysis bundle: {}", error))?;
+        persisted.push("bundle");
+
+        save_shot_annotation(
+            &project.path,
+            &args.id,
+            &asset.hash,
+            shot_results,
+            args.threshold,
+            args.min_shot_duration,
+        )?;
+        persisted.push("annotations");
+    }
+
+    let total_duration_sec = detected.last().map(|shot| shot.end_sec).unwrap_or(0.0);
+    let mut payload = json!({
+        "status": "ok",
+        "assetId": args.id,
+        "shotCount": detected.len(),
+        "totalDurationSec": total_duration_sec,
+        "shots": detected
+            .iter()
+            .enumerate()
+            .map(|(index, shot)| json!({
+                "index": index,
+                "startSec": shot.start_sec,
+                "endSec": shot.end_sec,
+                "durationSec": shot.duration(),
+                "confidence": shot.quality_score.unwrap_or(DEFAULT_SHOT_CONFIDENCE),
+            }))
+            .collect::<Vec<_>>(),
+        "persisted": persisted,
+    });
+    if !warnings.is_empty() {
+        payload["warnings"] = json!(warnings);
+    }
+
+    output::print_json_pretty(&payload)
+}
+
+/// Detects silence regions, caching them only when the parameters match the
+/// shared cache contract.
+pub fn silence(args: SilenceArgs) -> anyhow::Result<()> {
+    validate::non_empty(&args.id, "id")?;
+    if !args.threshold_db.is_finite() {
+        return Err(anyhow::anyhow!(
+            "Invalid value for --threshold-db: must be a finite number"
+        ));
+    }
+    if !args.min_duration.is_finite() || args.min_duration <= 0.0 {
+        return Err(anyhow::anyhow!(
+            "Invalid value for --min-duration: must be a positive finite number"
+        ));
+    }
+
+    let project = super::load_project(&args.path)?;
+    let asset = resolve_asset(&project, &args.id)?;
+    let media_path = asset.resolved_path(&project.path);
+    let ffmpeg_info = ensure_ffmpeg()?;
+
+    let runtime = build_runtime()?;
+    let profiler = AudioProfiler::new(ffmpeg_info.ffmpeg_path.clone());
+    let regions = runtime
+        .block_on(profiler.detect_silence_custom(&media_path, args.threshold_db, args.min_duration))
+        .map_err(|error| anyhow::anyhow!("Silence detection failed: {}", error))?;
+
+    let rejection = silence_cache_rejection(args.threshold_db, args.min_duration);
+    if rejection.is_none() {
+        let metadata =
+            runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
+        let cached_regions = regions.clone();
+        AnalysisJobRunner::new(&project.path)
+            .merge_bundle_update(&args.id, &metadata, move |bundle| {
+                apply_silence_regions(bundle, cached_regions)
+            })
+            .map_err(|error| anyhow::anyhow!("Failed to update the analysis bundle: {}", error))?;
+    }
+
+    let total_silence_sec: f64 = regions.iter().map(|region| region.duration()).sum();
+    let mut payload = json!({
+        "status": "ok",
+        "assetId": args.id,
+        "thresholdDb": args.threshold_db,
+        "minDurationSec": args.min_duration,
+        "regionCount": regions.len(),
+        "totalSilenceSec": total_silence_sec,
+        "regions": regions
+            .iter()
+            .map(|region| json!({
+                "startSec": region.start_sec,
+                "endSec": region.end_sec,
+                "durationSec": region.duration(),
+            }))
+            .collect::<Vec<_>>(),
+        "persisted": rejection.is_none(),
+    });
+    if let Some(reason) = rejection {
+        payload["reason"] = json!(reason);
+    }
+
+    output::print_json_pretty(&payload)
+}
+
+/// Runs the full audio profile (silence, loudness, BPM, speech regions).
+pub fn audio(args: AudioArgs) -> anyhow::Result<()> {
+    validate::non_empty(&args.id, "id")?;
+
+    let project = super::load_project(&args.path)?;
+    let asset = resolve_asset(&project, &args.id)?;
+    let media_path = asset.resolved_path(&project.path);
+    let ffmpeg_info = ensure_ffmpeg()?;
+
+    let runtime = build_runtime()?;
+    let metadata = runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
+    if !metadata.duration_sec.is_finite() || metadata.duration_sec <= 0.0 {
+        return Err(anyhow::anyhow!(
+            "Asset '{}' has no usable duration; audio profiling needs a decodable media file",
+            args.id
+        ));
+    }
+
+    let profiler = AudioProfiler::new(ffmpeg_info.ffmpeg_path.clone());
+    let profile = runtime
+        .block_on(profiler.analyze(&media_path, metadata.duration_sec))
+        .map_err(|error| anyhow::anyhow!("Audio profiling failed: {}", error))?;
+
+    AnalysisJobRunner::new(&project.path)
+        .merge_bundle_audio_profile(&args.id, &metadata, profile.clone())
+        .map_err(|error| anyhow::anyhow!("Failed to update the analysis bundle: {}", error))?;
+
+    let total_silence_sec: f64 = profile
+        .silence_regions
+        .iter()
+        .map(|region| region.duration())
+        .sum();
+    let total_speech_sec: f64 = profile
+        .speech_regions
+        .iter()
+        .map(|region| region.duration())
+        .sum();
+
+    output::print_json_pretty(&json!({
+        "status": "ok",
+        "assetId": args.id,
+        "durationSec": metadata.duration_sec,
+        "bpm": profile.bpm,
+        "peakDb": profile.peak_db,
+        "spectralCentroidHz": profile.spectral_centroid_hz,
+        "loudnessSampleCount": profile.loudness_profile.len(),
+        "silenceRegionCount": profile.silence_regions.len(),
+        "totalSilenceSec": total_silence_sec,
+        "speechRegionCount": profile.speech_regions.len(),
+        "totalSpeechSec": total_speech_sec,
+        "persisted": true,
+    }))
+}
+
+/// Runs the composable analysis pipeline and caches the resulting bundle.
+pub fn run(args: RunArgs) -> anyhow::Result<()> {
+    validate::non_empty(&args.id, "id")?;
+
+    let options = build_analysis_options(&args);
+    if !options.has_any() {
+        return Err(anyhow::anyhow!("No analysis sub-jobs were selected"));
+    }
+    if options.transcript {
+        ensure_transcription_ready()?;
+    }
+
+    let project = super::load_project(&args.path)?;
+    let asset = resolve_asset(&project, &args.id)?;
+    let media_path = asset.resolved_path(&project.path);
+    let ffmpeg_info = ensure_ffmpeg()?;
+
+    let runtime = build_runtime()?;
+    let metadata = runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
+
+    let runner = AnalysisJobRunner::new(&project.path);
+    // Captured before the run: `analyze_full_with_metadata` writes the bundle
+    // itself, so results the enabled sub-jobs do not produce are merged back
+    // afterwards instead of being dropped.
+    let previous = runner
+        .load_bundle_optional(&args.id)
+        .map_err(|error| anyhow::anyhow!("Failed to read the cached analysis bundle: {}", error))?;
+
+    let emit_progress = args.progress;
+    let bundle = runtime
+        .block_on(runner.analyze_full_with_metadata(
+            &args.id,
+            &media_path.to_string_lossy(),
+            metadata.clone(),
+            &options,
+            |job, status, detail| {
+                if emit_progress {
+                    emit_progress_line(job, status, detail);
+                }
+            },
+        ))
+        .map_err(|error| anyhow::anyhow!("Analysis run failed: {}", error))?;
+
+    let bundle = match previous {
+        Some(previous) => runner
+            .merge_bundle_update(&args.id, &metadata, |merged| {
+                merged.backfill_missing_from(&previous)
+            })
+            .map_err(|error| anyhow::anyhow!("Failed to merge the analysis bundle: {}", error))?,
+        None => bundle,
+    };
+
+    let enabled = enabled_job_names(&options);
+    let failed = enabled
+        .iter()
+        .filter(|job| bundle.errors.contains_key(**job))
+        .copied()
+        .collect::<Vec<_>>();
+    let all_failed = !enabled.is_empty() && failed.len() == enabled.len();
+    let status = if failed.is_empty() {
+        "ok"
+    } else if all_failed {
+        "failed"
+    } else {
+        "partial"
+    };
+
+    output::print_json_pretty(&json!({
+        "status": status,
+        "assetId": args.id,
+        "bundlePath": bundle_path(&project.path, &args.id).display().to_string(),
+        "options": {
+            "shots": options.shots,
+            "audio": options.audio,
+            "segments": options.segments,
+            "transcript": options.transcript,
+            "visual": options.visual,
+            "localOnly": options.local_only,
+        },
+        "durationSec": bundle.metadata.duration_sec,
+        "shotCount": bundle.shots.as_ref().map(Vec::len),
+        "segmentCount": bundle.segments.as_ref().map(Vec::len),
+        "transcriptSegmentCount": bundle.transcript.as_ref().map(Vec::len),
+        "frameAnalysisCount": bundle.frame_analysis.as_ref().map(Vec::len),
+        "hasAudioProfile": bundle.audio_profile.is_some(),
+        "contactSheetPath": bundle.contact_sheet.as_ref().map(|sheet| sheet.path.clone()),
+        "analyzedAt": bundle.analyzed_at,
+        "errors": bundle.errors,
+    }))?;
+
+    if all_failed {
+        return Err(anyhow::anyhow!(
+            "Every enabled analysis sub-job failed: {}",
+            failed.join(", ")
+        ));
+    }
+
+    Ok(())
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────────
+
+/// Confidence recorded for shots when FFmpeg reports no quality score.
+///
+/// Matches what `AnalysisJobRunner` stores, so bundles written by the CLI and
+/// by the GUI stay comparable.
+const DEFAULT_SHOT_CONFIDENCE: f64 = 0.9;
+
+fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))
+}
+
+fn resolve_asset<'a>(project: &'a ActiveProject, asset_id: &str) -> anyhow::Result<&'a Asset> {
+    project
+        .state
+        .assets
+        .get(asset_id)
+        .ok_or_else(|| anyhow::anyhow!("Asset '{}' not found", asset_id))
+}
+
+/// Path of the cached analysis bundle for an asset.
+fn bundle_path(project_dir: &Path, asset_id: &str) -> PathBuf {
+    project_dir
+        .join(".openreelio")
+        .join("analysis")
+        .join(asset_id)
+        .join("bundle.json")
+}
+
+/// Adds actionable guidance to the two shot-detection failures an agent can fix.
+fn describe_shot_error(error: CoreError, timeout_sec: u64) -> anyhow::Error {
+    match &error {
+        CoreError::ResourceExhausted(_) => anyhow::anyhow!(
+            "{}. Raise --threshold or --min-shot-duration so FFmpeg reports fewer scene cuts.",
+            error
+        ),
+        CoreError::Timeout(_) => anyhow::anyhow!(
+            "{}. Raise --timeout-sec above {}s for long sources.",
+            error,
+            timeout_sec
+        ),
+        _ => anyhow::anyhow!("Shot detection failed: {}", error),
+    }
+}
+
+/// Builds the analysis metadata, falling back to FFprobe when the asset record
+/// has no usable duration.
+async fn resolve_video_metadata(
+    asset: &Asset,
+    media_path: &Path,
+    ffmpeg_info: &FFmpegInfo,
+) -> anyhow::Result<VideoMetadata> {
+    if let Some(duration_sec) = asset.duration_sec.filter(|value| *value > 0.0) {
+        let has_audio = asset.audio.is_some();
+        return Ok(match asset.video.as_ref() {
+            Some(video) => VideoMetadata::new(duration_sec)
+                .with_dimensions(video.width, video.height)
+                .with_fps(video.fps.as_f64())
+                .with_codec(&video.codec)
+                .with_audio(has_audio),
+            None => VideoMetadata::new(duration_sec).with_audio(has_audio),
+        });
+    }
+
+    let runner = FFmpegRunner::new(ffmpeg_info.clone());
+    let probed = runner.probe(media_path).await.map_err(|error| {
+        anyhow::anyhow!("Failed to probe '{}': {}", media_path.display(), error)
+    })?;
+
+    let mut metadata = VideoMetadata::new(probed.duration_sec).with_audio(probed.audio.is_some());
+    if let Some(video) = probed.video.as_ref() {
+        metadata = metadata
+            .with_dimensions(video.width, video.height)
+            .with_fps(video.fps)
+            .with_codec(&video.codec);
+    }
+
+    Ok(metadata)
+}
+
+fn to_shot_results(shots: &[Shot]) -> Vec<ShotResult> {
+    shots
+        .iter()
+        .map(|shot| {
+            ShotResult::new(
+                shot.start_sec,
+                shot.end_sec,
+                shot.quality_score.unwrap_or(DEFAULT_SHOT_CONFIDENCE),
+            )
+        })
+        .collect()
+}
+
+/// Writes shots into the project's `index.db`, retrying transient lock errors.
+///
+/// A running GUI instance can hold the same database, so a busy database is
+/// retried rather than reported as a detection failure.
+async fn save_shots_to_index_db(
+    project_dir: &Path,
+    detector: &ShotDetector,
+    shots: &[Shot],
+) -> anyhow::Result<()> {
+    if shots.is_empty() {
+        return Ok(());
+    }
+
+    let index_db_path = project_dir.join("index.db");
+    let db = if index_db_path.exists() {
+        IndexDb::open(&index_db_path)
+    } else {
+        IndexDb::create(&index_db_path)
+    }
+    .map_err(|error| anyhow::anyhow!("{}", error))?;
+
+    let mut last_error = None;
+    for attempt in 0..INDEX_DB_WRITE_ATTEMPTS {
+        match detector.save_to_db(&db, shots) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(INDEX_DB_RETRY_BACKOFF * (attempt + 1)).await;
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "{}",
+        last_error.expect("a failed attempt always records an error")
+    ))
+}
+
+/// Stores shot results in the per-asset annotation file.
+fn save_shot_annotation(
+    project_dir: &Path,
+    asset_id: &str,
+    asset_hash: &str,
+    shots: Vec<ShotResult>,
+    threshold: f64,
+    min_shot_duration: f64,
+) -> anyhow::Result<()> {
+    let store = AnnotationStore::new(project_dir);
+    let mut annotation = store
+        .load(asset_id)
+        .map_err(|error| anyhow::anyhow!("Failed to read the asset annotation: {}", error))?
+        .unwrap_or_else(|| AssetAnnotation::new(asset_id, asset_hash));
+
+    // Assets imported without a computed hash keep whatever the annotation
+    // already recorded, so staleness detection is never downgraded.
+    if !asset_hash.is_empty() {
+        annotation.asset_hash = asset_hash.to_string();
+    }
+
+    annotation.set_shots(
+        AnalysisResult::new(AnalysisProvider::Ffmpeg, shots).with_config(json!({
+            "detector": SHOT_DETECTOR_NAME,
+            "threshold": threshold,
+            "minShotDuration": min_shot_duration,
+        })),
+    );
+
+    store
+        .save(&annotation)
+        .map_err(|error| anyhow::anyhow!("Failed to write the asset annotation: {}", error))
+}
+
+/// Writes freshly detected silence into the bundle's audio profile.
+///
+/// When no profile exists yet the remaining fields stay at their unmeasured
+/// defaults; `analysis audio` fills them in.
+fn apply_silence_regions(
+    bundle: &mut AnalysisBundle,
+    regions: Vec<openreelio_core::analysis::SilenceRegion>,
+) {
+    match bundle.audio_profile.as_mut() {
+        Some(profile) => profile.silence_regions = regions,
+        None => {
+            bundle.audio_profile = Some(AudioProfile {
+                bpm: None,
+                spectral_centroid_hz: 0.0,
+                loudness_profile: Vec::new(),
+                peak_db: SILENCE_FLOOR_DB,
+                silence_regions: regions,
+                speech_regions: Vec::new(),
+            })
+        }
+    }
+}
+
+/// Returns why freshly detected silence must not enter the shared cache.
+///
+/// The cache is defined to hold regions detected at -40 dB over 0.5 s: readers
+/// (the GUI cleanup panel) reuse it by *filtering* to a longer minimum
+/// duration. Writing regions detected with other parameters would silently
+/// answer those reads with the wrong set, so anything else stays output-only.
+///
+/// Note the asymmetry with `can_reuse_cached_silence_regions`: a reader asking
+/// for a longer minimum duration may reuse the cache, but a detection run with
+/// that longer minimum duration may not populate it.
+fn silence_cache_rejection(threshold_db: f64, min_duration_sec: f64) -> Option<&'static str> {
+    if (threshold_db - DEFAULT_SILENCE_THRESHOLD_DB).abs() > SILENCE_PARAMETER_EPSILON {
+        return Some("non-default threshold");
+    }
+    if (min_duration_sec - DEFAULT_SILENCE_MIN_DURATION_SEC).abs() > SILENCE_PARAMETER_EPSILON {
+        return Some("non-default min-duration");
+    }
+    None
+}
+
+/// Maps the `analysis run` flags onto the pipeline options.
+///
+/// With no sub-job flag the pipeline defaults apply (shots, audio, segments).
+/// `--all` adds visual analysis; transcription stays opt-in because it needs a
+/// downloaded Whisper model. `local_only` is always forced: the CLI has no
+/// vision-provider credentials, and the non-local path would extract keyframes
+/// twice for the same local result.
+fn build_analysis_options(args: &RunArgs) -> AnalysisOptions {
+    if args.all {
+        return AnalysisOptions {
+            shots: true,
+            audio: true,
+            segments: true,
+            transcript: args.transcript,
+            visual: true,
+            local_only: true,
+        };
+    }
+
+    let explicit = args.shots || args.audio || args.segments || args.transcript || args.visual;
+    if !explicit {
+        return AnalysisOptions {
+            local_only: true,
+            ..AnalysisOptions::default()
+        };
+    }
+
+    AnalysisOptions {
+        shots: args.shots,
+        audio: args.audio,
+        segments: args.segments,
+        transcript: args.transcript,
+        visual: args.visual,
+        local_only: true,
+    }
+}
+
+/// Names of the sub-jobs that were requested, in bundle error-key form.
+fn enabled_job_names(options: &AnalysisOptions) -> Vec<&'static str> {
+    let mut names = Vec::new();
+    if options.shots {
+        names.push("shots");
+    }
+    if options.audio {
+        names.push("audio");
+    }
+    if options.transcript {
+        names.push("transcript");
+    }
+    if options.segments {
+        names.push("segments");
+    }
+    if options.visual {
+        names.push("visual");
+    }
+    names
+}
+
+/// Fails before any FFmpeg work when transcription cannot succeed.
+fn ensure_transcription_ready() -> anyhow::Result<()> {
+    let status = super::transcription::build_transcription_status();
+    if !status.feature_available {
+        return Err(anyhow::anyhow!(
+            "Transcription is unavailable: this build was compiled without the whisper feature"
+        ));
+    }
+    if status.installed_count == 0 {
+        return Err(anyhow::anyhow!(
+            "No Whisper model is installed in '{}'. Run 'openreelio-cli transcription install --model auto' first.",
+            status.models_dir
+        ));
+    }
+    Ok(())
+}
+
+/// Writes one NDJSON progress record to stderr.
+///
+/// stdout stays reserved for the single result object.
+fn emit_progress_line(job: &str, status: &str, detail: Option<String>) {
+    let line: Value = json!({
+        "type": "progress",
+        "job": job,
+        "status": status,
+        "detail": detail,
+    });
+    eprintln!("{}", line);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openreelio_core::analysis::cleanup::can_reuse_cached_silence_regions;
+
+    fn run_args() -> RunArgs {
+        RunArgs {
+            path: PathBuf::from("."),
+            id: "asset_001".to_string(),
+            shots: false,
+            audio: false,
+            segments: false,
+            transcript: false,
+            visual: false,
+            all: false,
+            progress: false,
+        }
+    }
+
+    #[test]
+    fn build_analysis_options_should_use_pipeline_defaults_without_flags() {
+        let options = build_analysis_options(&run_args());
+
+        assert!(options.shots);
+        assert!(options.audio);
+        assert!(options.segments);
+        assert!(!options.transcript);
+        assert!(!options.visual);
+        assert!(options.local_only);
+    }
+
+    #[test]
+    fn build_analysis_options_should_honour_an_explicit_single_job() {
+        let options = build_analysis_options(&RunArgs {
+            shots: true,
+            ..run_args()
+        });
+
+        assert!(options.shots);
+        assert!(!options.audio);
+        assert!(!options.segments);
+        assert!(options.local_only);
+    }
+
+    #[test]
+    fn build_analysis_options_should_keep_transcription_off_for_all() {
+        let options = build_analysis_options(&RunArgs {
+            all: true,
+            ..run_args()
+        });
+
+        assert!(options.shots);
+        assert!(options.audio);
+        assert!(options.segments);
+        assert!(options.visual);
+        assert!(!options.transcript);
+    }
+
+    #[test]
+    fn build_analysis_options_should_add_transcription_to_all_when_requested() {
+        let options = build_analysis_options(&RunArgs {
+            all: true,
+            transcript: true,
+            ..run_args()
+        });
+
+        assert!(options.transcript);
+        assert!(options.visual);
+    }
+
+    #[test]
+    fn build_analysis_options_should_always_force_local_only() {
+        for args in [
+            run_args(),
+            RunArgs {
+                all: true,
+                ..run_args()
+            },
+            RunArgs {
+                visual: true,
+                ..run_args()
+            },
+        ] {
+            assert!(build_analysis_options(&args).local_only);
+        }
+    }
+
+    #[test]
+    fn enabled_job_names_should_list_only_requested_jobs() {
+        let options = build_analysis_options(&RunArgs {
+            shots: true,
+            visual: true,
+            ..run_args()
+        });
+
+        assert_eq!(enabled_job_names(&options), vec!["shots", "visual"]);
+    }
+
+    #[test]
+    fn silence_cache_rejection_should_accept_the_cached_contract() {
+        assert!(silence_cache_rejection(
+            DEFAULT_SILENCE_THRESHOLD_DB,
+            DEFAULT_SILENCE_MIN_DURATION_SEC
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn silence_cache_rejection_should_reject_other_thresholds() {
+        assert_eq!(
+            silence_cache_rejection(-30.0, DEFAULT_SILENCE_MIN_DURATION_SEC),
+            Some("non-default threshold")
+        );
+        assert_eq!(
+            silence_cache_rejection(-50.0, DEFAULT_SILENCE_MIN_DURATION_SEC),
+            Some("non-default threshold")
+        );
+    }
+
+    #[test]
+    fn silence_cache_rejection_should_reject_other_minimum_durations() {
+        assert_eq!(
+            silence_cache_rejection(DEFAULT_SILENCE_THRESHOLD_DB, 0.25),
+            Some("non-default min-duration")
+        );
+        assert_eq!(
+            silence_cache_rejection(DEFAULT_SILENCE_THRESHOLD_DB, 2.0),
+            Some("non-default min-duration")
+        );
+    }
+
+    #[test]
+    fn silence_cache_rejection_should_be_stricter_than_the_reuse_gate() {
+        // A reader asking for a longer minimum duration may filter the cache,
+        // but a run detecting at that duration must not populate it.
+        assert!(can_reuse_cached_silence_regions(
+            DEFAULT_SILENCE_THRESHOLD_DB,
+            2.0
+        ));
+        assert!(silence_cache_rejection(DEFAULT_SILENCE_THRESHOLD_DB, 2.0).is_some());
+    }
+
+    #[test]
+    fn apply_silence_regions_should_create_a_profile_when_none_exists() {
+        let mut bundle = AnalysisBundle::new("asset_001", VideoMetadata::new(10.0));
+
+        apply_silence_regions(
+            &mut bundle,
+            vec![openreelio_core::analysis::SilenceRegion::new(1.0, 3.0)],
+        );
+
+        let profile = bundle.audio_profile.expect("profile must be created");
+        assert_eq!(profile.silence_regions.len(), 1);
+        assert!(profile.loudness_profile.is_empty());
+        assert!(profile.bpm.is_none());
+    }
+
+    #[test]
+    fn apply_silence_regions_should_keep_measured_fields_of_an_existing_profile() {
+        let mut bundle = AnalysisBundle::new("asset_001", VideoMetadata::new(10.0));
+        bundle.audio_profile = Some(AudioProfile {
+            bpm: Some(120.0),
+            spectral_centroid_hz: 2500.0,
+            loudness_profile: vec![-18.0],
+            peak_db: -3.0,
+            silence_regions: Vec::new(),
+            speech_regions: Vec::new(),
+        });
+
+        apply_silence_regions(
+            &mut bundle,
+            vec![openreelio_core::analysis::SilenceRegion::new(0.0, 1.0)],
+        );
+
+        let profile = bundle.audio_profile.expect("profile must be preserved");
+        assert_eq!(profile.bpm, Some(120.0));
+        assert_eq!(profile.peak_db, -3.0);
+        assert_eq!(profile.silence_regions.len(), 1);
+    }
+
+    #[test]
+    fn bundle_path_should_match_the_cached_bundle_layout() {
+        let path = bundle_path(Path::new("/projects/demo"), "asset_001");
+
+        assert!(path.ends_with("asset_001/bundle.json"));
+        assert!(path
+            .to_string_lossy()
+            .contains(&format!(".openreelio{}analysis", std::path::MAIN_SEPARATOR)));
+    }
+
+    #[test]
+    fn to_shot_results_should_default_confidence_when_unscored() {
+        let results = to_shot_results(&[Shot::new("asset_001", 0.0, 2.0)]);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].confidence, DEFAULT_SHOT_CONFIDENCE);
+        assert_eq!(results[0].end_sec, 2.0);
+    }
+}

--- a/crates/openreelio-cli/src/commands/perception.rs
+++ b/crates/openreelio-cli/src/commands/perception.rs
@@ -162,6 +162,10 @@ pub struct RunArgs {
 // ── Verb entry points ───────────────────────────────────────────────────
 
 /// Detects shot boundaries and persists them for the GUI and the analysis cache.
+///
+/// The three persistence targets are independent: `persisted` names the stores
+/// that were written and `warnings` explains every store that was not, so a
+/// failure halfway through never leaves the agent guessing what changed.
 pub fn shots(args: ShotsArgs) -> anyhow::Result<()> {
     validate::non_empty(&args.id, "id")?;
     validate::time_non_negative(args.min_shot_duration, "min-shot-duration")?;
@@ -206,23 +210,35 @@ pub fn shots(args: ShotsArgs) -> anyhow::Result<()> {
         }
 
         let shot_results = to_shot_results(&detected);
-        let metadata =
-            runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
 
-        AnalysisJobRunner::new(&project.path)
-            .merge_bundle_shots(&args.id, &metadata, shot_results.clone())
-            .map_err(|error| anyhow::anyhow!("Failed to update the analysis bundle: {}", error))?;
-        persisted.push("bundle");
+        // Each target reports its own outcome: an early success followed by a
+        // later failure must still tell the agent which stores now hold the new
+        // shots, so no target aborts the command.
+        let bundle_write = runtime
+            .block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))
+            .and_then(|metadata| {
+                AnalysisJobRunner::new(&project.path)
+                    .merge_bundle_shots(&args.id, &metadata, shot_results.clone())
+                    .map_err(|error| {
+                        anyhow::anyhow!("Failed to update the analysis bundle: {}", error)
+                    })
+            });
+        match bundle_write {
+            Ok(_) => persisted.push("bundle"),
+            Err(error) => warnings.push(format!("bundle write skipped: {}", error)),
+        }
 
-        save_shot_annotation(
+        match save_shot_annotation(
             &project.path,
             &args.id,
             &asset.hash,
             shot_results,
             args.threshold,
             args.min_shot_duration,
-        )?;
-        persisted.push("annotations");
+        ) {
+            Ok(()) => persisted.push("annotations"),
+            Err(error) => warnings.push(format!("annotation write skipped: {}", error)),
+        }
     }
 
     let total_duration_sec = detected.last().map(|shot| shot.end_sec).unwrap_or(0.0);

--- a/crates/openreelio-cli/src/commands/perception.rs
+++ b/crates/openreelio-cli/src/commands/perception.rs
@@ -21,8 +21,7 @@ use openreelio_core::analysis::cleanup::{
     DEFAULT_SILENCE_MIN_DURATION_SEC, DEFAULT_SILENCE_THRESHOLD_DB,
 };
 use openreelio_core::analysis::{
-    AnalysisBundle, AnalysisJobRunner, AnalysisOptions, AudioProfile, VideoMetadata,
-    SILENCE_FLOOR_DB,
+    AnalysisBundle, AnalysisJobRunner, AnalysisOptions, VideoMetadata,
 };
 use openreelio_core::annotations::{
     AnalysisProvider, AnalysisResult, AnnotationStore, AssetAnnotation, ShotResult,
@@ -54,6 +53,9 @@ const SILENCE_PARAMETER_EPSILON: f64 = 0.001;
 
 /// Provider label recorded on annotations written by `analysis shots`.
 const SHOT_DETECTOR_NAME: &str = "ffmpeg-scenedetect";
+
+/// Reported when silence cannot be cached because no audio profile exists yet.
+const NO_AUDIO_PROFILE_REASON: &str = "no audio profile in bundle; run `analysis audio` first";
 
 // ── Arguments ───────────────────────────────────────────────────────────
 
@@ -250,7 +252,10 @@ pub fn shots(args: ShotsArgs) -> anyhow::Result<()> {
 }
 
 /// Detects silence regions, caching them only when the parameters match the
-/// shared cache contract.
+/// shared cache contract and an audio profile already exists to merge into.
+///
+/// Detection always runs and always reports its regions; `persisted` says
+/// whether they also entered the bundle, and `reason` says why not.
 pub fn silence(args: SilenceArgs) -> anyhow::Result<()> {
     validate::non_empty(&args.id, "id")?;
     if !args.threshold_db.is_finite() {
@@ -275,16 +280,35 @@ pub fn silence(args: SilenceArgs) -> anyhow::Result<()> {
         .block_on(profiler.detect_silence_custom(&media_path, args.threshold_db, args.min_duration))
         .map_err(|error| anyhow::anyhow!("Silence detection failed: {}", error))?;
 
-    let rejection = silence_cache_rejection(args.threshold_db, args.min_duration);
+    let mut rejection = silence_cache_rejection(args.threshold_db, args.min_duration);
     if rejection.is_none() {
-        let metadata =
-            runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
-        let cached_regions = regions.clone();
-        AnalysisJobRunner::new(&project.path)
-            .merge_bundle_update(&args.id, &metadata, move |bundle| {
-                apply_silence_regions(bundle, cached_regions)
-            })
-            .map_err(|error| anyhow::anyhow!("Failed to update the analysis bundle: {}", error))?;
+        let runner = AnalysisJobRunner::new(&project.path);
+        // Silence regions live inside the audio profile, and the rest of that
+        // profile is measured, not defaulted. Without an existing profile there
+        // is nothing to merge into, and inventing one would publish invented
+        // measurements to `analysis report` and the GUI cleanup panel.
+        let has_audio_profile = runner
+            .load_bundle_optional(&args.id)
+            .map_err(|error| {
+                anyhow::anyhow!("Failed to read the cached analysis bundle: {}", error)
+            })?
+            .and_then(|bundle| bundle.audio_profile)
+            .is_some();
+
+        if has_audio_profile {
+            let metadata =
+                runtime.block_on(resolve_video_metadata(asset, &media_path, &ffmpeg_info))?;
+            let cached_regions = regions.clone();
+            runner
+                .merge_bundle_update(&args.id, &metadata, move |bundle| {
+                    apply_silence_regions(bundle, cached_regions)
+                })
+                .map_err(|error| {
+                    anyhow::anyhow!("Failed to update the analysis bundle: {}", error)
+                })?;
+        } else {
+            rejection = Some(NO_AUDIO_PROFILE_REASON);
+        }
     }
 
     let total_silence_sec: f64 = regions.iter().map(|region| region.duration()).sum();
@@ -634,26 +658,19 @@ fn save_shot_annotation(
         .map_err(|error| anyhow::anyhow!("Failed to write the asset annotation: {}", error))
 }
 
-/// Writes freshly detected silence into the bundle's audio profile.
+/// Writes freshly detected silence into an existing audio profile.
 ///
-/// When no profile exists yet the remaining fields stay at their unmeasured
-/// defaults; `analysis audio` fills them in.
+/// Does nothing when the bundle carries no profile: every other field of an
+/// [`AudioProfile`](openreelio_core::analysis::AudioProfile) is a measurement,
+/// and a placeholder would be indistinguishable from one. Callers check for the
+/// profile first and report `persisted: false` instead (see
+/// [`NO_AUDIO_PROFILE_REASON`]).
 fn apply_silence_regions(
     bundle: &mut AnalysisBundle,
     regions: Vec<openreelio_core::analysis::SilenceRegion>,
 ) {
-    match bundle.audio_profile.as_mut() {
-        Some(profile) => profile.silence_regions = regions,
-        None => {
-            bundle.audio_profile = Some(AudioProfile {
-                bpm: None,
-                spectral_centroid_hz: 0.0,
-                loudness_profile: Vec::new(),
-                peak_db: SILENCE_FLOOR_DB,
-                silence_regions: regions,
-                speech_regions: Vec::new(),
-            })
-        }
+    if let Some(profile) = bundle.audio_profile.as_mut() {
+        profile.silence_regions = regions;
     }
 }
 
@@ -769,6 +786,7 @@ fn emit_progress_line(job: &str, status: &str, detail: Option<String>) {
 mod tests {
     use super::*;
     use openreelio_core::analysis::cleanup::can_reuse_cached_silence_regions;
+    use openreelio_core::analysis::AudioProfile;
 
     fn run_args() -> RunArgs {
         RunArgs {
@@ -908,7 +926,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_silence_regions_should_create_a_profile_when_none_exists() {
+    fn apply_silence_regions_should_not_fabricate_a_profile_when_none_exists() {
         let mut bundle = AnalysisBundle::new("asset_001", VideoMetadata::new(10.0));
 
         apply_silence_regions(
@@ -916,10 +934,10 @@ mod tests {
             vec![openreelio_core::analysis::SilenceRegion::new(1.0, 3.0)],
         );
 
-        let profile = bundle.audio_profile.expect("profile must be created");
-        assert_eq!(profile.silence_regions.len(), 1);
-        assert!(profile.loudness_profile.is_empty());
-        assert!(profile.bpm.is_none());
+        assert!(
+            bundle.audio_profile.is_none(),
+            "a placeholder peak level and centroid would read as measurements"
+        );
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -1,10 +1,9 @@
 //! Render and export commands.
 
+use crate::ffmpeg_env::ensure_ffmpeg;
 use crate::output;
 use clap::Subcommand;
-use openreelio_core::ffmpeg::{
-    detect_bundled_at_path, detect_system_ffmpeg, set_resolved_paths, FFmpegRunner,
-};
+use openreelio_core::ffmpeg::FFmpegRunner;
 use openreelio_core::render::{
     build_render_graph, build_render_plan, validate_export_settings, AudioCodec, ExportEngine,
     ExportPreset, ExportSettings, HdrMode, VideoCodec,
@@ -114,7 +113,7 @@ pub fn execute(action: RenderAction) -> anyhow::Result<()> {
             }
             let plan_hash = render_plan.plan_hash.clone();
 
-            let ffmpeg_info = detect_cli_ffmpeg()?;
+            let ffmpeg_info = ensure_ffmpeg()?;
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
@@ -198,32 +197,4 @@ fn build_export_settings(preset: &str, output_path: PathBuf) -> anyhow::Result<E
     };
 
     Ok(settings)
-}
-
-fn detect_cli_ffmpeg() -> anyhow::Result<openreelio_core::ffmpeg::FFmpegInfo> {
-    let candidate_roots = [
-        std::env::current_dir()
-            .ok()
-            .map(|path| path.join("src-tauri")),
-        std::env::current_dir().ok(),
-        std::env::current_exe()
-            .ok()
-            .and_then(|path| path.parent().map(|parent| parent.to_path_buf())),
-    ];
-
-    let info = candidate_roots
-        .into_iter()
-        .flatten()
-        .find_map(|root| detect_bundled_at_path(&root).ok())
-        .map(Ok)
-        .unwrap_or_else(|| {
-            detect_system_ffmpeg()
-                .map_err(|error| anyhow::anyhow!("FFmpeg initialization failed: {}", error))
-        })?;
-
-    // Publish the detected paths so core modules that spawn ffmpeg/ffprobe
-    // directly resolve the same binaries instead of relying on PATH.
-    set_resolved_paths(info.ffmpeg_path.clone(), info.ffprobe_path.clone());
-
-    Ok(info)
 }

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -9,6 +9,7 @@ use openreelio_core::render::{
     build_render_graph, build_render_plan, validate_export_settings, AudioCodec, ExportEngine,
     ExportPreset, ExportProgress, ExportSettings, HdrMode, VideoCodec,
 };
+use openreelio_core::timeline::Canvas;
 use std::path::PathBuf;
 
 /// Canonical list of render presets. Single source of truth for both
@@ -175,7 +176,8 @@ fn start_render(args: StartArgs) -> anyhow::Result<()> {
         .clone();
     let assets = project.state.assets.clone();
     let effects = project.state.effects.clone();
-    let settings = build_export_settings(&preset_id, output_path, start, end)?;
+    let settings =
+        build_export_settings(&preset_id, output_path, &sequence.format.canvas, start, end)?;
     let graph = build_render_graph(&project.state, &seq_id)
         .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
 
@@ -303,9 +305,14 @@ fn default_extension(path: PathBuf, extension: &str) -> PathBuf {
     path.with_extension(extension)
 }
 
+/// Builds export settings for a named preset.
+///
+/// `canvas` is the sequence canvas: the proxy preset fits its frame to it so a
+/// vertical or square edit is not pillarboxed into a 16:9 proxy.
 fn build_export_settings(
     preset: &str,
     output_path: PathBuf,
+    canvas: &Canvas,
     start_time: Option<f64>,
     end_time: Option<f64>,
 ) -> anyhow::Result<ExportSettings> {
@@ -343,7 +350,7 @@ fn build_export_settings(
         "mp4_draft" | "mp4_h264_720p" | "draft" => {
             ExportSettings::from_preset(ExportPreset::Mp4Draft, output_path)
         }
-        "proxy_480p" | "proxy" => ExportSettings::proxy(output_path, start_time, end_time),
+        "proxy_480p" | "proxy" => ExportSettings::proxy(output_path, canvas, start_time, end_time),
         "webm_vp9_1080p" | "webm_vp9" | "webm" => {
             ExportSettings::from_preset(ExportPreset::WebmVp9, output_path)
         }
@@ -380,8 +387,14 @@ mod tests {
 
     #[test]
     fn build_export_settings_should_apply_proxy_dimensions_and_speed() {
-        let settings =
-            build_export_settings(PROXY_PRESET_ID, PathBuf::from("proxy.mp4"), None, None).unwrap();
+        let settings = build_export_settings(
+            PROXY_PRESET_ID,
+            PathBuf::from("proxy.mp4"),
+            &Canvas::new(1920, 1080),
+            None,
+            None,
+        )
+        .unwrap();
 
         assert_eq!(settings.width, Some(854));
         assert_eq!(settings.height, Some(480));
@@ -389,10 +402,26 @@ mod tests {
     }
 
     #[test]
+    fn build_export_settings_should_fit_the_proxy_to_a_vertical_canvas() {
+        let settings = build_export_settings(
+            PROXY_PRESET_ID,
+            PathBuf::from("proxy.mp4"),
+            &Canvas::new(1080, 1920),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(settings.width, Some(480));
+        assert_eq!(settings.height, Some(854));
+    }
+
+    #[test]
     fn build_export_settings_should_carry_the_requested_range() {
         let settings = build_export_settings(
             "mp4_h264_1080p",
             PathBuf::from("out.mp4"),
+            &Canvas::new(1920, 1080),
             Some(1.5),
             Some(4.0),
         )

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -2,11 +2,12 @@
 
 use crate::ffmpeg_env::ensure_ffmpeg;
 use crate::output;
+use crate::validate;
 use clap::Subcommand;
 use openreelio_core::ffmpeg::FFmpegRunner;
 use openreelio_core::render::{
     build_render_graph, build_render_plan, validate_export_settings, AudioCodec, ExportEngine,
-    ExportPreset, ExportSettings, HdrMode, VideoCodec,
+    ExportPreset, ExportProgress, ExportSettings, HdrMode, VideoCodec,
 };
 use std::path::PathBuf;
 
@@ -16,9 +17,18 @@ const RENDER_PRESETS: &[(&str, &str, &str)] = &[
     ("mp4_h264_1080p", "MP4 H.264 1080p", "mp4"),
     ("mp4_h264_4k", "MP4 H.264 4K", "mp4"),
     ("mp4_h265_1080p", "MP4 H.265 1080p", "mp4"),
+    ("mp4_draft", "MP4 H.264 720p Draft", "mp4"),
+    ("proxy_480p", "Proxy 480p (fast, agent inspection)", "mp4"),
     ("webm_vp9_1080p", "WebM VP9 1080p", "webm"),
     ("prores_422", "ProRes 422", "mov"),
 ];
+
+/// Preset identifier selected by the `--proxy` shorthand.
+const PROXY_PRESET_ID: &str = "proxy_480p";
+
+/// Progress channel depth. Bounded so a slow stderr consumer applies
+/// backpressure to the progress reader instead of growing without limit.
+const PROGRESS_CHANNEL_CAPACITY: usize = 32;
 
 #[derive(Subcommand)]
 pub enum RenderAction {
@@ -50,9 +60,25 @@ pub enum RenderAction {
         #[arg(long, default_value = "mp4_h264_1080p")]
         preset: String,
 
+        /// Render a fast 480p proxy for inspection (shorthand for --preset proxy_480p)
+        #[arg(long, conflicts_with = "preset")]
+        proxy: bool,
+
         /// Sequence ID (defaults to active)
         #[arg(long)]
         sequence: Option<String>,
+
+        /// Start of the rendered range in timeline seconds
+        #[arg(long)]
+        start: Option<f64>,
+
+        /// End of the rendered range in timeline seconds
+        #[arg(long)]
+        end: Option<f64>,
+
+        /// Stream NDJSON encode progress to stderr
+        #[arg(long)]
+        progress: bool,
     },
 }
 
@@ -81,76 +107,210 @@ pub fn execute(action: RenderAction) -> anyhow::Result<()> {
             path,
             output: output_path,
             preset,
+            proxy,
             sequence,
-        } => {
-            let project = super::load_project(&path)?;
-            let seq_id = super::resolve_sequence_id(&project, sequence)?;
-            let sequence = project
-                .state
-                .sequences
-                .get(&seq_id)
-                .ok_or_else(|| anyhow::anyhow!("Sequence '{}' not found", seq_id))?
-                .clone();
-            let assets = project.state.assets.clone();
-            let effects = project.state.effects.clone();
-            let settings = build_export_settings(&preset, output_path.clone())?;
-            let graph = build_render_graph(&project.state, &seq_id)
-                .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
-
-            let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
-            if !validation.is_valid {
-                return Err(anyhow::anyhow!(
-                    "Render validation failed: {}",
-                    validation.errors.join("; ")
-                ));
-            }
-            let render_plan = build_render_plan(&graph, &assets, &effects, &settings);
-            if !render_plan.validation.is_valid {
-                return Err(anyhow::anyhow!(
-                    "Render plan validation failed: {}",
-                    render_plan.validation.errors.join("; ")
-                ));
-            }
-            let plan_hash = render_plan.plan_hash.clone();
-
-            let ffmpeg_info = ensure_ffmpeg()?;
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))?;
-            let result = runtime.block_on(async move {
-                let engine = ExportEngine::new(FFmpegRunner::new(ffmpeg_info));
-                engine
-                    .export_sequence_with_effects_for_plan(
-                        &sequence,
-                        &assets,
-                        &effects,
-                        &settings,
-                        &render_plan,
-                        None,
-                        None,
-                    )
-                    .await
-            })?;
-
-            output::print_json_pretty(&serde_json::json!({
-                "status": "ok",
-                "sequenceId": seq_id,
-                "preset": preset,
-                "outputPath": result.output_path.display().to_string(),
-                "durationSec": result.duration_sec,
-                "fileSize": result.file_size,
-                "encodingTimeSec": result.encoding_time_sec,
-                "planHash": plan_hash,
-                "warnings": validation.warnings,
-            }))
-        }
+            start,
+            end,
+            progress,
+        } => start_render(StartArgs {
+            path,
+            output_path,
+            preset,
+            proxy,
+            sequence,
+            start,
+            end,
+            progress,
+        }),
     }
 }
 
-fn build_export_settings(preset: &str, output_path: PathBuf) -> anyhow::Result<ExportSettings> {
+/// Parsed `render start` inputs.
+///
+/// Kept as a struct so the `Commands` enum stays small (see the crate-level
+/// `large_enum_variant` allowance) and the handler signature stays readable.
+struct StartArgs {
+    path: PathBuf,
+    output_path: PathBuf,
+    preset: String,
+    proxy: bool,
+    sequence: Option<String>,
+    start: Option<f64>,
+    end: Option<f64>,
+    progress: bool,
+}
+
+fn start_render(args: StartArgs) -> anyhow::Result<()> {
+    let StartArgs {
+        path,
+        output_path,
+        preset,
+        proxy,
+        sequence,
+        start,
+        end,
+        progress,
+    } = args;
+
+    validate_render_range(start, end)?;
+
+    let preset_id = if proxy {
+        PROXY_PRESET_ID.to_string()
+    } else {
+        preset
+    };
+    let output_path = if proxy {
+        default_extension(output_path, "mp4")
+    } else {
+        output_path
+    };
+
+    let project = super::load_project(&path)?;
+    let seq_id = super::resolve_sequence_id(&project, sequence)?;
+    let sequence = project
+        .state
+        .sequences
+        .get(&seq_id)
+        .ok_or_else(|| anyhow::anyhow!("Sequence '{}' not found", seq_id))?
+        .clone();
+    let assets = project.state.assets.clone();
+    let effects = project.state.effects.clone();
+    let settings = build_export_settings(&preset_id, output_path, start, end)?;
+    let graph = build_render_graph(&project.state, &seq_id)
+        .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
+
+    let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
+    if !validation.is_valid {
+        return Err(anyhow::anyhow!(
+            "Render validation failed: {}",
+            validation.errors.join("; ")
+        ));
+    }
+    let render_plan = build_render_plan(&graph, &assets, &effects, &settings);
+    if !render_plan.validation.is_valid {
+        return Err(anyhow::anyhow!(
+            "Render plan validation failed: {}",
+            render_plan.validation.errors.join("; ")
+        ));
+    }
+    let plan_hash = render_plan.plan_hash.clone();
+
+    let ffmpeg_info = ensure_ffmpeg()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))?;
+    let result = runtime.block_on(async move {
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+        // Ctrl-C must reach FFmpeg: without this the CLI would exit while the
+        // child keeps encoding into a half-written output file.
+        let signal_task = tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                let _ = cancel_tx.send(());
+            }
+        });
+
+        let (progress_tx, progress_task) = if progress {
+            let (tx, mut rx) =
+                tokio::sync::mpsc::channel::<ExportProgress>(PROGRESS_CHANNEL_CAPACITY);
+            let task = tokio::spawn(async move {
+                while let Some(update) = rx.recv().await {
+                    emit_progress_line(&update);
+                }
+            });
+            (Some(tx), Some(task))
+        } else {
+            (None, None)
+        };
+
+        let engine = ExportEngine::new(FFmpegRunner::new(ffmpeg_info));
+        let export = engine
+            .export_sequence_with_effects_for_plan(
+                &sequence,
+                &assets,
+                &effects,
+                &settings,
+                &render_plan,
+                progress_tx,
+                Some(cancel_rx),
+            )
+            .await;
+
+        signal_task.abort();
+        if let Some(task) = progress_task {
+            let _ = task.await;
+        }
+
+        export
+    });
+
+    let result = result.map_err(|error| match error {
+        openreelio_core::render::ExportError::Cancelled => {
+            anyhow::anyhow!("Render cancelled; the partial output file was removed")
+        }
+        other => anyhow::anyhow!(other),
+    })?;
+
+    output::print_json_pretty(&serde_json::json!({
+        "status": "ok",
+        "sequenceId": seq_id,
+        "preset": preset_id,
+        "outputPath": result.output_path.display().to_string(),
+        "durationSec": result.duration_sec,
+        "fileSize": result.file_size,
+        "encodingTimeSec": result.encoding_time_sec,
+        "planHash": plan_hash,
+        "warnings": validation.warnings,
+    }))
+}
+
+/// Write one NDJSON progress record to stderr.
+///
+/// stdout stays reserved for the single result object, so progress goes to
+/// stderr where a supervising agent can read it line by line.
+fn emit_progress_line(update: &ExportProgress) {
+    let line = serde_json::json!({
+        "type": "progress",
+        "percent": update.percent,
+        "frame": update.frame,
+        "totalFrames": update.total_frames,
+        "fps": update.fps,
+        "etaSeconds": update.eta_seconds,
+        "message": update.message,
+    });
+    eprintln!("{}", line);
+}
+
+/// Validates the optional `--start` / `--end` render range.
+fn validate_render_range(start: Option<f64>, end: Option<f64>) -> anyhow::Result<()> {
+    if let Some(start) = start {
+        validate::time_non_negative(start, "start")?;
+    }
+    if let Some(end) = end {
+        validate::time_non_negative(end, "end")?;
+    }
+    if let (Some(start), Some(end)) = (start, end) {
+        validate::time_range_ordered(start, end, "start", "end")?;
+    }
+    Ok(())
+}
+
+/// Appends `extension` when the path has none, leaving explicit extensions alone.
+fn default_extension(path: PathBuf, extension: &str) -> PathBuf {
+    if path.extension().is_some() {
+        return path;
+    }
+    path.with_extension(extension)
+}
+
+fn build_export_settings(
+    preset: &str,
+    output_path: PathBuf,
+    start_time: Option<f64>,
+    end_time: Option<f64>,
+) -> anyhow::Result<ExportSettings> {
     let normalized = preset.trim().to_lowercase();
-    let settings = match normalized.as_str() {
+    let mut settings = match normalized.as_str() {
         "mp4_h264_1080p" | "youtube_1080p" | "youtube1080p" => {
             ExportSettings::from_preset(ExportPreset::Youtube1080p, output_path)
         }
@@ -178,7 +338,12 @@ fn build_export_settings(preset: &str, output_path: PathBuf) -> anyhow::Result<E
             tonemap_mode: None,
             hardware_accel: Default::default(),
             resolved_encoder_name: None,
+            encoder_speed: None,
         },
+        "mp4_draft" | "mp4_h264_720p" | "draft" => {
+            ExportSettings::from_preset(ExportPreset::Mp4Draft, output_path)
+        }
+        "proxy_480p" | "proxy" => ExportSettings::proxy(output_path, start_time, end_time),
         "webm_vp9_1080p" | "webm_vp9" | "webm" => {
             ExportSettings::from_preset(ExportPreset::WebmVp9, output_path)
         }
@@ -196,5 +361,64 @@ fn build_export_settings(preset: &str, output_path: PathBuf) -> anyhow::Result<E
         }
     };
 
+    settings.start_time = start_time;
+    settings.end_time = end_time;
+
     Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_presets_should_expose_the_proxy_preset() {
+        assert!(RENDER_PRESETS
+            .iter()
+            .any(|(id, _, ext)| *id == PROXY_PRESET_ID && *ext == "mp4"));
+    }
+
+    #[test]
+    fn build_export_settings_should_apply_proxy_dimensions_and_speed() {
+        let settings =
+            build_export_settings(PROXY_PRESET_ID, PathBuf::from("proxy.mp4"), None, None).unwrap();
+
+        assert_eq!(settings.width, Some(854));
+        assert_eq!(settings.height, Some(480));
+        assert_eq!(settings.encoder_speed.as_deref(), Some("ultrafast"));
+    }
+
+    #[test]
+    fn build_export_settings_should_carry_the_requested_range() {
+        let settings = build_export_settings(
+            "mp4_h264_1080p",
+            PathBuf::from("out.mp4"),
+            Some(1.5),
+            Some(4.0),
+        )
+        .unwrap();
+
+        assert_eq!(settings.start_time, Some(1.5));
+        assert_eq!(settings.end_time, Some(4.0));
+    }
+
+    #[test]
+    fn validate_render_range_should_reject_inverted_ranges() {
+        assert!(validate_render_range(Some(5.0), Some(1.0)).is_err());
+        assert!(validate_render_range(Some(-1.0), None).is_err());
+        assert!(validate_render_range(Some(0.0), Some(1.0)).is_ok());
+        assert!(validate_render_range(None, None).is_ok());
+    }
+
+    #[test]
+    fn default_extension_should_only_fill_missing_extensions() {
+        assert_eq!(
+            default_extension(PathBuf::from("out"), "mp4"),
+            PathBuf::from("out.mp4")
+        );
+        assert_eq!(
+            default_extension(PathBuf::from("out.mov"), "mp4"),
+            PathBuf::from("out.mov")
+        );
+    }
 }

--- a/crates/openreelio-cli/src/commands/transcription.rs
+++ b/crates/openreelio-cli/src/commands/transcription.rs
@@ -1,5 +1,6 @@
 //! Speech-to-text transcription commands.
 
+use crate::ffmpeg_env::ensure_ffmpeg;
 use crate::output;
 use clap::Subcommand;
 use openreelio_core::assets::AssetKind;
@@ -459,7 +460,10 @@ pub(crate) fn generate_asset_transcription(
         ));
     }
 
-    let asset_path = PathBuf::from(&asset.uri);
+    // Audio extraction spawns ffmpeg, so the binaries must be registered first.
+    ensure_ffmpeg()?;
+
+    let asset_path = asset.resolved_path(&project.path);
     let temp_dir = std::env::temp_dir()
         .join("openreelio")
         .join("cli-transcription");
@@ -544,6 +548,9 @@ pub(crate) fn generate_sequence_transcription(
             model_size.filename()
         ));
     }
+
+    // The sequence mixdown spawns ffmpeg, so the binaries must be registered first.
+    ensure_ffmpeg()?;
 
     let temp_dir = std::env::temp_dir()
         .join("openreelio")

--- a/crates/openreelio-cli/src/commands/verify.rs
+++ b/crates/openreelio-cli/src/commands/verify.rs
@@ -1,0 +1,894 @@
+//! Deterministic QC for a sequence, with or without a rendered file.
+//!
+//! `verify` is the agent's self-check: it runs the shared QC engine over the
+//! project state and, when a rendered file is supplied, over measurements taken
+//! from that file. Every check that ran appears in the output — including the
+//! ones that passed — because an agent cannot act on a report that silently
+//! omits what it did not look at.
+//!
+//! Exit codes: `0` ran without breaching the threshold, `1` threshold breached,
+//! `2` the tool itself failed (bad arguments, unreadable file, FFmpeg failure,
+//! or a rule that errored, leaving the verdict incomplete).
+//!
+//! Measurement times are file-relative while structural findings are
+//! timeline-relative. The two are compared directly (see
+//! [`crossref_black_ranges_with_gaps`]), so `--file` expects a render of the
+//! whole sequence from timeline zero; a partial render (`render start --start`)
+//! still measures correctly but its timestamps no longer line up with the
+//! timeline.
+
+use crate::ffmpeg_env::ensure_ffmpeg;
+use crate::output;
+use clap::Args;
+use openreelio_core::ffmpeg::FFmpegRunner;
+use openreelio_core::qc::{
+    crossref_black_ranges_with_gaps, measure_rendered_file_detailed, MeasureOptions,
+    MeasurementReport, QCEngine, QCEngineConfig, QCReport, QCSeverityFilter, RuleStatus, Severity,
+};
+use openreelio_core::timeline::Sequence;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Exit code for a report that breached the `--fail-on` threshold.
+const EXIT_THRESHOLD_BREACHED: i32 = 1;
+
+/// Exit code for a failure of the tool itself.
+const EXIT_TOOL_FAILURE: i32 = 2;
+
+/// Checks that are disabled unless explicitly requested via `--checks`.
+///
+/// Both encode expectations `verify` cannot confirm on its own: licence
+/// paperwork lives outside the project file, and duration limits depend on the
+/// delivery platform. Left on by default they would fail every healthy project.
+const OPT_IN_CHECK_IDS: &[&str] = &["asset.license", "sequence.duration"];
+
+/// Check ID of the loudness rule, wired to `--target-lufs`.
+const LOUDNESS_CHECK_ID: &str = "audio.loudness";
+
+/// Check ID of the peak rule, wired to `--max-true-peak`.
+const PEAK_CHECK_ID: &str = "audio.peak";
+
+/// Arguments for `verify`.
+#[derive(Args)]
+pub struct VerifyArgs {
+    /// Project directory path
+    #[arg(long)]
+    pub path: PathBuf,
+
+    /// Sequence ID (defaults to active)
+    #[arg(long)]
+    pub sequence: Option<String>,
+
+    /// Rendered file to measure; without it only structural checks run
+    #[arg(long, conflicts_with = "structural_only")]
+    pub file: Option<PathBuf>,
+
+    /// Run structural checks only and never touch FFmpeg
+    #[arg(long)]
+    pub structural_only: bool,
+
+    /// Run only these check IDs (comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    pub checks: Option<Vec<String>>,
+
+    /// Skip these check IDs (comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    pub skip: Option<Vec<String>>,
+
+    /// Integrated loudness target in LUFS
+    #[arg(long)]
+    pub target_lufs: Option<f64>,
+
+    /// Maximum acceptable true peak in dBTP
+    #[arg(long)]
+    pub max_true_peak: Option<f64>,
+
+    /// Lowest severity that fails the run: info, warning, error, critical
+    #[arg(long, default_value = "error")]
+    pub fail_on: String,
+
+    /// Timeout for the rendered-file measurement pass, in seconds
+    #[arg(long, default_value_t = 600)]
+    pub timeout_sec: u64,
+
+    /// Pretty-print the JSON output
+    #[arg(long)]
+    pub json_pretty: bool,
+}
+
+pub fn execute(args: VerifyArgs) -> anyhow::Result<()> {
+    match run(args) {
+        Ok(0) => Ok(()),
+        Ok(exit_code) => {
+            flush_stdout();
+            std::process::exit(exit_code)
+        }
+        Err(error) => {
+            flush_stdout();
+            eprintln!("error: {error}");
+            std::process::exit(EXIT_TOOL_FAILURE)
+        }
+    }
+}
+
+/// Runs the verification and returns the process exit code.
+///
+/// Returning `Err` means the tool failed before it could produce a report; a
+/// report that merely found problems returns `Ok` with a non-zero code.
+fn run(args: VerifyArgs) -> anyhow::Result<i32> {
+    let fail_on = parse_severity(&args.fail_on)?;
+    if args.timeout_sec == 0 {
+        return Err(anyhow::anyhow!(
+            "Invalid value for --timeout-sec: must be >= 1"
+        ));
+    }
+
+    let project = super::load_project(&args.path)?;
+    let sequence_id = super::resolve_sequence_id(&project, args.sequence.clone())?;
+    let sequence = project
+        .state
+        .sequences
+        .get(&sequence_id)
+        .ok_or_else(|| anyhow::anyhow!("Sequence '{}' not found", sequence_id))?;
+
+    let engine = QCEngine::new();
+    let config = build_engine_config(&engine, &args)?;
+    let selected_ids = enabled_check_ids(&engine, &config);
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))?;
+    runtime.block_on(engine.set_config(config));
+
+    let mut warnings: Vec<String> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    let mut measurement: Option<MeasurementReport> = None;
+
+    if let Some(file) = args.file.as_ref() {
+        if !file.exists() {
+            return Err(anyhow::anyhow!(
+                "Rendered file '{}' does not exist",
+                file.display()
+            ));
+        }
+
+        // FFmpeg is only required once a rendered file is in play; structural
+        // runs must work on machines without it.
+        let ffmpeg_info = ensure_ffmpeg()?;
+        let runner = FFmpegRunner::new(ffmpeg_info);
+        let options = MeasureOptions {
+            timeout: Duration::from_secs(args.timeout_sec),
+            ..Default::default()
+        };
+
+        match runtime.block_on(measure_rendered_file_detailed(&runner, file, &options)) {
+            Ok(report) => {
+                warnings.extend(report.notes.iter().cloned());
+                measurement = Some(report);
+            }
+            Err(error) => {
+                // A failed measurement leaves the rendered checks unrun; the
+                // structural half of the report is still worth emitting.
+                errors.push(format!("Rendered-file measurement failed: {error}"));
+            }
+        }
+    }
+
+    let measurement_failed = args.file.is_some() && measurement.is_none();
+
+    let mut report = runtime.block_on(async {
+        match measurement.as_ref() {
+            Some(measured) => {
+                engine
+                    .check_with_measurements(
+                        sequence,
+                        &project.state,
+                        measured.measurements.clone(),
+                    )
+                    .await
+            }
+            None => engine.check(sequence, &project.state).await,
+        }
+    })?;
+
+    // Black pixels only become an error once they are known to sit over a hole
+    // in the timeline, which needs both halves of the report.
+    let frame_duration_sec = frame_duration_sec(sequence);
+    crossref_black_ranges_with_gaps(&mut report, sequence, frame_duration_sec);
+
+    for failure in &report.errored_rules {
+        errors.push(format!(
+            "Check '{}' failed to run: {}",
+            failure.rule_name, failure.message
+        ));
+    }
+
+    let output_value = build_output(
+        OutputInputs {
+            sequence,
+            sequence_id: &sequence_id,
+            report: &report,
+            engine: &engine,
+            selected_ids: &selected_ids,
+            measurement: measurement.as_ref(),
+            rendered_file: args.file.as_deref(),
+            structural_only: args.structural_only,
+        },
+        warnings,
+        errors,
+    );
+
+    if args.json_pretty {
+        output::print_json_pretty(&output_value)?;
+    } else {
+        output::print_json(&output_value)?;
+    }
+
+    let breached = report
+        .violations
+        .iter()
+        .any(|violation| violation.severity.meets_threshold(fail_on));
+
+    if breached {
+        return Ok(EXIT_THRESHOLD_BREACHED);
+    }
+    if measurement_failed || !report.errored_rules.is_empty() {
+        return Ok(EXIT_TOOL_FAILURE);
+    }
+
+    Ok(0)
+}
+
+// ── Configuration ───────────────────────────────────────────────────────
+
+/// Parses a severity threshold name.
+fn parse_severity(raw: &str) -> anyhow::Result<Severity> {
+    match raw.trim().to_lowercase().as_str() {
+        "info" => Ok(Severity::Info),
+        "warning" | "warn" => Ok(Severity::Warning),
+        "error" => Ok(Severity::Error),
+        "critical" => Ok(Severity::Critical),
+        other => Err(anyhow::anyhow!(
+            "Invalid value for --fail-on: expected info, warning, error, or critical (got '{}')",
+            other
+        )),
+    }
+}
+
+/// Builds the engine configuration from the selection and threshold arguments.
+fn build_engine_config(engine: &QCEngine, args: &VerifyArgs) -> anyhow::Result<QCEngineConfig> {
+    let mut config = QCEngineConfig {
+        // Informational findings carry the metrics agents steer by, so the
+        // report keeps every severity and lets `--fail-on` decide the verdict.
+        severity_filter: QCSeverityFilter::All,
+        ..Default::default()
+    };
+
+    let known_ids: Vec<String> = engine
+        .rules()
+        .iter()
+        .map(|rule| rule.check_id().to_string())
+        .collect();
+
+    if let Some(requested) = args.checks.as_ref() {
+        let requested = normalize_ids(requested);
+        for id in &requested {
+            if !known_ids.contains(id) {
+                return Err(unknown_check_error(id, &known_ids));
+            }
+        }
+        for rule in engine.rules() {
+            if !requested.iter().any(|id| id == rule.check_id()) {
+                config.disable_rule(rule.name());
+            }
+        }
+    } else {
+        for rule in engine.rules() {
+            if OPT_IN_CHECK_IDS.contains(&rule.check_id()) {
+                config.disable_rule(rule.name());
+            }
+        }
+    }
+
+    if let Some(skipped) = args.skip.as_ref() {
+        for id in normalize_ids(skipped) {
+            if !known_ids.contains(&id) {
+                return Err(unknown_check_error(&id, &known_ids));
+            }
+            if let Some(rule) = engine.get_rule_by_check_id(&id) {
+                config.disable_rule(rule.name());
+            }
+        }
+    }
+
+    if let Some(target_lufs) = args.target_lufs {
+        if !target_lufs.is_finite() {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --target-lufs: must be a finite number"
+            ));
+        }
+        set_param(
+            engine,
+            &mut config,
+            LOUDNESS_CHECK_ID,
+            "target_lufs",
+            target_lufs,
+        );
+    }
+
+    if let Some(max_true_peak) = args.max_true_peak {
+        if !max_true_peak.is_finite() {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --max-true-peak: must be a finite number"
+            ));
+        }
+        set_param(engine, &mut config, PEAK_CHECK_ID, "peak_db", max_true_peak);
+    }
+
+    Ok(config)
+}
+
+/// Sets a rule parameter, addressed by check ID rather than rule name.
+fn set_param(
+    engine: &QCEngine,
+    config: &mut QCEngineConfig,
+    check_id: &str,
+    key: &str,
+    value: f64,
+) {
+    let Some(rule) = engine.get_rule_by_check_id(check_id) else {
+        return;
+    };
+    let mut rule_config = config.get_rule_config(rule.name());
+    rule_config.set_param(key, value);
+    config.set_rule_config(rule.name(), rule_config);
+}
+
+/// Trims and lowercases requested check IDs, dropping empty entries.
+fn normalize_ids(ids: &[String]) -> Vec<String> {
+    ids.iter()
+        .map(|id| id.trim().to_lowercase())
+        .filter(|id| !id.is_empty())
+        .collect()
+}
+
+fn unknown_check_error(id: &str, known_ids: &[String]) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Unknown check '{}'. Available checks: {}",
+        id,
+        known_ids.join(", ")
+    )
+}
+
+/// Lists the check IDs left enabled by a configuration.
+fn enabled_check_ids(engine: &QCEngine, config: &QCEngineConfig) -> Vec<String> {
+    engine
+        .rules()
+        .iter()
+        .filter(|rule| config.is_rule_enabled(rule.name()))
+        .map(|rule| rule.check_id().to_string())
+        .collect()
+}
+
+/// Returns the sequence frame duration, falling back to 30 fps.
+fn frame_duration_sec(sequence: &Sequence) -> f64 {
+    let fps = sequence.format.fps.as_f64();
+    if fps.is_finite() && fps > 0.0 {
+        1.0 / fps
+    } else {
+        1.0 / 30.0
+    }
+}
+
+fn flush_stdout() {
+    let _ = std::io::stdout().flush();
+}
+
+// ── Output ──────────────────────────────────────────────────────────────
+
+/// A time span attached to a check result.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TimeSpan {
+    start_sec: f64,
+    end_sec: f64,
+}
+
+/// One violation, as reported inside a check entry.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ViolationEntry {
+    id: String,
+    severity: String,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    time_range: Option<TimeSpan>,
+    entities: Vec<String>,
+    metrics: Map<String, Value>,
+    auto_fixable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suggested_fix: Option<Value>,
+}
+
+/// One check, whether it passed, failed, was skipped, or errored.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CheckEntry {
+    id: String,
+    rule: String,
+    category: String,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    severity: Option<String>,
+    passed: bool,
+    skipped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skip_reason: Option<String>,
+    message: String,
+    violation_count: usize,
+    time_ranges: Vec<TimeSpan>,
+    entities: Vec<String>,
+    metrics: Map<String, Value>,
+    auto_fixable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suggested_fix: Option<Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    violations: Vec<ViolationEntry>,
+}
+
+/// Everything the output document is assembled from.
+struct OutputInputs<'a> {
+    sequence: &'a Sequence,
+    sequence_id: &'a str,
+    report: &'a QCReport,
+    engine: &'a QCEngine,
+    selected_ids: &'a [String],
+    measurement: Option<&'a MeasurementReport>,
+    rendered_file: Option<&'a Path>,
+    structural_only: bool,
+}
+
+/// Assembles the CLI output document.
+fn build_output(inputs: OutputInputs<'_>, mut warnings: Vec<String>, errors: Vec<String>) -> Value {
+    let report = inputs.report;
+    let checks = build_checks(report, inputs.engine);
+    let skipped_count = checks.iter().filter(|check| check.skipped).count();
+
+    let rendered_skipped = checks
+        .iter()
+        .filter(|check| check.skipped && check.category == "rendered")
+        .count();
+    if rendered_skipped > 0 && inputs.rendered_file.is_none() && !inputs.structural_only {
+        warnings.push(format!(
+            "{} rendered check(s) were skipped; pass --file <RENDER> to run them",
+            rendered_skipped
+        ));
+    }
+
+    // The verdict follows the findings, not the diagnostics: a clean run that
+    // simply had nothing rendered to inspect is still "ok".
+    let status = if !report.passed || !errors.is_empty() {
+        "failed"
+    } else if report.count(Severity::Warning) > 0 {
+        "warning"
+    } else {
+        "ok"
+    };
+
+    serde_json::json!({
+        "status": status,
+        "passed": report.passed && errors.is_empty(),
+        "checkedAt": report.checked_at.to_rfc3339(),
+        "durationMs": report.duration_ms,
+        "target": {
+            "sequenceId": inputs.sequence_id,
+            "sequenceName": inputs.sequence.name,
+            "renderedFile": inputs.rendered_file.map(|path| path.display().to_string()),
+            "measured": inputs.measurement.is_some(),
+            "selectedChecks": inputs.selected_ids,
+        },
+        "summary": {
+            "critical": report.count(Severity::Critical),
+            "error": report.count(Severity::Error),
+            "warning": report.count(Severity::Warning),
+            "info": report.count(Severity::Info),
+            "skipped": skipped_count,
+        },
+        "checks": checks,
+        "measurements": build_measurements(inputs.measurement, inputs.rendered_file),
+        "warnings": warnings,
+        "errors": errors,
+    })
+}
+
+/// Turns the per-rule outcomes and violations into one entry per check.
+fn build_checks(report: &QCReport, engine: &QCEngine) -> Vec<CheckEntry> {
+    report
+        .rule_outcomes
+        .iter()
+        .map(|outcome| {
+            let violations: Vec<_> = report
+                .violations
+                .iter()
+                .filter(|violation| violation.rule_name == outcome.rule_name)
+                .collect();
+
+            let max_severity = violations.iter().map(|violation| violation.severity).max();
+
+            let status = match outcome.status {
+                RuleStatus::Skipped => "skipped",
+                RuleStatus::Errored => "errored",
+                RuleStatus::Ran => {
+                    if max_severity.is_some_and(|severity| severity >= Severity::Error) {
+                        "failed"
+                    } else {
+                        "passed"
+                    }
+                }
+            };
+
+            let description = engine
+                .get_rule_by_check_id(&outcome.check_id)
+                .map(|rule| rule.description().to_string())
+                .unwrap_or_default();
+
+            let message = match outcome.status {
+                RuleStatus::Skipped => format!(
+                    "Skipped: {}",
+                    outcome.reason.as_deref().unwrap_or("no reason recorded")
+                ),
+                RuleStatus::Errored => format!(
+                    "Check failed to run: {}",
+                    outcome.reason.as_deref().unwrap_or("unknown error")
+                ),
+                RuleStatus::Ran => match violations.first() {
+                    Some(first) if violations.len() == 1 => first.message.clone(),
+                    Some(first) => format!("{} findings, e.g. {}", violations.len(), first.message),
+                    None => description,
+                },
+            };
+
+            // Metrics only make sense at check level when a single finding owns
+            // them; otherwise they stay on the individual violations.
+            let metrics = if violations.len() == 1 {
+                to_json_map(&violations[0].metrics)
+            } else {
+                Map::new()
+            };
+
+            let mut entities: Vec<String> = violations
+                .iter()
+                .flat_map(|violation| violation.affected_entities.iter().cloned())
+                .collect();
+            entities.sort();
+            entities.dedup();
+
+            let suggested_fix = violations
+                .iter()
+                .find_map(|violation| violation.suggested_fix.as_ref())
+                .map(to_edit_script);
+
+            CheckEntry {
+                id: outcome.check_id.clone(),
+                rule: outcome.rule_name.clone(),
+                category: outcome.category.to_string(),
+                status,
+                severity: max_severity.map(|severity| severity_key(severity).to_string()),
+                passed: matches!(outcome.status, RuleStatus::Ran)
+                    && max_severity.is_none_or(|severity| severity < Severity::Error),
+                skipped: matches!(outcome.status, RuleStatus::Skipped),
+                skip_reason: match outcome.status {
+                    RuleStatus::Skipped => outcome.reason.clone(),
+                    _ => None,
+                },
+                message,
+                violation_count: violations.len(),
+                time_ranges: violations
+                    .iter()
+                    .filter_map(|violation| violation.location.as_ref())
+                    .map(|range| TimeSpan {
+                        start_sec: range.start_sec,
+                        end_sec: range.end_sec,
+                    })
+                    .collect(),
+                entities,
+                metrics,
+                auto_fixable: violations.iter().any(|violation| violation.auto_fixable),
+                suggested_fix,
+                violations: violations
+                    .iter()
+                    .map(|violation| ViolationEntry {
+                        id: violation.id.clone(),
+                        severity: severity_key(violation.severity).to_string(),
+                        message: violation.message.clone(),
+                        details: violation.details.clone(),
+                        time_range: violation.location.as_ref().map(|range| TimeSpan {
+                            start_sec: range.start_sec,
+                            end_sec: range.end_sec,
+                        }),
+                        entities: violation.affected_entities.clone(),
+                        metrics: to_json_map(&violation.metrics),
+                        auto_fixable: violation.auto_fixable,
+                        suggested_fix: violation.suggested_fix.as_ref().map(to_edit_script),
+                    })
+                    .collect(),
+            }
+        })
+        .collect()
+}
+
+/// Serialises the measurement block, or records that nothing was measured.
+fn build_measurements(measurement: Option<&MeasurementReport>, file: Option<&Path>) -> Value {
+    let Some(report) = measurement else {
+        return serde_json::json!({ "measured": false });
+    };
+
+    let measurements = &report.measurements;
+    serde_json::json!({
+        "measured": true,
+        "file": file.map(|path| path.display().to_string()),
+        "durationSec": report.duration_sec,
+        "videoMeasured": report.video_measured,
+        "audioMeasured": report.audio_measured,
+        "blackRanges": spans_json(&measurements.black_ranges),
+        "freezeRanges": spans_json(&measurements.freeze_ranges),
+        "silenceRanges": spans_json(&measurements.silence_ranges),
+        "integratedLufs": measurements.integrated_lufs,
+        "loudnessRangeLu": measurements.loudness_range_lu,
+        "truePeakDbtp": measurements.true_peak_dbtp,
+        "samplePeakDb": measurements.sample_peak_db,
+        "flatFactor": measurements.flat_factor,
+        "notes": report.notes,
+    })
+}
+
+fn spans_json(ranges: &[(f64, f64)]) -> Vec<Value> {
+    ranges
+        .iter()
+        .map(|(start, end)| serde_json::json!({ "startSec": start, "endSec": end }))
+        .collect()
+}
+
+/// Lowercase severity key, matching the serde representation of `Severity`.
+fn severity_key(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Info => "info",
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+        Severity::Critical => "critical",
+    }
+}
+
+fn to_json_map(metrics: &std::collections::BTreeMap<String, Value>) -> Map<String, Value> {
+    metrics
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+/// Converts a QC fix into the plan-step shape `plan execute` accepts.
+///
+/// QC rules describe fixes as flat `{"type": …, …}` command descriptors; edit
+/// plans expect `{"commandType": …, "payload": {…}}`. Translating here keeps the
+/// suggestion directly executable instead of merely descriptive.
+fn to_edit_script(fix: &openreelio_core::qc::ViolationFix) -> Value {
+    let steps: Vec<Value> = fix
+        .commands
+        .iter()
+        .enumerate()
+        .filter_map(|(index, command)| {
+            let object = command.as_object()?;
+            let command_type = object.get("type")?.as_str()?.to_string();
+
+            let payload: Map<String, Value> = object
+                .iter()
+                .filter(|(key, _)| key.as_str() != "type")
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
+
+            Some(serde_json::json!({
+                "id": format!("fix_{}", index + 1),
+                "commandType": command_type,
+                "payload": payload,
+                "dependsOn": [],
+            }))
+        })
+        .collect();
+
+    serde_json::json!({
+        "description": fix.description,
+        "confidence": fix.confidence,
+        "steps": steps,
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openreelio_core::qc::ViolationFix;
+
+    #[test]
+    fn test_parse_severity_should_accept_every_threshold_name() {
+        assert_eq!(parse_severity("info").expect("info"), Severity::Info);
+        assert_eq!(
+            parse_severity("WARNING").expect("warning"),
+            Severity::Warning
+        );
+        assert_eq!(parse_severity(" error ").expect("error"), Severity::Error);
+        assert_eq!(
+            parse_severity("critical").expect("critical"),
+            Severity::Critical
+        );
+        assert!(parse_severity("nonsense").is_err());
+    }
+
+    #[test]
+    fn test_default_config_should_disable_only_the_opt_in_checks() {
+        let engine = QCEngine::new();
+        let args = VerifyArgs {
+            path: PathBuf::from("."),
+            sequence: None,
+            file: None,
+            structural_only: true,
+            checks: None,
+            skip: None,
+            target_lufs: None,
+            max_true_peak: None,
+            fail_on: "error".to_string(),
+            timeout_sec: 600,
+            json_pretty: false,
+        };
+
+        let config = build_engine_config(&engine, &args).expect("config builds");
+        let enabled = enabled_check_ids(&engine, &config);
+
+        assert!(enabled.contains(&"timeline.gap".to_string()));
+        assert!(enabled.contains(&"shot.length_stats".to_string()));
+        for opt_in in OPT_IN_CHECK_IDS {
+            assert!(
+                !enabled.contains(&opt_in.to_string()),
+                "{opt_in} must stay opt-in"
+            );
+        }
+    }
+
+    #[test]
+    fn test_checks_argument_should_restrict_the_run_to_the_named_checks() {
+        let engine = QCEngine::new();
+        let mut args = VerifyArgs {
+            path: PathBuf::from("."),
+            sequence: None,
+            file: None,
+            structural_only: true,
+            checks: Some(vec!["timeline.gap".to_string()]),
+            skip: None,
+            target_lufs: None,
+            max_true_peak: None,
+            fail_on: "error".to_string(),
+            timeout_sec: 600,
+            json_pretty: false,
+        };
+
+        let config = build_engine_config(&engine, &args).expect("config builds");
+        assert_eq!(enabled_check_ids(&engine, &config), vec!["timeline.gap"]);
+
+        args.checks = Some(vec!["nope.not.a.check".to_string()]);
+        assert!(build_engine_config(&engine, &args).is_err());
+    }
+
+    #[test]
+    fn test_skip_argument_should_disable_the_named_check() {
+        let engine = QCEngine::new();
+        let args = VerifyArgs {
+            path: PathBuf::from("."),
+            sequence: None,
+            file: None,
+            structural_only: true,
+            checks: None,
+            skip: Some(vec!["timeline.gap".to_string()]),
+            target_lufs: None,
+            max_true_peak: None,
+            fail_on: "error".to_string(),
+            timeout_sec: 600,
+            json_pretty: false,
+        };
+
+        let config = build_engine_config(&engine, &args).expect("config builds");
+
+        assert!(!enabled_check_ids(&engine, &config).contains(&"timeline.gap".to_string()));
+    }
+
+    #[test]
+    fn test_loudness_target_should_reach_the_rule_configuration() {
+        let engine = QCEngine::new();
+        let args = VerifyArgs {
+            path: PathBuf::from("."),
+            sequence: None,
+            file: None,
+            structural_only: false,
+            checks: None,
+            skip: None,
+            target_lufs: Some(-16.0),
+            max_true_peak: Some(-2.0),
+            fail_on: "error".to_string(),
+            timeout_sec: 600,
+            json_pretty: false,
+        };
+
+        let config = build_engine_config(&engine, &args).expect("config builds");
+
+        let loudness_rule = engine
+            .get_rule_by_check_id(LOUDNESS_CHECK_ID)
+            .expect("loudness rule registered");
+        let peak_rule = engine
+            .get_rule_by_check_id(PEAK_CHECK_ID)
+            .expect("peak rule registered");
+
+        assert_eq!(
+            config
+                .get_rule_config(loudness_rule.name())
+                .get_param::<f64>("target_lufs"),
+            Some(-16.0)
+        );
+        assert_eq!(
+            config
+                .get_rule_config(peak_rule.name())
+                .get_param::<f64>("peak_db"),
+            Some(-2.0)
+        );
+    }
+
+    #[test]
+    fn test_to_edit_script_should_produce_executable_plan_steps() {
+        let fix = ViolationFix::new(
+            "Close the gap",
+            vec![serde_json::json!({
+                "type": "CloseGap",
+                "sequenceId": "seq_1",
+                "trackId": "track_v1",
+                "gapStart": 2.0,
+                "gapEnd": 3.0
+            })],
+        );
+
+        let script = to_edit_script(&fix);
+
+        assert_eq!(script["description"], "Close the gap");
+        assert_eq!(script["steps"][0]["commandType"], "CloseGap");
+        assert_eq!(script["steps"][0]["payload"]["trackId"], "track_v1");
+        assert!(script["steps"][0]["payload"].get("type").is_none());
+    }
+
+    #[test]
+    fn test_build_measurements_should_report_when_nothing_was_measured() {
+        let value = build_measurements(None, None);
+
+        assert_eq!(value["measured"], false);
+    }
+
+    #[test]
+    fn test_severity_key_matches_the_serde_representation() {
+        for severity in [
+            Severity::Info,
+            Severity::Warning,
+            Severity::Error,
+            Severity::Critical,
+        ] {
+            let serialized = serde_json::to_value(severity).expect("severity serializes");
+            assert_eq!(
+                serialized,
+                Value::String(severity_key(severity).to_string())
+            );
+        }
+    }
+}

--- a/crates/openreelio-cli/src/commands/verify.rs
+++ b/crates/openreelio-cli/src/commands/verify.rs
@@ -279,6 +279,13 @@ fn build_engine_config(engine: &QCEngine, args: &VerifyArgs) -> anyhow::Result<Q
 
     if let Some(requested) = args.checks.as_ref() {
         let requested = normalize_ids(requested);
+        // An empty selection would disable every rule and report a clean run
+        // over nothing checked, which an agent reads as "verified".
+        if requested.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Invalid value for --checks: at least one check ID is required"
+            ));
+        }
         for id in &requested {
             if !known_ids.contains(id) {
                 return Err(unknown_check_error(id, &known_ids));
@@ -565,7 +572,7 @@ fn build_checks(report: &QCReport, engine: &QCEngine) -> Vec<CheckEntry> {
             let suggested_fix = violations
                 .iter()
                 .find_map(|violation| violation.suggested_fix.as_ref())
-                .map(to_edit_script);
+                .and_then(to_edit_script);
 
             CheckEntry {
                 id: outcome.check_id.clone(),
@@ -608,7 +615,7 @@ fn build_checks(report: &QCReport, engine: &QCEngine) -> Vec<CheckEntry> {
                         entities: violation.affected_entities.clone(),
                         metrics: to_json_map(&violation.metrics),
                         auto_fixable: violation.auto_fixable,
-                        suggested_fix: violation.suggested_fix.as_ref().map(to_edit_script),
+                        suggested_fix: violation.suggested_fix.as_ref().and_then(to_edit_script),
                     })
                     .collect(),
             }
@@ -670,12 +677,16 @@ fn to_json_map(metrics: &std::collections::BTreeMap<String, Value>) -> Map<Strin
 /// QC rules describe fixes as flat `{"type": …, …}` command descriptors; edit
 /// plans expect `{"commandType": …, "payload": {…}}`. Translating here keeps the
 /// suggestion directly executable instead of merely descriptive.
-fn to_edit_script(fix: &openreelio_core::qc::ViolationFix) -> Value {
-    let steps: Vec<Value> = fix
+///
+/// Returns `None` when any command cannot be translated: a plan missing steps
+/// would still carry the full description and apply only part of the fix. Each
+/// step depends on its predecessor so `plan execute` preserves command order.
+fn to_edit_script(fix: &openreelio_core::qc::ViolationFix) -> Option<Value> {
+    let steps: Option<Vec<Value>> = fix
         .commands
         .iter()
         .enumerate()
-        .filter_map(|(index, command)| {
+        .map(|(index, command)| {
             let object = command.as_object()?;
             let command_type = object.get("type")?.as_str()?.to_string();
 
@@ -685,20 +696,26 @@ fn to_edit_script(fix: &openreelio_core::qc::ViolationFix) -> Value {
                 .map(|(key, value)| (key.clone(), value.clone()))
                 .collect();
 
+            let depends_on: Vec<String> = if index == 0 {
+                Vec::new()
+            } else {
+                vec![format!("fix_{}", index)]
+            };
+
             Some(serde_json::json!({
                 "id": format!("fix_{}", index + 1),
                 "commandType": command_type,
                 "payload": payload,
-                "dependsOn": [],
+                "dependsOn": depends_on,
             }))
         })
         .collect();
 
-    serde_json::json!({
+    Some(serde_json::json!({
         "description": fix.description,
         "confidence": fix.confidence,
-        "steps": steps,
-    })
+        "steps": steps?,
+    }))
 }
 
 // ============================================================================
@@ -854,12 +871,66 @@ mod tests {
             })],
         );
 
-        let script = to_edit_script(&fix);
+        let script = to_edit_script(&fix).expect("fix translates");
 
         assert_eq!(script["description"], "Close the gap");
         assert_eq!(script["steps"][0]["commandType"], "CloseGap");
         assert_eq!(script["steps"][0]["payload"]["trackId"], "track_v1");
         assert!(script["steps"][0]["payload"].get("type").is_none());
+        assert_eq!(script["steps"][0]["dependsOn"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_to_edit_script_should_chain_steps_in_command_order() {
+        let fix = ViolationFix::new(
+            "Two ordered commands",
+            vec![
+                serde_json::json!({ "type": "SplitClip", "clipId": "clip_1" }),
+                serde_json::json!({ "type": "RemoveClip", "clipId": "clip_2" }),
+            ],
+        );
+
+        let script = to_edit_script(&fix).expect("fix translates");
+
+        assert_eq!(script["steps"][0]["id"], "fix_1");
+        assert_eq!(script["steps"][1]["id"], "fix_2");
+        assert_eq!(
+            script["steps"][1]["dependsOn"],
+            serde_json::json!(["fix_1"])
+        );
+    }
+
+    #[test]
+    fn test_to_edit_script_should_reject_a_fix_it_cannot_translate_in_full() {
+        let fix = ViolationFix::new(
+            "Half-translatable",
+            vec![
+                serde_json::json!({ "type": "CloseGap", "trackId": "track_v1" }),
+                serde_json::json!({ "missingType": true }),
+            ],
+        );
+
+        assert!(to_edit_script(&fix).is_none());
+    }
+
+    #[test]
+    fn test_empty_checks_selection_should_be_rejected() {
+        let engine = QCEngine::new();
+        let args = VerifyArgs {
+            path: PathBuf::from("."),
+            sequence: None,
+            file: None,
+            structural_only: true,
+            checks: Some(vec![String::new(), "  ".to_string()]),
+            skip: None,
+            target_lufs: None,
+            max_true_peak: None,
+            fail_on: "error".to_string(),
+            timeout_sec: 600,
+            json_pretty: false,
+        };
+
+        assert!(build_engine_config(&engine, &args).is_err());
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/verify.rs
+++ b/crates/openreelio-cli/src/commands/verify.rs
@@ -23,7 +23,8 @@ use clap::Args;
 use openreelio_core::ffmpeg::FFmpegRunner;
 use openreelio_core::qc::{
     crossref_black_ranges_with_gaps, measure_rendered_file_detailed, MeasureOptions,
-    MeasurementReport, QCEngine, QCEngineConfig, QCReport, QCSeverityFilter, RuleStatus, Severity,
+    MeasurementReport, QCContext, QCEngine, QCEngineConfig, QCReport, QCSeverityFilter, RuleStatus,
+    Severity,
 };
 use openreelio_core::timeline::Sequence;
 use serde::Serialize;
@@ -196,8 +197,10 @@ fn run(args: VerifyArgs) -> anyhow::Result<i32> {
     })?;
 
     // Black pixels only become an error once they are known to sit over a hole
-    // in the timeline, which needs both halves of the report.
-    let frame_duration_sec = frame_duration_sec(sequence);
+    // in the timeline, which needs both halves of the report. The tolerance is
+    // the same one the rules use, so it comes from the shared context rather
+    // than a second definition of "one frame".
+    let frame_duration_sec = QCContext::from_sequence(sequence).frame_duration_sec();
     crossref_black_ranges_with_gaps(&mut report, sequence, frame_duration_sec);
 
     for failure in &report.errored_rules {
@@ -372,16 +375,6 @@ fn enabled_check_ids(engine: &QCEngine, config: &QCEngineConfig) -> Vec<String> 
         .filter(|rule| config.is_rule_enabled(rule.name()))
         .map(|rule| rule.check_id().to_string())
         .collect()
-}
-
-/// Returns the sequence frame duration, falling back to 30 fps.
-fn frame_duration_sec(sequence: &Sequence) -> f64 {
-    let fps = sequence.format.fps.as_f64();
-    if fps.is_finite() && fps > 0.0 {
-        1.0 / fps
-    } else {
-        1.0 / 30.0
-    }
 }
 
 fn flush_stdout() {

--- a/crates/openreelio-cli/src/ffmpeg_env.rs
+++ b/crates/openreelio-cli/src/ffmpeg_env.rs
@@ -1,0 +1,56 @@
+//! FFmpeg resolution for the CLI process.
+//!
+//! Every command that spawns ffmpeg/ffprobe (directly or through a core
+//! module) must call [`ensure_ffmpeg`] first: core modules read the globally
+//! registered paths, and without registration they fall back to bare `ffmpeg`,
+//! which fails on installs where FFmpeg is only bundled or managed.
+
+use openreelio_core::ffmpeg::{resolve_and_register, FFmpegInfo, FFmpegResolveOptions};
+use std::path::PathBuf;
+
+/// Resolve FFmpeg and publish the paths process-wide.
+///
+/// Search order: `OPENREELIO_FFMPEG_PATH` / `OPENREELIO_FFPROBE_PATH` →
+/// bundled binaries next to the project or executable → managed install →
+/// dev-mode binaries → system PATH.
+pub fn ensure_ffmpeg() -> anyhow::Result<FFmpegInfo> {
+    resolve_and_register(&resolve_options())
+        .map_err(|error| anyhow::anyhow!("FFmpeg initialization failed: {}", error))
+}
+
+/// Resolve FFmpeg without failing the command when it is missing.
+///
+/// For paths where FFmpeg only enriches the result (media metadata probing on
+/// import), a missing toolchain must stay a degraded success rather than an
+/// error.
+pub fn ensure_ffmpeg_optional() -> Option<FFmpegInfo> {
+    match resolve_and_register(&resolve_options()) {
+        Ok(info) => Some(info),
+        Err(error) => {
+            tracing::debug!("FFmpeg not available: {}", error);
+            None
+        }
+    }
+}
+
+fn resolve_options() -> FFmpegResolveOptions {
+    let mut resource_roots = Vec::new();
+
+    if let Ok(cwd) = std::env::current_dir() {
+        resource_roots.push(cwd.join("src-tauri"));
+        resource_roots.push(cwd);
+    }
+
+    if let Some(exe_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(PathBuf::from))
+    {
+        resource_roots.push(exe_dir);
+    }
+
+    FFmpegResolveOptions {
+        resource_roots,
+        use_env: true,
+        ..Default::default()
+    }
+}

--- a/crates/openreelio-cli/src/main.rs
+++ b/crates/openreelio-cli/src/main.rs
@@ -15,6 +15,7 @@
 //! openreelio-cli state dump --path ./my-project
 //! ```
 mod commands;
+mod ffmpeg_env;
 mod output;
 mod validate;
 

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2345,6 +2345,10 @@ fn test_analysis_silence_caches_regions_at_default_thresholds() {
         return;
     };
 
+    // Silence lives inside the audio profile, so the profile has to exist
+    // before there is anything to merge into.
+    run_cli_ok(&["analysis", "audio", "--path", &path, "--id", &asset_id]);
+
     let result = run_cli_ok(&["analysis", "silence", "--path", &path, "--id", &asset_id]);
 
     assert_eq!(result["status"], "ok");
@@ -2362,6 +2366,34 @@ fn test_analysis_silence_caches_regions_at_default_thresholds() {
 
     let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
     assert_eq!(report["coverage"]["audio"], true);
+}
+
+#[test]
+fn test_analysis_silence_is_output_only_without_an_audio_profile() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "silence_no_profile_test",
+        "with_audio.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let result = run_cli_ok(&["analysis", "silence", "--path", &path, "--id", &asset_id]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["persisted"], false);
+    assert_eq!(
+        result["reason"],
+        "no audio profile in bundle; run `analysis audio` first"
+    );
+    assert!(
+        result["regionCount"].as_u64().unwrap() >= 1,
+        "detection still runs and reports its regions"
+    );
+    assert!(
+        !bundle_path(&path, &asset_id).exists(),
+        "a fabricated audio profile must never reach the bundle"
+    );
 }
 
 #[test]

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -854,6 +854,36 @@ fn test_render_start_invalid_preset() {
 }
 
 #[test]
+fn test_ffmpeg_info_reports_resolved_binaries() {
+    if system_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let result = run_cli_ok(&["ffmpeg", "info"]);
+
+    assert_eq!(result["status"], "ok");
+    assert!(
+        !result["ffmpegPath"].as_str().unwrap_or_default().is_empty(),
+        "Expected a resolved ffmpeg path, got: {}",
+        result
+    );
+    assert!(
+        !result["ffprobePath"]
+            .as_str()
+            .unwrap_or_default()
+            .is_empty(),
+        "Expected a resolved ffprobe path, got: {}",
+        result
+    );
+    let source = result["source"].as_str().unwrap_or_default();
+    assert!(
+        ["explicit", "env", "bundled", "managed", "dev", "system"].contains(&source),
+        "Unexpected ffmpeg source: {}",
+        source
+    );
+}
+
+#[test]
 fn test_render_start_exports_video_when_ffmpeg_is_available() {
     if system_ffmpeg_path().is_none() {
         return;

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -180,6 +180,30 @@ fn ffprobe_duration_secs(path: &std::path::Path) -> Option<f64> {
     String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
+/// Probe the height (in pixels) of the first video stream via ffprobe.
+/// Returns `None` if ffprobe is unavailable or the output cannot be parsed.
+fn ffprobe_video_height(path: &std::path::Path) -> Option<u32> {
+    let ffprobe_path = system_ffprobe_path()?;
+    let output = Command::new(ffprobe_path)
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=height",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
 // =============================================================================
 // Project Commands
 // =============================================================================
@@ -807,9 +831,17 @@ fn test_validation_caption_inverted_range() {
 fn test_render_presets() {
     let result = run_cli_ok(&["render", "presets"]);
     let presets = result["presets"].as_array().unwrap();
-    assert_eq!(presets.len(), 5);
+    assert_eq!(presets.len(), 7);
     // Verify first preset structure
     assert_eq!(presets[0]["id"], "mp4_h264_1080p");
+    let ids: Vec<&str> = presets
+        .iter()
+        .filter_map(|preset| preset["id"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&"proxy_480p") && ids.contains(&"mp4_draft"),
+        "expected proxy and draft presets, got: {ids:?}"
+    );
 }
 
 #[test]
@@ -942,6 +974,141 @@ fn test_render_start_exports_video_when_ffmpeg_is_available() {
         output_path.metadata().unwrap().len() > 0,
         "Expected rendered output to be non-empty"
     );
+}
+
+#[test]
+fn test_render_start_rejects_proxy_combined_with_preset() {
+    let dir = create_temp_project("render_proxy_conflict");
+    let path = project_path(&dir, "render_proxy_conflict");
+    let (_stdout, stderr) = run_cli_err(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--output",
+        "proxy.mp4",
+        "--proxy",
+        "--preset",
+        "mp4_h264_1080p",
+    ]);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "Expected a clap conflict error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_render_start_rejects_inverted_range() {
+    let dir = create_temp_project("render_range_err");
+    let path = project_path(&dir, "render_range_err");
+    let (_stdout, stderr) = run_cli_err(&[
+        "render", "start", "--path", &path, "--output", "out.mp4", "--start", "5", "--end", "1",
+    ]);
+    assert!(
+        stderr.contains("Invalid time range"),
+        "Expected a range validation error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_render_start_proxy_renders_480p_range_with_progress() {
+    if system_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("render_proxy_test");
+    let path = project_path(&dir, "render_proxy_test");
+
+    let source_path = dir.path().join("proxy_source.mp4");
+    if !create_sample_video_with_duration(&source_path, 2) {
+        return;
+    }
+
+    let import = run_cli_ok(&[
+        "asset",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        source_path.to_str().unwrap(),
+    ]);
+    let asset_id = import["createdIds"][0].as_str().unwrap().to_string();
+
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", &path]);
+    let track_id = tracks["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|track| track["kind"] == "Video")
+        .and_then(|track| track["id"].as_str())
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+
+    let output_path = dir.path().join("proxy-output.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--proxy",
+        "--start",
+        "0",
+        "--end",
+        "1",
+        "--progress",
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "Proxy render failed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let result: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("Failed to parse proxy render output: {error}\n{stdout}"));
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["preset"], "proxy_480p");
+
+    assert!(output_path.exists(), "Expected proxy output to exist");
+    assert!(
+        output_path.metadata().unwrap().len() > 0,
+        "Expected proxy output to be non-empty"
+    );
+
+    // Progress must be NDJSON on stderr so stdout stays a single JSON object.
+    let progress_lines: Vec<serde_json::Value> = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line.trim()).ok())
+        .filter(|value| value["type"] == "progress")
+        .collect();
+    assert!(
+        !progress_lines.is_empty(),
+        "Expected NDJSON progress on stderr, got: {stderr}"
+    );
+    assert!(
+        progress_lines
+            .iter()
+            .all(|line| line["percent"].is_number() && line["totalFrames"].is_number()),
+        "Expected progress lines to carry percent and totalFrames, got: {progress_lines:?}"
+    );
+
+    if let Some(height) = ffprobe_video_height(&output_path) {
+        assert_eq!(height, 480, "Expected a 480p proxy, got height {height}");
+    }
+
+    if let Some(duration) = ffprobe_duration_secs(&output_path) {
+        assert!(
+            (duration - 1.0).abs() < 0.35,
+            "Expected proxy output duration near 1s, got {duration}"
+        );
+    }
 }
 
 // =============================================================================

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2879,7 +2879,7 @@ fn timeline_program_end_sec(project_path: &str) -> f64 {
         .fold(0.0_f64, f64::max)
 }
 
-// ponytail: This is THE single end-to-end guard for the headless perception
+// This is THE single end-to-end guard for the headless perception
 // loop an external agent drives: perceive (shots + silence) -> edit informed by
 // what was perceived -> render a proxy -> look at the result (still + contact
 // sheet) -> verify the render. It drives the real CLI binary and asserts only

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -256,6 +256,66 @@ fn create_sample_video_with_audio(path: &std::path::Path) -> bool {
     status.success()
 }
 
+/// Generates a 4-second fixture with a hard black-to-white cut at 2s and an
+/// attenuated tone whose 1s–3s window is muted.
+///
+/// The agent loop needs one asset that both shot detection and silence
+/// detection can find something in. The tone is deliberately attenuated so the
+/// rendered proxy stays well under the true-peak ceiling `verify` enforces;
+/// a full-scale sine would be a clipped, not a healthy, render.
+fn create_sample_video_with_scene_change_and_audio(path: &std::path::Path) -> bool {
+    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+        return false;
+    };
+    let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
+        eprintln!("Skipping agent-loop test: ffmpeg lacks a supported video encoder");
+        return false;
+    };
+    if !ffmpeg_supports_encoder(&ffmpeg_path, "aac") {
+        eprintln!("Skipping agent-loop test: ffmpeg lacks the aac encoder");
+        return false;
+    }
+
+    let mut command = Command::new(ffmpeg_path);
+    command.args([
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=320x240:r=25:d=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=white:s=320x240:r=25:d=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:sample_rate=44100:duration=4",
+        "-filter_complex",
+        "[0:v][1:v]concat=n=2:v=1:a=0[v];\
+         [2:a]volume=0.25,volume=enable='between(t,1,3)':volume=0[a]",
+        "-map",
+        "[v]",
+        "-map",
+        "[a]",
+        "-c:v",
+        video_encoder,
+    ]);
+    if video_encoder == "libx264" {
+        command.args(["-pix_fmt", "yuv420p"]);
+    }
+    command.args(["-c:a", "aac", "-shortest"]);
+
+    let status = command
+        .arg(path)
+        .status()
+        .expect("Failed to generate agent-loop sample with ffmpeg");
+    if !status.success() {
+        eprintln!("Skipping agent-loop test: ffmpeg could not generate the agent-loop sample");
+    }
+    status.success()
+}
+
 fn system_ffprobe_path() -> Option<PathBuf> {
     openreelio_core::ffmpeg::detect_system_ffmpeg()
         .ok()
@@ -2753,4 +2813,279 @@ fn test_verify_reports_a_missing_render_file_as_a_tool_failure() {
         stderr.contains("does not exist"),
         "expected a missing-file error, got: {stderr}"
     );
+}
+
+// =============================================================================
+// Agent Perception Loop Regression Guard
+// =============================================================================
+
+/// Returns the first shot boundary strictly inside `(0, program_end)`.
+///
+/// A single-shot result has no interior cut, so callers get `None` and decide
+/// their own fallback rather than splitting at 0 or at the very end.
+fn first_interior_shot_boundary(shots: &serde_json::Value, program_end: f64) -> Option<f64> {
+    const EDGE_MARGIN_SEC: f64 = 0.1;
+
+    shots["shots"]
+        .as_array()?
+        .iter()
+        .filter_map(|shot| shot["startSec"].as_f64())
+        .find(|start| *start > EDGE_MARGIN_SEC && *start < program_end - EDGE_MARGIN_SEC)
+}
+
+/// Total program length of the active sequence, from the CLI's own clip listing.
+fn timeline_program_end_sec(project_path: &str) -> f64 {
+    let clips = run_cli_ok(&["timeline", "clips", "--path", project_path]);
+    clips["clips"]
+        .as_array()
+        .expect("clips array")
+        .iter()
+        .map(|clip| {
+            clip["timelineInSec"].as_f64().unwrap_or(0.0)
+                + clip["durationSec"].as_f64().unwrap_or(0.0)
+        })
+        .fold(0.0_f64, f64::max)
+}
+
+// ponytail: This is THE single end-to-end guard for the headless perception
+// loop an external agent drives: perceive (shots + silence) -> edit informed by
+// what was perceived -> render a proxy -> look at the result (still + contact
+// sheet) -> verify the render. It drives the real CLI binary and asserts only
+// on CLI-observable JSON and on files the CLI claims to have written, so it
+// stays valid as the internals move.
+//
+// It deliberately does NOT cover: detector accuracy, codec quality, or the
+// per-verb argument surface. Those have their own focused tests above. This
+// guard exists only to catch a SILENT break of the whole agent loop. It skips
+// cleanly (returns, does not fail) when FFmpeg is absent.
+#[test]
+fn test_agent_perception_loop_end_to_end() {
+    // 1. Create the project and import a fixture that has both a hard cut and
+    //    a silent window.
+    let Some((dir, path, asset_id)) = create_project_with_media(
+        "agent_loop_e2e",
+        "agent_loop_source.mp4",
+        create_sample_video_with_scene_change_and_audio,
+    ) else {
+        eprintln!("Skipping agent-loop E2E test: ffmpeg fixture unavailable");
+        return;
+    };
+
+    // 2. Perceive: shot detection.
+    let shots = run_cli_ok(&["analysis", "shots", "--path", &path, "--id", &asset_id]);
+    assert_eq!(shots["status"], "ok");
+    assert!(
+        shots["shotCount"].as_u64().unwrap() >= 1,
+        "Expected at least one detected shot, got {}",
+        shots["shotCount"]
+    );
+    assert!(shots["totalDurationSec"].as_f64().unwrap() > 0.0);
+
+    // 3. Perceive: silence detection over the same asset.
+    let silence = run_cli_ok(&["analysis", "silence", "--path", &path, "--id", &asset_id]);
+    assert_eq!(silence["status"], "ok");
+    let regions = silence["regions"].as_array().unwrap();
+    assert!(
+        !regions.is_empty(),
+        "Expected the muted 1s-3s window to be reported, got {silence}"
+    );
+    assert!(
+        regions.iter().any(|region| {
+            region["startSec"].as_f64().unwrap() >= 0.5 && region["endSec"].as_f64().unwrap() <= 3.5
+        }),
+        "Expected a silent region inside the muted window, got {regions:?}"
+    );
+
+    // 4. Edit: place the asset, then cut it where perception said the shot
+    //    changes.
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", &path]);
+    let track_id = tracks["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|track| track["kind"] == "Video")
+        .and_then(|track| track["id"].as_str())
+        .unwrap()
+        .to_string();
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+
+    let clips = run_cli_ok(&["timeline", "clips", "--path", &path]);
+    assert_eq!(clips["count"], 1);
+    let clip_id = clips["clips"][0]["id"].as_str().unwrap().to_string();
+
+    // `asset import` does not probe duration, so the placed clip carries the
+    // default length. Perception is what tells the agent how long the media
+    // actually is; trim to it before cutting so the edit stays inside the media.
+    let media_end = shots["totalDurationSec"].as_f64().unwrap();
+    run_cli_ok(&[
+        "timeline",
+        "trim",
+        "--path",
+        &path,
+        "--clip",
+        &clip_id,
+        "--track",
+        &track_id,
+        "--source-in",
+        "0.0",
+        "--source-out",
+        &media_end.to_string(),
+    ]);
+
+    let program_end = timeline_program_end_sec(&path);
+    assert!(
+        (program_end - media_end).abs() < 1e-6,
+        "Expected the trim to shrink the program to the perceived media length, got {program_end}"
+    );
+
+    // The fixture cuts at 2s; fall back to it when the detector merged the two
+    // shots so the loop still exercises a real split.
+    let split_at = first_interior_shot_boundary(&shots, program_end).unwrap_or(2.0);
+    let split = run_cli_ok(&[
+        "timeline",
+        "split",
+        "--path",
+        &path,
+        "--clip",
+        &clip_id,
+        "--track",
+        &track_id,
+        "--at",
+        &split_at.to_string(),
+    ]);
+    assert_eq!(split["status"], "ok");
+
+    let clips = run_cli_ok(&["timeline", "clips", "--path", &path]);
+    assert_eq!(
+        clips["count"], 2,
+        "Expected the shot-informed split to yield two clips: {clips}"
+    );
+
+    // 5. Render a proxy of the edit, streaming progress to stderr.
+    let proxy_path = dir.path().join("agent_loop_proxy.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--proxy",
+        "--progress",
+        "--output",
+        proxy_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "Proxy render failed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let render: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("Failed to parse proxy render output: {error}\n{stdout}"));
+    assert_eq!(render["status"], "ok");
+    assert_eq!(render["preset"], "proxy_480p");
+    assert!(proxy_path.exists(), "Expected the proxy render to exist");
+    assert!(
+        proxy_path.metadata().unwrap().len() > 0,
+        "Expected the proxy render to be non-empty"
+    );
+    assert!(
+        stderr
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line.trim()).ok())
+            .any(|value| value["type"] == "progress"),
+        "Expected NDJSON render progress on stderr, got: {stderr}"
+    );
+
+    // 6. Look: a single still from the second half of the edit.
+    let still_path = dir.path().join("agent_loop_still.png");
+    let mid_second_clip = (split_at + program_end) / 2.0;
+    let still = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--time",
+        &mid_second_clip.to_string(),
+        "--out",
+        still_path.to_str().unwrap(),
+    ]);
+    assert_eq!(still["status"], "ok");
+    assert_eq!(still["count"], 1);
+    assert!(still["frames"][0]["clipId"].is_string());
+    assert!(still_path.exists(), "Expected the extracted still to exist");
+    assert!(
+        still_path.metadata().unwrap().len() > 0,
+        "Expected the extracted still to be non-empty"
+    );
+
+    // 7. Look: a contact sheet spanning the whole program, so a VLM can map
+    //    cells back to timecodes.
+    let sheet_path = dir.path().join("agent_loop_sheet.jpg");
+    let sheet = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--grid",
+        "2x2",
+        "--between",
+        "0",
+        &program_end.to_string(),
+        "--format",
+        "jpeg",
+        "--out",
+        sheet_path.to_str().unwrap(),
+    ]);
+    assert_eq!(sheet["status"], "ok");
+    assert_eq!(sheet["sheet"]["cols"], 2);
+    assert_eq!(sheet["sheet"]["rows"], 2);
+    assert_eq!(sheet["sheet"]["cells"].as_array().unwrap().len(), 4);
+    assert!(sheet_path.exists(), "Expected the contact sheet to exist");
+    assert!(
+        sheet_path.metadata().unwrap().len() > 0,
+        "Expected the contact sheet to be non-empty"
+    );
+
+    // 8. Verify the rendered proxy. A healthy project must clear the critical
+    //    threshold, and both halves of the report have to be present.
+    let (stdout, stderr, code) = run_cli_exit(&[
+        "verify",
+        "--path",
+        &path,
+        "--file",
+        proxy_path.to_str().unwrap(),
+        "--fail-on",
+        "critical",
+    ]);
+    assert_eq!(
+        code, 0,
+        "A healthy project must clear --fail-on critical.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let report: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("Failed to parse verify report: {error}\n{stdout}"));
+    assert_eq!(report["summary"]["critical"], 0);
+    assert_eq!(report["target"]["measured"], true);
+    assert_eq!(report["measurements"]["measured"], true);
+    assert!(report["measurements"]["durationSec"].as_f64().unwrap() > 0.0);
+
+    let checks = report["checks"].as_array().expect("checks array");
+    assert!(
+        checks
+            .iter()
+            .any(|check| check["category"] == "structural" && check["status"] != "skipped"),
+        "Expected at least one structural check to have run: {report}"
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|check| check["category"] == "rendered" && check["status"] != "skipped"),
+        "Expected at least one rendered check to have run once a file was measured: {report}"
+    );
+
+    // The split closed onto the following clip, so the edit must be gapless.
+    let gap = find_check(&report, "timeline.gap");
+    assert_eq!(gap["status"], "passed");
+    assert_eq!(gap["violationCount"], 0);
 }

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -152,6 +152,110 @@ fn create_sample_video_with_duration(path: &std::path::Path, duration_secs: u32)
     status.success()
 }
 
+/// Picks the best available H.264-ish encoder, or `None` when ffmpeg has none.
+fn preferred_video_encoder(ffmpeg_path: &std::path::Path) -> Option<&'static str> {
+    if ffmpeg_supports_encoder(ffmpeg_path, "libx264") {
+        Some("libx264")
+    } else if ffmpeg_supports_encoder(ffmpeg_path, "mpeg4") {
+        Some("mpeg4")
+    } else {
+        None
+    }
+}
+
+/// Generates a 4-second video with a hard black-to-white cut at 2s.
+///
+/// Shot detection needs an unambiguous scene change; a single flat colour
+/// source produces none.
+fn create_sample_video_with_scene_change(path: &std::path::Path) -> bool {
+    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+        return false;
+    };
+    let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
+        eprintln!("Skipping perception test: ffmpeg lacks a supported video encoder");
+        return false;
+    };
+
+    let mut command = Command::new(ffmpeg_path);
+    command.args([
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=320x240:r=25:d=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=white:s=320x240:r=25:d=2",
+        "-filter_complex",
+        "[0:v][1:v]concat=n=2:v=1:a=0[v]",
+        "-map",
+        "[v]",
+        "-c:v",
+        video_encoder,
+    ]);
+    if video_encoder == "libx264" {
+        command.args(["-pix_fmt", "yuv420p"]);
+    }
+
+    let status = command
+        .arg(path)
+        .status()
+        .expect("Failed to generate scene-change sample with ffmpeg");
+    if !status.success() {
+        eprintln!("Skipping perception test: ffmpeg could not generate the scene-change sample");
+    }
+    status.success()
+}
+
+/// Generates a 4-second video whose audio is a tone with a silent 1s–3s gap.
+///
+/// Silence detection and audio profiling need a real audio stream; the plain
+/// colour fixture is video-only.
+fn create_sample_video_with_audio(path: &std::path::Path) -> bool {
+    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+        return false;
+    };
+    let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
+        eprintln!("Skipping perception test: ffmpeg lacks a supported video encoder");
+        return false;
+    };
+    if !ffmpeg_supports_encoder(&ffmpeg_path, "aac") {
+        eprintln!("Skipping perception test: ffmpeg lacks the aac encoder");
+        return false;
+    }
+
+    let mut command = Command::new(ffmpeg_path);
+    command.args([
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=320x240:r=25:d=4",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:sample_rate=44100:duration=4",
+        "-af",
+        "volume=enable='between(t,1,3)':volume=0",
+        "-c:v",
+        video_encoder,
+    ]);
+    if video_encoder == "libx264" {
+        command.args(["-pix_fmt", "yuv420p"]);
+    }
+    command.args(["-c:a", "aac", "-shortest"]);
+
+    let status = command
+        .arg(path)
+        .status()
+        .expect("Failed to generate audio sample with ffmpeg");
+    if !status.success() {
+        eprintln!("Skipping perception test: ffmpeg could not generate the audio sample");
+    }
+    status.success()
+}
+
 fn system_ffprobe_path() -> Option<PathBuf> {
     openreelio_core::ffmpeg::detect_system_ffmpeg()
         .ok()
@@ -2022,4 +2126,320 @@ fn test_core_flow_create_import_edit_caption_render_end_to_end() {
             "Expected rendered output to have a positive duration, got {duration}"
         );
     }
+}
+
+// =============================================================================
+// Perception Commands
+// =============================================================================
+
+/// Creates a project and imports media produced by `build_media`.
+///
+/// Returns `None` when FFmpeg cannot produce the fixture so callers can skip.
+fn create_project_with_media(
+    name: &str,
+    file_name: &str,
+    build_media: impl Fn(&std::path::Path) -> bool,
+) -> Option<(tempfile::TempDir, String, String)> {
+    system_ffmpeg_path()?;
+
+    let dir = create_temp_project(name);
+    let path = project_path(&dir, name);
+
+    let source_path = dir.path().join(file_name);
+    if !build_media(&source_path) {
+        return None;
+    }
+
+    let import = run_cli_ok(&[
+        "asset",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        source_path.to_str().unwrap(),
+    ]);
+    let asset_id = import["createdIds"][0].as_str().unwrap().to_string();
+
+    Some((dir, path, asset_id))
+}
+
+/// Path of the cached analysis bundle written by the perception verbs.
+fn bundle_path(project_path: &str, asset_id: &str) -> PathBuf {
+    PathBuf::from(project_path)
+        .join(".openreelio")
+        .join("analysis")
+        .join(asset_id)
+        .join("bundle.json")
+}
+
+#[test]
+fn test_analysis_shots_detects_and_persists_scene_change() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "shots_persist_test",
+        "scene_change.mp4",
+        create_sample_video_with_scene_change,
+    ) else {
+        return;
+    };
+
+    let result = run_cli_ok(&["analysis", "shots", "--path", &path, "--id", &asset_id]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["assetId"], asset_id.as_str());
+    assert!(
+        result["shotCount"].as_u64().unwrap() >= 1,
+        "Expected at least one detected shot, got {}",
+        result["shotCount"]
+    );
+    assert!(result["totalDurationSec"].as_f64().unwrap() > 0.0);
+
+    let persisted: Vec<&str> = result["persisted"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect();
+    assert!(persisted.contains(&"bundle"), "persisted: {:?}", persisted);
+    assert!(
+        persisted.contains(&"annotations"),
+        "persisted: {:?}",
+        persisted
+    );
+    assert!(persisted.contains(&"indexDb"), "persisted: {:?}", persisted);
+
+    assert!(
+        bundle_path(&path, &asset_id).exists(),
+        "Expected the analysis bundle to be written"
+    );
+    assert!(
+        PathBuf::from(&path).join("index.db").exists(),
+        "Expected the shot index database to be written"
+    );
+
+    // The cached artifacts must be visible to the reporting verbs.
+    let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
+    assert_eq!(report["coverage"]["shots"], true);
+    assert_eq!(report["shots"]["count"], result["shotCount"]);
+}
+
+#[test]
+fn test_analysis_shots_writes_nothing_with_no_persist() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "shots_no_persist_test",
+        "scene_change.mp4",
+        create_sample_video_with_scene_change,
+    ) else {
+        return;
+    };
+
+    let result = run_cli_ok(&[
+        "analysis",
+        "shots",
+        "--path",
+        &path,
+        "--id",
+        &asset_id,
+        "--no-persist",
+    ]);
+
+    assert_eq!(result["status"], "ok");
+    assert!(result["shotCount"].as_u64().unwrap() >= 1);
+    assert_eq!(result["persisted"].as_array().unwrap().len(), 0);
+    assert!(
+        !bundle_path(&path, &asset_id).exists(),
+        "Expected --no-persist to leave the analysis bundle untouched"
+    );
+
+    let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
+    assert_eq!(report["coverage"]["shots"], false);
+}
+
+#[test]
+fn test_analysis_shots_rejects_out_of_range_threshold() {
+    let dir = create_temp_project("shots_threshold_test");
+    let path = project_path(&dir, "shots_threshold_test");
+
+    let (_stdout, stderr) = run_cli_err(&[
+        "analysis",
+        "shots",
+        "--path",
+        &path,
+        "--id",
+        "asset_missing",
+        "--threshold",
+        "1.5",
+    ]);
+    assert!(
+        stderr.contains("threshold"),
+        "Expected a threshold validation error, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_analysis_silence_caches_regions_at_default_thresholds() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "silence_default_test",
+        "with_audio.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let result = run_cli_ok(&["analysis", "silence", "--path", &path, "--id", &asset_id]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["persisted"], true);
+    assert!(result.get("reason").is_none() || result["reason"].is_null());
+    assert!(
+        result["regionCount"].as_u64().unwrap() >= 1,
+        "Expected the muted 1s-3s window to be detected"
+    );
+    assert!(result["totalSilenceSec"].as_f64().unwrap() > 0.0);
+    assert!(
+        bundle_path(&path, &asset_id).exists(),
+        "Expected default-threshold silence to be cached"
+    );
+
+    let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
+    assert_eq!(report["coverage"]["audio"], true);
+}
+
+#[test]
+fn test_analysis_silence_is_output_only_for_non_default_threshold() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "silence_custom_test",
+        "with_audio.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let result = run_cli_ok(&[
+        "analysis",
+        "silence",
+        "--path",
+        &path,
+        "--id",
+        &asset_id,
+        "--threshold-db",
+        "-30",
+    ]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["persisted"], false);
+    assert_eq!(result["reason"], "non-default threshold");
+    assert!(
+        !bundle_path(&path, &asset_id).exists(),
+        "Non-default silence parameters must not poison the shared cache"
+    );
+}
+
+#[test]
+fn test_analysis_audio_profiles_and_caches_the_bundle() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "audio_profile_test",
+        "with_audio.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let result = run_cli_ok(&["analysis", "audio", "--path", &path, "--id", &asset_id]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["persisted"], true);
+    assert!(result["durationSec"].as_f64().unwrap() > 0.0);
+    assert!(result["silenceRegionCount"].as_u64().unwrap() >= 1);
+    assert!(result["peakDb"].is_number());
+    assert!(
+        bundle_path(&path, &asset_id).exists(),
+        "Expected the audio profile to be cached"
+    );
+
+    let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
+    assert_eq!(report["coverage"]["audio"], true);
+}
+
+#[test]
+fn test_analysis_run_streams_progress_and_caches_the_bundle() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "analysis_run_test",
+        "with_audio.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let (stdout, stderr, success) = run_cli(&[
+        "analysis",
+        "run",
+        "--path",
+        &path,
+        "--id",
+        &asset_id,
+        "--progress",
+    ]);
+    assert!(
+        success,
+        "analysis run failed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let result: serde_json::Value =
+        serde_json::from_str(&stdout).expect("analysis run must print one JSON object to stdout");
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["options"]["localOnly"], true);
+    assert_eq!(result["options"]["transcript"], false);
+    assert_eq!(result["hasAudioProfile"], true);
+    assert!(result["shotCount"].as_u64().unwrap() >= 1);
+    assert!(result["segmentCount"].as_u64().unwrap() >= 1);
+    assert!(result["errors"].as_object().unwrap().is_empty());
+    assert!(bundle_path(&path, &asset_id).exists());
+
+    // Progress must be NDJSON on stderr so stdout stays a single JSON object.
+    let progress_lines: Vec<serde_json::Value> = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line.trim()).ok())
+        .filter(|value| value["type"] == "progress")
+        .collect();
+    assert!(
+        !progress_lines.is_empty(),
+        "Expected NDJSON progress on stderr, got: {stderr}"
+    );
+    assert!(progress_lines
+        .iter()
+        .any(|line| line["job"] == "shots" && line["status"] == "started"));
+    assert!(progress_lines
+        .iter()
+        .any(|line| line["job"] == "bundle" && line["status"] == "saved"));
+
+    let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
+    assert_eq!(report["coverage"]["shots"], true);
+    assert_eq!(report["coverage"]["audio"], true);
+    assert_eq!(report["coverage"]["segments"], true);
+}
+
+#[test]
+fn test_analysis_run_preserves_results_from_earlier_partial_runs() {
+    let Some((_dir, path, asset_id)) = create_project_with_media(
+        "analysis_run_merge_test",
+        "with_audio.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let audio = run_cli_ok(&["analysis", "audio", "--path", &path, "--id", &asset_id]);
+    assert_eq!(audio["status"], "ok");
+
+    // A shots-only run must not drop the audio profile the previous run cached.
+    let result = run_cli_ok(&[
+        "analysis", "run", "--path", &path, "--id", &asset_id, "--shots",
+    ]);
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["options"]["audio"], false);
+    assert_eq!(result["hasAudioProfile"], true);
+
+    let report = run_cli_ok(&["analysis", "report", "--path", &path, "--id", &asset_id]);
+    assert_eq!(report["coverage"]["shots"], true);
+    assert_eq!(report["coverage"]["audio"], true);
 }

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -945,6 +945,206 @@ fn test_render_start_exports_video_when_ffmpeg_is_available() {
 }
 
 // =============================================================================
+// Frame Commands
+// =============================================================================
+
+/// Creates a project with `sample.mp4` imported and inserted on a video track.
+///
+/// Returns `None` when FFmpeg cannot produce the sample so callers can skip.
+fn create_project_with_timeline_clip(
+    name: &str,
+    duration_secs: u32,
+) -> Option<(tempfile::TempDir, String, String)> {
+    system_ffmpeg_path()?;
+
+    let dir = create_temp_project(name);
+    let path = project_path(&dir, name);
+
+    let source_path = dir.path().join("frame_source.mp4");
+    if !create_sample_video_with_duration(&source_path, duration_secs) {
+        return None;
+    }
+
+    let import = run_cli_ok(&[
+        "asset",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        source_path.to_str().unwrap(),
+    ]);
+    let asset_id = import["createdIds"][0].as_str().unwrap().to_string();
+
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", &path]);
+    let track_id = tracks["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|track| track["kind"] == "Video")
+        .and_then(|track| track["id"].as_str())
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+
+    Some((dir, path, asset_id))
+}
+
+#[test]
+fn test_frame_extract_writes_still_from_asset_source_time() {
+    let Some((dir, path, asset_id)) = create_project_with_timeline_clip("frame_asset_test", 4)
+    else {
+        return;
+    };
+
+    let output_path = dir.path().join("asset_frame.png");
+    let result = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--asset",
+        &asset_id,
+        "--source-time",
+        "1.0",
+        "--out",
+        output_path.to_str().unwrap(),
+    ]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["mode"], "asset");
+    assert_eq!(result["count"], 1);
+    assert_eq!(result["frames"][0]["assetId"], asset_id.as_str());
+    assert_eq!(result["frames"][0]["sourceTimeSec"], 1.0);
+    assert!(output_path.exists(), "Expected extracted frame to exist");
+    assert!(
+        output_path.metadata().unwrap().len() > 0,
+        "Expected extracted frame to be non-empty"
+    );
+}
+
+#[test]
+fn test_frame_extract_writes_still_from_timeline_time() {
+    let Some((dir, path, asset_id)) = create_project_with_timeline_clip("frame_timeline_test", 4)
+    else {
+        return;
+    };
+
+    let output_path = dir.path().join("timeline_frame.png");
+    let result = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--time",
+        "1.5",
+        "--out",
+        output_path.to_str().unwrap(),
+    ]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["mode"], "fast");
+    assert_eq!(result["count"], 1);
+    assert_eq!(result["frames"][0]["timeSec"], 1.5);
+    assert_eq!(result["frames"][0]["assetId"], asset_id.as_str());
+    assert!(result["frames"][0]["clipId"].is_string());
+    assert!(result["frames"][0]["width"].as_u64().unwrap() > 0);
+    assert!(output_path.exists(), "Expected extracted frame to exist");
+    assert!(
+        output_path.metadata().unwrap().len() > 0,
+        "Expected extracted frame to be non-empty"
+    );
+}
+
+#[test]
+fn test_frame_extract_writes_one_file_per_requested_time() {
+    let Some((dir, path, _)) = create_project_with_timeline_clip("frame_batch_test", 4) else {
+        return;
+    };
+
+    let output_dir = dir.path().join("stills");
+    let result = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--times",
+        "0.5,1.5,2.5",
+        "--out",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["count"], 3);
+
+    let frames = result["frames"].as_array().unwrap();
+    assert_eq!(frames.len(), 3);
+    for frame in frames {
+        let frame_path = std::path::Path::new(frame["path"].as_str().unwrap());
+        assert!(
+            frame_path.exists(),
+            "Expected batch frame {} to exist",
+            frame_path.display()
+        );
+        assert!(
+            frame_path.metadata().unwrap().len() > 0,
+            "Expected batch frame {} to be non-empty",
+            frame_path.display()
+        );
+    }
+}
+
+#[test]
+fn test_frame_extract_builds_contact_sheet_for_grid() {
+    let Some((dir, path, _)) = create_project_with_timeline_clip("frame_grid_test", 4) else {
+        return;
+    };
+
+    let sheet_path = dir.path().join("sheet.jpg");
+    let result = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--grid",
+        "2x2",
+        "--between",
+        "0",
+        "4",
+        "--format",
+        "jpeg",
+        "--out",
+        sheet_path.to_str().unwrap(),
+    ]);
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["sheet"]["cols"], 2);
+    assert_eq!(result["sheet"]["rows"], 2);
+
+    let cells = result["sheet"]["cells"].as_array().unwrap();
+    assert_eq!(cells.len(), 4);
+    let times: Vec<f64> = cells
+        .iter()
+        .map(|cell| cell["timelineSec"].as_f64().unwrap())
+        .collect();
+    assert!(
+        times.windows(2).all(|pair| pair[0] < pair[1]),
+        "Expected ascending cell times, got {:?}",
+        times
+    );
+    assert!(times.iter().all(|time| *time > 0.0 && *time < 4.0));
+
+    assert!(sheet_path.exists(), "Expected contact sheet to exist");
+    assert!(
+        sheet_path.metadata().unwrap().len() > 0,
+        "Expected contact sheet to be non-empty"
+    );
+}
+
+// =============================================================================
 // Plan Commands
 // =============================================================================
 

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2443,3 +2443,314 @@ fn test_analysis_run_preserves_results_from_earlier_partial_runs() {
     assert_eq!(report["coverage"]["shots"], true);
     assert_eq!(report["coverage"]["audio"], true);
 }
+
+// =============================================================================
+// verify
+// =============================================================================
+
+/// Runs the CLI and returns (stdout, stderr, exit code).
+///
+/// `verify` distinguishes "found problems" (1) from "could not run" (2), so its
+/// tests need the code itself rather than a success flag.
+fn run_cli_exit(args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(cli_bin())
+        .args(args)
+        .output()
+        .expect("Failed to execute CLI binary");
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+/// Creates a project holding one dummy asset placed on the first video track.
+///
+/// Deliberately FFmpeg-free: structural verification must work on a machine
+/// without a media toolchain.
+fn create_project_with_placed_dummy(name: &str) -> (tempfile::TempDir, String, String, String) {
+    let dir = create_temp_project(name);
+    let path = project_path(&dir, name);
+
+    let dummy_file = dir.path().join("clip.mp4");
+    std::fs::write(&dummy_file, b"dummy video").unwrap();
+    let import = run_cli_ok(&[
+        "asset",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        dummy_file.to_str().unwrap(),
+    ]);
+    let asset_id = import["createdIds"][0].as_str().unwrap().to_string();
+
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", &path]);
+    let track_id = tracks["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|track| track["kind"] == "Video")
+        .and_then(|track| track["id"].as_str())
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+
+    (dir, path, asset_id, track_id)
+}
+
+/// Finds a check entry by its stable ID.
+fn find_check<'a>(report: &'a serde_json::Value, check_id: &str) -> &'a serde_json::Value {
+    report["checks"]
+        .as_array()
+        .expect("checks array")
+        .iter()
+        .find(|check| check["id"] == check_id)
+        .unwrap_or_else(|| panic!("check '{check_id}' missing from report: {report}"))
+}
+
+#[test]
+fn test_verify_structural_only_passes_on_a_healthy_project() {
+    let (_dir, path, _asset_id, _track_id) =
+        create_project_with_placed_dummy("verify_structural_ok");
+
+    let (stdout, stderr, code) = run_cli_exit(&["verify", "--path", &path, "--structural-only"]);
+    assert_eq!(
+        code, 0,
+        "expected a clean structural run.\nstderr: {stderr}"
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|error| panic!("{error}\n{stdout}"));
+
+    assert_eq!(report["status"], "ok");
+    assert_eq!(report["passed"], true);
+    assert_eq!(report["summary"]["error"], 0);
+    assert_eq!(report["summary"]["critical"], 0);
+
+    // Structural runs must never reach for FFmpeg.
+    assert_eq!(report["target"]["measured"], false);
+    assert_eq!(report["measurements"]["measured"], false);
+
+    let stats = find_check(&report, "shot.length_stats");
+    assert_eq!(stats["status"], "passed");
+    assert_eq!(stats["metrics"]["count"], 1);
+    assert!(stats["metrics"]["medianSec"].as_f64().unwrap() > 0.0);
+
+    // A passing check still has to appear, or an agent cannot tell it ran.
+    let gap = find_check(&report, "timeline.gap");
+    assert_eq!(gap["status"], "passed");
+    assert_eq!(gap["violationCount"], 0);
+
+    // Rendered checks are skipped with a reason rather than silently passed.
+    let black = find_check(&report, "render.black_frames");
+    assert_eq!(black["status"], "skipped");
+    assert_eq!(black["passed"], false);
+    assert!(black["skipReason"]
+        .as_str()
+        .unwrap()
+        .contains("measurements"));
+}
+
+#[test]
+fn test_verify_reports_a_timeline_gap_as_an_error_and_exits_one() {
+    let (dir, path, asset_id, track_id) = create_project_with_placed_dummy("verify_gap_error");
+
+    // The dummy asset yields a 10s clip; placing the next one at 11s leaves a
+    // deliberate one-second hole in the picture.
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "11.0",
+    ]);
+
+    let (stdout, stderr, code) = run_cli_exit(&[
+        "verify",
+        "--path",
+        &path,
+        "--structural-only",
+        "--fail-on",
+        "error",
+    ]);
+    assert_eq!(
+        code, 1,
+        "a gap must breach the error threshold.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|error| panic!("{error}\n{stdout}"));
+
+    assert_eq!(report["status"], "failed");
+    assert_eq!(report["passed"], false);
+    assert_eq!(report["summary"]["error"], 1);
+
+    let gap = find_check(&report, "timeline.gap");
+    assert_eq!(gap["status"], "failed");
+    assert_eq!(gap["severity"], "error");
+    assert_eq!(gap["violationCount"], 1);
+    assert!((gap["timeRanges"][0]["startSec"].as_f64().unwrap() - 10.0).abs() < 1e-6);
+    assert!((gap["timeRanges"][0]["endSec"].as_f64().unwrap() - 11.0).abs() < 1e-6);
+
+    // The suggested fix has to be executable, not merely descriptive.
+    let step = &gap["suggestedFix"]["steps"][0];
+    assert_eq!(step["commandType"], "CloseGap");
+    assert_eq!(step["payload"]["trackId"], track_id.as_str());
+
+    let plan_file = dir.path().join("fix-plan.json");
+    std::fs::write(
+        &plan_file,
+        serde_json::json!({
+            "id": "plan_verify_fix",
+            "steps": gap["suggestedFix"]["steps"],
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let applied = run_cli_ok(&[
+        "plan",
+        "execute",
+        "--path",
+        &path,
+        "--file",
+        plan_file.to_str().unwrap(),
+    ]);
+    assert_eq!(applied["status"], "ok");
+
+    let (stdout, _stderr, code) = run_cli_exit(&["verify", "--path", &path, "--structural-only"]);
+    assert_eq!(code, 0, "the suggested fix must close the gap: {stdout}");
+}
+
+#[test]
+fn test_verify_rejects_an_unknown_check_id_with_the_tool_failure_code() {
+    let (_dir, path, _asset_id, _track_id) = create_project_with_placed_dummy("verify_bad_check");
+
+    let (_stdout, stderr, code) = run_cli_exit(&[
+        "verify",
+        "--path",
+        &path,
+        "--structural-only",
+        "--checks",
+        "not.a.real.check",
+    ]);
+
+    assert_eq!(code, 2, "bad arguments are a tool failure, not a finding");
+    assert!(
+        stderr.contains("Unknown check"),
+        "expected the error to list the known checks, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_verify_measures_a_rendered_file() {
+    let Some((dir, path, asset_id)) = create_project_with_media(
+        "verify_rendered_test",
+        "verify_source.mp4",
+        create_sample_video_with_audio,
+    ) else {
+        return;
+    };
+
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", &path]);
+    let track_id = tracks["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|track| track["kind"] == "Video")
+        .and_then(|track| track["id"].as_str())
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+
+    let render_path = dir.path().join("verify-proxy.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--proxy",
+        "--start",
+        "0",
+        "--end",
+        "2",
+        "--output",
+        render_path.to_str().unwrap(),
+    ]);
+    if !success {
+        eprintln!("Skipping verify render test: proxy render failed.\n{stdout}\n{stderr}");
+        return;
+    }
+
+    // The fixture is a bare test tone, so its absolute loudness says nothing
+    // about the edit; the measurement itself is still asserted below.
+    let (stdout, stderr, code) = run_cli_exit(&[
+        "verify",
+        "--path",
+        &path,
+        "--file",
+        render_path.to_str().unwrap(),
+        "--skip",
+        "audio.loudness",
+    ]);
+    assert_eq!(
+        code, 0,
+        "rendered verification should run cleanly.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|error| panic!("{error}\n{stdout}"));
+
+    assert_eq!(report["target"]["measured"], true);
+    assert_eq!(report["measurements"]["measured"], true);
+    assert_eq!(report["measurements"]["videoMeasured"], true);
+    assert_eq!(report["measurements"]["audioMeasured"], true);
+    assert!(report["measurements"]["durationSec"].as_f64().unwrap() > 0.0);
+
+    // Loudness is measured even though the check itself was skipped.
+    assert!(
+        report["measurements"]["integratedLufs"].is_number(),
+        "expected an EBU R128 reading: {}",
+        report["measurements"]
+    );
+
+    let black = find_check(&report, "render.black_frames");
+    assert_ne!(
+        black["status"], "skipped",
+        "rendered checks must run once a file was measured: {black}"
+    );
+
+    let peak = find_check(&report, "audio.peak");
+    assert_ne!(
+        peak["status"], "skipped",
+        "peak check should have run: {peak}"
+    );
+
+    let loudness = find_check(&report, "audio.loudness");
+    assert_eq!(loudness["status"], "skipped");
+}
+
+#[test]
+fn test_verify_reports_a_missing_render_file_as_a_tool_failure() {
+    let (_dir, path, _asset_id, _track_id) =
+        create_project_with_placed_dummy("verify_missing_file");
+
+    let (_stdout, stderr, code) = run_cli_exit(&[
+        "verify",
+        "--path",
+        &path,
+        "--file",
+        "definitely-not-here.mp4",
+    ]);
+
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("does not exist"),
+        "expected a missing-file error, got: {stderr}"
+    );
+}

--- a/docs/AGENT_PERCEPTION_CLI_PLAN.md
+++ b/docs/AGENT_PERCEPTION_CLI_PLAN.md
@@ -60,7 +60,7 @@ These were decided during implementation and are deliberate; do not "fix" them b
 Problem: three divergent resolution paths; CLI never checks the managed install (PR #784), so in-app FFmpeg installs are invisible to every CLI verb; non-render CLI verbs never register paths at all and silently fall back to bare `ffmpeg`.
 
 - Add to `core/ffmpeg/resolver.rs`:
-  - `pub struct FFmpegResolveOptions { pub explicit_ffmpeg: Option<PathBuf>, pub explicit_ffprobe: Option<PathBuf>, pub resource_roots: Vec<PathBuf> }`
+  - `pub struct FFmpegResolveOptions { pub explicit_ffmpeg: Option<PathBuf>, pub explicit_ffprobe: Option<PathBuf>, pub resource_roots: Vec<PathBuf>, pub use_env: bool }` — `use_env` decides whether the `OPENREELIO_FFMPEG_PATH` / `OPENREELIO_FFPROBE_PATH` overrides participate; it defaults to `false` so a GUI process never inherits a stray variable, and the CLI sets it to `true` (`crates/openreelio-cli/src/ffmpeg_env.rs`).
   - `pub fn resolve_ffmpeg(&FFmpegResolveOptions) -> FFmpegResult<FFmpegInfo>` — order: explicit → `OPENREELIO_FFMPEG_PATH`/`OPENREELIO_FFPROBE_PATH` env → `resource_roots` via `detect_bundled_at_path` → `detect_managed_ffmpeg()` → `detect_dev_mode_binaries()` → `detect_system_ffmpeg()`. Validate candidates with `get_ffmpeg_version`.
   - `pub fn resolve_and_register(...)` — same + `set_resolved_paths`.
 - GUI `state.rs detect_ffmpeg` delegates with `resource_roots = [resource_dir]` (bundled-resources-first order preserved; env override intentionally CLI-only — pass a flag or skip env in the GUI call).

--- a/docs/AGENT_PERCEPTION_CLI_PLAN.md
+++ b/docs/AGENT_PERCEPTION_CLI_PLAN.md
@@ -1,7 +1,40 @@
 # Agent Perception CLI — Design & Implementation Plan
 
 **Branch**: `feature/agent-headless-perception`
+**Status**: **COMPLETE** — T1–T7 all landed on the branch.
 **Goal**: Give the headless CLI the primitives an external coding agent (Claude Code / Codex) needs to *see* media and *verify* its own edits: frame extraction, proxy renders, perception generation (shots/silence/audio/full analysis), and a deterministic QC `verify` tool. This is the shared foundation for both the in-app agent quality roadmap and the agent-native external surface.
+
+## Status summary
+
+| Task | Status | Commit |
+|------|--------|--------|
+| T1 — Unified FFmpeg resolution | DONE | `9abe13c8` |
+| T2 — QC bring-up refactor | DONE | `3433d95b` |
+| T3 — Frame extraction | DONE | `6100a72c` |
+| T4 — Proxy render | DONE | `310b86c9` |
+| T5 — Headless perception | DONE | `1bf586ba` |
+| T6 — `verify` | DONE | `b6568eba` |
+| T7 — Integration & polish | DONE | (this commit) |
+
+### Accepted deviations from the plan
+
+These were decided during implementation and are deliberate; do not "fix" them back.
+
+- **`ebur128` uses `framelog=quiet`, not `framelog=summary`** (T6). The summary block is
+  emitted regardless, and `framelog=summary` still logs per-frame lines on some builds; `quiet`
+  keeps the single-pass stderr capture small and the parse deterministic.
+- **`caption.reading_rate` is warning-only** (T6). The plan reserved `error` for >25 CPS on
+  Latin script, but reading rate is taste-adjacent and script detection is heuristic, so every
+  finding stays a warning. `error` remains reserved for objectively broken output.
+- **`analysis silence`'s write gate is stricter than `can_reuse_cached_silence_regions`** (T5).
+  The plan reused the read gate for writes, but that gate accepts a *longer* `min-duration`
+  (a reader may filter a cached set down). A run detecting at that duration would populate the
+  cache with fewer regions than the contract promises, so writing requires both parameters to
+  equal the defaults exactly; anything else is output-only with `"persisted": false` and a
+  `reason` of `"non-default threshold"` or `"non-default min-duration"`.
+- **Proxy is an `ExportSettings` constructor, not an enum variant** (T4). `--proxy` is an alias
+  that selects the `proxy_480p` preset rather than a new render-mode variant, so the existing
+  preset plumbing and `plan_hash` behaviour are untouched.
 
 ## Design principles
 
@@ -13,7 +46,7 @@
 
 ## Task breakdown (sequential; one commit each unless noted)
 
-### T1 — Unified FFmpeg resolution (`fix(core)` + `feat(api)`)
+### T1 — Unified FFmpeg resolution (`fix(core)` + `feat(api)`) — DONE (`9abe13c8`)
 
 Problem: three divergent resolution paths; CLI never checks the managed install (PR #784), so in-app FFmpeg installs are invisible to every CLI verb; non-render CLI verbs never register paths at all and silently fall back to bare `ffmpeg`.
 
@@ -26,7 +59,7 @@ Problem: three divergent resolution paths; CLI never checks the managed install 
 - New verb `ffmpeg info` → `{status, ffmpegPath, ffprobePath, version, source}` for agent self-diagnosis.
 - Unit tests for resolution order; keep `dev_mode` visibility inside the module.
 
-### T2 — QC bring-up refactor (`refactor(core)`)
+### T2 — QC bring-up refactor (`refactor(core)`) — DONE (`3433d95b`)
 
 Per "Refactor Before Feature". `core/qc/` is dead code with three simulated rule bodies.
 
@@ -35,7 +68,7 @@ Per "Refactor Before Feature". `core/qc/` is dead code with three simulated rule
 - `QCEngine::check`: record `errored_rules` in `QCReport` instead of log-and-continue masquerading as pass.
 - No CLI exposure yet; module unit tests only.
 
-### T3 — Frame extraction (`feat(api)`)
+### T3 — Frame extraction (`feat(api)`) — DONE (`6100a72c`)
 
 `openreelio-cli frame extract --path P --out F [--asset ID --source-time T | --time T] [--sequence S] [--mode fast|composite] [--width N] [--format png|jpeg] [--grid CxR --between A B [--count N]]`
 
@@ -45,14 +78,14 @@ Per "Refactor Before Feature". `core/qc/` is dead code with three simulated rule
 - `--grid`: sample N evenly over `[a,b]` into `%d.jpg` sequence dir → `VisualAnalyzer::generate_contact_sheet`; JSON returns `cells:[{index,row,col,timelineSec}]` for VLM cell→timecode mapping.
 - Output: `{status, frames:[{index, timeSec, sourceTimeSec, clipId, assetId, path, width, height}], count}` (or `{sheet: {...}}` for grid).
 
-### T4 — Proxy render (`feat(render)`)
+### T4 — Proxy render (`feat(render)`) — DONE (`310b86c9`)
 
 - `ExportSettings`: add `encoder_speed: Option<String>` threaded into quality args (check `plan_hash` includes it deliberately).
 - New preset `proxy_480p` (854x480, CRF 30, H264/AAC 96k, `ultrafast`) + expose `mp4_draft` in CLI `RENDER_PRESETS`.
 - `render start --proxy` (alias for proxy_480p) + `--start/--end` args (ExportSettings already supports).
 - `--progress`: pass `mpsc::Sender<ExportProgress>`, stream NDJSON to stderr. Add tokio `sync`+`signal` features to CLI Cargo.toml; wire Ctrl-C to the existing oneshot cancel.
 
-### T5 — Headless perception (`feat(api)`)
+### T5 — Headless perception (`feat(api)`) — DONE (`1bf586ba`)
 
 - src-tauri visibility: promote `AnalysisJobRunner::save_bundle` + `asset_analysis_dir` to `pub`; or add public load-merge-save helpers (`merge_bundle_shots`, `merge_bundle_audio_profile`) — prefer merge helpers to prevent partial-bundle clobbering.
 - `analysis shots [--threshold 0.3] [--min-shot-duration 0.5] [--timeout-sec 600]` → `ShotDetector`; **triple-write**: (1) sqlite `index.db` `shots` table via `save_to_db` with the 3-attempt SQLITE_BUSY retry (GUI markers read only this), (2) merge into `bundle.json`, (3) `AnnotationStore.set_shots` (provider Ffmpeg, config recorded; use asset's stored hash, tolerate empty).
@@ -61,7 +94,7 @@ Per "Refactor Before Feature". `core/qc/` is dead code with three simulated rule
 - `analysis run [--shots|--audio|--segments|--transcript|--visual|--all]` → `analyze_full_with_metadata` with `local_only: true` forced; transcript off by default, fail fast with `transcription install` hint when the whisper model is missing; surface `bundle.errors`, non-zero exit only if every enabled sub-job failed. NDJSON progress on stderr.
 - All media paths via `asset.resolved_path(&project.path)`.
 
-### T6 — `verify` (`feat(core)` then `feat(api)`; may be two commits)
+### T6 — `verify` (`feat(core)` then `feat(api)`; may be two commits) — DONE (`b6568eba`)
 
 - `core/qc/measure.rs`: `FFmpegRunner::run_filter_capture_stderr(input, filter_complex, maps, timeout)` (public, `tokio::time::timeout`, `configure_tokio_command`, pinned `-loglevel info`); refactor `AudioProfiler::run_ffmpeg_filter` onto it (closes the no-timeout gap everywhere). Single-pass invocation:
   `-filter_complex "[0:v]blackdetect=d=0.1:pic_th=0.98:pix_th=0.10,freezedetect=n=-60dB:d=2[v];[0:a]ebur128=peak=true:framelog=summary,silencedetect=n=-50dB:d=1.5,astats=metadata=0:measure_perchannel=none:measure_overall=Peak_level+Flat_factor[a]" -map "[v]" -map "[a]" -f null -`
@@ -70,11 +103,23 @@ Per "Refactor Before Feature". `core/qc/` is dead code with three simulated rule
 - Cross-reference: rendered black ranges overlapping structural gaps ⇒ error; non-overlapping ⇒ info (title cards/fades are legitimate).
 - `crates/openreelio-cli/src/commands/verify.rs`: `verify --path P [--sequence S] [--file RENDER] [--structural-only] [--checks a,b] [--skip a,b] [--target-lufs -14] [--max-true-peak -1] [--fail-on error] [--timeout-sec 600]`. No `--file` ⇒ structural only. Exit codes: 0 ran+passed threshold, 1 threshold breached, 2 tool error. Output schema mirrors `build_diagnostics` top-level (`status/warnings/errors`) plus `checks[]`, `measurements{}`, per-check `timeRanges`, `suggestedFix` (EditScript) so violations stay agent-actionable. Keep taste-adjacent checks at warning/info; `error` reserved for objectively broken output.
 
-### T7 — Integration & polish
+### T7 — Integration & polish — DONE
 
 - Extend `integration.rs` e2e: perceive (shots+silence) → edit → proxy render → frame extract → verify (structural + rendered) in one flow; plus targeted tests per verb.
 - help-json entries for every new leaf; update `docs/COMMAND_REFERENCE.md` CLI tree in CLAUDE.md if needed.
 - Workspace-wide `cargo fmt --check`, `cargo clippy -D warnings` (gui lib AND cli AND core), full `cargo test`, `npm run type-check` (bindings untouched but verify).
+
+Outcome:
+
+- `test_agent_perception_loop_end_to_end` drives the whole loop through the real binary
+  (create → import → `analysis shots` → `analysis silence` → insert + shot-informed split →
+  `render start --proxy --progress` → `frame extract --time` → `frame extract --grid` →
+  `verify --file`), asserting only on CLI-observable JSON. Runs in ~3 s; skips without FFmpeg.
+- The loop needs a `timeline trim` step before the split: `asset import` does not probe media
+  duration, so the placed clip carries the default length and perception's `totalDurationSec`
+  is what tells the agent how long the media actually is.
+- `docs/COMMAND_REFERENCE.md` documents edit Commands and analysis IPC only — no CLI verb tree,
+  so it was left untouched. The CLI tree in `CLAUDE.md` carries the new verbs.
 
 ## Known risks (from investigation — do not rediscover)
 

--- a/docs/AGENT_PERCEPTION_CLI_PLAN.md
+++ b/docs/AGENT_PERCEPTION_CLI_PLAN.md
@@ -20,9 +20,11 @@
 
 These were decided during implementation and are deliberate; do not "fix" them back.
 
-- **`ebur128` uses `framelog=quiet`, not `framelog=summary`** (T6). The summary block is
-  emitted regardless, and `framelog=summary` still logs per-frame lines on some builds; `quiet`
-  keeps the single-pass stderr capture small and the parse deterministic.
+- ~~**`ebur128` uses `framelog=quiet`, not `framelog=summary`** (T6).~~ **Reverted.** FFmpeg 4.4
+  and 6.1 only accept `info`/`verbose` for `framelog`, so `quiet` failed option parsing and made
+  `verify --file` exit 2 on every system FFmpeg. The option is now omitted entirely: per-frame
+  lines carry the `[Parsed_ebur128` marker so the bounded filter buffer absorbs them, and the
+  summary parser keys off labels, not position.
 - **`caption.reading_rate` is warning-only** (T6). The plan reserved `error` for >25 CPS on
   Latin script, but reading rate is taste-adjacent and script detection is heuristic, so every
   finding stays a warning. `error` remains reserved for objectively broken output.
@@ -34,7 +36,14 @@ These were decided during implementation and are deliberate; do not "fix" them b
   `reason` of `"non-default threshold"` or `"non-default min-duration"`.
 - **Proxy is an `ExportSettings` constructor, not an enum variant** (T4). `--proxy` is an alias
   that selects the `proxy_480p` preset rather than a new render-mode variant, so the existing
-  preset plumbing and `plan_hash` behaviour are untouched.
+  preset plumbing and `plan_hash` behaviour are untouched. The constructor takes the sequence
+  canvas: a fixed 854x480 frame pillarboxed every non-16:9 edit, so the frame is fitted to the
+  canvas within a 480p budget (long edge ≤ 854, short edge ≤ 480).
+
+- **`analysis silence` only persists into an existing audio profile** (T5). The regions live
+  inside `bundle.audioProfile`, whose other fields are measurements; with no profile to merge
+  into, the run is output-only with `"persisted": false` and a `reason` of
+  `"no audio profile in bundle; run \`analysis audio\` first"`.
 
 ## Design principles
 

--- a/docs/AGENT_PERCEPTION_CLI_PLAN.md
+++ b/docs/AGENT_PERCEPTION_CLI_PLAN.md
@@ -1,0 +1,86 @@
+# Agent Perception CLI — Design & Implementation Plan
+
+**Branch**: `feature/agent-headless-perception`
+**Goal**: Give the headless CLI the primitives an external coding agent (Claude Code / Codex) needs to *see* media and *verify* its own edits: frame extraction, proxy renders, perception generation (shots/silence/audio/full analysis), and a deterministic QC `verify` tool. This is the shared foundation for both the in-app agent quality roadmap and the agent-native external surface.
+
+## Design principles
+
+1. **Core once, three surfaces.** All logic lives in Tauri-free `src-tauri/src/core/*` (auto-exposed to CLI via `openreelio-core`'s glob re-export). CLI verbs are thin wrappers. The in-app agent and MCP server pick these up later at wrapper cost.
+2. **Resurrect, don't duplicate.** `core/qc/` (engine + rules + violations, currently dead code), `ExportEngine::export_frame`, `VisualAnalyzer::generate_contact_sheet`, `AudioProfiler`, `ShotDetector`, `AnalysisJobRunner` all exist. This branch wires and completes them.
+3. **stdout is one JSON object; progress/diagnostics go to stderr.** Existing CLI contract (see `caption.rs:715` comment). Long-running verbs stream NDJSON progress to stderr under `--progress`.
+4. **Every new clap leaf gets a `help_json.rs` entry** — the parity test `build_schema_covers_all_clap_leaf_commands` enforces this.
+5. **Integration tests skip cleanly without FFmpeg** (`if system_ffmpeg_path().is_none() { return; }` pattern).
+
+## Task breakdown (sequential; one commit each unless noted)
+
+### T1 — Unified FFmpeg resolution (`fix(core)` + `feat(api)`)
+
+Problem: three divergent resolution paths; CLI never checks the managed install (PR #784), so in-app FFmpeg installs are invisible to every CLI verb; non-render CLI verbs never register paths at all and silently fall back to bare `ffmpeg`.
+
+- Add to `core/ffmpeg/resolver.rs`:
+  - `pub struct FFmpegResolveOptions { pub explicit_ffmpeg: Option<PathBuf>, pub explicit_ffprobe: Option<PathBuf>, pub resource_roots: Vec<PathBuf> }`
+  - `pub fn resolve_ffmpeg(&FFmpegResolveOptions) -> FFmpegResult<FFmpegInfo>` — order: explicit → `OPENREELIO_FFMPEG_PATH`/`OPENREELIO_FFPROBE_PATH` env → `resource_roots` via `detect_bundled_at_path` → `detect_managed_ffmpeg()` → `detect_dev_mode_binaries()` → `detect_system_ffmpeg()`. Validate candidates with `get_ffmpeg_version`.
+  - `pub fn resolve_and_register(...)` — same + `set_resolved_paths`.
+- GUI `state.rs detect_ffmpeg` delegates with `resource_roots = [resource_dir]` (bundled-resources-first order preserved; env override intentionally CLI-only — pass a flag or skip env in the GUI call).
+- CLI: delete private `detect_cli_ffmpeg`; call `resolve_and_register` once in `commands::execute` for media-touching commands (render, frame, analysis, transcription, verify, asset import). Fix transcription's `PathBuf::from(&asset.uri)` → `asset.resolved_path(&project.path)` while touching it.
+- New verb `ffmpeg info` → `{status, ffmpegPath, ffprobePath, version, source}` for agent self-diagnosis.
+- Unit tests for resolution order; keep `dev_mode` visibility inside the module.
+
+### T2 — QC bring-up refactor (`refactor(core)`)
+
+Per "Refactor Before Feature". `core/qc/` is dead code with three simulated rule bodies.
+
+- Add `QCContext { fps: f64, canvas: Canvas, measurements: Option<RenderMeasurements> }` as 4th arg to `QCRule::check` (trait + 7 rules + engine + tests).
+- Replace simulated bodies with real structural logic where possible now (BlackFrame → defer to measurements, mark `skipped` when `measurements: None`; AudioPeak → same; CaptionSafeArea → real structural check from `clip.caption_position`/`caption_style` JSON, defensively deserialized).
+- `QCEngine::check`: record `errored_rules` in `QCReport` instead of log-and-continue masquerading as pass.
+- No CLI exposure yet; module unit tests only.
+
+### T3 — Frame extraction (`feat(api)`)
+
+`openreelio-cli frame extract --path P --out F [--asset ID --source-time T | --time T] [--sequence S] [--mode fast|composite] [--width N] [--format png|jpeg] [--grid CxR --between A B [--count N]]`
+
+- Asset source-time: `FFmpegRunner::extract_frame` + scale filter. Fix its stale-output short-circuit (force overwrite).
+- Timeline-time `--mode fast` (default): `ExportEngine::export_frame`; extend `FrameExportSettings` with `width`/`height` (default max-width 1280 for VLM-friendly size). Document limitation: topmost video clip only, no effects/text/compositing; when `find_topmost_clip_at_time` returns None (e.g. title card), auto-fall back to composite mode.
+- `--mode composite`: render `[t, t + max(2/fps, 0.05)]` via `ExportSettings::preview` → temp mp4 → extract frame 0. (Range renders decode from 0 — document cost; `normalize_output_time_range` rejects zero-length ranges.)
+- `--grid`: sample N evenly over `[a,b]` into `%d.jpg` sequence dir → `VisualAnalyzer::generate_contact_sheet`; JSON returns `cells:[{index,row,col,timelineSec}]` for VLM cell→timecode mapping.
+- Output: `{status, frames:[{index, timeSec, sourceTimeSec, clipId, assetId, path, width, height}], count}` (or `{sheet: {...}}` for grid).
+
+### T4 — Proxy render (`feat(render)`)
+
+- `ExportSettings`: add `encoder_speed: Option<String>` threaded into quality args (check `plan_hash` includes it deliberately).
+- New preset `proxy_480p` (854x480, CRF 30, H264/AAC 96k, `ultrafast`) + expose `mp4_draft` in CLI `RENDER_PRESETS`.
+- `render start --proxy` (alias for proxy_480p) + `--start/--end` args (ExportSettings already supports).
+- `--progress`: pass `mpsc::Sender<ExportProgress>`, stream NDJSON to stderr. Add tokio `sync`+`signal` features to CLI Cargo.toml; wire Ctrl-C to the existing oneshot cancel.
+
+### T5 — Headless perception (`feat(api)`)
+
+- src-tauri visibility: promote `AnalysisJobRunner::save_bundle` + `asset_analysis_dir` to `pub`; or add public load-merge-save helpers (`merge_bundle_shots`, `merge_bundle_audio_profile`) — prefer merge helpers to prevent partial-bundle clobbering.
+- `analysis shots [--threshold 0.3] [--min-shot-duration 0.5] [--timeout-sec 600]` → `ShotDetector`; **triple-write**: (1) sqlite `index.db` `shots` table via `save_to_db` with the 3-attempt SQLITE_BUSY retry (GUI markers read only this), (2) merge into `bundle.json`, (3) `AnnotationStore.set_shots` (provider Ffmpeg, config recorded; use asset's stored hash, tolerate empty).
+- `analysis silence [--threshold-db -40] [--min-duration 0.5]` → `detect_silence_custom`. Persist into `bundle.audioProfile.silence_regions` **only when** `cleanup::can_reuse_cached_silence_regions(t,d)` holds; otherwise output-only with `"persisted": false, "reason": "non-default threshold"` (protects the GUI cleanup cache contract).
+- `analysis audio` → full `AudioProfiler::analyze` (silence+loudness+BPM+VAD) → `bundle.audioProfile`.
+- `analysis run [--shots|--audio|--segments|--transcript|--visual|--all]` → `analyze_full_with_metadata` with `local_only: true` forced; transcript off by default, fail fast with `transcription install` hint when the whisper model is missing; surface `bundle.errors`, non-zero exit only if every enabled sub-job failed. NDJSON progress on stderr.
+- All media paths via `asset.resolved_path(&project.path)`.
+
+### T6 — `verify` (`feat(core)` then `feat(api)`; may be two commits)
+
+- `core/qc/measure.rs`: `FFmpegRunner::run_filter_capture_stderr(input, filter_complex, maps, timeout)` (public, `tokio::time::timeout`, `configure_tokio_command`, pinned `-loglevel info`); refactor `AudioProfiler::run_ffmpeg_filter` onto it (closes the no-timeout gap everywhere). Single-pass invocation:
+  `-filter_complex "[0:v]blackdetect=d=0.1:pic_th=0.98:pix_th=0.10,freezedetect=n=-60dB:d=2[v];[0:a]ebur128=peak=true:framelog=summary,silencedetect=n=-50dB:d=1.5,astats=metadata=0:measure_perchannel=none:measure_overall=Peak_level+Flat_factor[a]" -map "[v]" -map "[a]" -f null -`
+  New parsers (pure fns + fixture tests): blackdetect ranges, freezedetect ranges, ebur128 Summary (`I:`, `LRA:`, True peak — degrade to sample peak if absent), astats peak/flat. Reuse `parse_silence_regions`. If `has_no_audio_indicator` → audio checks `skipped`, never `failed`. Assert ≥1 filter line seen, else check = `skipped` (guards against a future `-loglevel` regression silently passing everything).
+- `core/qc/structural.rs` checks: `timeline.gap` (error; `find_gaps`, autofix `CloseGapCommand`), `clip.orphan` (<2/fps, warning), `clip.missing_asset` (critical), `audio.silent_clip` (warning), `caption.overlap` (error), `caption.reading_rate` (CPS from `clip.label` — **script-aware: default off/adjusted for CJK**; warn >20, error >25 Latin only), `caption.out_of_bounds` (error), `caption.safe_area` (structural from position JSON, warning), `shot.length_stats` (info, always emits metrics).
+- Cross-reference: rendered black ranges overlapping structural gaps ⇒ error; non-overlapping ⇒ info (title cards/fades are legitimate).
+- `crates/openreelio-cli/src/commands/verify.rs`: `verify --path P [--sequence S] [--file RENDER] [--structural-only] [--checks a,b] [--skip a,b] [--target-lufs -14] [--max-true-peak -1] [--fail-on error] [--timeout-sec 600]`. No `--file` ⇒ structural only. Exit codes: 0 ran+passed threshold, 1 threshold breached, 2 tool error. Output schema mirrors `build_diagnostics` top-level (`status/warnings/errors`) plus `checks[]`, `measurements{}`, per-check `timeRanges`, `suggestedFix` (EditScript) so violations stay agent-actionable. Keep taste-adjacent checks at warning/info; `error` reserved for objectively broken output.
+
+### T7 — Integration & polish
+
+- Extend `integration.rs` e2e: perceive (shots+silence) → edit → proxy render → frame extract → verify (structural + rendered) in one flow; plus targeted tests per verb.
+- help-json entries for every new leaf; update `docs/COMMAND_REFERENCE.md` CLI tree in CLAUDE.md if needed.
+- Workspace-wide `cargo fmt --check`, `cargo clippy -D warnings` (gui lib AND cli AND core), full `cargo test`, `npm run type-check` (bindings untouched but verify).
+
+## Known risks (from investigation — do not rediscover)
+
+- Resolution must be registered **before** constructing `AnalysisJobRunner`/`ThumbnailService`/`AudioProfiler` (they read resolver globals at construction/use).
+- `plan_hash` sensitivity when adding `encoder_speed` — decide cache invalidation deliberately.
+- `ShotDetector` hard limits: 20k cuts (`ResourceExhausted`), 600s timeout — surface `--timeout-sec` and guidance in errors.
+- Concurrent GUI+CLI `index.db` writes → SQLITE_BUSY retry loop required.
+- `Commands` enum carries `#[allow(clippy::large_enum_variant)]` — keep args in structs.
+- Windows: every spawn through `configure_tokio_command`; no `kill_on_drop` today — wire cancel to signal handler for long renders.

--- a/src-tauri/src/core/analysis/audio.rs
+++ b/src-tauri/src/core/analysis/audio.rs
@@ -157,8 +157,8 @@ impl AudioProfiler {
             "silencedetect=n={}:d={}",
             SILENCE_THRESHOLD_DB, SILENCE_MIN_DURATION
         );
-        let stderr = self.run_ffmpeg_filter(video_path, &filter).await?;
-        Ok(parse_silence_regions(&stderr))
+        let capture = self.run_ffmpeg_filter(video_path, &filter).await?;
+        Ok(parse_silence_regions(&capture.stderr))
     }
 
     /// Detects silence regions with custom threshold and minimum duration.
@@ -180,8 +180,8 @@ impl AudioProfiler {
         let threshold = format!("{}dB", threshold_db.clamp(-90.0, 0.0));
         let duration = format!("{:.3}", min_duration_sec.clamp(0.01, 30.0));
         let filter = format!("silencedetect=n={}:d={}", threshold, duration);
-        let stderr = self.run_ffmpeg_filter(video_path, &filter).await?;
-        Ok(parse_silence_regions(&stderr))
+        let capture = self.run_ffmpeg_filter(video_path, &filter).await?;
+        Ok(parse_silence_regions(&capture.stderr))
     }
 
     /// Detect speech regions using a lightweight WebRTC VAD pass.
@@ -230,9 +230,9 @@ impl AudioProfiler {
         video_path: &Path,
     ) -> CoreResult<(Vec<f64>, f64, Vec<f64>)> {
         let filter = "ebur128=metadata=1";
-        let stderr = self.run_ffmpeg_filter(video_path, filter).await?;
-        let (loudness_profile, peak_db) = parse_loudness_and_peak(&stderr);
-        let momentary_values = parse_momentary_loudness_values(&stderr);
+        let capture = self.run_ffmpeg_filter(video_path, filter).await?;
+        let (loudness_profile, peak_db) = parse_loudness_and_peak(&capture.stderr);
+        let momentary_values = parse_momentary_loudness_values(&capture.stderr);
         Ok((loudness_profile, peak_db, momentary_values))
     }
 
@@ -250,7 +250,7 @@ impl AudioProfiler {
             "aspectralstats=measure=centroid,ametadata=mode=print:key=lavfi.aspectralstats.1.centroid";
 
         match self.run_ffmpeg_filter(video_path, filter).await {
-            Ok(stderr) => Ok(parse_spectral_centroid(&stderr)),
+            Ok(capture) => Ok(parse_spectral_centroid(&capture.stderr)),
             Err(err) => {
                 let msg = err.to_string();
                 // Only swallow explicit missing-filter errors; other failures propagate.
@@ -330,12 +330,25 @@ impl AudioProfiler {
     // FFmpeg Helper
     // =========================================================================
 
-    /// Runs FFmpeg with the given audio filter and returns stderr as a string.
+    /// Runs FFmpeg with the given audio filter and returns the whole capture.
     ///
     /// Delegates spawning, bounded stderr retention, and the watchdog timeout to
     /// [`capture_filter_stderr`]; only the audio-specific interpretation of the
     /// result (missing audio stream vs. genuine failure) lives here.
-    async fn run_ffmpeg_filter(&self, video_path: &Path, filter: &str) -> CoreResult<String> {
+    ///
+    /// The [`FilterCapture`] is returned rather than just its text so the
+    /// truncation flag is not silently dropped: per-frame filters such as
+    /// `aspectralstats` overflow the retention limit on very long inputs, and a
+    /// parser fed the surviving tail would average only the end of the file.
+    /// Truncation is logged here — the audio profile has no warnings channel to
+    /// carry it — so an unexpectedly flat measurement is at least traceable.
+    ///
+    /// [`FilterCapture`]: crate::core::ffmpeg::FilterCapture
+    async fn run_ffmpeg_filter(
+        &self,
+        video_path: &Path,
+        filter: &str,
+    ) -> CoreResult<crate::core::ffmpeg::FilterCapture> {
         let capture = capture_filter_stderr(
             &self.ffmpeg_path,
             video_path,
@@ -367,7 +380,16 @@ impl AudioProfiler {
             )));
         }
 
-        Ok(capture.stderr)
+        if capture.truncated {
+            tracing::warn!(
+                filter = %filter,
+                input = %video_path.display(),
+                "FFmpeg filter output exceeded the stderr retention limit; \
+                 the parsed result covers only the end of the input"
+            );
+        }
+
+        Ok(capture)
     }
 }
 

--- a/src-tauri/src/core/analysis/audio.rs
+++ b/src-tauri/src/core/analysis/audio.rs
@@ -7,17 +7,15 @@
 //! spectral centroid, and silence region detection.
 
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 use uuid::Uuid;
 use webrtc_vad::{SampleRate as VadSampleRate, Vad, VadMode};
 
 use super::ducking::invert_silence_to_speech;
 use super::types::{AudioProfile, SilenceRegion, SpeechRegion, SILENCE_FLOOR_DB};
 use crate::core::captions::audio::{extract_audio_for_transcription_async, load_audio_samples_i16};
-use crate::core::process::configure_tokio_command;
+use crate::core::ffmpeg::{capture_filter_stderr, FFmpegError, FilterMode};
 use crate::core::{CoreError, CoreResult};
 
 // =============================================================================
@@ -48,6 +46,12 @@ const MAX_BPM: f64 = 300.0;
 
 /// Number of tail lines to keep from FFmpeg stderr for error reporting.
 const STDERR_TAIL_SIZE: usize = 20;
+
+/// Watchdog timeout for a single FFmpeg analysis pass.
+///
+/// Matches the analysis job budget elsewhere in the pipeline; without it a
+/// stalled decoder would hang the calling job forever.
+const ANALYSIS_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// VAD frame size in milliseconds.
 const VAD_FRAME_MS: usize = 30;
@@ -328,73 +332,42 @@ impl AudioProfiler {
 
     /// Runs FFmpeg with the given audio filter and returns stderr as a string.
     ///
-    /// Handles process spawning errors and non-zero exit codes. Uses
-    /// [`configure_tokio_command`] for Windows compatibility.
+    /// Delegates spawning, bounded stderr retention, and the watchdog timeout to
+    /// [`capture_filter_stderr`]; only the audio-specific interpretation of the
+    /// result (missing audio stream vs. genuine failure) lives here.
     async fn run_ffmpeg_filter(&self, video_path: &Path, filter: &str) -> CoreResult<String> {
-        let mut cmd = Command::new(&self.ffmpeg_path);
-        configure_tokio_command(&mut cmd);
-
-        cmd.arg("-hide_banner")
-            .arg("-nostdin")
-            .arg("-i")
-            .arg(video_path)
-            .arg("-af")
-            .arg(filter)
-            .arg("-vn")
-            .arg("-f")
-            .arg("null")
-            .arg("-")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped());
-
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| CoreError::Internal(format!("Failed to spawn FFmpeg: {}", e)))?;
-
-        let stderr_handle = child
-            .stderr
-            .take()
-            .ok_or_else(|| CoreError::Internal("Failed to capture FFmpeg stderr".to_string()))?;
-
-        let mut reader = BufReader::new(stderr_handle).lines();
-        let mut all_lines: Vec<String> = Vec::new();
-
-        // Stream stderr line by line
-        while let Some(line) = reader
-            .next_line()
-            .await
-            .map_err(|e| CoreError::Internal(format!("Failed reading FFmpeg stderr: {}", e)))?
-        {
-            all_lines.push(line);
-        }
-
-        let status = child
-            .wait()
-            .await
-            .map_err(|e| CoreError::Internal(format!("Failed to wait for FFmpeg: {}", e)))?;
-
-        let full_stderr = all_lines.join("\n");
+        let capture = capture_filter_stderr(
+            &self.ffmpeg_path,
+            video_path,
+            FilterMode::Audio(filter),
+            ANALYSIS_TIMEOUT,
+        )
+        .await
+        .map_err(|error| match error {
+            FFmpegError::Timeout => CoreError::Internal(format!(
+                "Audio analysis timed out after {}s",
+                ANALYSIS_TIMEOUT.as_secs()
+            )),
+            other => CoreError::Internal(format!("Failed to run FFmpeg: {}", other)),
+        })?;
 
         // Check for no-audio-stream condition before checking exit status,
         // because FFmpeg may exit non-zero when there is no audio stream.
-        if has_no_audio_indicator(&full_stderr) {
+        if has_no_audio_indicator(&capture.stderr) {
             return Err(CoreError::Internal(
                 "No audio stream found in input".to_string(),
             ));
         }
 
-        if !status.success() {
-            let code = status.code().unwrap_or(-1);
-            let tail_start = all_lines.len().saturating_sub(STDERR_TAIL_SIZE);
-            let tail = all_lines[tail_start..].join("\n");
+        if !capture.success {
             return Err(CoreError::Internal(format!(
                 "Audio analysis failed (exit {}): {}",
-                code, tail
+                capture.exit_code.unwrap_or(-1),
+                capture.stderr_tail(STDERR_TAIL_SIZE)
             )));
         }
 
-        Ok(full_stderr)
+        Ok(capture.stderr)
     }
 }
 
@@ -533,7 +506,7 @@ fn derive_speech_regions_from_silence(
 /// [silencedetect @ ...] silence_start: 1.234
 /// [silencedetect @ ...] silence_end: 5.678 | silence_duration: 4.444
 /// ```
-fn parse_silence_regions(stderr: &str) -> Vec<SilenceRegion> {
+pub(crate) fn parse_silence_regions(stderr: &str) -> Vec<SilenceRegion> {
     let mut regions = Vec::new();
     let mut current_start: Option<f64> = None;
 

--- a/src-tauri/src/core/analysis/mod.rs
+++ b/src-tauri/src/core/analysis/mod.rs
@@ -426,6 +426,61 @@ impl AnalysisJobRunner {
         Ok(())
     }
 
+    /// Applies `mutate` to the asset's cached bundle and writes it back.
+    ///
+    /// The bundle is loaded from disk first, so a caller that produces only one
+    /// kind of result (shot detection, an audio profile) updates its own slot
+    /// without discarding what earlier runs stored. When no bundle exists yet,
+    /// a fresh one is created from `fallback_metadata`.
+    ///
+    /// Returns the merged bundle that was persisted.
+    pub fn merge_bundle_update<F>(
+        &self,
+        asset_id: &str,
+        fallback_metadata: &VideoMetadata,
+        mutate: F,
+    ) -> CoreResult<AnalysisBundle>
+    where
+        F: FnOnce(&mut AnalysisBundle),
+    {
+        let mut bundle = match self.load_bundle_optional(asset_id)? {
+            Some(bundle) => bundle,
+            None => AnalysisBundle::new(asset_id, fallback_metadata.clone()),
+        };
+
+        mutate(&mut bundle);
+        bundle.analyzed_at = chrono::Utc::now().to_rfc3339();
+
+        self.save_bundle(&bundle)?;
+        Ok(bundle)
+    }
+
+    /// Merges shot-detection results into the asset's cached bundle.
+    pub fn merge_bundle_shots(
+        &self,
+        asset_id: &str,
+        fallback_metadata: &VideoMetadata,
+        shots: Vec<ShotResult>,
+    ) -> CoreResult<AnalysisBundle> {
+        self.merge_bundle_update(asset_id, fallback_metadata, |bundle| {
+            bundle.shots = Some(shots);
+            bundle.errors.remove("shots");
+        })
+    }
+
+    /// Merges an audio profile into the asset's cached bundle.
+    pub fn merge_bundle_audio_profile(
+        &self,
+        asset_id: &str,
+        fallback_metadata: &VideoMetadata,
+        audio_profile: AudioProfile,
+    ) -> CoreResult<AnalysisBundle> {
+        self.merge_bundle_update(asset_id, fallback_metadata, |bundle| {
+            bundle.audio_profile = Some(audio_profile);
+            bundle.errors.remove("audio");
+        })
+    }
+
     async fn generate_contact_sheet_if_possible(
         &self,
         asset_id: &str,
@@ -784,6 +839,82 @@ mod tests {
         assert_eq!(loaded.shots.as_ref().unwrap().len(), 2);
         assert_eq!(loaded.audio_profile.as_ref().unwrap().bpm, Some(120.0));
         assert_eq!(loaded.contact_sheet.as_ref().unwrap().columns, 2);
+    }
+
+    #[test]
+    fn should_create_bundle_from_fallback_metadata_when_merging_into_nothing() {
+        let temp_dir = TempDir::new().unwrap();
+        let runner = AnalysisJobRunner::new(temp_dir.path());
+        let metadata = VideoMetadata::new(12.0).with_audio(true);
+
+        let merged = runner
+            .merge_bundle_shots(
+                "asset_100",
+                &metadata,
+                vec![ShotResult::new(0.0, 12.0, 0.9)],
+            )
+            .unwrap();
+
+        assert_eq!(merged.metadata.duration_sec, 12.0);
+        assert_eq!(merged.shots.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            runner
+                .load_bundle("asset_100")
+                .unwrap()
+                .shots
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn should_preserve_other_results_when_merging_shots_into_an_existing_bundle() {
+        let temp_dir = TempDir::new().unwrap();
+        let runner = AnalysisJobRunner::new(temp_dir.path());
+
+        let mut existing = AnalysisBundle::new("asset_101", VideoMetadata::new(30.0));
+        existing.audio_profile = Some(AudioProfile::silent(30.0));
+        existing.segments = Some(Vec::new());
+        runner.save_bundle(&existing).unwrap();
+
+        runner
+            .merge_bundle_shots(
+                "asset_101",
+                &VideoMetadata::new(0.0),
+                vec![ShotResult::new(0.0, 30.0, 0.8)],
+            )
+            .unwrap();
+
+        let loaded = runner.load_bundle("asset_101").unwrap();
+        assert_eq!(loaded.shots.as_ref().unwrap().len(), 1);
+        assert!(loaded.audio_profile.is_some());
+        assert!(loaded.segments.is_some());
+        // The fallback metadata must not overwrite what the bundle already knows.
+        assert_eq!(loaded.metadata.duration_sec, 30.0);
+    }
+
+    #[test]
+    fn should_clear_the_matching_error_when_merging_a_successful_result() {
+        let temp_dir = TempDir::new().unwrap();
+        let runner = AnalysisJobRunner::new(temp_dir.path());
+
+        let mut existing = AnalysisBundle::new("asset_102", VideoMetadata::new(30.0));
+        existing.add_error("audio", "FFmpeg missing".to_string());
+        existing.add_error("shots", "FFmpeg missing".to_string());
+        runner.save_bundle(&existing).unwrap();
+
+        runner
+            .merge_bundle_audio_profile(
+                "asset_102",
+                &VideoMetadata::new(30.0),
+                AudioProfile::silent(30.0),
+            )
+            .unwrap();
+
+        let loaded = runner.load_bundle("asset_102").unwrap();
+        assert!(!loaded.errors.contains_key("audio"));
+        assert!(loaded.errors.contains_key("shots"));
     }
 
     #[test]

--- a/src-tauri/src/core/analysis/mod.rs
+++ b/src-tauri/src/core/analysis/mod.rs
@@ -70,6 +70,23 @@ const BUNDLE_FILENAME: &str = "bundle.json";
 /// Name of the generated contact-sheet image
 const CONTACT_SHEET_FILENAME: &str = "contact-sheet.jpg";
 
+/// Name of the advisory lock file guarding bundle read-modify-write cycles
+const BUNDLE_LOCK_FILENAME: &str = "bundle.json.lock";
+
+/// Advisory lock held for the duration of a bundle read-modify-write cycle.
+///
+/// The GUI job worker and the CLI are separate processes writing the same
+/// bundle, so the lock is on the file system rather than in memory. The lock is
+/// released when the guard drops.
+struct BundleLock(std::fs::File);
+
+impl Drop for BundleLock {
+    fn drop(&mut self) {
+        // Keep the handle alive for the lifetime of the guard. Locks are released on drop.
+        let _ = &self.0;
+    }
+}
+
 // =============================================================================
 // Analysis Job Runner
 // =============================================================================
@@ -150,6 +167,29 @@ impl AnalysisJobRunner {
     /// Returns the path to an asset's bundle JSON file
     fn bundle_path(&self, asset_id: &str) -> CoreResult<PathBuf> {
         Ok(self.asset_analysis_dir(asset_id)?.join(BUNDLE_FILENAME))
+    }
+
+    /// Takes the exclusive advisory lock guarding an asset's bundle.
+    ///
+    /// Held across a whole load-mutate-save cycle so two processes updating
+    /// different slots of the same bundle cannot overwrite each other.
+    fn lock_bundle_exclusive(&self, asset_id: &str) -> CoreResult<BundleLock> {
+        let lock_path = self
+            .asset_analysis_dir(asset_id)?
+            .join(BUNDLE_LOCK_FILENAME);
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(lock_path)?;
+        // Use UFCS to avoid accidentally picking up newer std methods and violating MSRV.
+        fs2::FileExt::lock_exclusive(&file)?;
+        Ok(BundleLock(file))
     }
 
     /// Runs the full analysis pipeline with the given options.
@@ -433,6 +473,11 @@ impl AnalysisJobRunner {
     /// without discarding what earlier runs stored. When no bundle exists yet,
     /// a fresh one is created from `fallback_metadata`.
     ///
+    /// The load, the mutation and the write happen under an exclusive advisory
+    /// lock on the bundle: the GUI job worker and a CLI invocation can update
+    /// different slots of the same bundle at the same time, and without the lock
+    /// the later write would silently drop the earlier one.
+    ///
     /// Returns the merged bundle that was persisted.
     pub fn merge_bundle_update<F>(
         &self,
@@ -443,6 +488,8 @@ impl AnalysisJobRunner {
     where
         F: FnOnce(&mut AnalysisBundle),
     {
+        let _lock = self.lock_bundle_exclusive(asset_id)?;
+
         let mut bundle = match self.load_bundle_optional(asset_id)? {
             Some(bundle) => bundle,
             None => AnalysisBundle::new(asset_id, fallback_metadata.clone()),
@@ -865,6 +912,51 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn should_not_lose_a_slot_when_two_threads_merge_the_same_bundle() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_dir = temp_dir.path().to_path_buf();
+        let metadata = VideoMetadata::new(30.0).with_audio(true);
+
+        let shots_dir = project_dir.clone();
+        let shots_metadata = metadata.clone();
+        let shots_writer = std::thread::spawn(move || {
+            let runner = AnalysisJobRunner::new(&shots_dir);
+            for _ in 0..20 {
+                runner
+                    .merge_bundle_shots(
+                        "asset_200",
+                        &shots_metadata,
+                        vec![ShotResult::new(0.0, 30.0, 0.9)],
+                    )
+                    .unwrap();
+            }
+        });
+
+        let audio_writer = std::thread::spawn(move || {
+            let runner = AnalysisJobRunner::new(&project_dir);
+            for _ in 0..20 {
+                runner
+                    .merge_bundle_audio_profile("asset_200", &metadata, AudioProfile::silent(30.0))
+                    .unwrap();
+            }
+        });
+
+        shots_writer.join().unwrap();
+        audio_writer.join().unwrap();
+
+        let runner = AnalysisJobRunner::new(temp_dir.path());
+        let loaded = runner.load_bundle("asset_200").unwrap();
+        assert!(
+            loaded.shots.is_some(),
+            "the shots slot must survive concurrent audio merges"
+        );
+        assert!(
+            loaded.audio_profile.is_some(),
+            "the audio slot must survive concurrent shot merges"
         );
     }
 

--- a/src-tauri/src/core/analysis/types.rs
+++ b/src-tauri/src/core/analysis/types.rs
@@ -600,31 +600,45 @@ impl AnalysisBundle {
     ///
     /// Only empty slots are filled: freshly produced results, metadata, errors,
     /// and the analysis timestamp always win.
+    ///
+    /// A slot whose sub-job is recorded in [`Self::errors`] is never restored.
+    /// That job ran and failed in this bundle, so the older result is not
+    /// "missing", it is superseded — republishing it under a fresh
+    /// `analyzed_at` would present stale data as current, which is exactly
+    /// wrong when the failure came from media that changed underneath.
     pub fn backfill_missing_from(&mut self, previous: &AnalysisBundle) {
-        if self.shots.is_none() {
+        if self.shots.is_none() && !self.job_failed("shots") {
             self.shots = previous.shots.clone();
         }
-        if self.transcript.is_none() {
+        if self.transcript.is_none() && !self.job_failed("transcript") {
             self.transcript = previous.transcript.clone();
         }
-        if self.transcript_detail.is_none() {
+        if self.transcript_detail.is_none() && !self.job_failed("transcript") {
             self.transcript_detail = previous.transcript_detail.clone();
         }
-        if self.audio_profile.is_none() {
+        if self.audio_profile.is_none() && !self.job_failed("audio") {
             self.audio_profile = previous.audio_profile.clone();
         }
-        if self.segments.is_none() {
+        if self.segments.is_none() && !self.job_failed("segments") {
             self.segments = previous.segments.clone();
         }
-        if self.frame_analysis.is_none() {
+        if self.frame_analysis.is_none() && !self.job_failed("visual") {
             self.frame_analysis = previous.frame_analysis.clone();
         }
-        if self.frame_observations.is_none() {
+        if self.frame_observations.is_none() && !self.job_failed("visual") {
             self.frame_observations = previous.frame_observations.clone();
         }
-        if self.contact_sheet.is_none() {
+        if self.contact_sheet.is_none() && !self.job_failed("contact_sheet") {
             self.contact_sheet = previous.contact_sheet.clone();
         }
+    }
+
+    /// Returns whether this bundle recorded a failure for `analysis_type`.
+    ///
+    /// Keys match the ones the analysis pipeline passes to [`Self::add_error`]:
+    /// `shots`, `audio`, `transcript`, `segments`, `visual`, `contact_sheet`.
+    fn job_failed(&self, analysis_type: &str) -> bool {
+        self.errors.contains_key(analysis_type)
     }
 }
 
@@ -889,6 +903,43 @@ mod tests {
         // Fresh results win, untouched slots are restored.
         assert_eq!(partial.shots.as_ref().unwrap().len(), 2);
         assert!(partial.audio_profile.is_some());
+    }
+
+    #[test]
+    fn should_not_backfill_a_slot_whose_sub_job_failed_in_the_fresh_run() {
+        let mut previous = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        previous.audio_profile = Some(AudioProfile::silent(60.0));
+        previous.shots = Some(vec![ShotResult::new(0.0, 60.0, 1.0)]);
+
+        // The fresh run asked for both jobs; audio failed, shots was not run.
+        let mut fresh = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        fresh.add_error("audio", "Audio analysis failed (exit 1)".to_string());
+
+        fresh.backfill_missing_from(&previous);
+
+        assert!(
+            fresh.audio_profile.is_none(),
+            "a failed sub-job must not republish the previous result as current"
+        );
+        assert!(
+            fresh.shots.is_some(),
+            "slots that simply were not run are still restored"
+        );
+    }
+
+    #[test]
+    fn should_not_backfill_visual_slots_when_visual_analysis_failed() {
+        let mut previous = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        previous.frame_analysis = Some(vec![FrameAnalysis::local_fallback(0, 0.5)]);
+        previous.frame_observations = Some(Vec::new());
+
+        let mut fresh = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        fresh.add_error("visual", "Vision API timeout".to_string());
+
+        fresh.backfill_missing_from(&previous);
+
+        assert!(fresh.frame_analysis.is_none());
+        assert!(fresh.frame_observations.is_none());
     }
 
     #[test]

--- a/src-tauri/src/core/analysis/types.rs
+++ b/src-tauri/src/core/analysis/types.rs
@@ -590,6 +590,42 @@ impl AnalysisBundle {
     pub fn is_complete(&self) -> bool {
         self.errors.is_empty()
     }
+
+    /// Restores result slots that this bundle does not populate from `previous`.
+    ///
+    /// A run that enables only some sub-jobs produces a bundle whose other
+    /// slots are `None`. Writing that bundle over an existing one would discard
+    /// results a previous run already paid for, so callers that re-save a
+    /// partial run merge the older results back in first.
+    ///
+    /// Only empty slots are filled: freshly produced results, metadata, errors,
+    /// and the analysis timestamp always win.
+    pub fn backfill_missing_from(&mut self, previous: &AnalysisBundle) {
+        if self.shots.is_none() {
+            self.shots = previous.shots.clone();
+        }
+        if self.transcript.is_none() {
+            self.transcript = previous.transcript.clone();
+        }
+        if self.transcript_detail.is_none() {
+            self.transcript_detail = previous.transcript_detail.clone();
+        }
+        if self.audio_profile.is_none() {
+            self.audio_profile = previous.audio_profile.clone();
+        }
+        if self.segments.is_none() {
+            self.segments = previous.segments.clone();
+        }
+        if self.frame_analysis.is_none() {
+            self.frame_analysis = previous.frame_analysis.clone();
+        }
+        if self.frame_observations.is_none() {
+            self.frame_observations = previous.frame_observations.clone();
+        }
+        if self.contact_sheet.is_none() {
+            self.contact_sheet = previous.contact_sheet.clone();
+        }
+    }
 }
 
 fn current_analysis_schema_version() -> u32 {
@@ -834,6 +870,37 @@ mod tests {
         assert!(!bundle.is_complete());
         assert_eq!(bundle.errors.len(), 1);
         assert!(bundle.errors.contains_key("transcript"));
+    }
+
+    #[test]
+    fn should_restore_missing_slots_when_backfilling_a_partial_bundle() {
+        let mut previous = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        previous.audio_profile = Some(AudioProfile::silent(60.0));
+        previous.shots = Some(vec![ShotResult::new(0.0, 60.0, 1.0)]);
+
+        let mut partial = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        partial.shots = Some(vec![
+            ShotResult::new(0.0, 30.0, 0.9),
+            ShotResult::new(30.0, 60.0, 0.9),
+        ]);
+
+        partial.backfill_missing_from(&previous);
+
+        // Fresh results win, untouched slots are restored.
+        assert_eq!(partial.shots.as_ref().unwrap().len(), 2);
+        assert!(partial.audio_profile.is_some());
+    }
+
+    #[test]
+    fn should_not_backfill_errors_or_metadata_from_a_previous_bundle() {
+        let mut previous = AnalysisBundle::new("asset_001", VideoMetadata::new(60.0));
+        previous.add_error("audio", "FFmpeg missing".to_string());
+
+        let mut fresh = AnalysisBundle::new("asset_001", VideoMetadata::new(90.0));
+        fresh.backfill_missing_from(&previous);
+
+        assert!(fresh.errors.is_empty());
+        assert_eq!(fresh.metadata.duration_sec, 90.0);
     }
 
     #[test]

--- a/src-tauri/src/core/analysis/visual.rs
+++ b/src-tauri/src/core/analysis/visual.rs
@@ -40,10 +40,10 @@ const DEFAULT_COMPLEXITY: f64 = 0.5;
 const CONTACT_SHEET_MAX_FRAMES: usize = 12;
 
 /// Width of each contact-sheet cell.
-const CONTACT_SHEET_CELL_WIDTH: usize = 320;
+pub const CONTACT_SHEET_CELL_WIDTH: usize = 320;
 
 /// Height of each contact-sheet cell.
-const CONTACT_SHEET_CELL_HEIGHT: usize = 180;
+pub const CONTACT_SHEET_CELL_HEIGHT: usize = 180;
 
 /// Minimum shot duration to attempt smarter thumbnail-based selection.
 const SMART_KEYFRAME_MIN_DURATION_SEC: f64 = 1.2;
@@ -212,13 +212,44 @@ impl VisualAnalyzer {
     }
 
     /// Generates a contact-sheet image from a sequence of extracted keyframes.
+    ///
+    /// The grid layout and the frame cap are derived from the keyframe count.
+    /// Use [`VisualAnalyzer::generate_contact_sheet_with_layout`] to pin an
+    /// explicit layout.
     pub async fn generate_contact_sheet(
         &self,
         keyframes: &[PathBuf],
         output_path: &Path,
     ) -> CoreResult<Option<ContactSheetArtifact>> {
+        self.generate_contact_sheet_with_layout(keyframes, output_path, None)
+            .await
+    }
+
+    /// Generates a contact-sheet image with an optional explicit grid layout.
+    ///
+    /// `layout` is a `(columns, rows)` pair. When supplied, its capacity
+    /// (`columns * rows`) replaces the default frame cap so caller-defined
+    /// grids larger than the built-in maximum are honoured. When `None`, a
+    /// compact layout is derived from the keyframe count.
+    ///
+    /// All keyframes must live in the same directory and be named as a
+    /// zero-based `%d.jpg` sequence — FFmpeg reads them as an image sequence.
+    pub async fn generate_contact_sheet_with_layout(
+        &self,
+        keyframes: &[PathBuf],
+        output_path: &Path,
+        layout: Option<(usize, usize)>,
+    ) -> CoreResult<Option<ContactSheetArtifact>> {
         if keyframes.is_empty() {
             return Ok(None);
+        }
+
+        if let Some((columns, rows)) = layout {
+            if columns == 0 || rows == 0 {
+                return Err(CoreError::AnalysisFailed(
+                    "Contact sheet layout requires at least one column and one row".to_string(),
+                ));
+            }
         }
 
         // No fast-path cache: the keyframe set may have changed since the file was written
@@ -234,7 +265,10 @@ impl VisualAnalyzer {
             })?;
         }
 
-        let frame_count = keyframes.len().min(CONTACT_SHEET_MAX_FRAMES);
+        let capacity = layout
+            .map(|(columns, rows)| columns.saturating_mul(rows))
+            .unwrap_or(CONTACT_SHEET_MAX_FRAMES);
+        let frame_count = keyframes.len().min(capacity);
         let first_keyframe = keyframes.first().ok_or_else(|| {
             CoreError::Internal("Contact sheet requires at least one keyframe".to_string())
         })?;
@@ -261,7 +295,7 @@ impl VisualAnalyzer {
             })?;
         }
 
-        let (columns, rows) = contact_sheet_layout(frame_count);
+        let (columns, rows) = layout.unwrap_or_else(|| contact_sheet_layout(frame_count));
         let input_pattern = keyframe_dir.join("%d.jpg");
         let filter = format!(
             "scale={w}:{h}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2:black,tile={cols}x{rows}:nb_frames={count}:padding=4:margin=2:color=black",

--- a/src-tauri/src/core/ffmpeg/detection.rs
+++ b/src-tauri/src/core/ffmpeg/detection.rs
@@ -12,6 +12,10 @@ use crate::core::process::configure_std_command;
 /// Where a detected FFmpeg installation came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FFmpegSource {
+    /// Explicitly configured by the caller (CLI flag or API argument).
+    Explicit,
+    /// Configured through the `OPENREELIO_FFMPEG_PATH` environment override.
+    Env,
     /// Bundled with the application (resource directory).
     Bundled,
     /// Installed by the in-app managed installer.
@@ -26,6 +30,8 @@ impl FFmpegSource {
     /// Stable lowercase identifier surfaced to the frontend.
     pub fn as_str(self) -> &'static str {
         match self {
+            FFmpegSource::Explicit => "explicit",
+            FFmpegSource::Env => "env",
             FFmpegSource::Bundled => "bundled",
             FFmpegSource::Managed => "managed",
             FFmpegSource::Dev => "dev",
@@ -420,9 +426,9 @@ fn get_common_ffmpeg_paths() -> Vec<PathBuf> {
     paths
 }
 
-/// Get FFmpeg version string
-fn get_ffmpeg_version(ffmpeg_path: &PathBuf) -> FFmpegResult<String> {
-    let mut cmd = Command::new(ffmpeg_path);
+/// Run `<binary> -version` and return its first output line
+fn run_version_probe(binary_path: &Path) -> FFmpegResult<String> {
+    let mut cmd = Command::new(binary_path);
     configure_std_command(&mut cmd);
     let output = cmd
         .arg("-version")
@@ -435,22 +441,34 @@ fn get_ffmpeg_version(ffmpeg_path: &PathBuf) -> FFmpegResult<String> {
         ));
     }
 
-    let output_str = String::from_utf8_lossy(&output.stdout);
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(|line| line.to_string())
+        .ok_or_else(|| FFmpegError::ParseError("Could not parse FFmpeg version".to_string()))
+}
+
+/// Get FFmpeg version string
+pub(super) fn get_ffmpeg_version(ffmpeg_path: &Path) -> FFmpegResult<String> {
+    let first_line = run_version_probe(ffmpeg_path)?;
 
     // Parse version from first line: "ffmpeg version X.X.X ..."
-    if let Some(first_line) = output_str.lines().next() {
-        if let Some(version_part) = first_line.strip_prefix("ffmpeg version ") {
-            if let Some(version) = version_part.split_whitespace().next() {
-                return Ok(version.to_string());
-            }
+    if let Some(version_part) = first_line.strip_prefix("ffmpeg version ") {
+        if let Some(version) = version_part.split_whitespace().next() {
+            return Ok(version.to_string());
         }
-        // Return the whole first line if parsing fails
-        return Ok(first_line.to_string());
     }
 
-    Err(FFmpegError::ParseError(
-        "Could not parse FFmpeg version".to_string(),
-    ))
+    // Return the whole first line if parsing fails
+    Ok(first_line)
+}
+
+/// Check that a binary is present and responds to `-version`
+///
+/// Used by the resolver to validate explicitly configured ffprobe binaries,
+/// which are not discovered through the filesystem probes above.
+pub(super) fn probe_binary_runs(binary_path: &Path) -> FFmpegResult<()> {
+    run_version_probe(binary_path).map(|_| ())
 }
 
 /// Validate that FFmpeg binaries are functional

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -33,7 +33,8 @@ pub use bundler::{
 pub use commands::*;
 pub use detection::*;
 pub use resolver::{
-    resolved_ffmpeg_path, resolved_ffprobe_path, set_resolved_paths, ResolvedFFmpeg,
+    resolve_and_register, resolve_ffmpeg, resolved_ffmpeg_path, resolved_ffprobe_path,
+    set_resolved_paths, FFmpegResolveOptions, ResolvedFFmpeg, FFMPEG_PATH_ENV, FFPROBE_PATH_ENV,
 };
 pub use runner::{
     AudioStreamInfo, FFmpegProgress, FFmpegRunner, MediaInfo, RenderSettings, VideoStreamInfo,
@@ -48,6 +49,9 @@ pub use state::{detect_ffmpeg, initialize_shared_ffmpeg};
 pub enum FFmpegError {
     #[error("FFmpeg not found. Please install FFmpeg or ensure bundled binaries are present.")]
     NotFound,
+
+    #[error("FFmpeg not found. Please install FFmpeg or ensure bundled binaries are present. Sources tried: {0}")]
+    NotFoundInSources(String),
 
     #[error("FFmpeg execution failed: {0}")]
     ExecutionFailed(String),

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -37,8 +37,8 @@ pub use resolver::{
     set_resolved_paths, FFmpegResolveOptions, ResolvedFFmpeg, FFMPEG_PATH_ENV, FFPROBE_PATH_ENV,
 };
 pub use runner::{
-    AudioStreamInfo, FFmpegProgress, FFmpegRunner, MediaInfo, RenderSettings, VideoStreamInfo,
-    WaveformData,
+    AudioStreamInfo, FFmpegProgress, FFmpegRunner, FrameExtractOptions, MediaInfo, RenderSettings,
+    VideoStreamInfo, WaveformData,
 };
 pub use state::{create_ffmpeg_state, FFmpegState, SharedFFmpegState};
 #[cfg(all(not(test), feature = "gui"))]

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -37,8 +37,8 @@ pub use resolver::{
     set_resolved_paths, FFmpegResolveOptions, ResolvedFFmpeg, FFMPEG_PATH_ENV, FFPROBE_PATH_ENV,
 };
 pub use runner::{
-    AudioStreamInfo, FFmpegProgress, FFmpegRunner, FrameExtractOptions, MediaInfo, RenderSettings,
-    VideoStreamInfo, WaveformData,
+    capture_filter_stderr, AudioStreamInfo, FFmpegProgress, FFmpegRunner, FilterCapture,
+    FilterMode, FrameExtractOptions, MediaInfo, RenderSettings, VideoStreamInfo, WaveformData,
 };
 pub use state::{create_ffmpeg_state, FFmpegState, SharedFFmpegState};
 #[cfg(all(not(test), feature = "gui"))]

--- a/src-tauri/src/core/ffmpeg/resolver.rs
+++ b/src-tauri/src/core/ffmpeg/resolver.rs
@@ -2,17 +2,30 @@
 //!
 //! Modules that spawn ffmpeg/ffprobe directly (metadata extraction, shot
 //! detection, audio extraction, ...) must not assume the binaries are on the
-//! system PATH: on installs where FFmpeg is only bundled, bare "ffmpeg"
-//! invocations silently fail. This module stores the paths resolved by
-//! `FFmpegState::initialize` (GUI) or `detect_cli_ffmpeg` (CLI) and exposes
-//! them process-wide. If nothing has been registered yet, a one-time lazy
-//! detection runs (dev-mode binaries, then system PATH), falling back to the
-//! bare binary name as the last resort so behavior never regresses.
+//! system PATH: on installs where FFmpeg is only bundled or only installed
+//! through the in-app installer, bare "ffmpeg" invocations silently fail.
+//!
+//! [`resolve_ffmpeg`] is the single resolution routine shared by the GUI and
+//! the CLI so both see the same installations. [`resolve_and_register`]
+//! additionally publishes the result process-wide via [`set_resolved_paths`].
+//! If nothing has been registered yet, a one-time lazy detection runs
+//! (dev-mode binaries, then system PATH), falling back to the bare binary name
+//! as the last resort so behavior never regresses.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
-use super::detection::{detect_dev_mode_binaries, detect_system_ffmpeg};
+use super::detection::{
+    detect_bundled_at_path, detect_dev_mode_binaries, detect_managed_ffmpeg, detect_system_ffmpeg,
+    get_bundled_binary_names, get_ffmpeg_version, probe_binary_runs, FFmpegInfo, FFmpegSource,
+};
+use super::{FFmpegError, FFmpegResult};
+
+/// Environment variable overriding the ffmpeg binary path.
+pub const FFMPEG_PATH_ENV: &str = "OPENREELIO_FFMPEG_PATH";
+
+/// Environment variable overriding the ffprobe binary path.
+pub const FFPROBE_PATH_ENV: &str = "OPENREELIO_FFPROBE_PATH";
 
 /// Globally resolved FFmpeg/FFprobe binary paths.
 #[derive(Clone, Debug)]
@@ -23,6 +36,207 @@ pub struct ResolvedFFmpeg {
     pub ffprobe: PathBuf,
 }
 
+/// Inputs controlling how [`resolve_ffmpeg`] searches for FFmpeg.
+///
+/// The search order is fixed; these options only decide which of the
+/// higher-priority sources participate at all.
+#[derive(Clone, Debug, Default)]
+pub struct FFmpegResolveOptions {
+    /// Explicitly configured ffmpeg binary (highest priority).
+    pub explicit_ffmpeg: Option<PathBuf>,
+    /// Explicitly configured ffprobe binary. Derived from `explicit_ffmpeg`
+    /// when only one of the two is supplied.
+    pub explicit_ffprobe: Option<PathBuf>,
+    /// Directories containing a bundled `binaries/` layout, in priority order.
+    pub resource_roots: Vec<PathBuf>,
+    /// Whether the `OPENREELIO_FFMPEG_PATH` / `OPENREELIO_FFPROBE_PATH`
+    /// overrides participate. Off by default so GUI processes never inherit a
+    /// stray variable from whatever launched them.
+    pub use_env: bool,
+}
+
+/// A single resolution source, evaluated in priority order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Candidate {
+    /// Caller-supplied paths.
+    Explicit { ffmpeg: PathBuf, ffprobe: PathBuf },
+    /// Paths from the environment overrides.
+    Env { ffmpeg: PathBuf, ffprobe: PathBuf },
+    /// A directory holding a bundled `binaries/` layout.
+    ResourceRoot(PathBuf),
+    /// The in-app managed installer directory.
+    Managed,
+    /// Dev-mode binaries under `src-tauri/binaries/`.
+    Dev,
+    /// System PATH and common install locations.
+    System,
+}
+
+impl Candidate {
+    /// Human-readable label listed in the aggregated "not found" error.
+    fn label(&self) -> String {
+        match self {
+            Candidate::Explicit { ffmpeg, .. } => format!("explicit({})", ffmpeg.display()),
+            Candidate::Env { ffmpeg, .. } => {
+                format!("env({FFMPEG_PATH_ENV}={})", ffmpeg.display())
+            }
+            Candidate::ResourceRoot(root) => format!("bundled({})", root.display()),
+            Candidate::Managed => "managed".to_string(),
+            Candidate::Dev => "dev".to_string(),
+            Candidate::System => "system".to_string(),
+        }
+    }
+
+    fn resolve(&self) -> FFmpegResult<FFmpegInfo> {
+        match self {
+            Candidate::Explicit { ffmpeg, ffprobe } => {
+                validate_pair(ffmpeg, ffprobe, FFmpegSource::Explicit)
+            }
+            Candidate::Env { ffmpeg, ffprobe } => validate_pair(ffmpeg, ffprobe, FFmpegSource::Env),
+            Candidate::ResourceRoot(root) => detect_bundled_at_path(root),
+            Candidate::Managed => detect_managed_ffmpeg(),
+            Candidate::Dev => detect_dev_mode_binaries(),
+            Candidate::System => detect_system_ffmpeg(),
+        }
+    }
+}
+
+/// Validate a caller-supplied binary pair with the same version probe the
+/// filesystem detectors use.
+fn validate_pair(ffmpeg: &Path, ffprobe: &Path, source: FFmpegSource) -> FFmpegResult<FFmpegInfo> {
+    let version = get_ffmpeg_version(ffmpeg)?;
+    probe_binary_runs(ffprobe)?;
+
+    Ok(FFmpegInfo {
+        ffmpeg_path: ffmpeg.to_path_buf(),
+        ffprobe_path: ffprobe.to_path_buf(),
+        version,
+        is_bundled: false,
+        source,
+    })
+}
+
+/// Derive the companion binary path next to an explicitly configured one.
+///
+/// A bare command name (no directory component) stays bare so PATH lookup
+/// still applies to the derived binary.
+fn sibling_binary(path: &Path, binary_name: &str) -> PathBuf {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.join(binary_name),
+        _ => PathBuf::from(binary_name),
+    }
+}
+
+/// Complete a partially supplied ffmpeg/ffprobe pair, or `None` when neither
+/// half was supplied.
+fn complete_pair(ffmpeg: Option<PathBuf>, ffprobe: Option<PathBuf>) -> Option<(PathBuf, PathBuf)> {
+    let (ffmpeg_name, ffprobe_name) = get_bundled_binary_names();
+
+    match (ffmpeg, ffprobe) {
+        (Some(ffmpeg), Some(ffprobe)) => Some((ffmpeg, ffprobe)),
+        (Some(ffmpeg), None) => {
+            let ffprobe = sibling_binary(&ffmpeg, ffprobe_name);
+            Some((ffmpeg, ffprobe))
+        }
+        (None, Some(ffprobe)) => {
+            let ffmpeg = sibling_binary(&ffprobe, ffmpeg_name);
+            Some((ffmpeg, ffprobe))
+        }
+        (None, None) => None,
+    }
+}
+
+/// Read a path override from the environment, ignoring empty values.
+fn read_env_override(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+/// Build the ordered candidate list.
+///
+/// Pure: the environment overrides are passed in rather than read here, and
+/// they are dropped entirely unless `opts.use_env` is set.
+fn build_candidates(
+    opts: &FFmpegResolveOptions,
+    env_ffmpeg: Option<PathBuf>,
+    env_ffprobe: Option<PathBuf>,
+) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+
+    if let Some((ffmpeg, ffprobe)) =
+        complete_pair(opts.explicit_ffmpeg.clone(), opts.explicit_ffprobe.clone())
+    {
+        candidates.push(Candidate::Explicit { ffmpeg, ffprobe });
+    }
+
+    if opts.use_env {
+        if let Some((ffmpeg, ffprobe)) = complete_pair(env_ffmpeg, env_ffprobe) {
+            candidates.push(Candidate::Env { ffmpeg, ffprobe });
+        }
+    }
+
+    candidates.extend(
+        opts.resource_roots
+            .iter()
+            .cloned()
+            .map(Candidate::ResourceRoot),
+    );
+    candidates.push(Candidate::Managed);
+    candidates.push(Candidate::Dev);
+    candidates.push(Candidate::System);
+
+    candidates
+}
+
+/// Resolve an FFmpeg installation without touching any shared state.
+///
+/// Order: explicit paths → environment overrides (when
+/// [`FFmpegResolveOptions::use_env`]) → each resource root → managed install →
+/// dev-mode binaries → system PATH. Every candidate is validated by probing
+/// `-version` on both binaries; the first valid one wins.
+///
+/// This spawns blocking process probes, so async callers must run it inside
+/// `spawn_blocking`.
+pub fn resolve_ffmpeg(opts: &FFmpegResolveOptions) -> FFmpegResult<FFmpegInfo> {
+    let candidates = build_candidates(
+        opts,
+        read_env_override(FFMPEG_PATH_ENV),
+        read_env_override(FFPROBE_PATH_ENV),
+    );
+
+    let mut tried = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        match candidate.resolve() {
+            Ok(info) => {
+                tracing::debug!(
+                    "Resolved FFmpeg from {}: {:?}",
+                    candidate.label(),
+                    info.ffmpeg_path
+                );
+                return Ok(info);
+            }
+            Err(error) => {
+                tracing::debug!("FFmpeg candidate {} rejected: {}", candidate.label(), error);
+                tried.push(candidate.label());
+            }
+        }
+    }
+
+    Err(FFmpegError::NotFoundInSources(tried.join(", ")))
+}
+
+/// Resolve an FFmpeg installation and publish it process-wide.
+///
+/// Callers that go on to spawn ffmpeg/ffprobe through core modules must use
+/// this instead of [`resolve_ffmpeg`], because those modules read the globals
+/// registered here.
+pub fn resolve_and_register(opts: &FFmpegResolveOptions) -> FFmpegResult<FFmpegInfo> {
+    let info = resolve_ffmpeg(opts)?;
+    set_resolved_paths(info.ffmpeg_path.clone(), info.ffprobe_path.clone());
+    Ok(info)
+}
+
 static RESOLVED: OnceLock<RwLock<Option<ResolvedFFmpeg>>> = OnceLock::new();
 
 fn resolved_cell() -> &'static RwLock<Option<ResolvedFFmpeg>> {
@@ -31,8 +245,8 @@ fn resolved_cell() -> &'static RwLock<Option<ResolvedFFmpeg>> {
 
 /// Registers the globally resolved FFmpeg/FFprobe paths.
 ///
-/// Called by `FFmpegState::initialize` (GUI) and `detect_cli_ffmpeg` (CLI)
-/// once detection succeeds. Overwrites any previously cached paths.
+/// Called by `FFmpegState::initialize` (GUI) and [`resolve_and_register`]
+/// (CLI) once detection succeeds. Overwrites any previously cached paths.
 pub fn set_resolved_paths(ffmpeg: PathBuf, ffprobe: PathBuf) {
     // A poisoned lock only means another thread panicked mid-write; the
     // stored Option is still valid, so recover the guard instead of panicking.
@@ -91,6 +305,123 @@ pub fn resolved_ffprobe_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn labels(candidates: &[Candidate]) -> Vec<String> {
+        candidates
+            .iter()
+            .map(|candidate| match candidate {
+                Candidate::Explicit { .. } => "explicit".to_string(),
+                Candidate::Env { .. } => "env".to_string(),
+                Candidate::ResourceRoot(root) => format!("root:{}", root.display()),
+                Candidate::Managed => "managed".to_string(),
+                Candidate::Dev => "dev".to_string(),
+                Candidate::System => "system".to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_candidates_orders_explicit_before_env_before_detectors() {
+        let opts = FFmpegResolveOptions {
+            explicit_ffmpeg: Some(PathBuf::from("/explicit/ffmpeg")),
+            explicit_ffprobe: Some(PathBuf::from("/explicit/ffprobe")),
+            resource_roots: vec![PathBuf::from("/root_a"), PathBuf::from("/root_b")],
+            use_env: true,
+        };
+
+        let candidates = build_candidates(
+            &opts,
+            Some(PathBuf::from("/env/ffmpeg")),
+            Some(PathBuf::from("/env/ffprobe")),
+        );
+
+        assert_eq!(
+            labels(&candidates),
+            vec![
+                "explicit",
+                "env",
+                &format!("root:{}", PathBuf::from("/root_a").display()),
+                &format!("root:{}", PathBuf::from("/root_b").display()),
+                "managed",
+                "dev",
+                "system",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_candidates_skips_env_when_disabled() {
+        let opts = FFmpegResolveOptions {
+            use_env: false,
+            ..Default::default()
+        };
+
+        let candidates = build_candidates(
+            &opts,
+            Some(PathBuf::from("/env/ffmpeg")),
+            Some(PathBuf::from("/env/ffprobe")),
+        );
+
+        assert_eq!(labels(&candidates), vec!["managed", "dev", "system"]);
+    }
+
+    #[test]
+    fn build_candidates_derives_missing_companion_binary() {
+        let (_, ffprobe_name) = get_bundled_binary_names();
+        let opts = FFmpegResolveOptions {
+            explicit_ffmpeg: Some(PathBuf::from("/opt/tools/ffmpeg")),
+            ..Default::default()
+        };
+
+        let candidates = build_candidates(&opts, None, None);
+
+        match &candidates[0] {
+            Candidate::Explicit { ffprobe, .. } => {
+                assert_eq!(ffprobe, &PathBuf::from("/opt/tools").join(ffprobe_name));
+            }
+            other => panic!("Expected an explicit candidate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_candidates_keeps_bare_command_names_bare() {
+        let (ffmpeg_name, _) = get_bundled_binary_names();
+        let opts = FFmpegResolveOptions {
+            explicit_ffprobe: Some(PathBuf::from("ffprobe")),
+            ..Default::default()
+        };
+
+        let candidates = build_candidates(&opts, None, None);
+
+        match &candidates[0] {
+            Candidate::Explicit { ffmpeg, .. } => {
+                assert_eq!(ffmpeg, &PathBuf::from(ffmpeg_name));
+            }
+            other => panic!("Expected an explicit candidate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_ffmpeg_falls_through_invalid_explicit_paths() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bogus = temp_dir.path().join("not-ffmpeg");
+        let opts = FFmpegResolveOptions {
+            explicit_ffmpeg: Some(bogus.clone()),
+            use_env: false,
+            ..Default::default()
+        };
+
+        // Whether a real installation exists depends on the machine, so only
+        // assert that the invalid explicit candidate is never accepted.
+        match resolve_ffmpeg(&opts) {
+            Ok(info) => assert_ne!(info.ffmpeg_path, bogus),
+            Err(error) => {
+                let message = error.to_string();
+                assert!(message.contains("explicit("), "unexpected error: {message}");
+                assert!(message.contains("system"), "unexpected error: {message}");
+            }
+        }
+    }
 
     // The resolver caches into process-global state shared by every test in
     // this binary, so all assertions live in a single test to keep ordering

--- a/src-tauri/src/core/ffmpeg/runner.rs
+++ b/src-tauri/src/core/ffmpeg/runner.rs
@@ -19,6 +19,34 @@ fn is_nonempty_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Default MJPEG quality (1-31, lower is better) used for extracted frames.
+const DEFAULT_FRAME_JPEG_QUALITY: u8 = 2;
+
+/// Builds a downscale-only `scale` filter that preserves the aspect ratio.
+///
+/// `min(max_width, iw)` keeps sources narrower than `max_width` untouched, and
+/// `-2` keeps the height on an even number as required by most encoders. The
+/// quotes protect the comma from FFmpeg's filtergraph separator.
+fn downscale_filter(max_width: u32) -> String {
+    format!("scale='min({},iw)':-2", max_width.max(1))
+}
+
+/// Options for [`FFmpegRunner::extract_frame_with_options`].
+#[derive(Clone, Debug, Default)]
+pub struct FrameExtractOptions {
+    /// Re-extract even when a non-empty output file already exists.
+    ///
+    /// The default (`false`) keeps the legacy cache behaviour used by
+    /// thumbnail and clip-analysis passes.
+    pub overwrite: bool,
+    /// Downscale the frame so its width never exceeds this value.
+    ///
+    /// Sources narrower than the limit are left at their native size.
+    pub max_width: Option<u32>,
+    /// MJPEG quality (1-31, lower is better). Ignored for PNG output.
+    pub quality: Option<u8>,
+}
+
 // =============================================================================
 // Waveform Data Types
 // =============================================================================
@@ -268,6 +296,11 @@ impl FFmpegRunner {
 
     /// Extract a single frame from a video file
     ///
+    /// An existing non-empty output file is treated as a cache hit and left
+    /// untouched. Callers that need a freshly decoded frame must use
+    /// [`FFmpegRunner::extract_frame_with_options`] with
+    /// [`FrameExtractOptions::overwrite`] set.
+    ///
     /// # Arguments
     /// * `input` - Path to the input video file
     /// * `time_sec` - Time position in seconds
@@ -278,6 +311,25 @@ impl FFmpegRunner {
         time_sec: f64,
         output: &Path,
     ) -> FFmpegResult<()> {
+        self.extract_frame_with_options(input, time_sec, output, &FrameExtractOptions::default())
+            .await
+    }
+
+    /// Extract a single frame from a video file with explicit caching, scaling
+    /// and quality control.
+    ///
+    /// # Arguments
+    /// * `input` - Path to the input video file
+    /// * `time_sec` - Time position in seconds
+    /// * `output` - Path to save the output image (JPEG or PNG)
+    /// * `options` - Overwrite/scale/quality behaviour
+    pub async fn extract_frame_with_options(
+        &self,
+        input: &Path,
+        time_sec: f64,
+        output: &Path,
+        options: &FrameExtractOptions,
+    ) -> FFmpegResult<()> {
         if !input.exists() {
             return Err(FFmpegError::InvalidInput(format!(
                 "Input file does not exist: {}",
@@ -285,8 +337,9 @@ impl FFmpegRunner {
             )));
         }
 
-        // If already extracted, treat as success.
-        if is_nonempty_file(output) {
+        // Without `overwrite`, an already extracted frame is treated as success
+        // so repeated thumbnail/analysis passes stay cheap.
+        if !options.overwrite && is_nonempty_file(output) {
             return Ok(());
         }
 
@@ -300,32 +353,58 @@ impl FFmpegRunner {
         // Build FFmpeg command
         // -ss before -i for fast seeking
         // -frames:v 1 to extract single frame
-        // -q:v 2 for good JPEG quality
+        let mut args = vec![
+            "-hide_banner".to_string(),
+            "-loglevel".to_string(),
+            "error".to_string(),
+            "-nostdin".to_string(),
+            "-ss".to_string(),
+            format!("{:.6}", time_sec),
+            "-i".to_string(),
+            input.to_string_lossy().to_string(),
+            "-frames:v".to_string(),
+            "1".to_string(),
+        ];
+
+        if let Some(max_width) = options.max_width {
+            args.push("-vf".to_string());
+            args.push(downscale_filter(max_width));
+        }
+
+        // PNG ignores `-q:v`; only the MJPEG path is quality controlled.
+        if output
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("png"))
+        {
+            args.extend([
+                "-c:v".to_string(),
+                "png".to_string(),
+                "-pix_fmt".to_string(),
+                "rgba".to_string(),
+            ]);
+        } else {
+            args.push("-q:v".to_string());
+            args.push(
+                options
+                    .quality
+                    .unwrap_or(DEFAULT_FRAME_JPEG_QUALITY)
+                    .to_string(),
+            );
+        }
+
+        args.push("-y".to_string()); // Overwrite output
+        args.push(output.to_string_lossy().to_string());
+
         let mut cmd = tokio::process::Command::new(&self.info.ffmpeg_path);
         configure_tokio_command(&mut cmd);
-        let output = cmd
-            .args([
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-nostdin",
-                "-ss",
-                &format!("{:.6}", time_sec),
-                "-i",
-                &input.to_string_lossy(),
-                "-frames:v",
-                "1",
-                "-q:v",
-                "2",
-                "-y", // Overwrite output
-                &output.to_string_lossy(),
-            ])
+        let result = cmd
+            .args(&args)
             .output()
             .await
             .map_err(FFmpegError::ProcessError)?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if !result.status.success() {
+            let stderr = String::from_utf8_lossy(&result.stderr);
             return Err(FFmpegError::ExecutionFailed(format!(
                 "Frame extraction failed: {}",
                 stderr

--- a/src-tauri/src/core/ffmpeg/runner.rs
+++ b/src-tauri/src/core/ffmpeg/runner.rs
@@ -22,6 +22,12 @@ fn is_nonempty_file(path: &Path) -> bool {
 /// Default MJPEG quality (1-31, lower is better) used for extracted frames.
 const DEFAULT_FRAME_JPEG_QUALITY: u8 = 2;
 
+/// Best MJPEG quality FFmpeg's `-q:v` accepts.
+const MIN_FRAME_JPEG_QUALITY: u8 = 1;
+
+/// Worst MJPEG quality FFmpeg's `-q:v` accepts.
+const MAX_FRAME_JPEG_QUALITY: u8 = 31;
+
 /// Builds a downscale-only `scale` filter that preserves the aspect ratio.
 ///
 /// `min(max_width, iw)` keeps sources narrower than `max_width` untouched, and
@@ -44,6 +50,9 @@ pub struct FrameExtractOptions {
     /// Sources narrower than the limit are left at their native size.
     pub max_width: Option<u32>,
     /// MJPEG quality (1-31, lower is better). Ignored for PNG output.
+    ///
+    /// Values outside the range are clamped to it, so the option can never
+    /// produce a command line FFmpeg refuses.
     pub quality: Option<u8>,
 }
 
@@ -384,10 +393,14 @@ impl FFmpegRunner {
             ]);
         } else {
             args.push("-q:v".to_string());
+            // FFmpeg rejects a `-q:v` outside 1-31 and the failure would surface
+            // as an opaque stderr dump, so an out-of-range option is clamped
+            // rather than handed to the encoder.
             args.push(
                 options
                     .quality
                     .unwrap_or(DEFAULT_FRAME_JPEG_QUALITY)
+                    .clamp(MIN_FRAME_JPEG_QUALITY, MAX_FRAME_JPEG_QUALITY)
                     .to_string(),
             );
         }
@@ -1190,6 +1203,11 @@ const STDERR_ERROR_TAIL_LINES: usize = 20;
 /// each retained line costs its text (~60 bytes for these filters) plus the
 /// `String` header and sequence number, i.e. under 100 bytes, so a full buffer
 /// stays below ~50 MB.
+///
+/// The cap is per capture, not per process. `AudioProfiler::analyze` runs its
+/// passes concurrently and two of them retain filter output in full, so a
+/// single long asset can hold two near-full buffers, and analysing assets in
+/// parallel multiplies that again.
 const MAX_RETAINED_FILTER_LINES: usize = 500_000;
 
 /// Maximum number of trailing lines retained regardless of content.

--- a/src-tauri/src/core/ffmpeg/runner.rs
+++ b/src-tauri/src/core/ffmpeg/runner.rs
@@ -1134,13 +1134,18 @@ impl FFmpegRunner {
     /// The call is aborted with [`FFmpegError::Timeout`] once `timeout`
     /// elapses, and stderr retention is bounded (see [`FilterStderrCapture`]),
     /// so a pathological input can neither hang nor exhaust memory.
+    ///
+    /// The whole [`FilterCapture`] is returned rather than just its text so
+    /// callers can see whether retention dropped lines and whether INFO-level
+    /// output was observed at all — both facts are lost once the buffers are
+    /// joined into a single string.
     pub async fn run_filter_capture_stderr(
         &self,
         input: &Path,
         filter_complex: &str,
         maps: &[&str],
         timeout: std::time::Duration,
-    ) -> FFmpegResult<String> {
+    ) -> FFmpegResult<FilterCapture> {
         let capture = capture_filter_stderr(
             &self.info.ffmpeg_path,
             input,
@@ -1160,7 +1165,7 @@ impl FFmpegRunner {
             )));
         }
 
-        Ok(capture.stderr)
+        Ok(capture)
     }
 }
 
@@ -1177,13 +1182,29 @@ const STDERR_ERROR_TAIL_LINES: usize = 20;
 /// on long inputs, so retention is capped: the oldest lines are dropped and the
 /// capture is flagged as truncated. The cap is deliberately generous — it exists
 /// to bound memory, not to trim ordinary output.
-const MAX_RETAINED_FILTER_LINES: usize = 200_000;
+///
+/// Sizing: `ametadata=mode=print` emits two lines per audio frame (a `frame:`
+/// header plus the metadata value) and a 48 kHz stream decodes at roughly 47
+/// frames per second, so the cap corresponds to about 88 minutes of audio
+/// (500 000 / 94 ≈ 5300 s). Worst-case memory is bounded by the same number:
+/// each retained line costs its text (~60 bytes for these filters) plus the
+/// `String` header and sequence number, i.e. under 100 bytes, so a full buffer
+/// stays below ~50 MB.
+const MAX_RETAINED_FILTER_LINES: usize = 500_000;
 
 /// Maximum number of trailing lines retained regardless of content.
 ///
 /// The `ebur128` summary block is emitted as indented continuation lines that
 /// carry no filter prefix, so the tail window is what keeps it intact.
 const MAX_RETAINED_TAIL_LINES: usize = 400;
+
+/// Line prefixes FFmpeg only prints at its INFO log level.
+///
+/// These are header lines, so they carry no filter marker and survive only
+/// inside the trailing window. Whether one was ever seen is therefore recorded
+/// while streaming rather than recovered from the joined text, which a long
+/// run would have evicted (see [`FilterCapture::saw_info_output`]).
+const INFO_LEVEL_LINE_PREFIXES: &[&str] = &["Input #", "Output #", "Stream mapping:", "Stream #"];
 
 /// Line prefixes/markers that identify output worth keeping in full.
 const FILTER_LINE_MARKERS: &[&str] = &[
@@ -1234,6 +1255,13 @@ pub struct FilterCapture {
     pub exit_code: Option<i32>,
     /// Whether stderr retention dropped lines.
     pub truncated: bool,
+    /// Whether any INFO-level FFmpeg output was observed while streaming.
+    ///
+    /// Detection filters log nothing when they find nothing, so "no detections"
+    /// is only meaningful if INFO output reached the capture at all. The fact is
+    /// recorded as lines arrive because the header lines that prove it are
+    /// evicted from the retained text by any long-running pass.
+    pub saw_info_output: bool,
 }
 
 impl FilterCapture {
@@ -1323,6 +1351,7 @@ pub async fn capture_filter_stderr(
         success: status.success(),
         exit_code: status.code(),
         truncated: capture.truncated,
+        saw_info_output: capture.saw_info_output,
     })
 }
 
@@ -1339,6 +1368,7 @@ struct FilterStderrCapture {
     filter_lines: std::collections::VecDeque<(usize, String)>,
     tail_lines: std::collections::VecDeque<(usize, String)>,
     truncated: bool,
+    saw_info_output: bool,
 }
 
 impl FilterStderrCapture {
@@ -1349,6 +1379,13 @@ impl FilterStderrCapture {
     fn push(&mut self, line: &str) {
         let seq = self.next_seq;
         self.next_seq += 1;
+
+        // Recorded here rather than re-scanned later: the header lines that
+        // prove INFO output arrived are not filter output, so a long run
+        // evicts them from the trailing window before anyone can look.
+        if !self.saw_info_output && is_info_level_line(line) {
+            self.saw_info_output = true;
+        }
 
         if is_filter_output_line(line) {
             if self.filter_lines.len() == MAX_RETAINED_FILTER_LINES {
@@ -1389,6 +1426,14 @@ impl FilterStderrCapture {
             .collect::<Vec<_>>()
             .join("\n")
     }
+}
+
+/// Returns whether a stderr line is one FFmpeg only prints at INFO level.
+fn is_info_level_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    INFO_LEVEL_LINE_PREFIXES
+        .iter()
+        .any(|prefix| trimmed.starts_with(prefix))
 }
 
 /// Returns whether a stderr line carries filter output worth retaining in full.
@@ -1798,12 +1843,63 @@ mod tests {
     }
 
     #[test]
+    fn test_is_info_level_line() {
+        assert!(is_info_level_line(
+            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'render.mp4':"
+        ));
+        assert!(is_info_level_line("Stream mapping:"));
+        assert!(is_info_level_line("  Stream #0:0 -> #0:0 (h264 (native))"));
+        assert!(is_info_level_line("Output #0, null, to 'pipe:':"));
+        assert!(!is_info_level_line(
+            "[silencedetect @ 0x1] silence_start: 1.0"
+        ));
+        assert!(!is_info_level_line("frame= 120 fps=30"));
+    }
+
+    #[test]
+    fn test_filter_capture_should_record_info_output_while_streaming() {
+        let mut capture = FilterStderrCapture::new();
+        assert!(!capture.saw_info_output);
+
+        capture.push("[silencedetect @ 0x1] silence_start: 1.0");
+        assert!(!capture.saw_info_output);
+
+        capture.push("Stream mapping:");
+        assert!(capture.saw_info_output);
+    }
+
+    #[test]
+    fn test_filter_capture_should_keep_the_info_flag_after_the_header_is_evicted() {
+        let mut capture = FilterStderrCapture::new();
+        capture.push("Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'render.mp4':");
+        capture.push("Stream mapping:");
+
+        // A content-rich render emits far more filter output than the trailing
+        // window holds, so the header lines are long gone by the time anyone
+        // reads the joined text.
+        for index in 0..(MAX_RETAINED_TAIL_LINES * 2) {
+            capture.push(&format!("[blackdetect @ 0x1] black_start:{}", index));
+        }
+
+        let joined = capture.joined();
+        assert!(
+            !joined.contains("Stream mapping:"),
+            "the header is expected to be evicted; the flag is what must survive"
+        );
+        assert!(
+            capture.saw_info_output,
+            "INFO-level output must stay recorded once the header is evicted"
+        );
+    }
+
+    #[test]
     fn test_filter_capture_stderr_tail() {
         let capture = FilterCapture {
             stderr: "a\nb\nc\nd".to_string(),
             success: false,
             exit_code: Some(1),
             truncated: false,
+            saw_info_output: true,
         };
 
         assert_eq!(capture.stderr_tail(2), "c\nd");

--- a/src-tauri/src/core/ffmpeg/runner.rs
+++ b/src-tauri/src/core/ffmpeg/runner.rs
@@ -1121,6 +1121,282 @@ impl FFmpegRunner {
 
         Ok(waveform)
     }
+
+    /// Runs a `-filter_complex` analysis pass and returns the captured stderr.
+    ///
+    /// Analysis filters (`blackdetect`, `freezedetect`, `silencedetect`,
+    /// `ebur128`, `astats`) report their findings to stderr at FFmpeg's INFO
+    /// log level, so the invocation pins `-loglevel info` and discards the
+    /// decoded output with `-f null -`.
+    ///
+    /// `maps` lists the filtergraph output labels to map (for example
+    /// `["[v]", "[a]"]`); an empty slice leaves stream selection to FFmpeg.
+    /// The call is aborted with [`FFmpegError::Timeout`] once `timeout`
+    /// elapses, and stderr retention is bounded (see [`FilterStderrCapture`]),
+    /// so a pathological input can neither hang nor exhaust memory.
+    pub async fn run_filter_capture_stderr(
+        &self,
+        input: &Path,
+        filter_complex: &str,
+        maps: &[&str],
+        timeout: std::time::Duration,
+    ) -> FFmpegResult<String> {
+        let capture = capture_filter_stderr(
+            &self.info.ffmpeg_path,
+            input,
+            FilterMode::Complex {
+                graph: filter_complex,
+                maps,
+            },
+            timeout,
+        )
+        .await?;
+
+        if !capture.success {
+            return Err(FFmpegError::ExecutionFailed(format!(
+                "Filter analysis failed (exit {}). Stderr tail:\n{}",
+                capture.exit_code.unwrap_or(-1),
+                capture.stderr_tail(STDERR_ERROR_TAIL_LINES)
+            )));
+        }
+
+        Ok(capture.stderr)
+    }
+}
+
+// =============================================================================
+// Filter analysis passes
+// =============================================================================
+
+/// Number of stderr tail lines quoted in filter-analysis error messages.
+const STDERR_ERROR_TAIL_LINES: usize = 20;
+
+/// Maximum number of filter-output lines retained from a capture.
+///
+/// Per-frame filters (`ametadata=mode=print`) emit tens of thousands of lines
+/// on long inputs, so retention is capped: the oldest lines are dropped and the
+/// capture is flagged as truncated. The cap is deliberately generous — it exists
+/// to bound memory, not to trim ordinary output.
+const MAX_RETAINED_FILTER_LINES: usize = 200_000;
+
+/// Maximum number of trailing lines retained regardless of content.
+///
+/// The `ebur128` summary block is emitted as indented continuation lines that
+/// carry no filter prefix, so the tail window is what keeps it intact.
+const MAX_RETAINED_TAIL_LINES: usize = 400;
+
+/// Line prefixes/markers that identify output worth keeping in full.
+const FILTER_LINE_MARKERS: &[&str] = &[
+    "[Parsed_",
+    "[silencedetect",
+    "[blackdetect",
+    "[freezedetect",
+    "[Parsed_ebur128",
+    "lavfi.",
+    "silence_start",
+    "silence_end",
+    "black_start",
+    "black_end",
+    "freeze_start",
+    "freeze_end",
+];
+
+/// How a filtergraph is attached to an analysis invocation.
+#[derive(Debug, Clone, Copy)]
+pub enum FilterMode<'a> {
+    /// `-af <filter> -vn`: audio-only pass over the first audio stream.
+    ///
+    /// Kept distinct from [`FilterMode::Complex`] because FFmpeg reports a
+    /// missing audio stream differently for the two forms, and callers match
+    /// on that message to tell "no audio" apart from "analysis failed".
+    Audio(&'a str),
+    /// `-filter_complex <graph>` with the given output labels mapped.
+    Complex {
+        /// The filtergraph description.
+        graph: &'a str,
+        /// Output labels to map, e.g. `["[v]", "[a]"]`.
+        maps: &'a [&'a str],
+    },
+}
+
+/// Result of an analysis pass, including runs that exited non-zero.
+///
+/// Failure is reported as data rather than an error so callers can inspect the
+/// captured stderr first: a missing audio stream, for example, surfaces only in
+/// the log text while FFmpeg exits non-zero.
+#[derive(Debug, Clone)]
+pub struct FilterCapture {
+    /// Retained stderr text (bounded; see [`FilterStderrCapture`]).
+    pub stderr: String,
+    /// Whether FFmpeg exited successfully.
+    pub success: bool,
+    /// Process exit code, when one was reported.
+    pub exit_code: Option<i32>,
+    /// Whether stderr retention dropped lines.
+    pub truncated: bool,
+}
+
+impl FilterCapture {
+    /// Returns the last `lines` lines of the captured stderr.
+    pub fn stderr_tail(&self, lines: usize) -> String {
+        let all: Vec<&str> = self.stderr.lines().collect();
+        let start = all.len().saturating_sub(lines);
+        all[start..].join("\n")
+    }
+}
+
+/// Runs an FFmpeg analysis pass and captures its stderr.
+///
+/// The output is discarded (`-f null -`); only the filter log matters. The
+/// invocation pins `-loglevel info` (filters log their findings at that level)
+/// and `-nostats` (the periodic encode progress line is noise here).
+///
+/// Returns [`FFmpegError::Timeout`] when `timeout` elapses; the child process
+/// is killed before returning so no orphan encoder is left behind.
+pub async fn capture_filter_stderr(
+    ffmpeg_path: &Path,
+    input: &Path,
+    mode: FilterMode<'_>,
+    timeout: std::time::Duration,
+) -> FFmpegResult<FilterCapture> {
+    if !input.exists() {
+        return Err(FFmpegError::InvalidInput(format!(
+            "Input file does not exist: {}",
+            input.display()
+        )));
+    }
+
+    let mut cmd = tokio::process::Command::new(ffmpeg_path);
+    configure_tokio_command(&mut cmd);
+    cmd.args(["-hide_banner", "-nostats", "-nostdin", "-loglevel", "info"]);
+    cmd.arg("-i").arg(input);
+
+    match mode {
+        FilterMode::Audio(filter) => {
+            cmd.arg("-af").arg(filter).arg("-vn");
+        }
+        FilterMode::Complex { graph, maps } => {
+            cmd.arg("-filter_complex").arg(graph);
+            for label in maps {
+                cmd.arg("-map").arg(label);
+            }
+        }
+    }
+
+    cmd.args(["-f", "null", "-"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(FFmpegError::ProcessError)?;
+
+    let stderr = child.stderr.take();
+    let (capture_tx, capture_rx) = tokio::sync::oneshot::channel::<FilterStderrCapture>();
+    let reader_task = tokio::spawn(async move {
+        let mut capture = FilterStderrCapture::new();
+        if let Some(stderr) = stderr {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                capture.push(&line);
+            }
+        }
+        let _ = capture_tx.send(capture);
+    });
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(result) => result.map_err(FFmpegError::ProcessError)?,
+        Err(_) => {
+            // Kill first, then drain: the reader task only ends once the child
+            // closes its stderr pipe.
+            let _ = child.kill().await;
+            reader_task.abort();
+            return Err(FFmpegError::Timeout);
+        }
+    };
+
+    let capture = capture_rx.await.unwrap_or_default();
+    let _ = reader_task.await;
+
+    Ok(FilterCapture {
+        stderr: capture.joined(),
+        success: status.success(),
+        exit_code: status.code(),
+        truncated: capture.truncated,
+    })
+}
+
+/// Bounded, order-preserving stderr buffer for analysis passes.
+///
+/// Filter findings can be numerous (one line per detected range) while the
+/// surrounding FFmpeg chatter is irrelevant, so lines that look like filter
+/// output are retained up to a high cap and everything else survives only
+/// inside a short trailing window. Sequence numbers keep the merged result in
+/// emission order without duplicating lines held by both buffers.
+#[derive(Debug, Default)]
+struct FilterStderrCapture {
+    next_seq: usize,
+    filter_lines: std::collections::VecDeque<(usize, String)>,
+    tail_lines: std::collections::VecDeque<(usize, String)>,
+    truncated: bool,
+}
+
+impl FilterStderrCapture {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn push(&mut self, line: &str) {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+
+        if is_filter_output_line(line) {
+            if self.filter_lines.len() == MAX_RETAINED_FILTER_LINES {
+                self.filter_lines.pop_front();
+                self.truncated = true;
+            }
+            self.filter_lines.push_back((seq, line.to_string()));
+        }
+
+        // Dropping an old non-filter line is the intended behaviour of the
+        // trailing window, so it does not count as truncation.
+        if self.tail_lines.len() == MAX_RETAINED_TAIL_LINES {
+            self.tail_lines.pop_front();
+        }
+        self.tail_lines.push_back((seq, line.to_string()));
+    }
+
+    /// Merges both buffers back into emission order, without duplicates.
+    fn joined(&self) -> String {
+        let mut merged: Vec<(usize, &str)> =
+            Vec::with_capacity(self.filter_lines.len() + self.tail_lines.len());
+        merged.extend(
+            self.filter_lines
+                .iter()
+                .map(|(seq, line)| (*seq, line.as_str())),
+        );
+        merged.extend(
+            self.tail_lines
+                .iter()
+                .map(|(seq, line)| (*seq, line.as_str())),
+        );
+        merged.sort_by_key(|(seq, _)| *seq);
+        merged.dedup_by_key(|(seq, _)| *seq);
+
+        merged
+            .into_iter()
+            .map(|(_, line)| line)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Returns whether a stderr line carries filter output worth retaining in full.
+fn is_filter_output_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    FILTER_LINE_MARKERS
+        .iter()
+        .any(|marker| trimmed.starts_with(marker) || trimmed.contains(marker))
 }
 
 /// Parse peak levels from FFmpeg astats filter output
@@ -1446,6 +1722,93 @@ fn parse_audio_stream(stream: &serde_json::Value) -> FFmpegResult<AudioStreamInf
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // Filter stderr capture Tests
+    // =========================================================================
+
+    #[test]
+    fn test_filter_capture_should_keep_lines_in_emission_order() {
+        let mut capture = FilterStderrCapture::new();
+        capture.push("[blackdetect @ 0x1] black_start:0 black_end:0.5");
+        capture.push("frame= 10 fps=0.0");
+        capture.push("[silencedetect @ 0x2] silence_start: 1.0");
+
+        let joined = capture.joined();
+        let lines: Vec<&str> = joined.lines().collect();
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("black_start"));
+        assert!(lines[1].contains("frame="));
+        assert!(lines[2].contains("silence_start"));
+        assert!(!capture.truncated);
+    }
+
+    #[test]
+    fn test_filter_capture_should_retain_filter_lines_beyond_the_tail_window() {
+        let mut capture = FilterStderrCapture::new();
+        capture.push("[blackdetect @ 0x1] black_start:0 black_end:0.5");
+        for index in 0..(MAX_RETAINED_TAIL_LINES * 2) {
+            capture.push(&format!("noise line {}", index));
+        }
+
+        let joined = capture.joined();
+
+        assert!(
+            joined.contains("black_start"),
+            "filter output must survive a flood of unrelated stderr"
+        );
+        assert!(
+            !joined.contains("noise line 0"),
+            "unrelated stderr must be bounded"
+        );
+        assert!(!capture.truncated);
+    }
+
+    #[test]
+    fn test_filter_capture_should_not_duplicate_lines_held_by_both_buffers() {
+        let mut capture = FilterStderrCapture::new();
+        capture.push("[silencedetect @ 0x2] silence_start: 1.0");
+        capture.push("[silencedetect @ 0x2] silence_end: 2.0 | silence_duration: 1.0");
+
+        let joined = capture.joined();
+
+        assert_eq!(joined.matches("silence_start").count(), 1);
+        assert_eq!(joined.matches("silence_end").count(), 1);
+    }
+
+    #[test]
+    fn test_filter_capture_should_flag_truncation_when_filter_output_overflows() {
+        let mut capture = FilterStderrCapture::new();
+        for index in 0..(MAX_RETAINED_FILTER_LINES + 5) {
+            capture.push(&format!("[blackdetect @ 0x1] black_start:{}", index));
+        }
+
+        assert!(capture.truncated);
+    }
+
+    #[test]
+    fn test_is_filter_output_line() {
+        assert!(is_filter_output_line("[Parsed_ebur128_0 @ 0x1] Summary:"));
+        assert!(is_filter_output_line(
+            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 2"
+        ));
+        assert!(!is_filter_output_line("  Integrated loudness:"));
+        assert!(!is_filter_output_line("frame= 120 fps=30"));
+    }
+
+    #[test]
+    fn test_filter_capture_stderr_tail() {
+        let capture = FilterCapture {
+            stderr: "a\nb\nc\nd".to_string(),
+            success: false,
+            exit_code: Some(1),
+            truncated: false,
+        };
+
+        assert_eq!(capture.stderr_tail(2), "c\nd");
+        assert_eq!(capture.stderr_tail(10), "a\nb\nc\nd");
+    }
 
     // =========================================================================
     // WaveformData Tests

--- a/src-tauri/src/core/ffmpeg/state.rs
+++ b/src-tauri/src/core/ffmpeg/state.rs
@@ -9,8 +9,10 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
+#[cfg(test)]
+use super::detect_system_ffmpeg;
 #[cfg(any(test, feature = "gui"))]
-use super::{detect_system_ffmpeg, FFmpegError};
+use super::FFmpegError;
 use super::{FFmpegInfo, FFmpegRunner};
 
 /// Global FFmpeg runner state.
@@ -91,25 +93,20 @@ impl Default for FFmpegState {
 /// [`initialize_shared_ffmpeg`]).
 #[cfg(all(not(test), feature = "gui"))]
 pub fn detect_ffmpeg(app_handle: Option<&tauri::AppHandle>) -> Result<FFmpegInfo, FFmpegError> {
-    // Try bundled resources first (if app_handle provided)
-    if let Some(handle) = app_handle {
-        if let Ok(info) = super::detect_bundled_resources(handle) {
-            return Ok(info);
-        }
-    }
+    use tauri::Manager;
 
-    // Managed install (in-app FFmpeg installer)
-    if let Ok(info) = super::detect_managed_ffmpeg() {
-        return Ok(info);
-    }
+    let resource_roots = app_handle
+        .and_then(|handle| handle.path().resource_dir().ok())
+        .into_iter()
+        .collect::<Vec<_>>();
 
-    // Dev-mode binaries (src-tauri/binaries during `npm run tauri dev`)
-    if let Ok(info) = super::detection::detect_dev_mode_binaries() {
-        return Ok(info);
-    }
-
-    // Fall back to system FFmpeg
-    detect_system_ffmpeg()
+    super::resolve_ffmpeg(&super::FFmpegResolveOptions {
+        resource_roots,
+        // Path overrides stay CLI-only: a GUI process must not silently inherit
+        // an FFmpeg override from whatever shell or launcher started it.
+        use_env: false,
+        ..Default::default()
+    })
 }
 
 /// Shared FFmpeg state for the async runtime.

--- a/src-tauri/src/core/qc/context.rs
+++ b/src-tauri/src/core/qc/context.rs
@@ -1,0 +1,137 @@
+//! QC Execution Context
+//!
+//! Carries the sequence-level facts and the optional rendered measurements that
+//! QC rules evaluate against. The context is built once per QC run and shared by
+//! reference with every rule, so a single (expensive) measurement pass can serve
+//! the whole rule set.
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::timeline::Sequence;
+
+/// Frame rate used when a sequence carries an unusable frame rate.
+///
+/// A zero or non-finite fps would poison every frame-tolerance calculation, so
+/// the context falls back to the project-wide default instead of propagating it.
+const FALLBACK_FPS: f64 = 30.0;
+
+/// Measurements captured from a rendered version of the sequence.
+///
+/// Produced by the render measurement pass. Every field is optional or empty so
+/// a partially successful pass still yields usable data; rules must read a
+/// missing field as "not measured" rather than "measured as zero".
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenderMeasurements {
+    /// Detected black ranges as `(start_sec, end_sec)` timeline pairs
+    pub black_ranges: Vec<(f64, f64)>,
+    /// Detected frozen-image ranges as `(start_sec, end_sec)` timeline pairs
+    pub freeze_ranges: Vec<(f64, f64)>,
+    /// Detected silent ranges as `(start_sec, end_sec)` timeline pairs
+    pub silence_ranges: Vec<(f64, f64)>,
+    /// Integrated program loudness in LUFS
+    pub integrated_lufs: Option<f64>,
+    /// True peak in dBTP
+    pub true_peak_dbtp: Option<f64>,
+    /// Loudness range in LU
+    pub loudness_range_lu: Option<f64>,
+    /// Sample peak in dBFS (fallback when true peak is unavailable)
+    pub sample_peak_db: Option<f64>,
+    /// Flatness factor reported by the audio statistics pass
+    pub flat_factor: Option<f64>,
+}
+
+/// Context handed to every QC rule for a single check run.
+#[derive(Debug, Clone)]
+pub struct QCContext {
+    /// Effective sequence frame rate in frames per second (always positive)
+    pub fps: f64,
+    /// Canvas width in pixels
+    pub canvas_width: u32,
+    /// Canvas height in pixels
+    pub canvas_height: u32,
+    /// Measurements from a rendered version of the sequence, when available
+    pub measurements: Option<RenderMeasurements>,
+}
+
+impl QCContext {
+    /// Builds a context from a sequence without rendered measurements.
+    pub fn from_sequence(sequence: &Sequence) -> Self {
+        let fps = sequence.format.fps.as_f64();
+
+        Self {
+            fps: if fps.is_finite() && fps > 0.0 {
+                fps
+            } else {
+                FALLBACK_FPS
+            },
+            canvas_width: sequence.format.canvas.width,
+            canvas_height: sequence.format.canvas.height,
+            measurements: None,
+        }
+    }
+
+    /// Attaches rendered measurements to this context.
+    pub fn with_measurements(mut self, measurements: RenderMeasurements) -> Self {
+        self.measurements = Some(measurements);
+        self
+    }
+
+    /// Returns the duration of a single frame in seconds.
+    pub fn frame_duration_sec(&self) -> f64 {
+        if self.fps.is_finite() && self.fps > 0.0 {
+            1.0 / self.fps
+        } else {
+            1.0 / FALLBACK_FPS
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::timeline::SequenceFormat;
+
+    #[test]
+    fn test_context_derives_fps_and_canvas_from_sequence() {
+        let sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let context = QCContext::from_sequence(&sequence);
+
+        assert_eq!(context.fps, 30.0);
+        assert_eq!(context.canvas_width, 1920);
+        assert_eq!(context.canvas_height, 1080);
+        assert!(context.measurements.is_none());
+    }
+
+    #[test]
+    fn test_context_falls_back_when_fps_is_unusable() {
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        sequence.format.fps.num = 0;
+
+        let context = QCContext::from_sequence(&sequence);
+
+        assert_eq!(context.fps, FALLBACK_FPS);
+        assert!((context.frame_duration_sec() - 1.0 / FALLBACK_FPS).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_context_with_measurements() {
+        let sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let measurements = RenderMeasurements {
+            black_ranges: vec![(0.0, 0.5)],
+            true_peak_dbtp: Some(-0.5),
+            ..Default::default()
+        };
+
+        let context = QCContext::from_sequence(&sequence).with_measurements(measurements);
+
+        let measured = context.measurements.expect("measurements attached");
+        assert_eq!(measured.black_ranges, vec![(0.0, 0.5)]);
+        assert_eq!(measured.true_peak_dbtp, Some(-0.5));
+        assert!(measured.silence_ranges.is_empty());
+    }
+}

--- a/src-tauri/src/core/qc/engine.rs
+++ b/src-tauri/src/core/qc/engine.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
+use super::context::{QCContext, RenderMeasurements};
 use super::rules::{
     AspectRatioRule, AudioPeakRule, BlackFrameRule, CaptionSafeAreaRule, CutRhythmRule,
     DurationRule, LicenseRule, QCRule, RuleConfig,
@@ -112,6 +113,16 @@ impl QCEngineConfig {
     }
 }
 
+/// A rule that returned an error instead of a result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleFailure {
+    /// Name of the rule that failed
+    pub rule_name: String,
+    /// Error reported by the rule
+    pub message: String,
+}
+
 /// QC check report
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QCReport {
@@ -125,8 +136,14 @@ pub struct QCReport {
     pub violations: Vec<QCViolation>,
     /// Count by severity
     pub severity_counts: HashMap<String, usize>,
-    /// Rules that were skipped
+    /// Rules that were skipped, either by configuration or for missing inputs
     pub skipped_rules: Vec<String>,
+    /// Rules that failed to run
+    ///
+    /// A failed rule leaves part of the sequence unchecked, so the report can
+    /// never be reported as passing while this list is non-empty.
+    #[serde(default)]
+    pub errored_rules: Vec<RuleFailure>,
     /// Whether the check was stopped early
     pub stopped_early: bool,
     /// Overall pass/fail status
@@ -143,6 +160,7 @@ impl QCReport {
             violations: Vec::new(),
             severity_counts: HashMap::new(),
             skipped_rules: Vec::new(),
+            errored_rules: Vec::new(),
             stopped_early: false,
             passed: true,
         }
@@ -158,6 +176,15 @@ impl QCReport {
         }
 
         self.violations.push(violation);
+    }
+
+    /// Records a rule failure and marks the report as not passing
+    fn record_rule_failure(&mut self, rule_name: &str, message: String) {
+        self.errored_rules.push(RuleFailure {
+            rule_name: rule_name.to_string(),
+            message,
+        });
+        self.passed = false;
     }
 
     /// Gets violations of a specific severity
@@ -188,7 +215,7 @@ impl QCReport {
 
     /// Generates a summary string
     pub fn summary(&self) -> String {
-        format!(
+        let mut summary = format!(
             "QC Report: {} ({} violations - {} critical, {} error, {} warning, {} info)",
             if self.passed { "PASSED" } else { "FAILED" },
             self.total_violations(),
@@ -196,7 +223,13 @@ impl QCReport {
             self.count(Severity::Error),
             self.count(Severity::Warning),
             self.count(Severity::Info)
-        )
+        );
+
+        if !self.errored_rules.is_empty() {
+            summary.push_str(&format!(" [{} rules errored]", self.errored_rules.len()));
+        }
+
+        summary
     }
 }
 
@@ -272,7 +305,33 @@ impl QCEngine {
     }
 
     /// Runs all enabled QC rules on a sequence
+    ///
+    /// The context is derived from the sequence alone, so rules that require
+    /// rendered measurements are reported as skipped. Use
+    /// [`QCEngine::check_with_measurements`] to run those rules.
     pub async fn check(&self, sequence: &Sequence, state: &ProjectState) -> CoreResult<QCReport> {
+        let context = QCContext::from_sequence(sequence);
+        self.check_with_context(sequence, state, &context).await
+    }
+
+    /// Runs all enabled QC rules with measurements from a rendered sequence
+    pub async fn check_with_measurements(
+        &self,
+        sequence: &Sequence,
+        state: &ProjectState,
+        measurements: RenderMeasurements,
+    ) -> CoreResult<QCReport> {
+        let context = QCContext::from_sequence(sequence).with_measurements(measurements);
+        self.check_with_context(sequence, state, &context).await
+    }
+
+    /// Runs all enabled QC rules against an explicit context
+    pub async fn check_with_context(
+        &self,
+        sequence: &Sequence,
+        state: &ProjectState,
+        context: &QCContext,
+    ) -> CoreResult<QCReport> {
         let start_time = std::time::Instant::now();
         let config = self.config.read().await;
 
@@ -294,8 +353,15 @@ impl QCEngine {
                 continue;
             }
 
+            // A rule missing its required inputs is skipped, never silently passed
+            if let Some(reason) = rule.skip_reason(context) {
+                tracing::debug!("Rule '{}' skipped: {}", rule_name, reason);
+                report.skipped_rules.push(rule_name.to_string());
+                continue;
+            }
+
             // Run the rule
-            match rule.check(sequence, state, &rule_config).await {
+            match rule.check(sequence, state, &rule_config, context).await {
                 Ok(violations) => {
                     for violation in violations {
                         // Apply severity filter
@@ -313,8 +379,10 @@ impl QCEngine {
                     }
                 }
                 Err(e) => {
-                    // Log rule error but continue with other rules
+                    // Continue with other rules, but record the failure so the
+                    // report cannot claim a check that never ran as passing
                     tracing::warn!("Rule '{}' failed: {}", rule_name, e);
+                    report.record_rule_failure(rule_name, e.to_string());
                 }
             }
         }
@@ -323,12 +391,29 @@ impl QCEngine {
         Ok(report)
     }
 
-    /// Runs a specific rule on a sequence
+    /// Runs a specific rule on a sequence with a context derived from it
     pub async fn check_rule(
         &self,
         rule_name: &str,
         sequence: &Sequence,
         state: &ProjectState,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let context = QCContext::from_sequence(sequence);
+        self.check_rule_with_context(rule_name, sequence, state, &context)
+            .await
+    }
+
+    /// Runs a specific rule on a sequence against an explicit context
+    ///
+    /// Rules that cannot run against the context return no violations; callers
+    /// that need to distinguish that from a clean result should consult
+    /// [`QCRule::skip_reason`] or run the full engine.
+    pub async fn check_rule_with_context(
+        &self,
+        rule_name: &str,
+        sequence: &Sequence,
+        state: &ProjectState,
+        context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
         let rule = self
             .get_rule(rule_name)
@@ -337,7 +422,7 @@ impl QCEngine {
         let config = self.config.read().await;
         let rule_config = config.get_rule_config(rule_name);
 
-        rule.check(sequence, state, &rule_config).await
+        rule.check(sequence, state, &rule_config, context).await
     }
 
     /// Gets suggested fixes for all auto-fixable violations
@@ -373,6 +458,69 @@ impl Default for QCEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::timeline::{Clip, SequenceFormat, Track};
+    use async_trait::async_trait;
+
+    // ========================================================================
+    // Test Fixtures
+    // ========================================================================
+
+    /// Rule that always fails, used to verify error reporting
+    struct FailingRule;
+
+    #[async_trait]
+    impl QCRule for FailingRule {
+        fn name(&self) -> &str {
+            "FailingRule"
+        }
+
+        fn description(&self) -> &str {
+            "Always returns an error"
+        }
+
+        fn default_severity(&self) -> Severity {
+            Severity::Error
+        }
+
+        async fn check(
+            &self,
+            _sequence: &Sequence,
+            _state: &ProjectState,
+            _config: &RuleConfig,
+            _context: &QCContext,
+        ) -> CoreResult<Vec<QCViolation>> {
+            Err(CoreError::Internal("rule exploded".to_string()))
+        }
+    }
+
+    /// Builds a sequence with one 30s video clip, long enough to satisfy the
+    /// duration rule so tests only observe the behavior under test.
+    fn test_sequence() -> Sequence {
+        let mut sequence = Sequence::new("QC Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("V1");
+        track.add_clip(Clip::with_range("asset_001", 0.0, 30.0));
+        sequence.add_track(track);
+        sequence
+    }
+
+    /// Builds an engine whose built-in rules are all disabled
+    async fn engine_with_only(rule: Arc<dyn QCRule>) -> QCEngine {
+        let mut engine = QCEngine::new();
+
+        let mut config = QCEngineConfig::default();
+        let builtin_names: Vec<String> = engine
+            .rule_names()
+            .into_iter()
+            .map(|name| name.to_string())
+            .collect();
+        for name in builtin_names {
+            config.disable_rule(&name);
+        }
+
+        engine.set_config(config).await;
+        engine.register_rule(rule);
+        engine
+    }
 
     // ========================================================================
     // QCSeverityFilter Tests
@@ -592,6 +740,69 @@ mod tests {
 
         let fixes = engine.get_fixes(&report);
         assert_eq!(fixes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_engine_check_should_record_errored_rules_and_not_pass() {
+        let engine = engine_with_only(Arc::new(FailingRule)).await;
+        let sequence = test_sequence();
+        let state = ProjectState::new("QC Test");
+
+        let report = engine.check(&sequence, &state).await.expect("check runs");
+
+        assert_eq!(report.errored_rules.len(), 1);
+        assert_eq!(report.errored_rules[0].rule_name, "FailingRule");
+        assert!(report.errored_rules[0].message.contains("rule exploded"));
+        assert!(report.violations.is_empty());
+        assert!(
+            !report.passed,
+            "a rule that never ran must not be reported as passing"
+        );
+        assert!(report.summary().contains("1 rules errored"));
+    }
+
+    #[tokio::test]
+    async fn test_engine_check_should_skip_measurement_rules_without_measurements() {
+        let engine = QCEngine::new();
+        let sequence = test_sequence();
+        let state = ProjectState::new("QC Test");
+
+        let report = engine.check(&sequence, &state).await.expect("check runs");
+
+        assert!(report.skipped_rules.contains(&"BlackFrameRule".to_string()));
+        assert!(report.skipped_rules.contains(&"AudioPeakRule".to_string()));
+        assert!(report.errored_rules.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_engine_check_with_measurements_should_run_measurement_rules() {
+        let engine = QCEngine::new();
+        let sequence = test_sequence();
+        let state = ProjectState::new("QC Test");
+
+        let report = engine
+            .check_with_measurements(
+                &sequence,
+                &state,
+                RenderMeasurements {
+                    black_ranges: vec![(0.0, 0.5)],
+                    true_peak_dbtp: Some(-0.2),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("check runs");
+
+        assert!(!report.skipped_rules.contains(&"BlackFrameRule".to_string()));
+        assert!(!report.skipped_rules.contains(&"AudioPeakRule".to_string()));
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.rule_name == "BlackFrameRule"));
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.rule_name == "AudioPeakRule"));
     }
 
     #[test]

--- a/src-tauri/src/core/qc/engine.rs
+++ b/src-tauri/src/core/qc/engine.rs
@@ -11,8 +11,12 @@ use tokio::sync::RwLock;
 
 use super::context::{QCContext, RenderMeasurements};
 use super::rules::{
-    AspectRatioRule, AudioPeakRule, BlackFrameRule, CaptionSafeAreaRule, CutRhythmRule,
-    DurationRule, LicenseRule, QCRule, RuleConfig,
+    AspectRatioRule, AudioLoudnessRule, AudioPeakRule, BlackFrameRule, CaptionSafeAreaRule,
+    CheckCategory, CutRhythmRule, DurationRule, LicenseRule, QCRule, RuleConfig,
+};
+use super::structural::{
+    CaptionOutOfBoundsRule, CaptionOverlapRule, CaptionReadingRateRule, ClipOrphanRule,
+    MissingAssetRule, ShotLengthStatsRule, SilentClipRule, TimelineGapRule,
 };
 use super::violation::{QCViolation, Severity, ViolationFix};
 use crate::core::project::ProjectState;
@@ -123,6 +127,39 @@ pub struct RuleFailure {
     pub message: String,
 }
 
+/// What happened to a single rule during a check run
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleStatus {
+    /// The rule ran to completion
+    Ran,
+    /// The rule was disabled or could not run against this context
+    Skipped,
+    /// The rule returned an error
+    Errored,
+}
+
+/// Per-rule record of a check run
+///
+/// The violation list alone cannot distinguish "this check passed" from "this
+/// check never ran", which is exactly the distinction an agent acting on the
+/// report needs. One outcome is recorded for every registered rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleOutcome {
+    /// Rule type name
+    pub rule_name: String,
+    /// Stable dotted check ID
+    pub check_id: String,
+    /// What the rule inspects
+    pub category: CheckCategory,
+    /// Whether the rule ran, was skipped, or failed
+    pub status: RuleStatus,
+    /// Why the rule was skipped, or the error it returned
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
 /// QC check report
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QCReport {
@@ -144,6 +181,9 @@ pub struct QCReport {
     /// never be reported as passing while this list is non-empty.
     #[serde(default)]
     pub errored_rules: Vec<RuleFailure>,
+    /// One record per registered rule, in registration order
+    #[serde(default)]
+    pub rule_outcomes: Vec<RuleOutcome>,
     /// Whether the check was stopped early
     pub stopped_early: bool,
     /// Overall pass/fail status
@@ -161,6 +201,7 @@ impl QCReport {
             severity_counts: HashMap::new(),
             skipped_rules: Vec::new(),
             errored_rules: Vec::new(),
+            rule_outcomes: Vec::new(),
             stopped_early: false,
             passed: true,
         }
@@ -185,6 +226,68 @@ impl QCReport {
             message,
         });
         self.passed = false;
+    }
+
+    /// Recomputes the derived counters and pass state from the violations
+    ///
+    /// Callers that re-grade violations after the run (see
+    /// [`crate::core::qc::structural::crossref_black_ranges_with_gaps`]) must
+    /// call this, otherwise the summary describes the pre-grading state.
+    pub fn recompute(&mut self) {
+        self.severity_counts.clear();
+        self.passed = self.errored_rules.is_empty();
+
+        for violation in &self.violations {
+            *self
+                .severity_counts
+                .entry(violation.severity.to_string())
+                .or_insert(0) += 1;
+
+            if violation.severity >= Severity::Error {
+                self.passed = false;
+            }
+        }
+    }
+
+    /// Returns the recorded outcome for a rule, when the run covered it
+    pub fn outcome_for(&self, rule_name: &str) -> Option<&RuleOutcome> {
+        self.rule_outcomes
+            .iter()
+            .find(|outcome| outcome.rule_name == rule_name)
+    }
+
+    /// Records that a rule ran to completion
+    fn record_ran(&mut self, rule: &dyn QCRule) {
+        self.rule_outcomes.push(RuleOutcome {
+            rule_name: rule.name().to_string(),
+            check_id: rule.check_id().to_string(),
+            category: rule.category(),
+            status: RuleStatus::Ran,
+            reason: None,
+        });
+    }
+
+    /// Records that a rule was skipped, and why
+    fn record_skip(&mut self, rule: &dyn QCRule, reason: &str) {
+        self.skipped_rules.push(rule.name().to_string());
+        self.rule_outcomes.push(RuleOutcome {
+            rule_name: rule.name().to_string(),
+            check_id: rule.check_id().to_string(),
+            category: rule.category(),
+            status: RuleStatus::Skipped,
+            reason: Some(reason.to_string()),
+        });
+    }
+
+    /// Records that a rule returned an error
+    fn record_error(&mut self, rule: &dyn QCRule, message: String) {
+        self.rule_outcomes.push(RuleOutcome {
+            rule_name: rule.name().to_string(),
+            check_id: rule.check_id().to_string(),
+            category: rule.category(),
+            status: RuleStatus::Errored,
+            reason: Some(message),
+        });
     }
 
     /// Gets violations of a specific severity
@@ -269,13 +372,25 @@ impl QCEngine {
 
     /// Registers all built-in rules
     fn register_builtin_rules(&mut self) {
-        self.register_rule(Arc::new(BlackFrameRule::new()));
-        self.register_rule(Arc::new(AudioPeakRule::new()));
+        // Structural rules: readable from project state alone.
+        self.register_rule(Arc::new(TimelineGapRule::new()));
+        self.register_rule(Arc::new(ClipOrphanRule::new()));
+        self.register_rule(Arc::new(MissingAssetRule::new()));
+        self.register_rule(Arc::new(SilentClipRule::new()));
+        self.register_rule(Arc::new(CaptionOverlapRule::new()));
+        self.register_rule(Arc::new(CaptionReadingRateRule::new()));
+        self.register_rule(Arc::new(CaptionOutOfBoundsRule::new()));
+        self.register_rule(Arc::new(ShotLengthStatsRule::new()));
         self.register_rule(Arc::new(CaptionSafeAreaRule::new()));
         self.register_rule(Arc::new(CutRhythmRule::new()));
         self.register_rule(Arc::new(LicenseRule::new()));
         self.register_rule(Arc::new(AspectRatioRule::new()));
         self.register_rule(Arc::new(DurationRule::new()));
+
+        // Rendered rules: need measurements from an exported file.
+        self.register_rule(Arc::new(BlackFrameRule::new()));
+        self.register_rule(Arc::new(AudioPeakRule::new()));
+        self.register_rule(Arc::new(AudioLoudnessRule::new()));
     }
 
     /// Registers a custom rule
@@ -283,9 +398,19 @@ impl QCEngine {
         self.rules.push(rule);
     }
 
+    /// Gets all registered rules
+    pub fn rules(&self) -> &[Arc<dyn QCRule>] {
+        &self.rules
+    }
+
     /// Gets all registered rule names
     pub fn rule_names(&self) -> Vec<&str> {
         self.rules.iter().map(|r| r.name()).collect()
+    }
+
+    /// Gets the rule registered for a check ID
+    pub fn get_rule_by_check_id(&self, check_id: &str) -> Option<&Arc<dyn QCRule>> {
+        self.rules.iter().find(|rule| rule.check_id() == check_id)
     }
 
     /// Gets a rule by name
@@ -342,27 +467,29 @@ impl QCEngine {
 
             // Check if rule is disabled
             if !config.is_rule_enabled(rule_name) {
-                report.skipped_rules.push(rule_name.to_string());
+                report.record_skip(rule.as_ref(), "disabled by configuration");
                 continue;
             }
 
             // Get rule-specific config
             let rule_config = config.get_rule_config(rule_name);
             if !rule_config.enabled {
-                report.skipped_rules.push(rule_name.to_string());
+                report.record_skip(rule.as_ref(), "disabled by rule configuration");
                 continue;
             }
 
             // A rule missing its required inputs is skipped, never silently passed
             if let Some(reason) = rule.skip_reason(context) {
                 tracing::debug!("Rule '{}' skipped: {}", rule_name, reason);
-                report.skipped_rules.push(rule_name.to_string());
+                report.record_skip(rule.as_ref(), &reason);
                 continue;
             }
 
             // Run the rule
             match rule.check(sequence, state, &rule_config, context).await {
                 Ok(violations) => {
+                    report.record_ran(rule.as_ref());
+
                     for violation in violations {
                         // Apply severity filter
                         if config.severity_filter.passes(violation.severity) {
@@ -383,6 +510,7 @@ impl QCEngine {
                     // report cannot claim a check that never ran as passing
                     tracing::warn!("Rule '{}' failed: {}", rule_name, e);
                     report.record_rule_failure(rule_name, e.to_string());
+                    report.record_error(rule.as_ref(), e.to_string());
                 }
             }
         }

--- a/src-tauri/src/core/qc/engine.rs
+++ b/src-tauri/src/core/qc/engine.rs
@@ -182,6 +182,11 @@ pub struct QCReport {
     #[serde(default)]
     pub errored_rules: Vec<RuleFailure>,
     /// One record per registered rule, in registration order
+    ///
+    /// A run that ends early (`stopped_early`) stops recording at the rule that
+    /// tripped `stop_on_critical`, so every rule after it has no outcome. A
+    /// consumer mapping outcomes to check IDs must read `stopped_early` to tell
+    /// "not reached" from "not registered".
     #[serde(default)]
     pub rule_outcomes: Vec<RuleOutcome>,
     /// Whether the check was stopped early

--- a/src-tauri/src/core/qc/measure.rs
+++ b/src-tauri/src/core/qc/measure.rs
@@ -1,0 +1,764 @@
+//! Rendered-file measurement pass for QC
+//!
+//! Runs a single FFmpeg analysis pass over a rendered file and turns the filter
+//! log into [`RenderMeasurements`]. Structural rules can read the timeline, but
+//! black frames, freezes, loudness, and peaks only exist in the pixels and
+//! samples that were actually written, so they are measured here once and
+//! shared with every rule through the QC context.
+//!
+//! Every parser in this module is a pure function over FFmpeg stderr text so it
+//! can be tested against captured output without invoking FFmpeg.
+
+use std::path::Path;
+use std::time::Duration;
+
+use super::context::RenderMeasurements;
+use crate::core::analysis::audio::parse_silence_regions;
+use crate::core::ffmpeg::FFmpegRunner;
+use crate::core::{CoreError, CoreResult};
+
+// =============================================================================
+// Options
+// =============================================================================
+
+/// Default minimum black duration to report, in seconds.
+const DEFAULT_BLACK_MIN_DURATION: f64 = 0.1;
+
+/// Default minimum freeze duration to report, in seconds.
+const DEFAULT_FREEZE_MIN_DURATION: f64 = 2.0;
+
+/// Default silence threshold in dBFS.
+const DEFAULT_SILENCE_THRESHOLD_DB: f64 = -50.0;
+
+/// Default minimum silence duration to report, in seconds.
+const DEFAULT_SILENCE_MIN_DURATION: f64 = 1.5;
+
+/// Default watchdog timeout for the measurement pass.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Luma threshold (fraction of pixels below the pixel threshold) for black detection.
+const BLACK_PICTURE_THRESHOLD: f64 = 0.98;
+
+/// Per-pixel luma threshold for black detection.
+const BLACK_PIXEL_THRESHOLD: f64 = 0.10;
+
+/// Noise tolerance for freeze detection, in dB.
+const FREEZE_NOISE_DB: f64 = -60.0;
+
+/// Tuning for the measurement pass.
+#[derive(Debug, Clone)]
+pub struct MeasureOptions {
+    /// Minimum black duration reported, in seconds.
+    pub black_min_duration: f64,
+    /// Minimum freeze duration reported, in seconds.
+    pub freeze_min_duration: f64,
+    /// Silence threshold in dBFS (negative).
+    pub silence_threshold_db: f64,
+    /// Minimum silence duration reported, in seconds.
+    pub silence_min_duration: f64,
+    /// Watchdog timeout for the whole pass.
+    pub timeout: Duration,
+}
+
+impl Default for MeasureOptions {
+    fn default() -> Self {
+        Self {
+            black_min_duration: DEFAULT_BLACK_MIN_DURATION,
+            freeze_min_duration: DEFAULT_FREEZE_MIN_DURATION,
+            silence_threshold_db: DEFAULT_SILENCE_THRESHOLD_DB,
+            silence_min_duration: DEFAULT_SILENCE_MIN_DURATION,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+// =============================================================================
+// Result
+// =============================================================================
+
+/// Outcome of a measurement pass, including what could not be measured.
+///
+/// [`RenderMeasurements`] alone cannot express "there was nothing to measure":
+/// an empty silence list means the same thing whether the file was loud
+/// throughout or carried no audio at all. The extra fields here let callers
+/// report untestable checks as skipped instead of passed.
+#[derive(Debug, Clone)]
+pub struct MeasurementReport {
+    /// Values extracted from the filter log.
+    pub measurements: RenderMeasurements,
+    /// Duration of the measured file in seconds, as reported by ffprobe.
+    pub duration_sec: f64,
+    /// Whether the video detection chain ran.
+    pub video_measured: bool,
+    /// Whether the audio detection chain ran.
+    pub audio_measured: bool,
+    /// Human-readable remarks about degraded or skipped measurements.
+    pub notes: Vec<String>,
+}
+
+// =============================================================================
+// Measurement pass
+// =============================================================================
+
+/// Measures a rendered file and returns the values QC rules consume.
+///
+/// See [`measure_rendered_file_detailed`] when the caller also needs to know
+/// which parts of the file could be measured at all.
+pub async fn measure_rendered_file(
+    runner: &FFmpegRunner,
+    file: &Path,
+    opts: &MeasureOptions,
+) -> CoreResult<RenderMeasurements> {
+    measure_rendered_file_detailed(runner, file, opts)
+        .await
+        .map(|report| report.measurements)
+}
+
+/// Measures a rendered file, reporting what was measured alongside the values.
+///
+/// The pass probes the file first so the filtergraph only references streams
+/// that exist (an `[0:a]` chain against a silent-film render fails the whole
+/// invocation), then runs one FFmpeg pass and parses its log.
+pub async fn measure_rendered_file_detailed(
+    runner: &FFmpegRunner,
+    file: &Path,
+    opts: &MeasureOptions,
+) -> CoreResult<MeasurementReport> {
+    if !file.exists() {
+        return Err(CoreError::FileNotFound(file.display().to_string()));
+    }
+
+    let media = runner
+        .probe(file)
+        .await
+        .map_err(|error| CoreError::FFprobeError(format!("Failed to probe {file:?}: {error}")))?;
+
+    let has_video = media.video.is_some();
+    let has_audio = media.audio.is_some();
+
+    if !has_video && !has_audio {
+        return Err(CoreError::ValidationError(format!(
+            "File '{}' has neither a video nor an audio stream to measure",
+            file.display()
+        )));
+    }
+
+    let mut notes = Vec::new();
+    if !has_video {
+        notes.push("File has no video stream; picture checks were not run".to_string());
+    }
+    if !has_audio {
+        notes.push("File has no audio stream; audio checks were not run".to_string());
+    }
+
+    let (graph, maps) = build_filter_graph(opts, has_video, has_audio);
+    let map_refs: Vec<&str> = maps.iter().map(String::as_str).collect();
+
+    let stderr = runner
+        .run_filter_capture_stderr(file, &graph, &map_refs, opts.timeout)
+        .await
+        .map_err(|error| {
+            CoreError::AnalysisFailed(format!("Rendered-file measurement failed: {error}"))
+        })?;
+
+    // Filters report their findings at FFmpeg's INFO level. If not a single
+    // INFO line came back, the log level was overridden somewhere and "no
+    // detections" would be indistinguishable from "detection never ran".
+    if !saw_info_level_output(&stderr) {
+        return Err(CoreError::AnalysisFailed(
+            "FFmpeg produced no INFO-level output, so detection results cannot be trusted"
+                .to_string(),
+        ));
+    }
+
+    let duration_sec = media.duration_sec;
+    let mut measurements = RenderMeasurements::default();
+
+    if has_video {
+        measurements.black_ranges = parse_black_ranges(&stderr, duration_sec)
+            .into_iter()
+            .filter(|(start, end)| end - start >= opts.black_min_duration)
+            .collect();
+        measurements.freeze_ranges = parse_freeze_ranges(&stderr, duration_sec)
+            .into_iter()
+            .filter(|(start, end)| end - start >= opts.freeze_min_duration)
+            .collect();
+    }
+
+    if has_audio {
+        measurements.silence_ranges = parse_silence_regions(&stderr)
+            .into_iter()
+            .map(|region| (region.start_sec, region.end_sec))
+            .collect();
+
+        let loudness = parse_loudness_summary(&stderr);
+        measurements.integrated_lufs = loudness.integrated_lufs;
+        measurements.loudness_range_lu = loudness.loudness_range_lu;
+        measurements.true_peak_dbtp = loudness.true_peak_dbtp;
+
+        let astats = parse_astats_overall(&stderr);
+        measurements.sample_peak_db = astats.sample_peak_db;
+        measurements.flat_factor = astats.flat_factor;
+
+        if measurements.integrated_lufs.is_none() {
+            notes.push(
+                "EBU R128 summary was not reported; loudness could not be measured".to_string(),
+            );
+        }
+        if measurements.true_peak_dbtp.is_none() {
+            if measurements.sample_peak_db.is_some() {
+                notes.push(
+                    "True peak was not reported; peak checks fall back to sample peak, which \
+                     under-reports inter-sample overs"
+                        .to_string(),
+                );
+            } else {
+                notes.push("Neither true peak nor sample peak could be measured".to_string());
+            }
+        }
+    }
+
+    Ok(MeasurementReport {
+        measurements,
+        duration_sec,
+        video_measured: has_video,
+        audio_measured: has_audio,
+        notes,
+    })
+}
+
+/// Builds the single-pass filtergraph and the output labels to map.
+fn build_filter_graph(
+    opts: &MeasureOptions,
+    has_video: bool,
+    has_audio: bool,
+) -> (String, Vec<String>) {
+    let mut chains: Vec<String> = Vec::new();
+    let mut maps: Vec<String> = Vec::new();
+
+    if has_video {
+        chains.push(format!(
+            "[0:v]blackdetect=d={black_d:.3}:pic_th={pic_th:.2}:pix_th={pix_th:.2},\
+             freezedetect=n={freeze_n}dB:d={freeze_d:.3}[v]",
+            black_d = opts.black_min_duration.clamp(0.01, 60.0),
+            pic_th = BLACK_PICTURE_THRESHOLD,
+            pix_th = BLACK_PIXEL_THRESHOLD,
+            freeze_n = FREEZE_NOISE_DB,
+            freeze_d = opts.freeze_min_duration.clamp(0.01, 600.0),
+        ));
+        maps.push("[v]".to_string());
+    }
+
+    if has_audio {
+        // `framelog=quiet` suppresses the per-frame loudness lines; the summary
+        // block is logged from the filter's uninit at INFO level regardless, so
+        // this keeps the log small without losing the values that matter.
+        chains.push(format!(
+            "[0:a]ebur128=peak=true:framelog=quiet,\
+             silencedetect=n={silence_n:.1}dB:d={silence_d:.3},\
+             astats=metadata=0:measure_perchannel=none:measure_overall=Peak_level+Flat_factor[a]",
+            silence_n = opts.silence_threshold_db.clamp(-90.0, 0.0),
+            silence_d = opts.silence_min_duration.clamp(0.01, 600.0),
+        ));
+        maps.push("[a]".to_string());
+    }
+
+    (chains.join(";"), maps)
+}
+
+// =============================================================================
+// Parsers (pure, testable without FFmpeg)
+// =============================================================================
+
+/// Loudness values read from the `ebur128` summary block.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LoudnessSummary {
+    /// Integrated program loudness in LUFS.
+    pub integrated_lufs: Option<f64>,
+    /// Loudness range in LU.
+    pub loudness_range_lu: Option<f64>,
+    /// True peak in dBTP.
+    pub true_peak_dbtp: Option<f64>,
+}
+
+/// Overall values read from the `astats` summary.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AstatsOverall {
+    /// Sample peak in dBFS.
+    pub sample_peak_db: Option<f64>,
+    /// Flatness factor (high values indicate a clipped or flat signal).
+    pub flat_factor: Option<f64>,
+}
+
+/// Returns whether the log contains lines FFmpeg only emits at INFO level.
+///
+/// Used as a canary: detection filters log nothing when they find nothing, so a
+/// silent log is only meaningful if INFO output reached us at all.
+pub fn saw_info_level_output(stderr: &str) -> bool {
+    stderr.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("Input #")
+            || line.starts_with("Output #")
+            || line.starts_with("Stream mapping:")
+            || line.starts_with("Stream #")
+    })
+}
+
+/// Parses `blackdetect` ranges from FFmpeg stderr.
+///
+/// Expects lines of the form:
+/// ```text
+/// [blackdetect @ 0x1] black_start:12.5 black_end:13.75 black_duration:1.25
+/// ```
+/// A range left open at end of file is closed at `duration_sec` when known.
+pub fn parse_black_ranges(stderr: &str, duration_sec: f64) -> Vec<(f64, f64)> {
+    let mut ranges = Vec::new();
+    let mut open_start: Option<f64> = None;
+
+    for line in stderr.lines() {
+        if !line.contains("black_start") && !line.contains("black_end") {
+            continue;
+        }
+
+        let start = extract_marker_value(line, "black_start");
+        let end = extract_marker_value(line, "black_end");
+
+        match (start, end) {
+            (Some(start), Some(end)) => push_range(&mut ranges, start, end),
+            (Some(start), None) => open_start = Some(start),
+            (None, Some(end)) => {
+                if let Some(start) = open_start.take() {
+                    push_range(&mut ranges, start, end);
+                }
+            }
+            (None, None) => {}
+        }
+    }
+
+    if let Some(start) = open_start {
+        if duration_sec > start {
+            push_range(&mut ranges, start, duration_sec);
+        }
+    }
+
+    ranges
+}
+
+/// Parses `freezedetect` ranges from FFmpeg stderr.
+///
+/// Expects lines of the form:
+/// ```text
+/// [freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 2.502
+/// [freezedetect @ 0x1] lavfi.freezedetect.freeze_end: 5.508
+/// ```
+/// `freezedetect` does not always emit a closing marker at end of file, so an
+/// open range is closed at `duration_sec` when known.
+pub fn parse_freeze_ranges(stderr: &str, duration_sec: f64) -> Vec<(f64, f64)> {
+    let mut ranges = Vec::new();
+    let mut open_start: Option<f64> = None;
+
+    for line in stderr.lines() {
+        if let Some(start) = extract_marker_value(line, "freeze_start") {
+            open_start = Some(start);
+        } else if let Some(end) = extract_marker_value(line, "freeze_end") {
+            if let Some(start) = open_start.take() {
+                push_range(&mut ranges, start, end);
+            }
+        }
+    }
+
+    if let Some(start) = open_start {
+        if duration_sec > start {
+            push_range(&mut ranges, start, duration_sec);
+        }
+    }
+
+    ranges
+}
+
+/// Parses the `ebur128` summary block.
+///
+/// The block is emitted once at end of stream and its values sit on indented
+/// continuation lines, so parsing keys off the labels rather than the layout:
+/// ```text
+/// [Parsed_ebur128_0 @ 0x1] Summary:
+///
+///   Integrated loudness:
+///     I:         -23.0 LUFS
+///     Threshold: -33.6 LUFS
+///
+///   Loudness range:
+///     LRA:         5.2 LU
+///
+///   True peak:
+///     Peak:       -1.2 dBFS
+/// ```
+/// A build without true-peak support simply omits the last section; the caller
+/// then falls back to the sample peak reported by `astats`.
+pub fn parse_loudness_summary(stderr: &str) -> LoudnessSummary {
+    let mut summary = LoudnessSummary::default();
+    let mut in_true_peak_section = false;
+
+    for line in stderr.lines() {
+        let content = strip_log_prefix(line).trim();
+
+        if content.starts_with("True peak") {
+            in_true_peak_section = true;
+            continue;
+        }
+        if content.starts_with("Integrated loudness") || content.starts_with("Loudness range") {
+            in_true_peak_section = false;
+            continue;
+        }
+
+        if let Some(rest) = content.strip_prefix("I:") {
+            if let Some(value) = parse_leading_f64(rest) {
+                summary.integrated_lufs = Some(value);
+            }
+        } else if let Some(rest) = content.strip_prefix("LRA:") {
+            if let Some(value) = parse_leading_f64(rest) {
+                summary.loudness_range_lu = Some(value);
+            }
+        } else if in_true_peak_section {
+            if let Some(rest) = content.strip_prefix("Peak:") {
+                if let Some(value) = parse_leading_f64(rest) {
+                    summary.true_peak_dbtp = Some(value);
+                }
+            }
+        }
+    }
+
+    summary
+}
+
+/// Parses the overall `astats` summary.
+///
+/// Expects lines of the form:
+/// ```text
+/// [Parsed_astats_2 @ 0x1] Peak level dB: -1.234567
+/// [Parsed_astats_2 @ 0x1] Flat factor: 0.000000
+/// ```
+/// A digital-silence pass reports `-inf`, which is returned as `None` rather
+/// than a numeric floor so callers can tell it apart from a measured level.
+pub fn parse_astats_overall(stderr: &str) -> AstatsOverall {
+    let mut overall = AstatsOverall::default();
+
+    for line in stderr.lines() {
+        let content = strip_log_prefix(line).trim();
+
+        if let Some(rest) = content.strip_prefix("Peak level dB:") {
+            if let Some(value) = parse_leading_f64(rest) {
+                overall.sample_peak_db = Some(value);
+            }
+        } else if let Some(rest) = content.strip_prefix("Flat factor:") {
+            if let Some(value) = parse_leading_f64(rest) {
+                overall.flat_factor = Some(value);
+            }
+        }
+    }
+
+    overall
+}
+
+/// Appends a range, ignoring degenerate or non-finite values.
+fn push_range(ranges: &mut Vec<(f64, f64)>, start: f64, end: f64) {
+    if start.is_finite() && end.is_finite() && end > start {
+        ranges.push((start, end));
+    }
+}
+
+/// Extracts the number following `marker` (with an optional `:` and spaces).
+fn extract_marker_value(line: &str, marker: &str) -> Option<f64> {
+    let position = line.find(marker)?;
+    let rest = line[position + marker.len()..].trim_start();
+    let rest = rest.strip_prefix(':').unwrap_or(rest);
+    parse_leading_f64(rest)
+}
+
+/// Parses the first numeric token of `text`, ignoring trailing units.
+fn parse_leading_f64(text: &str) -> Option<f64> {
+    let trimmed = text.trim_start();
+    let token: String = trimmed
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '-' || *c == '+' || *c == '.' || *c == 'e')
+        .collect();
+
+    token.parse::<f64>().ok().filter(|value| value.is_finite())
+}
+
+/// Removes a leading `[filter @ 0x…]` log prefix, if present.
+fn strip_log_prefix(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('[') {
+        return line;
+    }
+    match trimmed.find(']') {
+        Some(end) => &trimmed[end + 1..],
+        None => line,
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real `blackdetect` output from a clip that fades from black.
+    const BLACKDETECT_LOG: &str = "\
+[Parsed_blackdetect_0 @ 000001f3f6c0] black_start:0 black_end:1.04 black_duration:1.04
+[Parsed_blackdetect_0 @ 000001f3f6c0] black_start:12.52 black_end:12.6 black_duration:0.08";
+
+    /// Real `freezedetect` output for one frozen stretch.
+    const FREEZEDETECT_LOG: &str = "\
+[Parsed_freezedetect_1 @ 000001f3f6c0] lavfi.freezedetect.freeze_start: 2.502
+[Parsed_freezedetect_1 @ 000001f3f6c0] lavfi.freezedetect.freeze_duration: 3.006
+[Parsed_freezedetect_1 @ 000001f3f6c0] lavfi.freezedetect.freeze_end: 5.508";
+
+    /// Real `ebur128` summary block with true peak enabled.
+    const EBUR128_SUMMARY: &str = "\
+[Parsed_ebur128_0 @ 000001f3f7a0] Summary:
+
+  Integrated loudness:
+    I:         -18.3 LUFS
+    Threshold: -28.6 LUFS
+
+  Loudness range:
+    LRA:         7.4 LU
+    Threshold:  -38.8 LUFS
+    LRA low:    -22.8 LUFS
+    LRA high:   -15.4 LUFS
+
+  True peak:
+    Peak:       -1.2 dBFS";
+
+    /// Real `astats` overall section with per-channel measurement disabled.
+    const ASTATS_LOG: &str = "\
+[Parsed_astats_2 @ 000001f3f8c0] Overall
+[Parsed_astats_2 @ 000001f3f8c0] Peak level dB: -1.234567
+[Parsed_astats_2 @ 000001f3f8c0] Flat factor: 0.000000";
+
+    const SILENCEDETECT_LOG: &str = "\
+[silencedetect @ 000001f3f9e0] silence_start: 4.5
+[silencedetect @ 000001f3f9e0] silence_end: 7.25 | silence_duration: 2.75";
+
+    const INFO_HEADER: &str = "\
+Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'render.mp4':
+Stream mapping:
+  Stream #0:0 -> #0:0 (h264 (native) -> wrapped_avframe (native))
+Output #0, null, to 'pipe:':";
+
+    // ========================================================================
+    // blackdetect
+    // ========================================================================
+
+    #[test]
+    fn test_parse_black_ranges_should_read_start_and_end_pairs() {
+        let ranges = parse_black_ranges(BLACKDETECT_LOG, 20.0);
+
+        assert_eq!(ranges.len(), 2);
+        assert!((ranges[0].0 - 0.0).abs() < 1e-9);
+        assert!((ranges[0].1 - 1.04).abs() < 1e-9);
+        assert!((ranges[1].0 - 12.52).abs() < 1e-9);
+        assert!((ranges[1].1 - 12.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_parse_black_ranges_should_close_an_open_range_at_the_file_end() {
+        let log = "[Parsed_blackdetect_0 @ 0x1] black_start:8.5";
+
+        let ranges = parse_black_ranges(log, 10.0);
+
+        assert_eq!(ranges.len(), 1);
+        assert!((ranges[0].1 - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_parse_black_ranges_should_ignore_unrelated_output() {
+        assert!(parse_black_ranges(INFO_HEADER, 10.0).is_empty());
+    }
+
+    // ========================================================================
+    // freezedetect
+    // ========================================================================
+
+    #[test]
+    fn test_parse_freeze_ranges_should_pair_start_and_end_markers() {
+        let ranges = parse_freeze_ranges(FREEZEDETECT_LOG, 20.0);
+
+        assert_eq!(ranges.len(), 1);
+        assert!((ranges[0].0 - 2.502).abs() < 1e-9);
+        assert!((ranges[0].1 - 5.508).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_parse_freeze_ranges_should_close_an_open_range_at_the_file_end() {
+        let log = "[Parsed_freezedetect_1 @ 0x1] lavfi.freezedetect.freeze_start: 6";
+
+        let ranges = parse_freeze_ranges(log, 9.5);
+
+        assert_eq!(ranges, vec![(6.0, 9.5)]);
+    }
+
+    #[test]
+    fn test_parse_freeze_ranges_should_ignore_duration_markers() {
+        let log = "[Parsed_freezedetect_1 @ 0x1] lavfi.freezedetect.freeze_duration: 3.006";
+
+        assert!(parse_freeze_ranges(log, 10.0).is_empty());
+    }
+
+    // ========================================================================
+    // ebur128 summary
+    // ========================================================================
+
+    #[test]
+    fn test_parse_loudness_summary_should_read_integrated_range_and_true_peak() {
+        let summary = parse_loudness_summary(EBUR128_SUMMARY);
+
+        assert_eq!(summary.integrated_lufs, Some(-18.3));
+        assert_eq!(summary.loudness_range_lu, Some(7.4));
+        assert_eq!(summary.true_peak_dbtp, Some(-1.2));
+    }
+
+    #[test]
+    fn test_parse_loudness_summary_should_not_confuse_thresholds_with_values() {
+        let summary = parse_loudness_summary(EBUR128_SUMMARY);
+
+        // "LRA low"/"LRA high"/"Threshold" lines must not overwrite LRA or I.
+        assert_eq!(summary.loudness_range_lu, Some(7.4));
+        assert_eq!(summary.integrated_lufs, Some(-18.3));
+    }
+
+    #[test]
+    fn test_parse_loudness_summary_should_degrade_when_true_peak_is_absent() {
+        let without_true_peak = "\
+[Parsed_ebur128_0 @ 0x1] Summary:
+
+  Integrated loudness:
+    I:         -23.0 LUFS
+
+  Loudness range:
+    LRA:         2.0 LU";
+
+        let summary = parse_loudness_summary(without_true_peak);
+
+        assert_eq!(summary.integrated_lufs, Some(-23.0));
+        assert_eq!(summary.true_peak_dbtp, None);
+    }
+
+    #[test]
+    fn test_parse_loudness_summary_should_ignore_per_frame_lines() {
+        let per_frame =
+            "[Parsed_ebur128_0 @ 0x1] t: 1.19967   M: -22.9 S:-120.7     I: -30.0 LUFS  LRA: 0.0 LU";
+
+        let summary = parse_loudness_summary(per_frame);
+
+        assert_eq!(summary.integrated_lufs, None);
+        assert_eq!(summary.loudness_range_lu, None);
+    }
+
+    // ========================================================================
+    // astats
+    // ========================================================================
+
+    #[test]
+    fn test_parse_astats_overall_should_read_peak_and_flat_factor() {
+        let overall = parse_astats_overall(ASTATS_LOG);
+
+        assert_eq!(overall.sample_peak_db, Some(-1.234567));
+        assert_eq!(overall.flat_factor, Some(0.0));
+    }
+
+    #[test]
+    fn test_parse_astats_overall_should_return_none_for_digital_silence() {
+        let silent = "[Parsed_astats_2 @ 0x1] Peak level dB: -inf";
+
+        let overall = parse_astats_overall(silent);
+
+        assert_eq!(overall.sample_peak_db, None);
+    }
+
+    // ========================================================================
+    // Shared helpers
+    // ========================================================================
+
+    #[test]
+    fn test_saw_info_level_output() {
+        assert!(saw_info_level_output(INFO_HEADER));
+        assert!(!saw_info_level_output(
+            "[silencedetect @ 0x1] silence_start: 1.0"
+        ));
+        assert!(!saw_info_level_output(""));
+    }
+
+    #[test]
+    fn test_silence_parser_reuse_on_a_combined_log() {
+        let combined = format!("{INFO_HEADER}\n{SILENCEDETECT_LOG}\n{EBUR128_SUMMARY}");
+
+        let regions = parse_silence_regions(&combined);
+
+        assert_eq!(regions.len(), 1);
+        assert!((regions[0].start_sec - 4.5).abs() < 1e-9);
+        assert!((regions[0].end_sec - 7.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_strip_log_prefix() {
+        assert_eq!(
+            strip_log_prefix("[Parsed_x @ 0x1] I: -5.0").trim(),
+            "I: -5.0"
+        );
+        assert_eq!(strip_log_prefix("    I: -5.0").trim(), "I: -5.0");
+    }
+
+    // ========================================================================
+    // Filter graph
+    // ========================================================================
+
+    #[test]
+    fn test_build_filter_graph_should_include_both_chains_when_both_streams_exist() {
+        let (graph, maps) = build_filter_graph(&MeasureOptions::default(), true, true);
+
+        assert!(graph.contains("[0:v]blackdetect="));
+        assert!(graph.contains("freezedetect="));
+        assert!(graph.contains("[0:a]ebur128=peak=true:framelog=quiet"));
+        assert!(graph.contains("silencedetect="));
+        assert!(graph.contains("astats=metadata=0"));
+        assert_eq!(maps, vec!["[v]".to_string(), "[a]".to_string()]);
+    }
+
+    #[test]
+    fn test_build_filter_graph_should_drop_the_audio_chain_without_audio() {
+        let (graph, maps) = build_filter_graph(&MeasureOptions::default(), true, false);
+
+        assert!(!graph.contains("[0:a]"));
+        assert_eq!(maps, vec!["[v]".to_string()]);
+    }
+
+    #[test]
+    fn test_build_filter_graph_should_drop_the_video_chain_without_video() {
+        let (graph, maps) = build_filter_graph(&MeasureOptions::default(), false, true);
+
+        assert!(!graph.contains("[0:v]"));
+        assert_eq!(maps, vec!["[a]".to_string()]);
+    }
+
+    #[test]
+    fn test_build_filter_graph_should_clamp_out_of_range_options() {
+        let opts = MeasureOptions {
+            black_min_duration: -5.0,
+            freeze_min_duration: 0.0,
+            silence_threshold_db: -500.0,
+            silence_min_duration: 100_000.0,
+            timeout: Duration::from_secs(1),
+        };
+
+        let (graph, _) = build_filter_graph(&opts, true, true);
+
+        assert!(graph.contains("blackdetect=d=0.010"));
+        assert!(graph.contains("d=0.010[v]"));
+        assert!(graph.contains("silencedetect=n=-90.0dB:d=600.000"));
+    }
+}

--- a/src-tauri/src/core/qc/measure.rs
+++ b/src-tauri/src/core/qc/measure.rs
@@ -154,7 +154,7 @@ pub async fn measure_rendered_file_detailed(
     let (graph, maps) = build_filter_graph(opts, has_video, has_audio);
     let map_refs: Vec<&str> = maps.iter().map(String::as_str).collect();
 
-    let stderr = runner
+    let capture = runner
         .run_filter_capture_stderr(file, &graph, &map_refs, opts.timeout)
         .await
         .map_err(|error| {
@@ -163,14 +163,25 @@ pub async fn measure_rendered_file_detailed(
 
     // Filters report their findings at FFmpeg's INFO level. If not a single
     // INFO line came back, the log level was overridden somewhere and "no
-    // detections" would be indistinguishable from "detection never ran".
-    if !saw_info_level_output(&stderr) {
+    // detections" would be indistinguishable from "detection never ran". The
+    // flag is recorded while streaming, so a long pass that evicts the header
+    // lines from the retained text still answers correctly.
+    if !capture.saw_info_output {
         return Err(CoreError::AnalysisFailed(
             "FFmpeg produced no INFO-level output, so detection results cannot be trusted"
                 .to_string(),
         ));
     }
 
+    if capture.truncated {
+        notes.push(
+            "Filter output exceeded the stderr retention limit; detections near the start of \
+             the file may be missing"
+                .to_string(),
+        );
+    }
+
+    let stderr = capture.stderr;
     let duration_sec = media.duration_sec;
     let mut measurements = RenderMeasurements::default();
 
@@ -250,11 +261,13 @@ fn build_filter_graph(
     }
 
     if has_audio {
-        // `framelog=quiet` suppresses the per-frame loudness lines; the summary
-        // block is logged from the filter's uninit at INFO level regardless, so
-        // this keeps the log small without losing the values that matter.
+        // `framelog` is deliberately left at its default: FFmpeg 4.4 and 6.1
+        // only accept `info`/`verbose` there, so passing `quiet` fails option
+        // parsing on the builds most users have. The per-frame lines it would
+        // have suppressed carry the `[Parsed_ebur128` marker, so the bounded
+        // filter buffer absorbs them, and the Summary block still prints.
         chains.push(format!(
-            "[0:a]ebur128=peak=true:framelog=quiet,\
+            "[0:a]ebur128=peak=true,\
              silencedetect=n={silence_n:.1}dB:d={silence_d:.3},\
              astats=metadata=0:measure_perchannel=none:measure_overall=Peak_level+Flat_factor[a]",
             silence_n = opts.silence_threshold_db.clamp(-90.0, 0.0),
@@ -288,20 +301,6 @@ pub struct AstatsOverall {
     pub sample_peak_db: Option<f64>,
     /// Flatness factor (high values indicate a clipped or flat signal).
     pub flat_factor: Option<f64>,
-}
-
-/// Returns whether the log contains lines FFmpeg only emits at INFO level.
-///
-/// Used as a canary: detection filters log nothing when they find nothing, so a
-/// silent log is only meaningful if INFO output reached us at all.
-pub fn saw_info_level_output(stderr: &str) -> bool {
-    stderr.lines().any(|line| {
-        let line = line.trim_start();
-        line.starts_with("Input #")
-            || line.starts_with("Output #")
-            || line.starts_with("Stream mapping:")
-            || line.starts_with("Stream #")
-    })
 }
 
 /// Parses `blackdetect` ranges from FFmpeg stderr.
@@ -534,6 +533,13 @@ mod tests {
   True peak:
     Peak:       -1.2 dBFS";
 
+    /// Real `ebur128` per-frame lines, which print whenever `framelog` is left
+    /// at its default (the only portable setting across FFmpeg builds).
+    const EBUR128_PER_FRAME: &str = "\
+[Parsed_ebur128_0 @ 000001f3f7a0] t: 0.19999   M: -21.4 S:-120.7     I: -21.4 LUFS       LRA:   0.0 LU
+[Parsed_ebur128_0 @ 000001f3f7a0] t: 0.29999   M: -19.8 S:-120.7     I: -20.3 LUFS       LRA:   0.0 LU
+[Parsed_ebur128_0 @ 000001f3f7a0] t: 0.39999   M: -18.9 S: -21.1     I: -19.6 LUFS       LRA:   1.2 LU";
+
     /// Real `astats` overall section with per-channel measurement disabled.
     const ASTATS_LOG: &str = "\
 [Parsed_astats_2 @ 000001f3f8c0] Overall
@@ -659,6 +665,19 @@ Output #0, null, to 'pipe:':";
         assert_eq!(summary.loudness_range_lu, None);
     }
 
+    /// Feature: EBU R128 measurement without `framelog=quiet`
+    /// Scenario: should read the summary out of a log full of per-frame lines
+    #[test]
+    fn test_parse_loudness_summary_should_read_the_summary_after_per_frame_lines() {
+        let log = format!("{EBUR128_PER_FRAME}\n{EBUR128_SUMMARY}");
+
+        let summary = parse_loudness_summary(&log);
+
+        assert_eq!(summary.integrated_lufs, Some(-18.3));
+        assert_eq!(summary.loudness_range_lu, Some(7.4));
+        assert_eq!(summary.true_peak_dbtp, Some(-1.2));
+    }
+
     // ========================================================================
     // astats
     // ========================================================================
@@ -683,15 +702,6 @@ Output #0, null, to 'pipe:':";
     // ========================================================================
     // Shared helpers
     // ========================================================================
-
-    #[test]
-    fn test_saw_info_level_output() {
-        assert!(saw_info_level_output(INFO_HEADER));
-        assert!(!saw_info_level_output(
-            "[silencedetect @ 0x1] silence_start: 1.0"
-        ));
-        assert!(!saw_info_level_output(""));
-    }
 
     #[test]
     fn test_silence_parser_reuse_on_a_combined_log() {
@@ -723,7 +733,11 @@ Output #0, null, to 'pipe:':";
 
         assert!(graph.contains("[0:v]blackdetect="));
         assert!(graph.contains("freezedetect="));
-        assert!(graph.contains("[0:a]ebur128=peak=true:framelog=quiet"));
+        assert!(graph.contains("[0:a]ebur128=peak=true,"));
+        assert!(
+            !graph.contains("framelog"),
+            "framelog is unsupported on FFmpeg 4.4/6.1 and must stay off the graph: {graph}"
+        );
         assert!(graph.contains("silencedetect="));
         assert!(graph.contains("astats=metadata=0"));
         assert_eq!(maps, vec!["[v]".to_string(), "[a]".to_string()]);

--- a/src-tauri/src/core/qc/mod.rs
+++ b/src-tauri/src/core/qc/mod.rs
@@ -5,14 +5,26 @@
 
 pub mod context;
 pub mod engine;
+pub mod measure;
 pub mod rules;
+pub mod structural;
 pub mod violation;
 
 // Re-export main types
 pub use context::{QCContext, RenderMeasurements};
-pub use engine::{QCEngine, QCEngineConfig, QCReport, QCSeverityFilter, RuleFailure};
+pub use engine::{
+    QCEngine, QCEngineConfig, QCReport, QCSeverityFilter, RuleFailure, RuleOutcome, RuleStatus,
+};
+pub use measure::{
+    measure_rendered_file, measure_rendered_file_detailed, MeasureOptions, MeasurementReport,
+};
 pub use rules::{
-    AspectRatioRule, AudioPeakRule, BlackFrameRule, CaptionSafeAreaRule, CutRhythmRule,
-    DurationRule, LicenseRule, QCRule, RuleConfig,
+    AspectRatioRule, AudioLoudnessRule, AudioPeakRule, BlackFrameRule, CaptionSafeAreaRule,
+    CheckCategory, CutRhythmRule, DurationRule, LicenseRule, QCRule, RuleConfig,
+};
+pub use structural::{
+    crossref_black_ranges_with_gaps, CaptionOutOfBoundsRule, CaptionOverlapRule,
+    CaptionReadingRateRule, ClipOrphanRule, MissingAssetRule, ShotLengthStatsRule, SilentClipRule,
+    TimelineGapRule,
 };
 pub use violation::{QCViolation, Severity, TimeRange, ViolationFix};

--- a/src-tauri/src/core/qc/mod.rs
+++ b/src-tauri/src/core/qc/mod.rs
@@ -3,12 +3,14 @@
 //! Automated quality control rules for video editing validation.
 //! Provides rules engine, built-in rules, and auto-fix capabilities.
 
+pub mod context;
 pub mod engine;
 pub mod rules;
 pub mod violation;
 
 // Re-export main types
-pub use engine::{QCEngine, QCEngineConfig, QCReport, QCSeverityFilter};
+pub use context::{QCContext, RenderMeasurements};
+pub use engine::{QCEngine, QCEngineConfig, QCReport, QCSeverityFilter, RuleFailure};
 pub use rules::{
     AspectRatioRule, AudioPeakRule, BlackFrameRule, CaptionSafeAreaRule, CutRhythmRule,
     DurationRule, LicenseRule, QCRule, RuleConfig,

--- a/src-tauri/src/core/qc/rules.rs
+++ b/src-tauri/src/core/qc/rules.rs
@@ -59,11 +59,47 @@ impl RuleConfig {
     }
 }
 
+/// What a rule inspects.
+///
+/// Structural rules read the timeline alone; rendered rules need measurements
+/// taken from an exported file, so they are unavailable until one exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckCategory {
+    /// Derived from the project state (timeline, assets, captions)
+    Structural,
+    /// Derived from measurements of a rendered file
+    Rendered,
+}
+
+impl std::fmt::Display for CheckCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CheckCategory::Structural => write!(f, "structural"),
+            CheckCategory::Rendered => write!(f, "rendered"),
+        }
+    }
+}
+
 /// Trait for all QC rules
 #[async_trait]
 pub trait QCRule: Send + Sync {
     /// Returns the unique name of this rule
     fn name(&self) -> &str;
+
+    /// Returns the stable, dotted identifier reported to agents
+    ///
+    /// Rule names are Rust type names; check IDs are the vocabulary the CLI and
+    /// agent surfaces use (`timeline.gap`, `audio.loudness`, …). Defaults to
+    /// the rule name so custom rules stay usable without extra work.
+    fn check_id(&self) -> &str {
+        self.name()
+    }
+
+    /// Returns what this rule inspects
+    fn category(&self) -> CheckCategory {
+        CheckCategory::Structural
+    }
 
     /// Returns a human-readable description
     fn description(&self) -> &str;
@@ -137,6 +173,14 @@ impl BlackFrameRule {
 impl QCRule for BlackFrameRule {
     fn name(&self) -> &str {
         "BlackFrameRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "render.black_frames"
+    }
+
+    fn category(&self) -> CheckCategory {
+        CheckCategory::Rendered
     }
 
     fn description(&self) -> &str {
@@ -280,6 +324,14 @@ impl QCRule for AudioPeakRule {
         "AudioPeakRule"
     }
 
+    fn check_id(&self) -> &str {
+        "audio.peak"
+    }
+
+    fn category(&self) -> CheckCategory {
+        CheckCategory::Rendered
+    }
+
     fn description(&self) -> &str {
         "Detects audio peaks that may cause clipping or distortion"
     }
@@ -380,6 +432,179 @@ impl QCRule for AudioPeakRule {
         }
 
         Ok(violations)
+    }
+
+    fn supports_auto_fix(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// AudioLoudnessRule - Checks program loudness against a delivery target
+// ============================================================================
+
+/// Rule that compares measured integrated loudness against a delivery target
+///
+/// Platforms normalise playback to a fixed integrated loudness, so a program
+/// that lands far from the target is either turned down (wasting the mix) or
+/// turned up (revealing noise). Only the rendered program has a meaningful
+/// integrated loudness, so this rule reads the measurement pass.
+#[derive(Debug, Default)]
+pub struct AudioLoudnessRule;
+
+impl AudioLoudnessRule {
+    /// Creates a new AudioLoudnessRule
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Default delivery target in LUFS (streaming platform convention)
+    pub const DEFAULT_TARGET_LUFS: f64 = -14.0;
+
+    /// Deviation tolerated without comment, in LU
+    const DEFAULT_TOLERANCE_LU: f64 = 1.0;
+
+    /// Deviation that turns the finding into an error, in LU
+    const DEFAULT_ERROR_TOLERANCE_LU: f64 = 3.0;
+
+    /// Peak ceiling assumed when judging whether a boost is safe, in dB
+    const SAFE_PEAK_CEILING_DB: f64 = -1.0;
+
+    /// Master volume limits accepted by `SetMasterVolumeCommand`
+    const MASTER_MIN_VOLUME_DB: f64 = -60.0;
+    const MASTER_MAX_VOLUME_DB: f64 = 6.0;
+}
+
+#[async_trait]
+impl QCRule for AudioLoudnessRule {
+    fn name(&self) -> &str {
+        "AudioLoudnessRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "audio.loudness"
+    }
+
+    fn category(&self) -> CheckCategory {
+        CheckCategory::Rendered
+    }
+
+    fn description(&self) -> &str {
+        "Compares measured integrated loudness against the delivery target"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn skip_reason(&self, context: &QCContext) -> Option<String> {
+        let Some(measurements) = context.measurements.as_ref() else {
+            return Some("no rendered measurements available".to_string());
+        };
+        if measurements.integrated_lufs.is_none() {
+            return Some("no integrated loudness measurement available".to_string());
+        }
+        None
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let Some(measurements) = context.measurements.as_ref() else {
+            // The engine reports this rule as skipped (see `skip_reason`).
+            return Ok(Vec::new());
+        };
+        let Some(integrated_lufs) = measurements.integrated_lufs else {
+            return Ok(Vec::new());
+        };
+
+        let target_lufs = config
+            .get_param::<f64>("target_lufs")
+            .unwrap_or(Self::DEFAULT_TARGET_LUFS);
+        let tolerance_lu = config
+            .get_param::<f64>("tolerance_lu")
+            .unwrap_or(Self::DEFAULT_TOLERANCE_LU)
+            .abs();
+        let error_tolerance_lu = config
+            .get_param::<f64>("error_tolerance_lu")
+            .unwrap_or(Self::DEFAULT_ERROR_TOLERANCE_LU)
+            .abs();
+
+        let deviation = integrated_lufs - target_lufs;
+        if !deviation.is_finite() || deviation.abs() <= tolerance_lu {
+            return Ok(Vec::new());
+        }
+
+        let severity = config.severity_override.unwrap_or_else(|| {
+            if deviation.abs() > error_tolerance_lu {
+                Severity::Error
+            } else {
+                self.default_severity()
+            }
+        });
+
+        let direction = if deviation > 0.0 { "above" } else { "below" };
+        let mut violation = QCViolation::new(
+            self.name(),
+            severity,
+            format!(
+                "Integrated loudness is {:.1} LUFS, {:.1} LU {} the {:.1} LUFS target",
+                integrated_lufs,
+                deviation.abs(),
+                direction,
+                target_lufs
+            ),
+        )
+        .with_location(0.0, sequence.duration())
+        .with_metric("integratedLufs", integrated_lufs)
+        .with_metric("targetLufs", target_lufs)
+        .with_metric("deviationLu", (deviation * 100.0).round() / 100.0);
+
+        if let Some(range) = measurements.loudness_range_lu {
+            violation = violation.with_metric("loudnessRangeLu", range);
+        }
+
+        // A boost is only safe while the measured peak keeps enough headroom;
+        // otherwise the correction has to happen in the mix, not the master.
+        let measured_peak = measurements.true_peak_dbtp.or(measurements.sample_peak_db);
+        let boost_would_clip = deviation < 0.0
+            && measured_peak.is_some_and(|peak| peak - deviation > Self::SAFE_PEAK_CEILING_DB);
+
+        if boost_would_clip {
+            violation = violation.with_details(format!(
+                "Raising the master by {:.1} dB would push the measured peak of {:.1} dB past \
+                 {:.1} dB; rebalance the mix or apply a limiter instead.",
+                -deviation,
+                measured_peak.unwrap_or_default(),
+                Self::SAFE_PEAK_CEILING_DB
+            ));
+        } else {
+            let target_volume_db = (sequence.master_volume_db as f64 - deviation)
+                .clamp(Self::MASTER_MIN_VOLUME_DB, Self::MASTER_MAX_VOLUME_DB);
+
+            violation = violation
+                .with_details(format!(
+                    "Loudness normalisation will change playback level by {:.1} LU.",
+                    -deviation
+                ))
+                .with_fix(
+                    ViolationFix::new(
+                        format!("Set master volume to {:.1} dB", target_volume_db),
+                        vec![serde_json::json!({
+                            "type": "SetMasterVolume",
+                            "sequenceId": sequence.id,
+                            "volumeDb": target_volume_db
+                        })],
+                    )
+                    .with_confidence(0.7),
+                );
+        }
+
+        Ok(vec![violation])
     }
 
     fn supports_auto_fix(&self) -> bool {
@@ -489,6 +714,10 @@ impl CaptionSafeAreaRule {
 impl QCRule for CaptionSafeAreaRule {
     fn name(&self) -> &str {
         "CaptionSafeAreaRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "caption.safe_area"
     }
 
     fn description(&self) -> &str {
@@ -671,6 +900,10 @@ impl QCRule for CutRhythmRule {
         "CutRhythmRule"
     }
 
+    fn check_id(&self) -> &str {
+        "shot.cut_rhythm"
+    }
+
     fn description(&self) -> &str {
         "Checks if video cuts maintain appropriate rhythm and pacing"
     }
@@ -757,6 +990,10 @@ impl LicenseRule {
 impl QCRule for LicenseRule {
     fn name(&self) -> &str {
         "LicenseRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "asset.license"
     }
 
     fn description(&self) -> &str {
@@ -874,6 +1111,10 @@ impl QCRule for AspectRatioRule {
         "AspectRatioRule"
     }
 
+    fn check_id(&self) -> &str {
+        "clip.aspect_ratio"
+    }
+
     fn description(&self) -> &str {
         "Verifies all video clips match the sequence aspect ratio"
     }
@@ -976,6 +1217,10 @@ impl DurationRule {
 impl QCRule for DurationRule {
     fn name(&self) -> &str {
         "DurationRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "sequence.duration"
     }
 
     fn description(&self) -> &str {

--- a/src-tauri/src/core/qc/rules.rs
+++ b/src-tauri/src/core/qc/rules.rs
@@ -7,9 +7,11 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::context::QCContext;
 use super::violation::{QCViolation, Severity, ViolationFix};
+use crate::core::captions::{CaptionPosition, CaptionStyle, CustomPosition, VerticalPosition};
 use crate::core::project::ProjectState;
-use crate::core::timeline::Sequence;
+use crate::core::timeline::{Clip, Sequence};
 use crate::core::CoreResult;
 
 /// Configuration for QC rules
@@ -75,7 +77,16 @@ pub trait QCRule: Send + Sync {
         sequence: &Sequence,
         state: &ProjectState,
         config: &RuleConfig,
+        context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>>;
+
+    /// Returns why this rule cannot run against `context`, or `None` when it can.
+    ///
+    /// The engine records such rules in the report's skipped rules, so a rule
+    /// that is missing its inputs is never mistaken for a rule that passed.
+    fn skip_reason(&self, _context: &QCContext) -> Option<String> {
+        None
+    }
 
     /// Attempts to auto-fix a violation (if supported)
     async fn auto_fix(&self, violation: &QCViolation) -> Option<ViolationFix> {
@@ -88,11 +99,27 @@ pub trait QCRule: Send + Sync {
     }
 }
 
+/// Collects clips on video tracks that overlap the given timeline range.
+fn video_clips_in_range(sequence: &Sequence, start_sec: f64, end_sec: f64) -> Vec<&Clip> {
+    sequence
+        .tracks
+        .iter()
+        .filter(|track| track.is_video())
+        .flat_map(|track| track.clips.iter())
+        .filter(|clip| clip.place.timeline_in_sec < end_sec && clip.timeline_end() > start_sec)
+        .collect()
+}
+
 // ============================================================================
 // BlackFrameRule - Detects black frames at start/end
 // ============================================================================
 
-/// Rule that detects black frames at the beginning or end of clips
+/// Rule that reports black ranges found in the rendered sequence
+///
+/// Black detection is a pixel-level measurement, so this rule reads the ranges
+/// produced by the render measurement pass instead of inspecting the timeline.
+/// Luma/pixel thresholds belong to that pass; this rule only applies the
+/// duration threshold that decides which ranges are worth reporting.
 #[derive(Debug, Default)]
 pub struct BlackFrameRule;
 
@@ -101,9 +128,6 @@ impl BlackFrameRule {
     pub fn new() -> Self {
         Self
     }
-
-    /// Threshold for considering a frame "black" (0.0 - 1.0)
-    const DEFAULT_THRESHOLD: f64 = 0.05;
 
     /// Minimum duration to flag (seconds)
     const DEFAULT_MIN_DURATION: f64 = 0.1;
@@ -116,11 +140,18 @@ impl QCRule for BlackFrameRule {
     }
 
     fn description(&self) -> &str {
-        "Detects black frames at the start or end of clips"
+        "Reports black ranges detected in the rendered sequence"
     }
 
     fn default_severity(&self) -> Severity {
         Severity::Warning
+    }
+
+    fn skip_reason(&self, context: &QCContext) -> Option<String> {
+        if context.measurements.is_none() {
+            return Some("no rendered measurements available".to_string());
+        }
+        None
     }
 
     async fn check(
@@ -128,57 +159,69 @@ impl QCRule for BlackFrameRule {
         sequence: &Sequence,
         _state: &ProjectState,
         config: &RuleConfig,
+        context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
-        let mut violations = Vec::new();
+        let Some(measurements) = context.measurements.as_ref() else {
+            // The engine reports this rule as skipped (see `skip_reason`); an
+            // empty result here only guards direct single-rule invocations.
+            return Ok(Vec::new());
+        };
 
-        let _threshold = config
-            .get_param::<f64>("threshold")
-            .unwrap_or(Self::DEFAULT_THRESHOLD);
         let min_duration = config
             .get_param::<f64>("min_duration")
             .unwrap_or(Self::DEFAULT_MIN_DURATION);
 
         let severity = config.severity_override.unwrap_or(self.default_severity());
+        let frame_tolerance = context.frame_duration_sec();
 
-        // Check each clip in video tracks
-        for track in &sequence.tracks {
-            if !track.is_video() {
+        let mut violations = Vec::new();
+
+        for &(start_sec, end_sec) in &measurements.black_ranges {
+            let black_duration = end_sec - start_sec;
+            if !black_duration.is_finite() || black_duration < min_duration {
                 continue;
             }
 
-            for clip in &track.clips {
-                // Check for black frames at start (simulated check)
-                // In real implementation, this would analyze frame data.
-                if clip.place.timeline_in_sec == 0.0 {
-                    // Placeholder: detect black frame at start
-                    let black_duration = 0.5; // Simulated detection
-                    if black_duration >= min_duration {
-                        let fix = ViolationFix::new(
-                            format!("Trim {:.1}s from start", black_duration),
-                            vec![serde_json::json!({
-                                "type": "TrimClip",
-                                "clipId": clip.id,
-                                "trimStart": black_duration
-                            })],
-                        )
-                        .with_confidence(0.9);
+            let overlapping = video_clips_in_range(sequence, start_sec, end_sec);
+            let entity_ids: Vec<String> = overlapping.iter().map(|clip| clip.id.clone()).collect();
 
-                        let violation = QCViolation::new(
-                            self.name(),
-                            severity,
-                            format!("Black frame detected at start ({:.1}s)", black_duration),
-                        )
-                        .with_location(
-                            clip.place.timeline_in_sec,
-                            clip.place.timeline_in_sec + black_duration,
-                        )
-                        .with_entities(vec![clip.id.clone()])
-                        .with_fix(fix);
+            let mut violation = QCViolation::new(
+                self.name(),
+                severity,
+                format!(
+                    "Black frames detected for {:.2}s at {:.2}s",
+                    black_duration, start_sec
+                ),
+            )
+            .with_location(start_sec, end_sec)
+            .with_entities(entity_ids)
+            .with_details(if overlapping.is_empty() {
+                "No video clip covers this range; the timeline may have a gap here.".to_string()
+            } else {
+                format!("{} video clip(s) cover this range.", overlapping.len())
+            });
 
-                        violations.push(violation);
-                    }
-                }
+            // Only a black range that begins at a clip boundary can be trimmed
+            // away without shifting everything that follows it.
+            if let Some(clip) = overlapping
+                .iter()
+                .find(|clip| (clip.place.timeline_in_sec - start_sec).abs() <= frame_tolerance)
+            {
+                violation = violation.with_fix(
+                    ViolationFix::new(
+                        format!("Trim {:.2}s from the start of the clip", black_duration),
+                        vec![serde_json::json!({
+                            "type": "TrimClip",
+                            "sequenceId": sequence.id,
+                            "clipId": clip.id,
+                            "trimStart": black_duration
+                        })],
+                    )
+                    .with_confidence(0.9),
+                );
             }
+
+            violations.push(violation);
         }
 
         Ok(violations)
@@ -194,6 +237,11 @@ impl QCRule for BlackFrameRule {
 // ============================================================================
 
 /// Rule that detects audio peaks that may cause clipping
+///
+/// Peak level is a property of the rendered program, so this rule reads the
+/// measured peak instead of guessing from timeline structure. True peak is
+/// preferred; sample peak is used only when the measurement pass could not
+/// compute a true peak (it under-reports inter-sample overs).
 #[derive(Debug, Default)]
 pub struct AudioPeakRule;
 
@@ -208,6 +256,22 @@ impl AudioPeakRule {
 
     /// Default warning threshold in dB
     const DEFAULT_WARN_DB: f64 = -3.0;
+
+    /// Master volume limits accepted by `SetMasterVolumeCommand`
+    const MASTER_MIN_VOLUME_DB: f64 = -60.0;
+    const MASTER_MAX_VOLUME_DB: f64 = 6.0;
+
+    /// Returns the measured peak in dB and the label describing its kind.
+    fn measured_peak(context: &QCContext) -> Option<(f64, &'static str)> {
+        let measurements = context.measurements.as_ref()?;
+
+        if let Some(true_peak) = measurements.true_peak_dbtp {
+            return Some((true_peak, "true peak"));
+        }
+        measurements
+            .sample_peak_db
+            .map(|sample_peak| (sample_peak, "sample peak"))
+    }
 }
 
 #[async_trait]
@@ -224,13 +288,28 @@ impl QCRule for AudioPeakRule {
         Severity::Error
     }
 
+    fn skip_reason(&self, context: &QCContext) -> Option<String> {
+        if context.measurements.is_none() {
+            return Some("no rendered measurements available".to_string());
+        }
+        if Self::measured_peak(context).is_none() {
+            return Some("no audio peak measurement available".to_string());
+        }
+        None
+    }
+
     async fn check(
         &self,
         sequence: &Sequence,
         _state: &ProjectState,
         config: &RuleConfig,
+        context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
-        let mut violations = Vec::new();
+        let Some((measured_peak, peak_kind)) = Self::measured_peak(context) else {
+            // The engine reports this rule as skipped (see `skip_reason`); an
+            // empty result here only guards direct single-rule invocations.
+            return Ok(Vec::new());
+        };
 
         let peak_db = config
             .get_param::<f64>("peak_db")
@@ -239,57 +318,65 @@ impl QCRule for AudioPeakRule {
             .get_param::<f64>("warn_db")
             .unwrap_or(Self::DEFAULT_WARN_DB);
 
-        // Check audio tracks
-        for track in &sequence.tracks {
-            if !track.is_audio() {
-                continue;
-            }
+        // The measurement covers the whole rendered program, so violations are
+        // located across the full sequence rather than attributed to one clip.
+        let program_end = sequence.duration();
+        let mut violations = Vec::new();
 
-            for clip in &track.clips {
-                // Simulated peak detection (real implementation would analyze audio)
-                let detected_peak = -0.5; // Simulated peak
+        if measured_peak > peak_db {
+            let severity = config.severity_override.unwrap_or(Severity::Critical);
 
-                if detected_peak > peak_db {
-                    let severity = config.severity_override.unwrap_or(Severity::Critical);
+            // The measurement reflects the program as rendered, so the headroom
+            // is recovered by lowering the master output rather than one clip.
+            let target_volume_db = (sequence.master_volume_db as f64
+                + (peak_db - measured_peak - 0.5))
+                .clamp(Self::MASTER_MIN_VOLUME_DB, Self::MASTER_MAX_VOLUME_DB);
 
-                    let fix = ViolationFix::new(
-                        "Reduce audio gain to prevent clipping",
-                        vec![serde_json::json!({
-                            "type": "AdjustAudio",
-                            "clipId": clip.id,
-                            "gainDb": peak_db - detected_peak - 0.5
-                        })],
-                    )
-                    .with_confidence(0.85);
+            let fix = ViolationFix::new(
+                format!("Lower master volume to {:.1} dB", target_volume_db),
+                vec![serde_json::json!({
+                    "type": "SetMasterVolume",
+                    "sequenceId": sequence.id,
+                    "volumeDb": target_volume_db
+                })],
+            )
+            .with_confidence(0.85);
 
-                    let violation = QCViolation::new(
-                        self.name(),
-                        severity,
-                        format!("Audio clipping detected ({:.1} dB peak)", detected_peak),
-                    )
-                    .with_location(clip.place.timeline_in_sec, clip.timeline_end())
-                    .with_entities(vec![clip.id.clone()])
-                    .with_details(format!(
-                        "Peak exceeds threshold of {:.1} dB. May cause distortion.",
-                        peak_db
-                    ))
-                    .with_fix(fix);
+            violations.push(
+                QCViolation::new(
+                    self.name(),
+                    severity,
+                    format!(
+                        "Audio clipping detected ({:.1} dB {})",
+                        measured_peak, peak_kind
+                    ),
+                )
+                .with_location(0.0, program_end)
+                .with_details(format!(
+                    "Peak exceeds threshold of {:.1} dB. May cause distortion.",
+                    peak_db
+                ))
+                .with_fix(fix),
+            );
+        } else if measured_peak > warn_db {
+            let severity = config.severity_override.unwrap_or(Severity::Warning);
 
-                    violations.push(violation);
-                } else if detected_peak > warn_db {
-                    let severity = config.severity_override.unwrap_or(Severity::Warning);
-
-                    let violation = QCViolation::new(
-                        self.name(),
-                        severity,
-                        format!("High audio level detected ({:.1} dB peak)", detected_peak),
-                    )
-                    .with_location(clip.place.timeline_in_sec, clip.timeline_end())
-                    .with_entities(vec![clip.id.clone()]);
-
-                    violations.push(violation);
-                }
-            }
+            violations.push(
+                QCViolation::new(
+                    self.name(),
+                    severity,
+                    format!(
+                        "High audio level detected ({:.1} dB {})",
+                        measured_peak, peak_kind
+                    ),
+                )
+                .with_location(0.0, program_end)
+                .with_details(format!(
+                    "Peak is within {:.1} dB of the {:.1} dB ceiling.",
+                    measured_peak - warn_db,
+                    peak_db
+                )),
+            );
         }
 
         Ok(violations)
@@ -305,6 +392,11 @@ impl QCRule for AudioPeakRule {
 // ============================================================================
 
 /// Rule that ensures captions remain within the title-safe area
+///
+/// Works purely from timeline structure: caption clips carry their position and
+/// style as untyped JSON, which is deserialized defensively so a legacy or
+/// partially written blob degrades to the caption defaults instead of failing
+/// the whole check.
 #[derive(Debug, Default)]
 pub struct CaptionSafeAreaRule;
 
@@ -314,8 +406,83 @@ impl CaptionSafeAreaRule {
         Self
     }
 
-    /// Default safe area margin (percentage of screen)
+    /// Default title-safe margin (percentage of canvas)
     const DEFAULT_MARGIN_PERCENT: f64 = 10.0;
+
+    /// Action-safe margin (percentage of canvas)
+    ///
+    /// Text outside this band risks being cropped by overscan and covered by
+    /// platform UI overlays, so breaching it is reported at the rule severity
+    /// while breaching only the title-safe margin stays informational.
+    const ACTION_SAFE_MARGIN_PERCENT: f64 = 5.0;
+
+    /// Characters that fit across the full canvas width at the default font size
+    ///
+    /// Core has no text shaping, so rendered text width can only be
+    /// approximated; this average glyph advance keeps the estimate conservative
+    /// for Latin text and is intentionally coarse.
+    const CHARS_PER_CANVAS_WIDTH: f64 = 42.0;
+
+    /// Maximum estimated text-box width as a percentage of canvas width
+    const MAX_TEXT_BOX_WIDTH_PERCENT: f64 = 90.0;
+
+    /// Line height as a multiple of the font size (typographic default)
+    const LINE_HEIGHT_FACTOR: f64 = 1.2;
+
+    /// Reads the caption font size in pixels from the clip's style JSON.
+    fn font_size_px(style: Option<&serde_json::Value>) -> f64 {
+        let default_size = f64::from(CaptionStyle::default().font_size);
+
+        let Some(value) = style else {
+            return default_size;
+        };
+
+        if let Ok(parsed) = serde_json::from_value::<CaptionStyle>(value.clone()) {
+            return f64::from(parsed.font_size);
+        }
+
+        // Partial style blobs are common (only the edited fields are stored),
+        // so fall back to reading the single field this rule needs.
+        value
+            .get("fontSize")
+            .or_else(|| value.get("font_size"))
+            .and_then(serde_json::Value::as_f64)
+            .filter(|size| size.is_finite() && *size > 0.0)
+            .unwrap_or(default_size)
+    }
+
+    /// Returns the estimated text box size as (width, height) percentages.
+    fn estimate_text_box_percent(clip: &Clip, canvas_height: u32) -> (f64, f64) {
+        let char_count = clip
+            .label
+            .as_ref()
+            .map(|label| label.chars().count())
+            .unwrap_or(0) as f64;
+
+        let width_percent = (char_count / Self::CHARS_PER_CANVAS_WIDTH * 100.0)
+            .min(Self::MAX_TEXT_BOX_WIDTH_PERCENT);
+
+        let canvas_height = if canvas_height > 0 { canvas_height } else { 1 };
+        let height_percent = Self::font_size_px(clip.caption_style.as_ref())
+            * Self::LINE_HEIGHT_FACTOR
+            / f64::from(canvas_height)
+            * 100.0;
+
+        (width_percent, height_percent)
+    }
+
+    /// Centers a box of `size_percent` inside the safe band, without panicking
+    /// when the box is wider than the band itself.
+    fn clamp_center(center_percent: f64, size_percent: f64, margin_percent: f64) -> f64 {
+        let min = margin_percent + size_percent / 2.0;
+        let max = 100.0 - margin_percent - size_percent / 2.0;
+
+        if min > max {
+            50.0
+        } else {
+            center_percent.clamp(min, max)
+        }
+    }
 }
 
 #[async_trait]
@@ -337,51 +504,135 @@ impl QCRule for CaptionSafeAreaRule {
         sequence: &Sequence,
         _state: &ProjectState,
         config: &RuleConfig,
+        context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
         let mut violations = Vec::new();
 
-        let margin_percent = config
+        let title_safe_margin = config
             .get_param::<f64>("margin_percent")
             .unwrap_or(Self::DEFAULT_MARGIN_PERCENT);
+        let action_safe_margin = Self::ACTION_SAFE_MARGIN_PERCENT;
 
         let severity = config.severity_override.unwrap_or(self.default_severity());
 
-        // Check caption tracks
         for track in &sequence.tracks {
             if !track.is_caption() {
                 continue;
             }
 
             for clip in &track.clips {
-                // Check caption position (simulated - real impl would check Caption data)
-                let caption_y_percent = 95.0; // Simulated: near bottom edge
+                // A missing or unreadable position renders with the caption
+                // default, so the check follows the same fallback.
+                let position = clip
+                    .caption_position
+                    .as_ref()
+                    .and_then(|value| serde_json::from_value::<CaptionPosition>(value.clone()).ok())
+                    .unwrap_or_default();
 
-                if caption_y_percent > (100.0 - margin_percent) {
-                    let fix = ViolationFix::new(
-                        format!("Move caption to {}% from bottom", margin_percent),
-                        vec![serde_json::json!({
-                            "type": "UpdateCaption",
-                            "clipId": clip.id,
-                            "position": {"y": 100.0 - margin_percent - 5.0}
-                        })],
-                    )
-                    .with_confidence(0.95);
+                let (violation_severity, message, details, suggested_position) = match &position {
+                    CaptionPosition::Preset {
+                        vertical,
+                        margin_percent,
+                    } => {
+                        // Center-anchored captions sit mid-canvas, where an edge
+                        // margin has no meaning.
+                        if *vertical == VerticalPosition::Center {
+                            continue;
+                        }
 
-                    let violation = QCViolation::new(
-                        self.name(),
-                        severity,
-                        "Caption positioned outside title-safe area",
-                    )
+                        if *margin_percent < action_safe_margin {
+                            (
+                                severity,
+                                "Caption positioned outside the action-safe area".to_string(),
+                                format!(
+                                    "Margin of {:.1}% is below the {:.1}% action-safe margin",
+                                    margin_percent, action_safe_margin
+                                ),
+                                CaptionPosition::Preset {
+                                    vertical: vertical.clone(),
+                                    margin_percent: title_safe_margin,
+                                },
+                            )
+                        } else if *margin_percent < title_safe_margin {
+                            (
+                                Severity::Info,
+                                "Caption positioned outside the title-safe area".to_string(),
+                                format!(
+                                    "Margin of {:.1}% is below the {:.1}% title-safe margin but within the action-safe area",
+                                    margin_percent, title_safe_margin
+                                ),
+                                CaptionPosition::Preset {
+                                    vertical: vertical.clone(),
+                                    margin_percent: title_safe_margin,
+                                },
+                            )
+                        } else {
+                            continue;
+                        }
+                    }
+                    CaptionPosition::Custom(custom) => {
+                        let (box_width, box_height) =
+                            Self::estimate_text_box_percent(clip, context.canvas_height);
+
+                        let left = custom.x_percent - box_width / 2.0;
+                        let right = custom.x_percent + box_width / 2.0;
+                        let top = custom.y_percent - box_height / 2.0;
+                        let bottom = custom.y_percent + box_height / 2.0;
+
+                        let upper_bound = 100.0 - action_safe_margin;
+                        if left >= action_safe_margin
+                            && right <= upper_bound
+                            && top >= action_safe_margin
+                            && bottom <= upper_bound
+                        {
+                            continue;
+                        }
+
+                        (
+                            severity,
+                            "Caption positioned outside the action-safe area".to_string(),
+                            format!(
+                                "Estimated text box spans x {:.1}%-{:.1}%, y {:.1}%-{:.1}%, outside the {:.1}%-{:.1}% safe band (box size is an approximation)",
+                                left, right, top, bottom, action_safe_margin, upper_bound
+                            ),
+                            CaptionPosition::Custom(CustomPosition {
+                                x_percent: Self::clamp_center(
+                                    custom.x_percent,
+                                    box_width,
+                                    action_safe_margin,
+                                ),
+                                y_percent: Self::clamp_center(
+                                    custom.y_percent,
+                                    box_height,
+                                    action_safe_margin,
+                                ),
+                            }),
+                        )
+                    }
+                };
+
+                let mut violation = QCViolation::new(self.name(), violation_severity, message)
                     .with_location(clip.place.timeline_in_sec, clip.timeline_end())
                     .with_entities(vec![clip.id.clone()])
-                    .with_details(format!(
-                        "Caption at {}% exceeds safe area margin of {}%",
-                        caption_y_percent, margin_percent
-                    ))
-                    .with_fix(fix);
+                    .with_details(details);
 
-                    violations.push(violation);
+                if let Ok(position_json) = serde_json::to_value(&suggested_position) {
+                    violation = violation.with_fix(
+                        ViolationFix::new(
+                            "Move the caption inside the safe area",
+                            vec![serde_json::json!({
+                                "type": "UpdateCaption",
+                                "sequenceId": sequence.id,
+                                "trackId": track.id,
+                                "clipId": clip.id,
+                                "position": position_json
+                            })],
+                        )
+                        .with_confidence(0.95),
+                    );
                 }
+
+                violations.push(violation);
             }
         }
 
@@ -433,6 +684,7 @@ impl QCRule for CutRhythmRule {
         sequence: &Sequence,
         _state: &ProjectState,
         config: &RuleConfig,
+        _context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
         let mut violations = Vec::new();
 
@@ -520,6 +772,7 @@ impl QCRule for LicenseRule {
         sequence: &Sequence,
         state: &ProjectState,
         config: &RuleConfig,
+        _context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
         let mut violations = Vec::new();
 
@@ -634,6 +887,7 @@ impl QCRule for AspectRatioRule {
         sequence: &Sequence,
         state: &ProjectState,
         config: &RuleConfig,
+        _context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
         let mut violations = Vec::new();
 
@@ -737,6 +991,7 @@ impl QCRule for DurationRule {
         sequence: &Sequence,
         _state: &ProjectState,
         config: &RuleConfig,
+        _context: &QCContext,
     ) -> CoreResult<Vec<QCViolation>> {
         let mut violations = Vec::new();
 
@@ -801,6 +1056,54 @@ impl QCRule for DurationRule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::qc::context::RenderMeasurements;
+    use crate::core::timeline::{SequenceFormat, Track};
+
+    // ========================================================================
+    // Test Fixtures
+    // ========================================================================
+
+    /// Builds a 1920x1080 sequence with a single video clip on one video track
+    fn sequence_with_video_clip(timeline_in_sec: f64, duration_sec: f64) -> Sequence {
+        let mut sequence = Sequence::new("QC Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("V1");
+        track.add_clip(Clip::with_range("asset_001", 0.0, duration_sec).place_at(timeline_in_sec));
+        sequence.add_track(track);
+        sequence
+    }
+
+    /// Builds a 1920x1080 sequence with a single caption clip
+    fn sequence_with_caption(
+        label: &str,
+        position: Option<serde_json::Value>,
+        style: Option<serde_json::Value>,
+    ) -> Sequence {
+        let mut sequence = Sequence::new("QC Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_caption("C1");
+
+        let mut clip = Clip::with_range("caption_asset", 0.0, 2.0);
+        clip.label = Some(label.to_string());
+        clip.caption_position = position;
+        clip.caption_style = style;
+        track.add_clip(clip);
+
+        sequence.add_track(track);
+        sequence
+    }
+
+    fn measurements_with_black_ranges(ranges: Vec<(f64, f64)>) -> RenderMeasurements {
+        RenderMeasurements {
+            black_ranges: ranges,
+            ..Default::default()
+        }
+    }
+
+    fn measurements_with_true_peak(true_peak_dbtp: f64) -> RenderMeasurements {
+        RenderMeasurements {
+            true_peak_dbtp: Some(true_peak_dbtp),
+            ..Default::default()
+        }
+    }
 
     // ========================================================================
     // RuleConfig Tests
@@ -859,6 +1162,67 @@ mod tests {
         assert!(rule.supports_auto_fix());
     }
 
+    #[tokio::test]
+    async fn test_black_frame_rule_should_report_ranges_when_measurements_are_provided() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence)
+            // The 0.02s range is below the default 0.1s duration threshold
+            .with_measurements(measurements_with_black_ranges(vec![
+                (0.0, 0.6),
+                (2.0, 2.02),
+            ]));
+
+        let violations = BlackFrameRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        let location = violations[0].location.as_ref().expect("located violation");
+        assert_eq!(location.start_sec, 0.0);
+        assert_eq!(location.end_sec, 0.6);
+        assert_eq!(violations[0].affected_entities.len(), 1);
+        assert!(
+            violations[0].auto_fixable,
+            "a black range starting at the clip start is trimmable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_black_frame_rule_should_respect_min_duration_config() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence)
+            .with_measurements(measurements_with_black_ranges(vec![(0.0, 0.6)]));
+
+        let mut config = RuleConfig::default();
+        config.set_param("min_duration", 1.0);
+
+        let violations = BlackFrameRule::new()
+            .check(&sequence, &state, &config, &context)
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_black_frame_rule_should_skip_when_measurements_are_missing() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let rule = BlackFrameRule::new();
+        assert!(rule.skip_reason(&context).is_some());
+
+        let violations = rule
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+        assert!(violations.is_empty());
+    }
+
     // ========================================================================
     // AudioPeakRule Tests
     // ========================================================================
@@ -871,6 +1235,82 @@ mod tests {
         assert!(rule.supports_auto_fix());
     }
 
+    #[tokio::test]
+    async fn test_audio_peak_rule_should_report_clipping_from_measured_true_peak() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence)
+            .with_measurements(measurements_with_true_peak(-0.2));
+
+        let violations = AudioPeakRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Critical);
+        assert!(violations[0].message.contains("true peak"));
+
+        let fix = violations[0].suggested_fix.as_ref().expect("fix suggested");
+        assert_eq!(fix.commands[0]["type"], "SetMasterVolume");
+    }
+
+    #[tokio::test]
+    async fn test_audio_peak_rule_should_warn_below_ceiling() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence)
+            .with_measurements(measurements_with_true_peak(-2.0));
+
+        let violations = AudioPeakRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+        assert!(!violations[0].auto_fixable);
+    }
+
+    #[tokio::test]
+    async fn test_audio_peak_rule_should_fall_back_to_sample_peak() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence).with_measurements(RenderMeasurements {
+            sample_peak_db: Some(-0.2),
+            ..Default::default()
+        });
+
+        let violations = AudioPeakRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("sample peak"));
+    }
+
+    #[tokio::test]
+    async fn test_audio_peak_rule_should_skip_when_peak_is_not_measured() {
+        let sequence = sequence_with_video_clip(0.0, 5.0);
+        let state = ProjectState::new("QC Test");
+        let rule = AudioPeakRule::new();
+
+        let no_measurements = QCContext::from_sequence(&sequence);
+        assert!(rule.skip_reason(&no_measurements).is_some());
+
+        // Measurements without any peak figure (for example a silent render)
+        let no_peak =
+            QCContext::from_sequence(&sequence).with_measurements(RenderMeasurements::default());
+        assert!(rule.skip_reason(&no_peak).is_some());
+
+        let violations = rule
+            .check(&sequence, &state, &RuleConfig::default(), &no_peak)
+            .await
+            .expect("rule runs");
+        assert!(violations.is_empty());
+    }
+
     // ========================================================================
     // CaptionSafeAreaRule Tests
     // ========================================================================
@@ -881,6 +1321,130 @@ mod tests {
         assert_eq!(rule.name(), "CaptionSafeAreaRule");
         assert_eq!(rule.default_severity(), Severity::Warning);
         assert!(rule.supports_auto_fix());
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_flag_custom_position_near_bottom_edge() {
+        let sequence = sequence_with_caption(
+            "Caption near the bottom edge",
+            Some(serde_json::json!({
+                "type": "custom",
+                "xPercent": 50.0,
+                "yPercent": 98.0
+            })),
+            None,
+        );
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+        assert!(violations[0].auto_fixable);
+
+        let fix = violations[0].suggested_fix.as_ref().expect("fix suggested");
+        assert_eq!(fix.commands[0]["type"], "UpdateCaption");
+        assert_eq!(fix.commands[0]["position"]["type"], "custom");
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_pass_preset_at_title_safe_margin() {
+        let sequence = sequence_with_caption(
+            "Caption inside the safe area",
+            Some(serde_json::json!({
+                "type": "preset",
+                "vertical": "bottom",
+                "marginPercent": 10.0
+            })),
+            None,
+        );
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_flag_preset_below_action_safe_margin() {
+        let sequence = sequence_with_caption(
+            "Caption at the very edge",
+            Some(serde_json::json!({
+                "type": "preset",
+                "vertical": "top",
+                "marginPercent": 1.0
+            })),
+            None,
+        );
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+        assert_eq!(
+            violations[0]
+                .suggested_fix
+                .as_ref()
+                .expect("fix suggested")
+                .commands[0]["position"]["marginPercent"],
+            10.0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_ignore_center_preset() {
+        let sequence = sequence_with_caption(
+            "Centered caption",
+            Some(serde_json::json!({
+                "type": "preset",
+                "vertical": "center",
+                "marginPercent": 0.0
+            })),
+            None,
+        );
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_fall_back_to_default_position_when_unreadable() {
+        let sequence = sequence_with_caption(
+            "Caption without a stored position",
+            Some(serde_json::json!({ "type": "unknown-variant" })),
+            Some(serde_json::json!({ "fontSize": 64 })),
+        );
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        // The caption default (bottom, 5% margin) clears the action-safe margin
+        // but sits inside the title-safe margin, so it is informational only.
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Info);
     }
 
     // ========================================================================

--- a/src-tauri/src/core/qc/rules.rs
+++ b/src-tauri/src/core/qc/rules.rs
@@ -425,7 +425,7 @@ impl QCRule for AudioPeakRule {
                 .with_location(0.0, program_end)
                 .with_details(format!(
                     "Peak is within {:.1} dB of the {:.1} dB ceiling.",
-                    measured_peak - warn_db,
+                    peak_db - measured_peak,
                     peak_db
                 )),
             );

--- a/src-tauri/src/core/qc/rules.rs
+++ b/src-tauri/src/core/qc/rules.rs
@@ -449,6 +449,10 @@ impl QCRule for AudioPeakRule {
 /// that lands far from the target is either turned down (wasting the mix) or
 /// turned up (revealing noise). Only the rendered program has a meaningful
 /// integrated loudness, so this rule reads the measurement pass.
+///
+/// Findings are warnings at any deviation: the target is a delivery convention
+/// rather than a property of correct output. True-peak and clipping checks stay
+/// errors because they describe damage to the signal itself.
 #[derive(Debug, Default)]
 pub struct AudioLoudnessRule;
 
@@ -463,9 +467,6 @@ impl AudioLoudnessRule {
 
     /// Deviation tolerated without comment, in LU
     const DEFAULT_TOLERANCE_LU: f64 = 1.0;
-
-    /// Deviation that turns the finding into an error, in LU
-    const DEFAULT_ERROR_TOLERANCE_LU: f64 = 3.0;
 
     /// Peak ceiling assumed when judging whether a boost is safe, in dB
     const SAFE_PEAK_CEILING_DB: f64 = -1.0;
@@ -529,23 +530,19 @@ impl QCRule for AudioLoudnessRule {
             .get_param::<f64>("tolerance_lu")
             .unwrap_or(Self::DEFAULT_TOLERANCE_LU)
             .abs();
-        let error_tolerance_lu = config
-            .get_param::<f64>("error_tolerance_lu")
-            .unwrap_or(Self::DEFAULT_ERROR_TOLERANCE_LU)
-            .abs();
 
         let deviation = integrated_lufs - target_lufs;
         if !deviation.is_finite() || deviation.abs() <= tolerance_lu {
             return Ok(Vec::new());
         }
 
-        let severity = config.severity_override.unwrap_or_else(|| {
-            if deviation.abs() > error_tolerance_lu {
-                Severity::Error
-            } else {
-                self.default_severity()
-            }
-        });
+        // Every deviation is a warning, however large. A loudness target is a
+        // platform convention, not a property of correct output — a master
+        // mixed for cinema is not broken because it misses a streaming target —
+        // so `error` stays reserved for the objectively broken (true-peak overs,
+        // clipping). A caller that treats a specific target as a hard
+        // requirement can raise the grade with `severity_override`.
+        let severity = config.severity_override.unwrap_or(self.default_severity());
 
         let direction = if deviation > 0.0 { "above" } else { "below" };
         let mut violation = QCViolation::new(

--- a/src-tauri/src/core/qc/structural.rs
+++ b/src-tauri/src/core/qc/structural.rs
@@ -1,0 +1,1869 @@
+//! Structural QC rules
+//!
+//! Checks that read the project state alone — no render required. They catch
+//! the failures that are objectively wrong in the edit itself (holes in the
+//! picture, missing media, captions that cannot be read) plus a small number of
+//! informational metrics that give an agent something to steer by.
+//!
+//! Rules that need a rendered file live in [`super::rules`]; this module also
+//! hosts [`crossref_black_ranges_with_gaps`], which is where the two halves
+//! meet.
+
+use async_trait::async_trait;
+
+use super::context::QCContext;
+use super::engine::QCReport;
+use super::rules::{QCRule, RuleConfig};
+use super::violation::{QCViolation, Severity, ViolationFix};
+use crate::core::captions::{CaptionPosition, CaptionStyle, VerticalPosition};
+use crate::core::commands::find_gaps;
+use crate::core::project::ProjectState;
+use crate::core::timeline::{Clip, Sequence, Track};
+use crate::core::CoreResult;
+
+/// Asset ID used by caption clips, which have no media file behind them.
+///
+/// Mirrors `core::commands::caption::CAPTION_ASSET_ID`; duplicated here because
+/// QC must not depend on command internals.
+const CAPTION_VIRTUAL_ASSET_ID: &str = "caption";
+
+/// Prefix shared by every virtual asset ID (text, compound, adjustment layer).
+const VIRTUAL_ASSET_PREFIX: &str = "__";
+
+/// Volume at or below which a clip is treated as inaudible, in dB.
+const SILENT_VOLUME_DB: f64 = -60.0;
+
+// =============================================================================
+// Shared helpers
+// =============================================================================
+
+/// A hole in the picture: a gap on one track that no other track covers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UncoveredGap {
+    /// Track the gap was found on.
+    pub track_id: String,
+    /// Track name, for human-readable messages.
+    pub track_name: String,
+    /// Start of the uncovered span, in timeline seconds.
+    pub start_sec: f64,
+    /// End of the uncovered span, in timeline seconds.
+    pub end_sec: f64,
+    /// Start of the enclosing track gap (what [`CloseGap`](crate::core::commands::CloseGapCommand) closes).
+    pub gap_start_sec: f64,
+    /// End of the enclosing track gap.
+    pub gap_end_sec: f64,
+}
+
+impl UncoveredGap {
+    /// Duration of the uncovered span in seconds.
+    pub fn duration_sec(&self) -> f64 {
+        self.end_sec - self.start_sec
+    }
+}
+
+/// Returns whether a clip stands in for something other than imported media.
+fn is_virtual_clip(clip: &Clip) -> bool {
+    clip.is_adjustment_layer
+        || clip.compound_sequence_id.is_some()
+        || clip.asset_id.is_empty()
+        || clip.asset_id.starts_with(VIRTUAL_ASSET_PREFIX)
+        || clip.asset_id == CAPTION_VIRTUAL_ASSET_ID
+}
+
+/// Collects the timeline spans covered by enabled clips on the given tracks.
+fn covered_spans<'a>(
+    tracks: impl Iterator<Item = &'a Track>,
+    exclude_track_id: &str,
+) -> Vec<(f64, f64)> {
+    let mut spans: Vec<(f64, f64)> = tracks
+        .filter(|track| track.id != exclude_track_id && track.visible)
+        .flat_map(|track| track.clips.iter())
+        .filter(|clip| clip.enabled && clip.duration() > 0.0)
+        .map(|clip| (clip.place.timeline_in_sec, clip.timeline_end()))
+        .collect();
+
+    spans.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    // Merge so the subtraction below only walks disjoint spans.
+    let mut merged: Vec<(f64, f64)> = Vec::with_capacity(spans.len());
+    for span in spans {
+        match merged.last_mut() {
+            Some(last) if span.0 <= last.1 => last.1 = last.1.max(span.1),
+            _ => merged.push(span),
+        }
+    }
+
+    merged
+}
+
+/// Subtracts covered spans from `[start, end)`, returning what remains.
+fn subtract_coverage(start: f64, end: f64, covered: &[(f64, f64)]) -> Vec<(f64, f64)> {
+    let mut remaining = vec![(start, end)];
+
+    for &(cover_start, cover_end) in covered {
+        let mut next = Vec::with_capacity(remaining.len() + 1);
+        for (span_start, span_end) in remaining {
+            if cover_end <= span_start || cover_start >= span_end {
+                next.push((span_start, span_end));
+                continue;
+            }
+            if cover_start > span_start {
+                next.push((span_start, cover_start));
+            }
+            if cover_end < span_end {
+                next.push((cover_end, span_end));
+            }
+        }
+        remaining = next;
+    }
+
+    remaining
+}
+
+/// Finds gaps on video tracks that no other video track fills.
+///
+/// A gap on an overlay track above a continuous base track is not a hole in the
+/// program, so only the uncovered remainder is reported.
+pub fn uncovered_video_gaps(sequence: &Sequence, min_gap_sec: f64) -> Vec<UncoveredGap> {
+    let mut uncovered = Vec::new();
+
+    for track in sequence.tracks.iter().filter(|track| track.is_video()) {
+        let gaps = find_gaps(track);
+        if gaps.is_empty() {
+            continue;
+        }
+
+        let covered = covered_spans(
+            sequence.tracks.iter().filter(|other| other.is_video()),
+            &track.id,
+        );
+
+        for gap in gaps {
+            for (start_sec, end_sec) in subtract_coverage(gap.start, gap.end, &covered) {
+                if end_sec - start_sec < min_gap_sec {
+                    continue;
+                }
+                uncovered.push(UncoveredGap {
+                    track_id: track.id.clone(),
+                    track_name: track.name.clone(),
+                    start_sec,
+                    end_sec,
+                    gap_start_sec: gap.start,
+                    gap_end_sec: gap.end,
+                });
+            }
+        }
+    }
+
+    uncovered
+}
+
+// =============================================================================
+// TimelineGapRule
+// =============================================================================
+
+/// Rule that reports holes between clips on video tracks
+///
+/// A hole renders as black, so it is reported as an error rather than a matter
+/// of taste. Gaps that another video track covers are ignored.
+#[derive(Debug, Default)]
+pub struct TimelineGapRule;
+
+impl TimelineGapRule {
+    /// Creates a new TimelineGapRule
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl QCRule for TimelineGapRule {
+    fn name(&self) -> &str {
+        "TimelineGapRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "timeline.gap"
+    }
+
+    fn description(&self) -> &str {
+        "Reports gaps between clips on video tracks that no other track covers"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        // Sub-frame gaps are rounding artefacts, not holes in the picture.
+        let min_gap_sec = config
+            .get_param::<f64>("min_gap_sec")
+            .unwrap_or_else(|| context.frame_duration_sec());
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+
+        let violations = uncovered_video_gaps(sequence, min_gap_sec)
+            .into_iter()
+            .map(|gap| {
+                QCViolation::new(
+                    self.name(),
+                    severity,
+                    format!(
+                        "Gap of {:.2}s at {:.2}s on track '{}'",
+                        gap.duration_sec(),
+                        gap.start_sec,
+                        gap.track_name
+                    ),
+                )
+                .with_location(gap.start_sec, gap.end_sec)
+                .with_entities(vec![gap.track_id.clone()])
+                .with_details(
+                    "Nothing covers this range, so the program renders black here.".to_string(),
+                )
+                .with_metric("gapSec", gap.duration_sec())
+                .with_metric("trackId", gap.track_id.clone())
+                .with_fix(
+                    ViolationFix::new(
+                        format!("Close the gap on track '{}'", gap.track_name),
+                        vec![serde_json::json!({
+                            "type": "CloseGap",
+                            "sequenceId": sequence.id,
+                            "trackId": gap.track_id,
+                            "gapStart": gap.gap_start_sec,
+                            "gapEnd": gap.gap_end_sec
+                        })],
+                    )
+                    .with_confidence(0.85),
+                )
+            })
+            .collect();
+
+        Ok(violations)
+    }
+
+    fn supports_auto_fix(&self) -> bool {
+        true
+    }
+}
+
+// =============================================================================
+// ClipOrphanRule
+// =============================================================================
+
+/// Rule that reports clips too short to register on screen
+///
+/// Anything under two frames is a leftover from a split or a drag, not an edit
+/// a viewer can perceive.
+#[derive(Debug, Default)]
+pub struct ClipOrphanRule;
+
+impl ClipOrphanRule {
+    /// Creates a new ClipOrphanRule
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Frames below which a clip counts as an orphan
+    const DEFAULT_MIN_FRAMES: f64 = 2.0;
+}
+
+#[async_trait]
+impl QCRule for ClipOrphanRule {
+    fn name(&self) -> &str {
+        "ClipOrphanRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "clip.orphan"
+    }
+
+    fn description(&self) -> &str {
+        "Reports clips shorter than two frames"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let min_frames = config
+            .get_param::<f64>("min_frames")
+            .unwrap_or(Self::DEFAULT_MIN_FRAMES);
+        let min_duration = min_frames * context.frame_duration_sec();
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+
+        let mut violations = Vec::new();
+
+        for track in &sequence.tracks {
+            for clip in &track.clips {
+                let duration = clip.duration();
+                if duration >= min_duration {
+                    continue;
+                }
+
+                let message = if duration <= 0.0 {
+                    format!("Zero-length clip on track '{}'", track.name)
+                } else {
+                    format!(
+                        "Clip is {:.3}s long, under the {:.3}s ({:.0} frame) minimum",
+                        duration, min_duration, min_frames
+                    )
+                };
+
+                violations.push(
+                    QCViolation::new(self.name(), severity, message)
+                        .with_location(clip.place.timeline_in_sec, clip.timeline_end())
+                        .with_entities(vec![clip.id.clone()])
+                        .with_details(
+                            "Clips this short are invisible in playback and usually left over \
+                             from a split or drag."
+                                .to_string(),
+                        )
+                        .with_metric("durationSec", duration)
+                        .with_metric("minDurationSec", min_duration)
+                        .with_metric("trackId", track.id.clone())
+                        .with_fix(
+                            ViolationFix::new(
+                                "Remove the orphan clip",
+                                vec![serde_json::json!({
+                                    "type": "RemoveClip",
+                                    "sequenceId": sequence.id,
+                                    "trackId": track.id,
+                                    "clipId": clip.id
+                                })],
+                            )
+                            .with_confidence(0.6),
+                        ),
+                );
+            }
+        }
+
+        Ok(violations)
+    }
+
+    fn supports_auto_fix(&self) -> bool {
+        true
+    }
+}
+
+// =============================================================================
+// MissingAssetRule
+// =============================================================================
+
+/// Rule that reports clips whose source media cannot be resolved
+///
+/// A clip pointing at media that is gone cannot render at all, so this is the
+/// one structural failure classed as critical.
+#[derive(Debug, Default)]
+pub struct MissingAssetRule;
+
+impl MissingAssetRule {
+    /// Creates a new MissingAssetRule
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl QCRule for MissingAssetRule {
+    fn name(&self) -> &str {
+        "MissingAssetRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "clip.missing_asset"
+    }
+
+    fn description(&self) -> &str {
+        "Reports clips whose source asset is missing from the project or from disk"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Critical
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        state: &ProjectState,
+        config: &RuleConfig,
+        _context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+        let mut violations = Vec::new();
+
+        for track in &sequence.tracks {
+            if track.is_caption() {
+                continue;
+            }
+
+            for clip in &track.clips {
+                if is_virtual_clip(clip) {
+                    continue;
+                }
+
+                let (message, details) = match state.get_asset(&clip.asset_id) {
+                    None => (
+                        format!("Clip references unknown asset '{}'", clip.asset_id),
+                        "The asset is not part of this project; re-import the media or remove \
+                         the clip."
+                            .to_string(),
+                    ),
+                    Some(asset) if asset.missing => (
+                        format!("Source file for '{}' is missing from disk", asset.name),
+                        format!("Expected at '{}'. Relink or restore the file.", asset.uri),
+                    ),
+                    Some(_) => continue,
+                };
+
+                violations.push(
+                    QCViolation::new(self.name(), severity, message)
+                        .with_location(clip.place.timeline_in_sec, clip.timeline_end())
+                        .with_entities(vec![clip.id.clone(), clip.asset_id.clone()])
+                        .with_details(details)
+                        .with_metric("assetId", clip.asset_id.clone())
+                        .with_metric("trackId", track.id.clone()),
+                );
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+// =============================================================================
+// SilentClipRule
+// =============================================================================
+
+/// Rule that reports clips carrying audio that will never be heard
+///
+/// Muting is a legitimate edit (B-roll under narration), so this stays a
+/// warning: it flags the common mistake of leaving a dialogue clip muted.
+#[derive(Debug, Default)]
+pub struct SilentClipRule;
+
+impl SilentClipRule {
+    /// Creates a new SilentClipRule
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Returns why the clip is inaudible, or `None` when it is not.
+    fn silence_reason(track: &Track, clip: &Clip, silent_volume_db: f64) -> Option<String> {
+        if track.muted {
+            return Some(format!("track '{}' is muted", track.name));
+        }
+        if f64::from(track.volume) <= 0.0 {
+            return Some(format!("track '{}' volume is zero", track.name));
+        }
+        if clip.audio.muted {
+            return Some("clip audio is muted".to_string());
+        }
+        // Automation can bring the level back up, so a flat level only counts
+        // when there are no keyframes to contradict it.
+        if clip.audio.volume_keyframes.is_empty()
+            && f64::from(clip.audio.volume_db) <= silent_volume_db
+        {
+            return Some(format!("clip volume is {:.1} dB", clip.audio.volume_db));
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl QCRule for SilentClipRule {
+    fn name(&self) -> &str {
+        "SilentClipRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "audio.silent_clip"
+    }
+
+    fn description(&self) -> &str {
+        "Reports clips whose audio is muted or turned all the way down"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        state: &ProjectState,
+        config: &RuleConfig,
+        _context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let silent_volume_db = config
+            .get_param::<f64>("silent_volume_db")
+            .unwrap_or(SILENT_VOLUME_DB);
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+
+        let mut violations = Vec::new();
+
+        for track in &sequence.tracks {
+            if track.is_caption() {
+                continue;
+            }
+
+            for clip in &track.clips {
+                if is_virtual_clip(clip) {
+                    continue;
+                }
+
+                // Only clips that actually carry audio can be silenced.
+                let carries_audio = track.is_audio()
+                    || state
+                        .get_asset(&clip.asset_id)
+                        .is_some_and(|asset| asset.audio.is_some());
+                if !carries_audio {
+                    continue;
+                }
+
+                let Some(reason) = Self::silence_reason(track, clip, silent_volume_db) else {
+                    continue;
+                };
+
+                violations.push(
+                    QCViolation::new(
+                        self.name(),
+                        severity,
+                        format!("Clip audio will not be heard ({})", reason),
+                    )
+                    .with_location(clip.place.timeline_in_sec, clip.timeline_end())
+                    .with_entities(vec![clip.id.clone()])
+                    .with_details(
+                        "Confirm this is intentional; otherwise unmute the clip or raise its \
+                         level."
+                            .to_string(),
+                    )
+                    .with_metric("volumeDb", f64::from(clip.audio.volume_db))
+                    .with_metric("clipMuted", clip.audio.muted)
+                    .with_metric("trackMuted", track.muted)
+                    .with_metric("trackId", track.id.clone()),
+                );
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+// =============================================================================
+// CaptionOverlapRule
+// =============================================================================
+
+/// Rule that reports captions that collide on the same track
+///
+/// Two captions live at once render on top of each other, which is broken
+/// output rather than a stylistic choice.
+#[derive(Debug, Default)]
+pub struct CaptionOverlapRule;
+
+impl CaptionOverlapRule {
+    /// Creates a new CaptionOverlapRule
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl QCRule for CaptionOverlapRule {
+    fn name(&self) -> &str {
+        "CaptionOverlapRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "caption.overlap"
+    }
+
+    fn description(&self) -> &str {
+        "Reports captions that overlap in time on the same track"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        _context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+        let mut violations = Vec::new();
+
+        for track in sequence.tracks.iter().filter(|track| track.is_caption()) {
+            let mut clips: Vec<&Clip> = track.clips.iter().collect();
+            clips.sort_by(|a, b| {
+                a.place
+                    .timeline_in_sec
+                    .total_cmp(&b.place.timeline_in_sec)
+                    .then_with(|| a.id.cmp(&b.id))
+            });
+
+            for pair in clips.windows(2) {
+                let (first, second) = (pair[0], pair[1]);
+                if !first.place.overlaps(&second.place) {
+                    continue;
+                }
+
+                let start_sec = second.place.timeline_in_sec;
+                let end_sec = first.timeline_end().min(second.timeline_end());
+
+                violations.push(
+                    QCViolation::new(
+                        self.name(),
+                        severity,
+                        format!(
+                            "Captions overlap for {:.2}s at {:.2}s on track '{}'",
+                            end_sec - start_sec,
+                            start_sec,
+                            track.name
+                        ),
+                    )
+                    .with_location(start_sec, end_sec)
+                    .with_entities(vec![first.id.clone(), second.id.clone()])
+                    .with_details(
+                        "Overlapping captions render on top of each other; trim the earlier \
+                         caption or move the later one."
+                            .to_string(),
+                    )
+                    .with_metric("overlapSec", end_sec - start_sec)
+                    .with_metric("trackId", track.id.clone()),
+                );
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+// =============================================================================
+// CaptionReadingRateRule
+// =============================================================================
+
+/// Rule that reports captions shown too briefly to read
+///
+/// The comfortable rate depends on the script: a Hangul or Han glyph carries
+/// far more meaning than a Latin letter, so a CJK caption is measured against a
+/// much lower characters-per-second budget. Reading comfort is a judgement
+/// call, so findings stay at warning level.
+#[derive(Debug, Default)]
+pub struct CaptionReadingRateRule;
+
+/// Script family a caption is measured against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptionScript {
+    /// Latin and other alphabetic scripts.
+    Latin,
+    /// Chinese, Japanese, or Korean.
+    Cjk,
+}
+
+impl CaptionScript {
+    /// Identifier used in violation metrics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CaptionScript::Latin => "latin",
+            CaptionScript::Cjk => "cjk",
+        }
+    }
+}
+
+impl CaptionReadingRateRule {
+    /// Creates a new CaptionReadingRateRule
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Comfortable reading rate for Latin script, in characters per second
+    const LATIN_WARN_CPS: f64 = 20.0;
+
+    /// Rate at which Latin script becomes unreadable in practice
+    const LATIN_SEVERE_CPS: f64 = 25.0;
+
+    /// Comfortable reading rate for CJK script, in characters per second
+    const CJK_WARN_CPS: f64 = 9.0;
+
+    /// Rate at which CJK script becomes unreadable in practice
+    const CJK_SEVERE_CPS: f64 = 12.0;
+
+    /// Share of CJK characters above which CJK thresholds apply
+    const CJK_SHARE_THRESHOLD: f64 = 0.3;
+
+    /// Classifies caption text by script family.
+    pub fn detect_script(text: &str) -> CaptionScript {
+        let mut total = 0usize;
+        let mut cjk = 0usize;
+
+        for character in text.chars() {
+            if character.is_whitespace() || !character.is_alphanumeric() {
+                continue;
+            }
+            total += 1;
+            if is_cjk_char(character) {
+                cjk += 1;
+            }
+        }
+
+        if total == 0 {
+            return CaptionScript::Latin;
+        }
+
+        if cjk as f64 / total as f64 > Self::CJK_SHARE_THRESHOLD {
+            CaptionScript::Cjk
+        } else {
+            CaptionScript::Latin
+        }
+    }
+
+    /// Returns the (warn, severe) characters-per-second thresholds for a script.
+    pub fn thresholds(script: CaptionScript) -> (f64, f64) {
+        match script {
+            CaptionScript::Latin => (Self::LATIN_WARN_CPS, Self::LATIN_SEVERE_CPS),
+            CaptionScript::Cjk => (Self::CJK_WARN_CPS, Self::CJK_SEVERE_CPS),
+        }
+    }
+}
+
+/// Returns whether a character belongs to a CJK script block.
+fn is_cjk_char(character: char) -> bool {
+    matches!(character as u32,
+        0x1100..=0x11FF        // Hangul Jamo
+        | 0x3040..=0x309F      // Hiragana
+        | 0x30A0..=0x30FF      // Katakana
+        | 0x3130..=0x318F      // Hangul compatibility Jamo
+        | 0x3400..=0x4DBF      // CJK unified ideographs extension A
+        | 0x4E00..=0x9FFF      // CJK unified ideographs
+        | 0xA960..=0xA97F      // Hangul Jamo extended A
+        | 0xAC00..=0xD7A3      // Hangul syllables
+        | 0xD7B0..=0xD7FF      // Hangul Jamo extended B
+        | 0xF900..=0xFAFF      // CJK compatibility ideographs
+        | 0xFF66..=0xFF9D      // Halfwidth katakana
+    )
+}
+
+#[async_trait]
+impl QCRule for CaptionReadingRateRule {
+    fn name(&self) -> &str {
+        "CaptionReadingRateRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "caption.reading_rate"
+    }
+
+    fn description(&self) -> &str {
+        "Reports captions displayed too briefly for their length, per script"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        _context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+        let mut violations = Vec::new();
+
+        for track in sequence.tracks.iter().filter(|track| track.is_caption()) {
+            for clip in &track.clips {
+                let Some(text) = clip.label.as_ref().map(|label| label.trim()) else {
+                    continue;
+                };
+                if text.is_empty() {
+                    continue;
+                }
+
+                let duration = clip.duration();
+                if duration <= 0.0 {
+                    // Zero-length captions are reported by `clip.orphan`.
+                    continue;
+                }
+
+                let char_count = text.chars().count() as f64;
+                let cps = char_count / duration;
+
+                let script = Self::detect_script(text);
+                let (warn_cps, severe_cps) = Self::thresholds(script);
+                let warn_cps = config.get_param::<f64>("warn_cps").unwrap_or(warn_cps);
+                let severe_cps = config.get_param::<f64>("severe_cps").unwrap_or(severe_cps);
+
+                if cps <= warn_cps {
+                    continue;
+                }
+
+                let qualifier = if cps > severe_cps {
+                    "far above"
+                } else {
+                    "above"
+                };
+
+                violations.push(
+                    QCViolation::new(
+                        self.name(),
+                        severity,
+                        format!(
+                            "Caption reads at {:.1} characters/second, {} the {:.1} limit for {} text",
+                            cps,
+                            qualifier,
+                            warn_cps,
+                            script.as_str()
+                        ),
+                    )
+                    .with_location(clip.place.timeline_in_sec, clip.timeline_end())
+                    .with_entities(vec![clip.id.clone()])
+                    .with_details(format!(
+                        "{:.0} characters in {:.2}s. Script detected as {} (CJK glyphs carry more \
+                         meaning per character, so they use a lower budget). Extend the caption or \
+                         split the line.",
+                        char_count,
+                        duration,
+                        script.as_str()
+                    ))
+                    .with_metric("cps", (cps * 100.0).round() / 100.0)
+                    .with_metric("charCount", char_count)
+                    .with_metric("durationSec", duration)
+                    .with_metric("script", script.as_str())
+                    .with_metric("warnCps", warn_cps)
+                    .with_metric("severeCps", severe_cps),
+                );
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+// =============================================================================
+// CaptionOutOfBoundsRule
+// =============================================================================
+
+/// Rule that reports captions positioned outside the canvas
+///
+/// Distinct from the safe-area rule: this one fires only when the caption is
+/// (partly) off-frame, which crops the text and is objectively broken output.
+#[derive(Debug, Default)]
+pub struct CaptionOutOfBoundsRule;
+
+impl CaptionOutOfBoundsRule {
+    /// Creates a new CaptionOutOfBoundsRule
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Characters that fit across the canvas width at the default font size
+    ///
+    /// Core has no text shaping, so the box is an approximation; the check only
+    /// fires when the box leaves the canvas entirely, which keeps the estimate
+    /// from producing false errors.
+    const CHARS_PER_CANVAS_WIDTH: f64 = 42.0;
+
+    /// Maximum estimated text-box width as a percentage of canvas width
+    const MAX_TEXT_BOX_WIDTH_PERCENT: f64 = 90.0;
+
+    /// Line height as a multiple of the font size
+    const LINE_HEIGHT_FACTOR: f64 = 1.2;
+
+    /// Tolerance in percent for float noise at the canvas edge
+    const EDGE_TOLERANCE_PERCENT: f64 = 0.01;
+
+    /// Estimates the caption box as (width_percent, height_percent).
+    fn estimate_box_percent(clip: &Clip, canvas_height: u32) -> (f64, f64) {
+        let char_count = clip
+            .label
+            .as_ref()
+            .map(|label| label.chars().count())
+            .unwrap_or(0) as f64;
+
+        let width_percent = (char_count / Self::CHARS_PER_CANVAS_WIDTH * 100.0)
+            .min(Self::MAX_TEXT_BOX_WIDTH_PERCENT);
+
+        let canvas_height = if canvas_height > 0 { canvas_height } else { 1 };
+        let font_size = clip
+            .caption_style
+            .as_ref()
+            .and_then(|value| serde_json::from_value::<CaptionStyle>(value.clone()).ok())
+            .map(|style| f64::from(style.font_size))
+            .or_else(|| {
+                clip.caption_style
+                    .as_ref()
+                    .and_then(|value| value.get("fontSize").or_else(|| value.get("font_size")))
+                    .and_then(serde_json::Value::as_f64)
+            })
+            .filter(|size| size.is_finite() && *size > 0.0)
+            .unwrap_or_else(|| f64::from(CaptionStyle::default().font_size));
+
+        let height_percent =
+            font_size * Self::LINE_HEIGHT_FACTOR / f64::from(canvas_height) * 100.0;
+
+        (width_percent, height_percent)
+    }
+
+    /// Returns the caption box edges as (left, right, top, bottom) percentages.
+    fn box_edges(
+        position: &CaptionPosition,
+        box_width: f64,
+        box_height: f64,
+    ) -> (f64, f64, f64, f64) {
+        let (center_x, center_y) = match position {
+            CaptionPosition::Preset {
+                vertical,
+                margin_percent,
+            } => {
+                let center_y = match vertical {
+                    VerticalPosition::Bottom => 100.0 - margin_percent - box_height / 2.0,
+                    VerticalPosition::Top => margin_percent + box_height / 2.0,
+                    VerticalPosition::Center => 50.0,
+                };
+                (50.0, center_y)
+            }
+            CaptionPosition::Custom(custom) => (custom.x_percent, custom.y_percent),
+        };
+
+        (
+            center_x - box_width / 2.0,
+            center_x + box_width / 2.0,
+            center_y - box_height / 2.0,
+            center_y + box_height / 2.0,
+        )
+    }
+}
+
+#[async_trait]
+impl QCRule for CaptionOutOfBoundsRule {
+    fn name(&self) -> &str {
+        "CaptionOutOfBoundsRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "caption.out_of_bounds"
+    }
+
+    fn description(&self) -> &str {
+        "Reports captions whose estimated text box falls outside the canvas"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+        let tolerance = Self::EDGE_TOLERANCE_PERCENT;
+        let mut violations = Vec::new();
+
+        for track in sequence.tracks.iter().filter(|track| track.is_caption()) {
+            for clip in &track.clips {
+                // A missing or unreadable position renders with the caption
+                // default, so the check follows the same fallback.
+                let position = clip
+                    .caption_position
+                    .as_ref()
+                    .and_then(|value| serde_json::from_value::<CaptionPosition>(value.clone()).ok())
+                    .unwrap_or_default();
+
+                let (box_width, box_height) =
+                    Self::estimate_box_percent(clip, context.canvas_height);
+                let (left, right, top, bottom) = Self::box_edges(&position, box_width, box_height);
+
+                if left >= -tolerance
+                    && right <= 100.0 + tolerance
+                    && top >= -tolerance
+                    && bottom <= 100.0 + tolerance
+                {
+                    continue;
+                }
+
+                violations.push(
+                    QCViolation::new(
+                        self.name(),
+                        severity,
+                        "Caption is positioned outside the canvas".to_string(),
+                    )
+                    .with_location(clip.place.timeline_in_sec, clip.timeline_end())
+                    .with_entities(vec![clip.id.clone()])
+                    .with_details(format!(
+                        "Estimated text box spans x {:.1}%-{:.1}%, y {:.1}%-{:.1}%, outside the \
+                         0%-100% canvas. Text outside the frame is cropped away.",
+                        left, right, top, bottom
+                    ))
+                    .with_metric("leftPercent", left)
+                    .with_metric("rightPercent", right)
+                    .with_metric("topPercent", top)
+                    .with_metric("bottomPercent", bottom)
+                    .with_metric("trackId", track.id.clone()),
+                );
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+// =============================================================================
+// ShotLengthStatsRule
+// =============================================================================
+
+/// Rule that always reports shot-length statistics
+///
+/// Emits no judgement, only numbers: an agent comparing two edits needs the
+/// pacing distribution, and a check that never appears in the report is a check
+/// an agent cannot reason about.
+#[derive(Debug, Default)]
+pub struct ShotLengthStatsRule;
+
+impl ShotLengthStatsRule {
+    /// Creates a new ShotLengthStatsRule
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Shot-length distribution over the video clips of a sequence.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ShotLengthStats {
+    /// Number of video clips measured.
+    pub count: usize,
+    /// Shortest clip in seconds.
+    pub min_sec: f64,
+    /// Median clip length in seconds.
+    pub median_sec: f64,
+    /// 90th percentile clip length in seconds.
+    pub p90_sec: f64,
+    /// Longest clip in seconds.
+    pub max_sec: f64,
+    /// Mean clip length in seconds.
+    pub mean_sec: f64,
+    /// Total measured length in seconds.
+    pub total_sec: f64,
+}
+
+/// Computes shot-length statistics from the video clips of a sequence.
+pub fn shot_length_stats(sequence: &Sequence) -> ShotLengthStats {
+    let mut durations: Vec<f64> = sequence
+        .tracks
+        .iter()
+        .filter(|track| track.is_video())
+        .flat_map(|track| track.clips.iter())
+        .filter(|clip| !clip.is_adjustment_layer && clip.duration() > 0.0)
+        .map(|clip| clip.duration())
+        .collect();
+
+    if durations.is_empty() {
+        return ShotLengthStats::default();
+    }
+
+    durations.sort_by(|a, b| a.total_cmp(b));
+
+    let count = durations.len();
+    let total_sec: f64 = durations.iter().sum();
+
+    ShotLengthStats {
+        count,
+        min_sec: durations[0],
+        median_sec: percentile(&durations, 0.5),
+        p90_sec: percentile(&durations, 0.9),
+        max_sec: durations[count - 1],
+        mean_sec: total_sec / count as f64,
+        total_sec,
+    }
+}
+
+/// Returns the nearest-rank percentile of a sorted, non-empty slice.
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let rank = (fraction * sorted.len() as f64).ceil() as usize;
+    let index = rank.clamp(1, sorted.len()) - 1;
+    sorted[index]
+}
+
+#[async_trait]
+impl QCRule for ShotLengthStatsRule {
+    fn name(&self) -> &str {
+        "ShotLengthStatsRule"
+    }
+
+    fn check_id(&self) -> &str {
+        "shot.length_stats"
+    }
+
+    fn description(&self) -> &str {
+        "Reports the shot-length distribution of the sequence"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Info
+    }
+
+    async fn check(
+        &self,
+        sequence: &Sequence,
+        _state: &ProjectState,
+        config: &RuleConfig,
+        _context: &QCContext,
+    ) -> CoreResult<Vec<QCViolation>> {
+        let severity = config.severity_override.unwrap_or(self.default_severity());
+        let stats = shot_length_stats(sequence);
+
+        let message = if stats.count == 0 {
+            "No video clips to measure".to_string()
+        } else {
+            format!(
+                "{} shots, median {:.2}s, p90 {:.2}s, range {:.2}s-{:.2}s",
+                stats.count, stats.median_sec, stats.p90_sec, stats.min_sec, stats.max_sec
+            )
+        };
+
+        let violation = QCViolation::new(self.name(), severity, message)
+            .with_location(0.0, sequence.duration())
+            .with_details("Pacing metrics; no action implied.".to_string())
+            .with_metric("count", stats.count)
+            .with_metric("minSec", stats.min_sec)
+            .with_metric("medianSec", stats.median_sec)
+            .with_metric("p90Sec", stats.p90_sec)
+            .with_metric("maxSec", stats.max_sec)
+            .with_metric("meanSec", stats.mean_sec)
+            .with_metric("totalSec", stats.total_sec);
+
+        Ok(vec![violation])
+    }
+}
+
+// =============================================================================
+// Cross-reference: rendered black ranges vs. structural gaps
+// =============================================================================
+
+/// Re-grades detected black ranges against the structural gaps of a sequence.
+///
+/// Black pixels alone say nothing about intent: a fade-out or title card is
+/// black on purpose, while black over a hole in the timeline is broken output.
+/// Only the combination of both passes can tell them apart, so the regrade
+/// happens here rather than inside either rule:
+///
+/// * black overlapping an uncovered gap becomes [`Severity::Error`]
+/// * black anywhere else drops to [`Severity::Info`]
+///
+/// Black ranges are timed against the measured file while gaps are timed
+/// against the timeline, so this is only meaningful for a render that covers
+/// the whole sequence from zero.
+///
+/// The report's derived counters are recomputed afterwards. Returns the number
+/// of violations that were re-graded.
+pub fn crossref_black_ranges_with_gaps(
+    report: &mut QCReport,
+    sequence: &Sequence,
+    min_gap_sec: f64,
+) -> usize {
+    let black_rule = super::rules::BlackFrameRule::new();
+    let black_rule_name = black_rule.name().to_string();
+
+    if !report
+        .violations
+        .iter()
+        .any(|violation| violation.rule_name == black_rule_name)
+    {
+        return 0;
+    }
+
+    let gaps = uncovered_video_gaps(sequence, min_gap_sec);
+    let mut regraded = 0;
+
+    for violation in report
+        .violations
+        .iter_mut()
+        .filter(|violation| violation.rule_name == black_rule_name)
+    {
+        let Some(location) = violation.location.clone() else {
+            continue;
+        };
+
+        let overlapping = gaps
+            .iter()
+            .find(|gap| location.start_sec < gap.end_sec && location.end_sec > gap.start_sec);
+
+        match overlapping {
+            Some(gap) => {
+                violation.severity = Severity::Error;
+                violation.details = Some(format!(
+                    "Black covers a {:.2}s gap at {:.2}s on track '{}', so the program is \
+                     missing picture here.",
+                    gap.duration_sec(),
+                    gap.start_sec,
+                    gap.track_name
+                ));
+                violation
+                    .metrics
+                    .insert("overlapsGap".to_string(), serde_json::Value::Bool(true));
+                violation.affected_entities.push(gap.track_id.clone());
+            }
+            None => {
+                violation.severity = Severity::Info;
+                violation.details = Some(
+                    "No timeline gap covers this range, so the black is most likely a fade or \
+                     title card."
+                        .to_string(),
+                );
+                violation
+                    .metrics
+                    .insert("overlapsGap".to_string(), serde_json::Value::Bool(false));
+            }
+        }
+
+        regraded += 1;
+    }
+
+    report.recompute();
+    regraded
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::assets::{Asset, AudioInfo, VideoInfo};
+    use crate::core::qc::context::RenderMeasurements;
+    use crate::core::timeline::SequenceFormat;
+
+    // ========================================================================
+    // Fixtures
+    // ========================================================================
+
+    fn sequence_30fps() -> Sequence {
+        Sequence::new("QC Structural", SequenceFormat::youtube_1080())
+    }
+
+    fn context_for(sequence: &Sequence) -> QCContext {
+        QCContext::from_sequence(sequence)
+    }
+
+    fn video_clip(asset_id: &str, timeline_in: f64, duration: f64) -> Clip {
+        let mut clip = Clip::with_range(asset_id, 0.0, duration);
+        clip.place.timeline_in_sec = timeline_in;
+        clip.place.duration_sec = duration;
+        clip
+    }
+
+    fn caption_clip(text: &str, timeline_in: f64, duration: f64) -> Clip {
+        let mut clip = Clip::with_range(CAPTION_VIRTUAL_ASSET_ID, 0.0, duration);
+        clip.place.timeline_in_sec = timeline_in;
+        clip.place.duration_sec = duration;
+        clip.label = Some(text.to_string());
+        clip
+    }
+
+    fn video_asset(id: &str, with_audio: bool) -> Asset {
+        let mut asset = Asset::new_video(
+            "clip.mp4",
+            "clip.mp4",
+            VideoInfo {
+                width: 1920,
+                height: 1080,
+                codec: "h264".to_string(),
+                ..Default::default()
+            },
+        );
+        asset.id = id.to_string();
+        if with_audio {
+            asset.audio = Some(AudioInfo {
+                sample_rate: 48_000,
+                channels: 2,
+                codec: "aac".to_string(),
+                bitrate: None,
+            });
+        }
+        asset
+    }
+
+    fn state_with(assets: Vec<Asset>) -> ProjectState {
+        let mut state = ProjectState::new("QC Structural");
+        for asset in assets {
+            state.assets.insert(asset.id.clone(), asset);
+        }
+        state
+    }
+
+    // ========================================================================
+    // Coverage helpers
+    // ========================================================================
+
+    #[test]
+    fn test_subtract_coverage_should_return_the_whole_span_when_uncovered() {
+        assert_eq!(subtract_coverage(1.0, 3.0, &[]), vec![(1.0, 3.0)]);
+    }
+
+    #[test]
+    fn test_subtract_coverage_should_remove_a_fully_covered_span() {
+        assert!(subtract_coverage(1.0, 3.0, &[(0.0, 5.0)]).is_empty());
+    }
+
+    #[test]
+    fn test_subtract_coverage_should_split_around_partial_coverage() {
+        assert_eq!(
+            subtract_coverage(0.0, 10.0, &[(3.0, 6.0)]),
+            vec![(0.0, 3.0), (6.0, 10.0)]
+        );
+    }
+
+    // ========================================================================
+    // TimelineGapRule
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_gap_rule_should_report_an_uncovered_gap_as_an_error() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 0.0, 2.0));
+        track.add_clip(video_clip("asset_1", 3.0, 2.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Error);
+        let location = violations[0].location.as_ref().expect("location");
+        assert!((location.start_sec - 2.0).abs() < 1e-9);
+        assert!((location.end_sec - 3.0).abs() < 1e-9);
+        assert!(violations[0].auto_fixable);
+        assert_eq!(
+            violations[0].suggested_fix.as_ref().expect("fix").commands[0]["type"],
+            "CloseGap"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gap_rule_should_ignore_a_gap_covered_by_another_video_track() {
+        let mut sequence = sequence_30fps();
+        let mut overlay = Track::new_video("V2");
+        overlay.add_clip(video_clip("asset_1", 0.0, 2.0));
+        overlay.add_clip(video_clip("asset_1", 3.0, 2.0));
+        sequence.add_track(overlay);
+
+        let mut base = Track::new_video("V1");
+        base.add_clip(video_clip("asset_1", 0.0, 5.0));
+        sequence.add_track(base);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(
+            violations.is_empty(),
+            "a gap under an uninterrupted base track is not a hole"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gap_rule_should_ignore_sub_frame_gaps() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 0.0, 2.0));
+        track.add_clip(video_clip("asset_1", 2.001, 2.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    // ========================================================================
+    // ClipOrphanRule
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_orphan_rule_should_report_clips_under_two_frames() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 0.0, 0.02));
+        track.add_clip(video_clip("asset_1", 1.0, 2.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = ClipOrphanRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+        assert_eq!(
+            violations[0].suggested_fix.as_ref().expect("fix").commands[0]["type"],
+            "RemoveClip"
+        );
+    }
+
+    // ========================================================================
+    // MissingAssetRule
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_missing_asset_rule_should_report_unknown_and_missing_assets() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_unknown", 0.0, 2.0));
+        track.add_clip(video_clip("asset_gone", 2.0, 2.0));
+        track.add_clip(video_clip("asset_ok", 4.0, 2.0));
+        sequence.add_track(track);
+
+        let mut gone = video_asset("asset_gone", false);
+        gone.missing = true;
+        let state = state_with(vec![gone, video_asset("asset_ok", false)]);
+
+        let context = context_for(&sequence);
+        let violations = MissingAssetRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 2);
+        assert!(violations
+            .iter()
+            .all(|violation| violation.severity == Severity::Critical));
+    }
+
+    #[tokio::test]
+    async fn test_missing_asset_rule_should_ignore_virtual_clips() {
+        let mut sequence = sequence_30fps();
+        let mut captions = Track::new_caption("C1");
+        captions.add_clip(caption_clip("Hello", 0.0, 2.0));
+        sequence.add_track(captions);
+
+        let mut video = Track::new_video("V1");
+        video.add_clip(video_clip("__text__title", 0.0, 2.0));
+        sequence.add_track(video);
+
+        let context = context_for(&sequence);
+        let violations = MissingAssetRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    // ========================================================================
+    // SilentClipRule
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_silent_clip_rule_should_report_a_muted_audio_bearing_clip() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        let mut clip = video_clip("asset_a", 0.0, 2.0);
+        clip.audio.muted = true;
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let state = state_with(vec![video_asset("asset_a", true)]);
+        let context = context_for(&sequence);
+
+        let violations = SilentClipRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+    }
+
+    #[tokio::test]
+    async fn test_silent_clip_rule_should_ignore_clips_without_audio() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        let mut clip = video_clip("asset_a", 0.0, 2.0);
+        clip.audio.muted = true;
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let state = state_with(vec![video_asset("asset_a", false)]);
+        let context = context_for(&sequence);
+
+        let violations = SilentClipRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_silent_clip_rule_should_ignore_a_muted_clip_with_automation() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_audio("A1");
+        let mut clip = video_clip("asset_a", 0.0, 2.0);
+        clip.audio.volume_db = -60.0;
+        clip.audio.volume_keyframes = vec![crate::core::timeline::AudioKeyframe::new(
+            0.5,
+            0.0,
+            crate::core::timeline::KeyframeInterpolation::default(),
+        )];
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let state = state_with(vec![video_asset("asset_a", true)]);
+        let context = context_for(&sequence);
+
+        let violations = SilentClipRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    // ========================================================================
+    // CaptionOverlapRule
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_caption_overlap_rule_should_report_colliding_captions() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_caption("C1");
+        track.add_clip(caption_clip("First", 0.0, 2.0));
+        track.add_clip(caption_clip("Second", 1.5, 2.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = CaptionOverlapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Error);
+        let location = violations[0].location.as_ref().expect("location");
+        assert!((location.start_sec - 1.5).abs() < 1e-9);
+        assert!((location.end_sec - 2.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn test_caption_overlap_rule_should_accept_back_to_back_captions() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_caption("C1");
+        track.add_clip(caption_clip("First", 0.0, 2.0));
+        track.add_clip(caption_clip("Second", 2.0, 2.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = CaptionOverlapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    // ========================================================================
+    // CaptionReadingRateRule
+    // ========================================================================
+
+    #[test]
+    fn test_detect_script_should_classify_latin_and_cjk_text() {
+        assert_eq!(
+            CaptionReadingRateRule::detect_script("The quick brown fox"),
+            CaptionScript::Latin
+        );
+        assert_eq!(
+            CaptionReadingRateRule::detect_script("안녕하세요 여러분"),
+            CaptionScript::Cjk
+        );
+        assert_eq!(
+            CaptionReadingRateRule::detect_script("これはテストです"),
+            CaptionScript::Cjk
+        );
+        // A stray loanword must not flip a Korean caption to Latin thresholds.
+        assert_eq!(
+            CaptionReadingRateRule::detect_script("오늘의 AI 뉴스입니다"),
+            CaptionScript::Cjk
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reading_rate_rule_should_use_latin_thresholds_for_latin_text() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_caption("C1");
+        // 30 characters in 1s => 30 cps, above the 20 cps Latin limit.
+        track.add_clip(caption_clip("abcdefghij abcdefghij abcdefg", 0.0, 1.0));
+        // 15 characters in 1s => 15 cps, comfortable for Latin.
+        track.add_clip(caption_clip("abcdefghij abcd", 2.0, 1.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = CaptionReadingRateRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+        assert_eq!(violations[0].metrics["script"], "latin");
+    }
+
+    #[tokio::test]
+    async fn test_reading_rate_rule_should_use_cjk_thresholds_for_korean_text() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_caption("C1");
+        // 15 Hangul characters in 1s: fine for Latin, far too fast for CJK.
+        track.add_clip(caption_clip("가나다라마바사아자차카타파하가", 0.0, 1.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = CaptionReadingRateRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].metrics["script"], "cjk");
+        assert_eq!(violations[0].metrics["warnCps"], 9.0);
+    }
+
+    // ========================================================================
+    // CaptionOutOfBoundsRule
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_out_of_bounds_rule_should_report_a_caption_off_canvas() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_caption("C1");
+        let mut clip = caption_clip("Way off", 0.0, 2.0);
+        clip.caption_position = Some(serde_json::json!({
+            "type": "custom",
+            "xPercent": 120.0,
+            "yPercent": 50.0
+        }));
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = CaptionOutOfBoundsRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Error);
+    }
+
+    #[tokio::test]
+    async fn test_out_of_bounds_rule_should_accept_default_positions() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_caption("C1");
+        track.add_clip(caption_clip("Perfectly normal caption", 0.0, 2.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = CaptionOutOfBoundsRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty());
+    }
+
+    // ========================================================================
+    // ShotLengthStatsRule
+    // ========================================================================
+
+    #[test]
+    fn test_shot_length_stats_should_describe_the_distribution() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        for (index, duration) in [1.0, 2.0, 3.0, 10.0].iter().enumerate() {
+            track.add_clip(video_clip("asset_1", index as f64 * 20.0, *duration));
+        }
+        sequence.add_track(track);
+
+        let stats = shot_length_stats(&sequence);
+
+        assert_eq!(stats.count, 4);
+        assert!((stats.min_sec - 1.0).abs() < 1e-9);
+        assert!((stats.median_sec - 2.0).abs() < 1e-9);
+        assert!((stats.p90_sec - 10.0).abs() < 1e-9);
+        assert!((stats.max_sec - 10.0).abs() < 1e-9);
+        assert!((stats.total_sec - 16.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn test_shot_length_stats_rule_should_always_emit_metrics() {
+        let sequence = sequence_30fps();
+        let context = context_for(&sequence);
+
+        let violations = ShotLengthStatsRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Info);
+        assert_eq!(violations[0].metrics["count"], 0);
+    }
+
+    // ========================================================================
+    // Cross-reference
+    // ========================================================================
+
+    async fn report_with_black_range(sequence: &Sequence, range: (f64, f64)) -> QCReport {
+        let mut engine = super::super::engine::QCEngine::new();
+        let mut config = super::super::engine::QCEngineConfig::default();
+        for name in engine
+            .rule_names()
+            .into_iter()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>()
+        {
+            if name != "BlackFrameRule" {
+                config.disable_rule(&name);
+            }
+        }
+        engine.set_config(config).await;
+        // Keep the engine binding mutable-free after configuration.
+        let _ = &mut engine;
+
+        engine
+            .check_with_measurements(
+                sequence,
+                &ProjectState::new("p"),
+                RenderMeasurements {
+                    black_ranges: vec![range],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("check runs")
+    }
+
+    #[tokio::test]
+    async fn test_crossref_should_escalate_black_over_a_gap_to_error() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 0.0, 2.0));
+        track.add_clip(video_clip("asset_1", 3.0, 2.0));
+        sequence.add_track(track);
+
+        let mut report = report_with_black_range(&sequence, (2.0, 3.0)).await;
+        let regraded = crossref_black_ranges_with_gaps(&mut report, &sequence, 1.0 / 30.0);
+
+        assert_eq!(regraded, 1);
+        assert_eq!(report.violations[0].severity, Severity::Error);
+        assert_eq!(report.violations[0].metrics["overlapsGap"], true);
+        assert!(!report.passed);
+    }
+
+    #[tokio::test]
+    async fn test_crossref_should_demote_intentional_black_to_info() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 0.0, 5.0));
+        sequence.add_track(track);
+
+        let mut report = report_with_black_range(&sequence, (0.0, 1.0)).await;
+        let regraded = crossref_black_ranges_with_gaps(&mut report, &sequence, 1.0 / 30.0);
+
+        assert_eq!(regraded, 1);
+        assert_eq!(report.violations[0].severity, Severity::Info);
+        assert_eq!(report.violations[0].metrics["overlapsGap"], false);
+        assert!(report.passed);
+    }
+}

--- a/src-tauri/src/core/qc/structural.rs
+++ b/src-tauri/src/core/qc/structural.rs
@@ -52,6 +52,12 @@ pub struct UncoveredGap {
     pub gap_start_sec: f64,
     /// End of the enclosing track gap.
     pub gap_end_sec: f64,
+    /// Whether rippling the following clips left would remove this hole.
+    ///
+    /// A hole between clips closes when everything after it moves left, but a
+    /// hole past the last video clip has nothing to pull in, so it carries no
+    /// [`CloseGap`](crate::core::commands::CloseGapCommand) fix.
+    pub closable: bool,
 }
 
 impl UncoveredGap {
@@ -71,12 +77,15 @@ fn is_virtual_clip(clip: &Clip) -> bool {
 }
 
 /// Collects the timeline spans covered by enabled clips on the given tracks.
+///
+/// `exclude_track_id` drops one track from the calculation, which is how a
+/// track's own gaps are measured against everything else.
 fn covered_spans<'a>(
     tracks: impl Iterator<Item = &'a Track>,
-    exclude_track_id: &str,
+    exclude_track_id: Option<&str>,
 ) -> Vec<(f64, f64)> {
     let mut spans: Vec<(f64, f64)> = tracks
-        .filter(|track| track.id != exclude_track_id && track.visible)
+        .filter(|track| exclude_track_id != Some(track.id.as_str()) && track.visible)
         .flat_map(|track| track.clips.iter())
         .filter(|clip| clip.enabled && clip.duration() > 0.0)
         .map(|clip| (clip.place.timeline_in_sec, clip.timeline_end()))
@@ -124,6 +133,17 @@ fn subtract_coverage(start: f64, end: f64, covered: &[(f64, f64)]) -> Vec<(f64, 
 ///
 /// A gap on an overlay track above a continuous base track is not a hole in the
 /// program, so only the uncovered remainder is reported.
+///
+/// Three kinds of hole are reported:
+///
+/// * gaps between clips on a track (from [`find_gaps`]),
+/// * a head gap before the first video clip in the sequence,
+/// * a tail gap between the last video clip and the end of the sequence.
+///
+/// The last two are invisible to [`find_gaps`], which only walks pairs of
+/// clips, yet both render as black: a sequence whose picture starts at 2.0 s
+/// opens on two seconds of nothing, and audio or captions running past the last
+/// video clip extend the program over an empty canvas.
 pub fn uncovered_video_gaps(sequence: &Sequence, min_gap_sec: f64) -> Vec<UncoveredGap> {
     let mut uncovered = Vec::new();
 
@@ -135,7 +155,7 @@ pub fn uncovered_video_gaps(sequence: &Sequence, min_gap_sec: f64) -> Vec<Uncove
 
         let covered = covered_spans(
             sequence.tracks.iter().filter(|other| other.is_video()),
-            &track.id,
+            Some(&track.id),
         );
 
         for gap in gaps {
@@ -150,12 +170,107 @@ pub fn uncovered_video_gaps(sequence: &Sequence, min_gap_sec: f64) -> Vec<Uncove
                     end_sec,
                     gap_start_sec: gap.start,
                     gap_end_sec: gap.end,
+                    closable: true,
                 });
             }
         }
     }
 
+    uncovered.extend(program_edge_gaps(sequence, min_gap_sec));
     uncovered
+}
+
+/// One end of the program's video coverage, and the track that defines it.
+struct CoverageEdge<'a> {
+    time_sec: f64,
+    track: &'a Track,
+}
+
+/// Returns the first and last moment any visible video track shows a picture.
+///
+/// Returns `None` when no video track carries a usable clip: an audio-only
+/// sequence has no picture to be missing, so it is not graded here.
+fn video_coverage_edges(sequence: &Sequence) -> Option<(CoverageEdge<'_>, CoverageEdge<'_>)> {
+    let mut earliest: Option<CoverageEdge> = None;
+    let mut latest: Option<CoverageEdge> = None;
+
+    for track in sequence
+        .tracks
+        .iter()
+        .filter(|track| track.is_video() && track.visible)
+    {
+        for clip in track
+            .clips
+            .iter()
+            .filter(|clip| clip.enabled && clip.duration() > 0.0)
+        {
+            let start_sec = clip.place.timeline_in_sec;
+            let end_sec = clip.timeline_end();
+
+            if earliest
+                .as_ref()
+                .is_none_or(|edge| start_sec < edge.time_sec)
+            {
+                earliest = Some(CoverageEdge {
+                    time_sec: start_sec,
+                    track,
+                });
+            }
+            if latest.as_ref().is_none_or(|edge| end_sec > edge.time_sec) {
+                latest = Some(CoverageEdge {
+                    time_sec: end_sec,
+                    track,
+                });
+            }
+        }
+    }
+
+    Some((earliest?, latest?))
+}
+
+/// Reports black before the first and after the last video clip.
+///
+/// Both spans are uncovered by construction — they sit outside the union of
+/// every video track's coverage — so no subtraction is needed. The trailing
+/// span is measured against [`Sequence::duration`], which follows the longest
+/// track of any kind: audio or captions running past the picture keep the
+/// program alive over an empty canvas.
+fn program_edge_gaps(sequence: &Sequence, min_gap_sec: f64) -> Vec<UncoveredGap> {
+    let Some((earliest, latest)) = video_coverage_edges(sequence) else {
+        return Vec::new();
+    };
+
+    let mut gaps = Vec::new();
+
+    if earliest.time_sec >= min_gap_sec {
+        gaps.push(UncoveredGap {
+            track_id: earliest.track.id.clone(),
+            track_name: earliest.track.name.clone(),
+            start_sec: 0.0,
+            end_sec: earliest.time_sec,
+            gap_start_sec: 0.0,
+            gap_end_sec: earliest.time_sec,
+            // Rippling the clips left starts the picture at zero.
+            closable: true,
+        });
+    }
+
+    let program_end_sec = sequence.duration();
+    if program_end_sec - latest.time_sec >= min_gap_sec {
+        gaps.push(UncoveredGap {
+            track_id: latest.track.id.clone(),
+            track_name: latest.track.name.clone(),
+            start_sec: latest.time_sec,
+            end_sec: program_end_sec,
+            gap_start_sec: latest.time_sec,
+            gap_end_sec: program_end_sec,
+            // Nothing follows the last clip, so there is nothing to ripple in;
+            // the fix is to shorten the other tracks or extend the picture.
+            closable: false,
+        });
+    }
+
+    gaps
 }
 
 // =============================================================================
@@ -187,7 +302,7 @@ impl QCRule for TimelineGapRule {
     }
 
     fn description(&self) -> &str {
-        "Reports gaps between clips on video tracks that no other track covers"
+        "Reports ranges no video track covers, including before the first and after the last clip"
     }
 
     fn default_severity(&self) -> Severity {
@@ -210,7 +325,7 @@ impl QCRule for TimelineGapRule {
         let violations = uncovered_video_gaps(sequence, min_gap_sec)
             .into_iter()
             .map(|gap| {
-                QCViolation::new(
+                let violation = QCViolation::new(
                     self.name(),
                     severity,
                     format!(
@@ -226,8 +341,15 @@ impl QCRule for TimelineGapRule {
                     "Nothing covers this range, so the program renders black here.".to_string(),
                 )
                 .with_metric("gapSec", gap.duration_sec())
-                .with_metric("trackId", gap.track_id.clone())
-                .with_fix(
+                .with_metric("trackId", gap.track_id.clone());
+
+                if !gap.closable {
+                    // Trailing black has no following clip to ripple in, so
+                    // offering CloseGap would suggest a no-op.
+                    return violation;
+                }
+
+                violation.with_fix(
                     ViolationFix::new(
                         format!("Close the gap on track '{}'", gap.track_name),
                         vec![serde_json::json!({
@@ -1170,7 +1292,12 @@ impl QCRule for ShotLengthStatsRule {
 /// happens here rather than inside either rule:
 ///
 /// * black overlapping an uncovered gap becomes [`Severity::Error`]
-/// * black anywhere else drops to [`Severity::Info`]
+/// * black anywhere else drops to [`Severity::Info`] and is reported without a
+///   verdict — nothing here can distinguish a deliberate fade from footage that
+///   simply went dark, so the details state the fact and leave the call open
+///
+/// Uncovered gaps include the head and tail of the program (see
+/// [`uncovered_video_gaps`]), so black at either end still grades as an error.
 ///
 /// Black ranges are timed against the measured file while gaps are timed
 /// against the timeline, so this is only meaningful for a render that covers
@@ -1228,8 +1355,8 @@ pub fn crossref_black_ranges_with_gaps(
             None => {
                 violation.severity = Severity::Info;
                 violation.details = Some(
-                    "No timeline gap covers this range, so the black is most likely a fade or \
-                     title card."
+                    "No timeline gap overlaps this range; if this black is not an intentional \
+                     fade or title card, inspect the timeline."
                         .to_string(),
                 );
                 violation
@@ -1398,6 +1525,126 @@ mod tests {
             violations.is_empty(),
             "a gap under an uninterrupted base track is not a hole"
         );
+    }
+
+    /// Feature: Uncovered video gaps
+    /// Scenario: should report black before the first video clip
+    #[tokio::test]
+    async fn test_gap_rule_should_report_black_before_the_first_clip() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 2.0, 5.0));
+        sequence.add_track(track);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Error);
+        let location = violations[0].location.as_ref().expect("location");
+        assert!((location.start_sec - 0.0).abs() < 1e-9);
+        assert!((location.end_sec - 2.0).abs() < 1e-9);
+        assert!(
+            violations[0].auto_fixable,
+            "rippling the clips left removes a head gap"
+        );
+        assert_eq!(
+            violations[0].suggested_fix.as_ref().expect("fix").commands[0]["gapStart"],
+            0.0
+        );
+    }
+
+    /// Feature: Uncovered video gaps
+    /// Scenario: should report black after the last video clip when audio runs longer
+    #[tokio::test]
+    async fn test_gap_rule_should_report_black_after_the_last_video_clip() {
+        let mut sequence = sequence_30fps();
+        let mut video = Track::new_video("V1");
+        video.add_clip(video_clip("asset_1", 0.0, 4.0));
+        sequence.add_track(video);
+
+        let mut audio = Track::new_audio("A1");
+        audio.add_clip(video_clip("asset_1", 0.0, 9.0));
+        sequence.add_track(audio);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Error);
+        let location = violations[0].location.as_ref().expect("location");
+        assert!((location.start_sec - 4.0).abs() < 1e-9);
+        assert!((location.end_sec - 9.0).abs() < 1e-9);
+        assert!(
+            !violations[0].auto_fixable,
+            "nothing follows the last clip, so CloseGap would be a no-op"
+        );
+    }
+
+    /// Feature: Uncovered video gaps
+    /// Scenario: should stay quiet when the picture spans the whole program
+    #[tokio::test]
+    async fn test_gap_rule_should_ignore_edges_when_video_covers_the_program() {
+        let mut sequence = sequence_30fps();
+        let mut video = Track::new_video("V1");
+        video.add_clip(video_clip("asset_1", 0.0, 6.0));
+        sequence.add_track(video);
+
+        let mut audio = Track::new_audio("A1");
+        audio.add_clip(video_clip("asset_1", 0.0, 6.0));
+        sequence.add_track(audio);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty(), "got: {violations:?}");
+    }
+
+    /// Feature: Uncovered video gaps
+    /// Scenario: should not grade an audio-only sequence as missing picture
+    #[tokio::test]
+    async fn test_gap_rule_should_ignore_a_sequence_without_video_clips() {
+        let mut sequence = sequence_30fps();
+        let mut audio = Track::new_audio("A1");
+        audio.add_clip(video_clip("asset_1", 0.0, 8.0));
+        sequence.add_track(audio);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(violations.is_empty(), "got: {violations:?}");
     }
 
     #[tokio::test]
@@ -1865,5 +2112,27 @@ mod tests {
         assert_eq!(report.violations[0].severity, Severity::Info);
         assert_eq!(report.violations[0].metrics["overlapsGap"], false);
         assert!(report.passed);
+    }
+
+    /// Feature: Cross-referenced black detection
+    /// Scenario: should keep black over a head gap graded as an error
+    #[tokio::test]
+    async fn test_crossref_should_escalate_black_over_a_head_gap_to_error() {
+        let mut sequence = sequence_30fps();
+        let mut track = Track::new_video("V1");
+        track.add_clip(video_clip("asset_1", 2.0, 5.0));
+        sequence.add_track(track);
+
+        let mut report = report_with_black_range(&sequence, (0.0, 2.0)).await;
+        let regraded = crossref_black_ranges_with_gaps(&mut report, &sequence, 1.0 / 30.0);
+
+        assert_eq!(regraded, 1);
+        assert_eq!(
+            report.violations[0].severity,
+            Severity::Error,
+            "black over a two-second head gap is missing picture, not a title card"
+        );
+        assert_eq!(report.violations[0].metrics["overlapsGap"], true);
+        assert!(!report.passed);
     }
 }

--- a/src-tauri/src/core/qc/structural.rs
+++ b/src-tauri/src/core/qc/structural.rs
@@ -129,10 +129,11 @@ fn subtract_coverage(start: f64, end: f64, covered: &[(f64, f64)]) -> Vec<(f64, 
     remaining
 }
 
-/// Finds gaps on video tracks that no other video track fills.
+/// Finds gaps on visible video tracks that no other visible video track fills.
 ///
 /// A gap on an overlay track above a continuous base track is not a hole in the
-/// program, so only the uncovered remainder is reported.
+/// program, so only the uncovered remainder is reported. Hidden tracks are
+/// ignored on both sides: they neither contribute gaps nor count as coverage.
 ///
 /// Three kinds of hole are reported:
 ///
@@ -147,7 +148,14 @@ fn subtract_coverage(start: f64, end: f64, covered: &[(f64, f64)]) -> Vec<(f64, 
 pub fn uncovered_video_gaps(sequence: &Sequence, min_gap_sec: f64) -> Vec<UncoveredGap> {
     let mut uncovered = Vec::new();
 
-    for track in sequence.tracks.iter().filter(|track| track.is_video()) {
+    // Hidden tracks show nothing, so their gaps are not holes in the program.
+    // `covered_spans` already ignores them on the coverage side; collecting
+    // their gaps here would report holes in a track the viewer never sees.
+    for track in sequence
+        .tracks
+        .iter()
+        .filter(|track| track.is_video() && track.visible)
+    {
         let gaps = find_gaps(track);
         if gaps.is_empty() {
             continue;
@@ -1524,6 +1532,34 @@ mod tests {
         assert!(
             violations.is_empty(),
             "a gap under an uninterrupted base track is not a hole"
+        );
+    }
+
+    /// Feature: Uncovered video gaps
+    /// Scenario: should ignore a hidden track on both sides of the calculation
+    #[tokio::test]
+    async fn test_gap_rule_should_ignore_gaps_on_a_hidden_track() {
+        let mut sequence = sequence_30fps();
+        let mut hidden = Track::new_video("V1");
+        hidden.visible = false;
+        hidden.add_clip(video_clip("asset_1", 0.0, 2.0));
+        hidden.add_clip(video_clip("asset_1", 3.0, 2.0));
+        sequence.add_track(hidden);
+
+        let context = context_for(&sequence);
+        let violations = TimelineGapRule::new()
+            .check(
+                &sequence,
+                &ProjectState::new("p"),
+                &RuleConfig::default(),
+                &context,
+            )
+            .await
+            .expect("rule runs");
+
+        assert!(
+            violations.is_empty(),
+            "a hidden track shows nothing, so its gaps are not holes in the program"
         );
     }
 

--- a/src-tauri/src/core/qc/violation.rs
+++ b/src-tauri/src/core/qc/violation.rs
@@ -134,6 +134,12 @@ pub struct QCViolation {
     pub details: Option<String>,
     /// Affected entity IDs (clip_id, track_id, etc.)
     pub affected_entities: Vec<String>,
+    /// Machine-readable measurements behind this violation
+    ///
+    /// Keeps numbers out of prose: an agent reading the report can act on
+    /// `{"gapSec": 1.5}` without parsing [`QCViolation::message`].
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub metrics: std::collections::BTreeMap<String, serde_json::Value>,
     /// Whether this violation can be automatically fixed
     pub auto_fixable: bool,
     /// Suggested fix (if available)
@@ -155,6 +161,7 @@ impl QCViolation {
             message: message.into(),
             details: None,
             affected_entities: Vec::new(),
+            metrics: std::collections::BTreeMap::new(),
             auto_fixable: false,
             suggested_fix: None,
         }
@@ -175,6 +182,16 @@ impl QCViolation {
     /// Adds affected entity IDs
     pub fn with_entities(mut self, entities: Vec<String>) -> Self {
         self.affected_entities = entities;
+        self
+    }
+
+    /// Adds a single machine-readable metric
+    pub fn with_metric(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        self.metrics.insert(key.into(), value.into());
         self
     }
 

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -4411,18 +4411,21 @@ impl ExportEngine {
 
         // FFmpeg exits successfully but writes nothing when the seek lands past
         // the end of the source media, so a missing file is reported as a
-        // seek-out-of-range error instead of a bare IO error.
-        let metadata = tokio::fs::metadata(&settings.output_path)
-            .await
-            .map_err(|_| {
-                ExportError::InvalidSettings(format!(
+        // seek-out-of-range error instead of a bare IO error. Every other IO
+        // failure (permissions, a removed output directory) keeps its own cause.
+        let metadata = match tokio::fs::metadata(&settings.output_path).await {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(ExportError::InvalidSettings(format!(
                     "No frame was produced at time {:.3}s (source time {:.3}s in '{}'). \
                      The requested position is likely past the end of the source media.",
                     settings.time_sec,
                     source_time,
                     asset_path.display()
-                ))
-            })?;
+                )));
+            }
+            Err(error) => return Err(ExportError::IoError(error)),
+        };
         let file_size = metadata.len();
 
         // Source dimensions come from the asset's video stream when known,

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -1404,6 +1404,13 @@ pub struct FrameExportSettings {
     pub output_path: PathBuf,
     /// Optional JPEG quality (1-31, lower = better; only used for JPEG)
     pub quality: Option<u8>,
+    /// Optional maximum output width in pixels.
+    ///
+    /// `None` exports at the source's native resolution. When set, the frame is
+    /// downscaled to at most this width with the aspect ratio preserved;
+    /// narrower sources are never upscaled.
+    #[serde(default)]
+    pub max_width: Option<u32>,
 }
 
 impl FrameExportSettings {
@@ -1428,8 +1435,66 @@ impl FrameExportSettings {
             }
         }
 
+        if let Some(max_width) = self.max_width {
+            if max_width == 0 {
+                return Err(ExportError::InvalidSettings(
+                    "Maximum width must be greater than zero".to_string(),
+                ));
+            }
+        }
+
         Ok(())
     }
+}
+
+/// Computes the output dimensions of FFmpeg's `scale='min(max_width,iw)':-2`.
+///
+/// The width is clamped to `max_width` (never upscaled) and the height keeps
+/// the source aspect ratio rounded to the nearest even number, mirroring how
+/// FFmpeg resolves a `-2` dimension. `None` leaves the source size untouched.
+pub fn scaled_frame_dimensions(
+    src_width: u32,
+    src_height: u32,
+    max_width: Option<u32>,
+) -> (u32, u32) {
+    let Some(max_width) = max_width else {
+        return (src_width, src_height);
+    };
+    if src_width == 0 || src_height == 0 || max_width == 0 {
+        return (src_width, src_height);
+    }
+
+    let out_width = max_width.min(src_width);
+    // FFmpeg computes `av_rescale(out_width, src_height, src_width * 2) * 2`,
+    // i.e. a half-up rounded number of even steps.
+    let numerator = out_width as u64 * src_height as u64;
+    let denominator = src_width as u64 * 2;
+    let even_steps = (numerator + denominator / 2) / denominator;
+    let out_height = (even_steps * 2).max(2).min(u32::MAX as u64) as u32;
+
+    (out_width, out_height)
+}
+
+/// Reads the real pixel dimensions of a written image via FFprobe.
+///
+/// Returns `None` when probing fails or reports no usable video stream so
+/// callers can fall back to computed dimensions.
+pub async fn probed_image_dimensions(ffmpeg: &FFmpegRunner, path: &Path) -> Option<(u32, u32)> {
+    ffmpeg
+        .probe(path)
+        .await
+        .ok()
+        .and_then(|info| info.video)
+        .map(|video| (video.width, video.height))
+        .filter(|(width, height)| *width > 0 && *height > 0)
+}
+
+/// Maps a timeline time to the corresponding source-media time inside `clip`.
+///
+/// Accounts for the clip's timeline placement, source in-point and speed.
+pub fn clip_source_time_at(clip: &Clip, timeline_time_sec: f64) -> f64 {
+    let clip_relative_time = timeline_time_sec - clip.place.timeline_in_sec;
+    clip.range.source_in_sec + (clip_relative_time * clip.speed as f64)
 }
 
 /// Result of a single-frame export
@@ -4055,9 +4120,7 @@ impl ExportEngine {
 
         // Calculate the source time within the asset, accounting for
         // the clip's timeline position and source offset.
-        let clip_relative_time = settings.time_sec - clip.place.timeline_in_sec;
-        let speed = clip.speed as f64;
-        let source_time = clip.range.source_in_sec + (clip_relative_time * speed);
+        let source_time = clip_source_time_at(clip, settings.time_sec);
 
         // Resolve asset path
         let asset_path = Path::new(&asset.uri);
@@ -4086,6 +4149,13 @@ impl ExportEngine {
             "-frames:v".to_string(),
             "1".to_string(),
         ];
+
+        // Downscale-only filter: sources narrower than the limit stay native.
+        // The quotes protect the comma from the filtergraph separator.
+        if let Some(max_width) = settings.max_width {
+            args.push("-vf".to_string());
+            args.push(format!("scale='min({},iw)':-2", max_width));
+        }
 
         // Format-specific arguments
         match settings.format {
@@ -4134,17 +4204,34 @@ impl ExportEngine {
                 other => other,
             })?;
 
-        // Read output file metadata
-        let metadata = tokio::fs::metadata(&settings.output_path).await?;
+        // FFmpeg exits successfully but writes nothing when the seek lands past
+        // the end of the source media, so a missing file is reported as a
+        // seek-out-of-range error instead of a bare IO error.
+        let metadata = tokio::fs::metadata(&settings.output_path)
+            .await
+            .map_err(|_| {
+                ExportError::InvalidSettings(format!(
+                    "No frame was produced at time {:.3}s (source time {:.3}s in '{}'). \
+                     The requested position is likely past the end of the source media.",
+                    settings.time_sec, source_time, asset.uri
+                ))
+            })?;
         let file_size = metadata.len();
 
-        // The frame is extracted at the source asset's native resolution.
-        // Use asset video dimensions if available, otherwise fall back to sequence canvas.
-        let (width, height) = if let Some(ref video) = asset.video {
+        // Source dimensions come from the asset's video stream when known,
+        // otherwise the sequence canvas is the best available approximation.
+        let (source_width, source_height) = if let Some(ref video) = asset.video {
             (video.width, video.height)
         } else {
             (sequence.format.canvas.width, sequence.format.canvas.height)
         };
+        // Prefer the written image's real size: asset metadata can be stale or
+        // missing, and the scale filter resolves against the true source.
+        let (width, height) = probed_image_dimensions(&self.ffmpeg, &settings.output_path)
+            .await
+            .unwrap_or_else(|| {
+                scaled_frame_dimensions(source_width, source_height, settings.max_width)
+            });
 
         Ok(FrameExportResult {
             output_path: settings.output_path.clone(),
@@ -4356,7 +4443,11 @@ impl ExportEngine {
     ///
     /// Iterates video tracks from top to bottom (highest index first) and
     /// returns the first enabled clip that covers the requested time.
-    fn find_topmost_clip_at_time<'a>(
+    ///
+    /// Text clips and adjustment layers are skipped because they have no
+    /// file-backed source. `None` therefore means [`ExportEngine::export_frame`]
+    /// cannot serve the requested time and a composited render is required.
+    pub fn find_topmost_clip_at_time<'a>(
         &self,
         sequence: &'a Sequence,
         assets: &'a HashMap<String, Asset>,
@@ -10269,6 +10360,7 @@ mod tests {
             format: ImageFormat::Png,
             output_path: PathBuf::from("/tmp/frame.png"),
             quality: None,
+            max_width: None,
         };
         let result = settings.validate();
         assert!(result.is_err());
@@ -10284,6 +10376,7 @@ mod tests {
             format: ImageFormat::Jpeg,
             output_path: PathBuf::from("/tmp/frame.jpg"),
             quality: Some(0),
+            max_width: None,
         };
         assert!(settings.validate().is_err());
 
@@ -10303,6 +10396,7 @@ mod tests {
             format: ImageFormat::Png,
             output_path: std::env::temp_dir().join("frame.png"),
             quality: None,
+            max_width: None,
         };
         assert!(settings.validate().is_ok());
     }
@@ -10317,8 +10411,76 @@ mod tests {
             format: ImageFormat::Png,
             output_path: temp_dir.path().join("frames/stills/frame.png"),
             quality: None,
+            max_width: None,
         };
         assert!(settings.validate().is_ok());
+    }
+
+    /// Feature: Frame Export Settings
+    /// Scenario: should reject a zero maximum width
+    #[test]
+    fn frame_export_settings_should_reject_zero_max_width() {
+        let settings = FrameExportSettings {
+            time_sec: 1.0,
+            format: ImageFormat::Png,
+            output_path: std::env::temp_dir().join("frame.png"),
+            quality: None,
+            max_width: Some(0),
+        };
+        assert!(settings.validate().is_err());
+    }
+
+    /// Feature: Frame Scaling
+    /// Scenario: should keep native size when no maximum width is requested
+    #[test]
+    fn scaled_frame_dimensions_should_keep_native_size_without_limit() {
+        assert_eq!(scaled_frame_dimensions(1920, 1080, None), (1920, 1080));
+    }
+
+    /// Feature: Frame Scaling
+    /// Scenario: should never upscale narrower sources
+    #[test]
+    fn scaled_frame_dimensions_should_not_upscale() {
+        assert_eq!(scaled_frame_dimensions(640, 360, Some(1280)), (640, 360));
+    }
+
+    /// Feature: Frame Scaling
+    /// Scenario: should preserve aspect ratio with an even height
+    #[test]
+    fn scaled_frame_dimensions_should_preserve_aspect_with_even_height() {
+        assert_eq!(scaled_frame_dimensions(1920, 1080, Some(1280)), (1280, 720));
+        assert_eq!(scaled_frame_dimensions(3840, 2160, Some(1280)), (1280, 720));
+        // 1280 * 240 / 320 = 960 exactly.
+        assert_eq!(scaled_frame_dimensions(320, 240, Some(160)), (160, 120));
+        // 100 * 57 / 111 = 51.35 -> nearest even is 52.
+        assert_eq!(scaled_frame_dimensions(111, 57, Some(100)), (100, 52));
+    }
+
+    /// Feature: Frame Scaling
+    /// Scenario: should stay at a valid minimum height for extreme ratios
+    #[test]
+    fn scaled_frame_dimensions_should_clamp_height_to_two() {
+        assert_eq!(scaled_frame_dimensions(4000, 10, Some(2)), (2, 2));
+    }
+
+    /// Feature: Frame Scaling
+    /// Scenario: should tolerate unknown source dimensions
+    #[test]
+    fn scaled_frame_dimensions_should_tolerate_zero_source() {
+        assert_eq!(scaled_frame_dimensions(0, 0, Some(1280)), (0, 0));
+    }
+
+    /// Feature: Timeline To Source Mapping
+    /// Scenario: should account for placement, source in-point and speed
+    #[test]
+    fn clip_source_time_at_should_map_timeline_to_source() {
+        let mut clip = Clip::new("asset_1");
+        clip.place.timeline_in_sec = 10.0;
+        clip.range.source_in_sec = 2.0;
+        clip.speed = 2.0;
+
+        assert_eq!(clip_source_time_at(&clip, 10.0), 2.0);
+        assert_eq!(clip_source_time_at(&clip, 12.0), 6.0);
     }
 
     /// Feature: Frame Export Result

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -27,7 +27,7 @@ use crate::core::{
         execute_ffmpeg_invocation, execute_ffmpeg_output, RenderPlan,
     },
     timeline::{
-        BlendMode, Clip, Sequence, SlowMotionInterpolation, TimelineClock, Track, TrackKind,
+        BlendMode, Canvas, Clip, Sequence, SlowMotionInterpolation, TimelineClock, Track, TrackKind,
     },
 };
 
@@ -881,25 +881,38 @@ impl ExportSettings {
     ///
     /// Proxy renders exist so an agent (or a human) can look at what the timeline
     /// currently produces without paying for a full-quality encode:
-    /// - 854x480 (480p) — enough detail for visual QC, cheap to decode
+    /// - a 480p-class frame that follows the sequence aspect ratio (see
+    ///   [`proxy_frame_dimensions`]) — enough detail for visual QC, cheap to decode
     /// - CRF 30 with no target bitrate — quality-driven, small files
     /// - 96 kbps AAC — intelligible speech, negligible cost
     /// - `ultrafast` x264 preset — encode speed over compression efficiency
     /// - Frame rate follows the sequence (`fps: None`)
     ///
+    /// The canvas is a parameter because a fixed 854x480 frame pillarboxes every
+    /// sequence that is not 16:9 — a 1080x1920 vertical edit would arrive with
+    /// 270 px of usable picture inside a landscape frame.
+    ///
     /// # Arguments
     ///
     /// * `output_path` - Path where the proxy video will be saved
+    /// * `canvas` - The sequence canvas the proxy frame is fitted to
     /// * `start_time` - Optional start time in seconds for a partial render
     /// * `end_time` - Optional end time in seconds for a partial render
-    pub fn proxy(output_path: PathBuf, start_time: Option<f64>, end_time: Option<f64>) -> Self {
+    pub fn proxy(
+        output_path: PathBuf,
+        canvas: &Canvas,
+        start_time: Option<f64>,
+        end_time: Option<f64>,
+    ) -> Self {
+        let (width, height) = proxy_frame_dimensions(canvas.width, canvas.height);
+
         Self {
             preset: ExportPreset::Custom,
             output_path,
             video_codec: VideoCodec::H264,
             audio_codec: AudioCodec::Aac,
-            width: Some(854),
-            height: Some(480),
+            width: Some(width),
+            height: Some(height),
             video_bitrate: None,
             audio_bitrate: Some("96k".to_string()),
             fps: None,
@@ -1592,6 +1605,70 @@ pub fn scaled_frame_dimensions(
     let out_height = (even_steps * 2).max(2).min(u32::MAX as u64) as u32;
 
     (out_width, out_height)
+}
+
+/// Longest edge a 480p-class proxy frame may occupy, in pixels.
+///
+/// 854 is the conventional 16:9 partner of 480 (1920/1080 * 480, rounded up to
+/// an even number).
+const PROXY_MAX_LONG_EDGE: u32 = 854;
+
+/// Shortest edge a 480p-class proxy frame may occupy, in pixels.
+const PROXY_MAX_SHORT_EDGE: u32 = 480;
+
+/// Fits a sequence canvas into the 480p proxy budget, preserving its aspect.
+///
+/// The frame is scaled so its long edge is at most [`PROXY_MAX_LONG_EDGE`] and
+/// its short edge at most [`PROXY_MAX_SHORT_EDGE`], which keeps a proxy of any
+/// aspect ratio roughly as expensive to decode as the classic 854x480 one.
+/// Canvases already inside the budget are left alone — a proxy never upscales.
+///
+/// Both edges come back even, as H.264 with 4:2:0 chroma requires.
+///
+/// Worked examples: 1920x1080 → 854x480, 1080x1920 → 480x854, 1080x1080 →
+/// 480x480, 1920x800 → 854x356, 640x360 → 640x360 (unchanged).
+pub fn proxy_frame_dimensions(canvas_width: u32, canvas_height: u32) -> (u32, u32) {
+    if canvas_width == 0 || canvas_height == 0 {
+        return (PROXY_MAX_LONG_EDGE, PROXY_MAX_SHORT_EDGE);
+    }
+
+    // Fit the short edge first: that is the constraint 480p names. Extreme
+    // aspect ratios can still blow past the long-edge budget afterwards
+    // (2.39:1 at 480 tall is 1152 wide), so the result is re-fitted by the
+    // long edge when it does.
+    let (mut width, mut height) = fit_short_edge(canvas_width, canvas_height, PROXY_MAX_SHORT_EDGE);
+    if width.max(height) > PROXY_MAX_LONG_EDGE {
+        (width, height) = fit_long_edge(canvas_width, canvas_height, PROXY_MAX_LONG_EDGE);
+    }
+
+    (round_down_to_even(width), round_down_to_even(height))
+}
+
+/// Scales `(width, height)` so its shorter edge is at most `max_short_edge`.
+fn fit_short_edge(width: u32, height: u32, max_short_edge: u32) -> (u32, u32) {
+    if width >= height {
+        // `scaled_frame_dimensions` constrains the first axis, so the swap
+        // makes it constrain height instead of width.
+        let (height, width) = scaled_frame_dimensions(height, width, Some(max_short_edge));
+        (width, height)
+    } else {
+        scaled_frame_dimensions(width, height, Some(max_short_edge))
+    }
+}
+
+/// Scales `(width, height)` so its longer edge is at most `max_long_edge`.
+fn fit_long_edge(width: u32, height: u32, max_long_edge: u32) -> (u32, u32) {
+    if width >= height {
+        scaled_frame_dimensions(width, height, Some(max_long_edge))
+    } else {
+        let (height, width) = scaled_frame_dimensions(height, width, Some(max_long_edge));
+        (width, height)
+    }
+}
+
+/// Rounds a dimension down to the nearest even number, never below 2.
+fn round_down_to_even(value: u32) -> u32 {
+    (value & !1).max(2)
 }
 
 /// Reads the real pixel dimensions of a written image via FFprobe.
@@ -4222,11 +4299,16 @@ impl ExportEngine {
     ///
     /// * `sequence` - The sequence containing clips
     /// * `assets` - Map of asset ID to Asset
+    /// * `project_root` - Project directory, used to resolve project-relative
+    ///   asset paths via [`Asset::resolved_path`]. An asset imported relative to
+    ///   the project keeps a `uri` from wherever it was first seen, so a moved
+    ///   or copied project only finds its media through this.
     /// * `settings` - Frame export settings (time, format, output path)
     pub async fn export_frame(
         &self,
         sequence: &Sequence,
         assets: &HashMap<String, Asset>,
+        project_root: &Path,
         settings: &FrameExportSettings,
     ) -> Result<FrameExportResult, ExportError> {
         settings.validate()?;
@@ -4245,12 +4327,12 @@ impl ExportEngine {
         // the clip's timeline position and source offset.
         let source_time = clip_source_time_at(clip, settings.time_sec);
 
-        // Resolve asset path
-        let asset_path = Path::new(&asset.uri);
+        // Resolve asset path, preferring the project-relative location.
+        let asset_path = asset.resolved_path(project_root);
         if !asset_path.exists() {
             return Err(ExportError::InvalidSettings(format!(
                 "Asset file not found: {}",
-                asset.uri
+                asset_path.display()
             )));
         }
 
@@ -4336,7 +4418,9 @@ impl ExportEngine {
                 ExportError::InvalidSettings(format!(
                     "No frame was produced at time {:.3}s (source time {:.3}s in '{}'). \
                      The requested position is likely past the end of the source media.",
-                    settings.time_sec, source_time, asset.uri
+                    settings.time_sec,
+                    source_time,
+                    asset_path.display()
                 ))
             })?;
         let file_size = metadata.len();
@@ -7046,7 +7130,12 @@ mod tests {
     /// Scenario: should produce 480p, CRF 30, ultrafast settings that follow the sequence fps
     #[test]
     fn proxy_settings_should_use_fast_480p_configuration() {
-        let settings = ExportSettings::proxy(PathBuf::from("proxy.mp4"), None, None);
+        let settings = ExportSettings::proxy(
+            PathBuf::from("proxy.mp4"),
+            &Canvas::new(1920, 1080),
+            None,
+            None,
+        );
 
         assert_eq!(settings.width, Some(854));
         assert_eq!(settings.height, Some(480));
@@ -7061,10 +7150,60 @@ mod tests {
     }
 
     /// Feature: Proxy render preset
+    /// Scenario: should follow the sequence aspect instead of pillarboxing it
+    #[test]
+    fn proxy_settings_should_follow_a_vertical_canvas() {
+        let settings = ExportSettings::proxy(
+            PathBuf::from("proxy.mp4"),
+            &Canvas::new(1080, 1920),
+            None,
+            None,
+        );
+
+        assert_eq!(settings.width, Some(480));
+        assert_eq!(settings.height, Some(854));
+    }
+
+    /// Feature: Proxy frame fitting
+    /// Scenario: should fit any canvas inside the 480p budget without upscaling
+    #[test]
+    fn proxy_frame_dimensions_should_fit_the_480p_budget() {
+        // Landscape 16:9 keeps the classic 480p frame.
+        assert_eq!(proxy_frame_dimensions(1920, 1080), (854, 480));
+        // Vertical 9:16 is the same frame turned on its side, not a letterbox.
+        assert_eq!(proxy_frame_dimensions(1080, 1920), (480, 854));
+        // Square fits the short-edge budget on both axes.
+        assert_eq!(proxy_frame_dimensions(1080, 1080), (480, 480));
+        // 2.39:1 would be 1152 wide at 480 tall, so the long edge binds.
+        assert_eq!(proxy_frame_dimensions(1920, 800), (854, 356));
+    }
+
+    /// Feature: Proxy frame fitting
+    /// Scenario: should never upscale a canvas that already fits
+    #[test]
+    fn proxy_frame_dimensions_should_not_upscale_a_small_canvas() {
+        assert_eq!(proxy_frame_dimensions(640, 360), (640, 360));
+        assert_eq!(proxy_frame_dimensions(320, 240), (320, 240));
+    }
+
+    /// Feature: Proxy frame fitting
+    /// Scenario: should fall back to the 16:9 frame for an unusable canvas
+    #[test]
+    fn proxy_frame_dimensions_should_tolerate_a_zero_canvas() {
+        assert_eq!(proxy_frame_dimensions(0, 1080), (854, 480));
+        assert_eq!(proxy_frame_dimensions(1920, 0), (854, 480));
+    }
+
+    /// Feature: Proxy render preset
     /// Scenario: should carry the requested partial render range
     #[test]
     fn proxy_settings_should_carry_the_requested_range() {
-        let settings = ExportSettings::proxy(PathBuf::from("proxy.mp4"), Some(1.0), Some(3.5));
+        let settings = ExportSettings::proxy(
+            PathBuf::from("proxy.mp4"),
+            &Canvas::new(1920, 1080),
+            Some(1.0),
+            Some(3.5),
+        );
 
         assert_eq!(settings.start_time, Some(1.0));
         assert_eq!(settings.end_time, Some(3.5));
@@ -7075,7 +7214,12 @@ mod tests {
     #[test]
     fn proxy_settings_should_emit_ultrafast_preset_args() {
         let engine = test_export_engine();
-        let settings = ExportSettings::proxy(PathBuf::from("proxy.mp4"), None, None);
+        let settings = ExportSettings::proxy(
+            PathBuf::from("proxy.mp4"),
+            &Canvas::new(1920, 1080),
+            None,
+            None,
+        );
 
         let args = engine.build_simple_export_args(Path::new("/tmp/input.mp4"), &settings);
 
@@ -7170,7 +7314,12 @@ mod tests {
             &assets,
             &std::collections::HashMap::new(),
             &audio_info_map,
-            &ExportSettings::proxy(PathBuf::from("proxy.mp4"), None, None),
+            &ExportSettings::proxy(
+                PathBuf::from("proxy.mp4"),
+                &Canvas::new(1920, 1080),
+                None,
+                None,
+            ),
         )
         .expect("proxy settings should build export args");
 
@@ -10797,6 +10946,100 @@ mod tests {
             max_width: Some(0),
         };
         assert!(settings.validate().is_err());
+    }
+
+    /// Builds a one-clip sequence plus an asset whose `uri` no longer resolves
+    /// but whose `relative_path` still points at `relative` inside the project.
+    ///
+    /// This is the shape a project takes after it is moved or copied: the URI
+    /// records where the media was first seen, the relative path records where
+    /// it lives now.
+    fn relocated_project_fixture(
+        relative: &str,
+    ) -> (Sequence, std::collections::HashMap<String, Asset>) {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Relocated", SequenceFormat::youtube_1080());
+        let mut video_track = Track::new_video("Video 1");
+        video_track.add_clip(
+            Clip::new("video_asset")
+                .with_source_range(0.0, 5.0)
+                .place_at(0.0),
+        );
+        sequence.add_track(video_track);
+
+        let mut asset = Asset::new_video(
+            "clip.mp4",
+            "/previous/machine/clip.mp4",
+            VideoInfo::default(),
+        )
+        .with_duration(5.0)
+        .with_relative_path(relative);
+        asset.id = "video_asset".to_string();
+
+        let mut assets = std::collections::HashMap::new();
+        assets.insert("video_asset".to_string(), asset);
+
+        (sequence, assets)
+    }
+
+    /// Feature: Frame export on a relocated project
+    /// Scenario: should resolve media through the project root, not the stale URI
+    #[tokio::test]
+    async fn export_frame_should_resolve_media_relative_to_the_project() {
+        let project = tempfile::tempdir().expect("temp project");
+        let media_dir = project.path().join("media");
+        std::fs::create_dir_all(&media_dir).expect("create media dir");
+        std::fs::write(media_dir.join("clip.mp4"), b"").expect("write media");
+
+        let (sequence, assets) = relocated_project_fixture("media/clip.mp4");
+        let settings = FrameExportSettings {
+            time_sec: 1.0,
+            format: ImageFormat::Png,
+            output_path: project.path().join("frame.png"),
+            quality: None,
+            max_width: None,
+        };
+
+        let error = test_export_engine()
+            .export_frame(&sequence, &assets, project.path(), &settings)
+            .await
+            .expect_err("the fixture FFmpeg path does not exist, so the run cannot succeed");
+
+        // The run gets past asset resolution and fails only on the fake FFmpeg
+        // binary; the stale URI would have stopped it before that.
+        assert!(
+            !error.to_string().contains("Asset file not found"),
+            "media under the project root must resolve, got: {error}"
+        );
+    }
+
+    /// Feature: Frame export on a relocated project
+    /// Scenario: should name the resolved path when the media is genuinely missing
+    #[tokio::test]
+    async fn export_frame_should_report_the_resolved_path_when_media_is_missing() {
+        let project = tempfile::tempdir().expect("temp project");
+        let (sequence, assets) = relocated_project_fixture("media/clip.mp4");
+        let settings = FrameExportSettings {
+            time_sec: 1.0,
+            format: ImageFormat::Png,
+            output_path: project.path().join("frame.png"),
+            quality: None,
+            max_width: None,
+        };
+
+        let error = test_export_engine()
+            .export_frame(&sequence, &assets, project.path(), &settings)
+            .await
+            .expect_err("the media file was never created");
+
+        let message = error.to_string();
+        assert!(message.contains("Asset file not found"), "got: {message}");
+        assert!(
+            message.contains("clip.mp4") && !message.contains("previous"),
+            "the message must name the path that was actually looked up, got: {message}"
+        );
     }
 
     /// Feature: Frame Scaling

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -241,6 +241,32 @@ fn sequence_has_exportable_audio(
 // Types
 // =============================================================================
 
+/// Accepted values for [`ExportSettings::encoder_speed`], ordered fastest to slowest.
+///
+/// These are the x264/x265 `-preset` names. Faster values encode quicker at the cost
+/// of compression efficiency, which is the trade-off proxy and preview renders want.
+pub const ENCODER_SPEED_VALUES: &[&str] = &[
+    "ultrafast",
+    "superfast",
+    "veryfast",
+    "faster",
+    "fast",
+    "medium",
+    "slow",
+    "slower",
+    "veryslow",
+    "placebo",
+];
+
+/// Returns true when `value` is a supported software encoder speed preset.
+///
+/// Matching is case-insensitive and ignores surrounding whitespace so CLI and IPC
+/// callers do not have to normalize input themselves.
+pub fn is_valid_encoder_speed(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    ENCODER_SPEED_VALUES.contains(&normalized.as_str())
+}
+
 /// Export preset type
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -448,6 +474,15 @@ pub struct ExportSettings {
     /// When None, falls back to software encoder for the selected video codec.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_encoder_name: Option<String>,
+    /// Encoder speed/compression trade-off for software x264/x265 encoding.
+    ///
+    /// Maps directly to FFmpeg's `-preset` argument. Accepted values are listed in
+    /// [`ENCODER_SPEED_VALUES`] (`ultrafast` … `placebo`). When `None` no `-preset`
+    /// argument is emitted and FFmpeg's own default applies. Silently ignored for
+    /// hardware encoders and for codecs that do not accept `-preset` (VP9, ProRes),
+    /// which carry their own tuning parameters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoder_speed: Option<String>,
 }
 
 impl Default for ExportSettings {
@@ -473,6 +508,7 @@ impl Default for ExportSettings {
             tonemap_mode: None,
             hardware_accel: super::hardware::HardwareAccelMode::default(),
             resolved_encoder_name: None,
+            encoder_speed: None,
         }
     }
 }
@@ -487,6 +523,27 @@ impl ExportSettings {
             return name.clone();
         }
         super::hardware::software_encoder_name(&self.video_codec)
+    }
+
+    /// Build the `-preset` arguments for the resolved encoder, if any.
+    ///
+    /// Only software x264/x265 accept the `ultrafast … placebo` preset ladder.
+    /// Hardware encoders use their own preset namespace (handled by
+    /// [`resolve_quality_args`](super::hardware::resolve_quality_args)) and VP9/ProRes
+    /// have no equivalent, so this returns an empty vector for them rather than
+    /// emitting an argument FFmpeg would reject.
+    pub fn encoder_speed_args(&self, encoder_name: &str) -> Vec<String> {
+        let Some(speed) = self.encoder_speed.as_deref() else {
+            return Vec::new();
+        };
+        if !matches!(encoder_name, "libx264" | "libx265") {
+            return Vec::new();
+        }
+        let normalized = speed.trim().to_ascii_lowercase();
+        if !is_valid_encoder_speed(&normalized) {
+            return Vec::new();
+        }
+        vec!["-preset".to_string(), normalized]
     }
 
     /// Get the resolved audio encoder name for FFmpeg.
@@ -524,6 +581,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::Mp4Draft => Self {
                 preset: ExportPreset::Mp4Draft,
@@ -546,6 +604,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::Mp4High => Self {
                 preset: ExportPreset::Mp4High,
@@ -568,6 +627,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::Youtube4k => Self {
                 preset: ExportPreset::Youtube4k,
@@ -590,6 +650,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::YoutubeShorts => Self {
                 preset: ExportPreset::YoutubeShorts,
@@ -612,6 +673,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::Twitter => Self {
                 preset: ExportPreset::Twitter,
@@ -634,6 +696,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::Instagram => Self {
                 preset: ExportPreset::Instagram,
@@ -656,6 +719,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::WebmVp9 => Self {
                 preset: ExportPreset::WebmVp9,
@@ -678,6 +742,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::ProRes => Self {
                 preset: ExportPreset::ProRes,
@@ -700,6 +765,7 @@ impl ExportSettings {
                 tonemap_mode: None,
                 hardware_accel: super::hardware::HardwareAccelMode::default(),
                 resolved_encoder_name: None,
+                encoder_speed: None,
             },
             ExportPreset::Custom => Self {
                 preset: ExportPreset::Custom,
@@ -739,6 +805,7 @@ impl ExportSettings {
             tonemap_mode: None,
             hardware_accel: super::hardware::HardwareAccelMode::default(),
             resolved_encoder_name: None,
+            encoder_speed: None,
         })
     }
 
@@ -806,6 +873,48 @@ impl ExportSettings {
             tonemap_mode: None,
             hardware_accel: super::hardware::HardwareAccelMode::default(),
             resolved_encoder_name: None,
+            encoder_speed: None,
+        }
+    }
+
+    /// Create proxy render settings optimized for machine inspection and fast turnaround.
+    ///
+    /// Proxy renders exist so an agent (or a human) can look at what the timeline
+    /// currently produces without paying for a full-quality encode:
+    /// - 854x480 (480p) — enough detail for visual QC, cheap to decode
+    /// - CRF 30 with no target bitrate — quality-driven, small files
+    /// - 96 kbps AAC — intelligible speech, negligible cost
+    /// - `ultrafast` x264 preset — encode speed over compression efficiency
+    /// - Frame rate follows the sequence (`fps: None`)
+    ///
+    /// # Arguments
+    ///
+    /// * `output_path` - Path where the proxy video will be saved
+    /// * `start_time` - Optional start time in seconds for a partial render
+    /// * `end_time` - Optional end time in seconds for a partial render
+    pub fn proxy(output_path: PathBuf, start_time: Option<f64>, end_time: Option<f64>) -> Self {
+        Self {
+            preset: ExportPreset::Custom,
+            output_path,
+            video_codec: VideoCodec::H264,
+            audio_codec: AudioCodec::Aac,
+            width: Some(854),
+            height: Some(480),
+            video_bitrate: None,
+            audio_bitrate: Some("96k".to_string()),
+            fps: None,
+            crf: Some(30),
+            two_pass: false,
+            start_time,
+            end_time,
+            hdr_mode: HdrMode::Sdr,
+            max_cll: None,
+            max_fall: None,
+            bit_depth: None,
+            tonemap_mode: None,
+            hardware_accel: super::hardware::HardwareAccelMode::default(),
+            resolved_encoder_name: None,
+            encoder_speed: Some("ultrafast".to_string()),
         }
     }
 
@@ -1247,6 +1356,16 @@ fn validate_export_settings_options(settings: &ExportSettings) -> Vec<String> {
         errors.push(error);
     }
 
+    if let Some(ref speed) = settings.encoder_speed {
+        if !is_valid_encoder_speed(speed) {
+            errors.push(format!(
+                "Invalid encoder speed '{}'. Supported values: {}",
+                speed,
+                ENCODER_SPEED_VALUES.join(", ")
+            ));
+        }
+    }
+
     errors
 }
 
@@ -1654,6 +1773,7 @@ impl AudioExportSettings {
             tonemap_mode: None,
             hardware_accel: super::hardware::HardwareAccelMode::Cpu,
             resolved_encoder_name: None,
+            encoder_speed: None,
         }
     }
 }
@@ -3727,6 +3847,9 @@ impl ExportEngine {
                 args.extend(super::hardware::resolve_quality_args(&video_codec, crf));
             }
         }
+
+        // Encoder speed/compression trade-off (software x264/x265 only)
+        args.extend(settings.encoder_speed_args(&video_codec));
 
         // HDR metadata
         args.extend(settings.hdr_args());
@@ -6838,6 +6961,252 @@ mod tests {
             args.windows(2)
                 .any(|pair| pair[0] == "-crf" && pair[1] == "31"),
             "expected VP9 CRF args, got: {args:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Encoder speed / proxy render
+    // -------------------------------------------------------------------------
+
+    fn test_export_engine() -> ExportEngine {
+        use crate::core::ffmpeg::{FFmpegInfo, FFmpegRunner};
+
+        ExportEngine::new(FFmpegRunner::new(FFmpegInfo {
+            ffmpeg_path: PathBuf::from("/usr/bin/ffmpeg"),
+            ffprobe_path: PathBuf::from("/usr/bin/ffprobe"),
+            version: "test".to_string(),
+            is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
+        }))
+    }
+
+    fn preset_arg_value(args: &[String]) -> Option<&str> {
+        args.windows(2)
+            .find(|pair| pair[0] == "-preset")
+            .map(|pair| pair[1].as_str())
+    }
+
+    /// Feature: Encoder speed validation
+    /// Scenario: should accept the documented x264/x265 preset ladder
+    #[test]
+    fn is_valid_encoder_speed_should_accept_known_presets() {
+        for value in ENCODER_SPEED_VALUES {
+            assert!(
+                is_valid_encoder_speed(value),
+                "expected '{value}' to be accepted"
+            );
+        }
+        assert!(is_valid_encoder_speed("  UltraFast "));
+    }
+
+    /// Feature: Encoder speed validation
+    /// Scenario: should reject values FFmpeg would not understand
+    #[test]
+    fn is_valid_encoder_speed_should_reject_unknown_values() {
+        for value in ["", "turbo", "ultra fast", "p4", "0"] {
+            assert!(
+                !is_valid_encoder_speed(value),
+                "expected '{value}' to be rejected"
+            );
+        }
+    }
+
+    /// Feature: Encoder speed validation
+    /// Scenario: should surface a validation error for a bogus encoder speed
+    #[test]
+    fn validate_export_settings_options_should_reject_bogus_encoder_speed() {
+        let settings = ExportSettings {
+            encoder_speed: Some("turbo".to_string()),
+            ..ExportSettings::default()
+        };
+
+        let errors = validate_export_settings_options(&settings);
+
+        assert!(
+            errors.iter().any(|error| error.contains("turbo")),
+            "expected an encoder speed error, got: {errors:?}"
+        );
+    }
+
+    /// Feature: Encoder speed validation
+    /// Scenario: should accept a valid encoder speed without adding errors
+    #[test]
+    fn validate_export_settings_options_should_accept_valid_encoder_speed() {
+        let settings = ExportSettings {
+            encoder_speed: Some("ultrafast".to_string()),
+            ..ExportSettings::default()
+        };
+
+        let errors = validate_export_settings_options(&settings);
+
+        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+    }
+
+    /// Feature: Proxy render preset
+    /// Scenario: should produce 480p, CRF 30, ultrafast settings that follow the sequence fps
+    #[test]
+    fn proxy_settings_should_use_fast_480p_configuration() {
+        let settings = ExportSettings::proxy(PathBuf::from("proxy.mp4"), None, None);
+
+        assert_eq!(settings.width, Some(854));
+        assert_eq!(settings.height, Some(480));
+        assert_eq!(settings.crf, Some(30));
+        assert_eq!(settings.video_codec, VideoCodec::H264);
+        assert_eq!(settings.audio_codec, AudioCodec::Aac);
+        assert_eq!(settings.audio_bitrate.as_deref(), Some("96k"));
+        assert_eq!(settings.video_bitrate, None);
+        assert_eq!(settings.fps, None);
+        assert_eq!(settings.encoder_speed.as_deref(), Some("ultrafast"));
+        assert!(!settings.two_pass);
+    }
+
+    /// Feature: Proxy render preset
+    /// Scenario: should carry the requested partial render range
+    #[test]
+    fn proxy_settings_should_carry_the_requested_range() {
+        let settings = ExportSettings::proxy(PathBuf::from("proxy.mp4"), Some(1.0), Some(3.5));
+
+        assert_eq!(settings.start_time, Some(1.0));
+        assert_eq!(settings.end_time, Some(3.5));
+    }
+
+    /// Feature: Proxy render preset
+    /// Scenario: should pass the ultrafast preset through to the FFmpeg arguments
+    #[test]
+    fn proxy_settings_should_emit_ultrafast_preset_args() {
+        let engine = test_export_engine();
+        let settings = ExportSettings::proxy(PathBuf::from("proxy.mp4"), None, None);
+
+        let args = engine.build_simple_export_args(Path::new("/tmp/input.mp4"), &settings);
+
+        assert_eq!(
+            preset_arg_value(&args),
+            Some("ultrafast"),
+            "expected ultrafast preset args, got: {args:?}"
+        );
+    }
+
+    /// Feature: Encoder speed argument emission
+    /// Scenario: should keep existing output byte-identical when no encoder speed is set
+    #[test]
+    fn default_settings_should_not_emit_preset_args() {
+        let engine = test_export_engine();
+        let settings = ExportSettings::default();
+
+        let args = engine.build_simple_export_args(Path::new("/tmp/input.mp4"), &settings);
+
+        assert_eq!(preset_arg_value(&args), None, "unexpected args: {args:?}");
+    }
+
+    /// Feature: Encoder speed argument emission
+    /// Scenario: should ignore encoder speed for encoders that do not accept the x264 ladder
+    #[test]
+    fn encoder_speed_args_should_only_apply_to_software_x264_and_x265() {
+        let settings = ExportSettings {
+            encoder_speed: Some("ultrafast".to_string()),
+            ..ExportSettings::default()
+        };
+
+        assert_eq!(
+            settings.encoder_speed_args("libx264"),
+            vec!["-preset".to_string(), "ultrafast".to_string()]
+        );
+        assert_eq!(
+            settings.encoder_speed_args("libx265"),
+            vec!["-preset".to_string(), "ultrafast".to_string()]
+        );
+        assert!(settings.encoder_speed_args("h264_nvenc").is_empty());
+        assert!(settings.encoder_speed_args("h264_videotoolbox").is_empty());
+        assert!(settings.encoder_speed_args("libvpx-vp9").is_empty());
+        assert!(settings.encoder_speed_args("prores_ks").is_empty());
+    }
+
+    /// Feature: Encoder speed argument emission
+    /// Scenario: should drop an invalid encoder speed rather than hand FFmpeg a bad flag
+    #[test]
+    fn encoder_speed_args_should_drop_invalid_values() {
+        let settings = ExportSettings {
+            encoder_speed: Some("turbo".to_string()),
+            ..ExportSettings::default()
+        };
+
+        assert!(settings.encoder_speed_args("libx264").is_empty());
+    }
+
+    /// Feature: Encoder speed argument emission
+    /// Scenario: should reach the plan/filter-complex export path used by `render start`
+    #[test]
+    fn sequence_export_args_should_carry_the_proxy_encoder_speed() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut video_track = Track::new_video("Video 1");
+        video_track.add_clip(
+            Clip::new("video_asset")
+                .with_source_range(0.0, 3.0)
+                .place_at(0.0),
+        );
+        sequence.add_track(video_track);
+
+        let video_path = create_temp_media_file("proxy_encoder_speed.mp4");
+        let mut video_asset =
+            Asset::new_video("proxy_encoder_speed.mp4", &video_path, VideoInfo::default())
+                .with_duration(3.0)
+                .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+
+        let mut assets = std::collections::HashMap::new();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let mut audio_info_map = std::collections::HashMap::new();
+        audio_info_map.insert(
+            "video_asset".to_string(),
+            AssetAudioInfo { has_audio: false },
+        );
+
+        let proxy_args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &std::collections::HashMap::new(),
+            &audio_info_map,
+            &ExportSettings::proxy(PathBuf::from("proxy.mp4"), None, None),
+        )
+        .expect("proxy settings should build export args");
+
+        assert_eq!(
+            preset_arg_value(&proxy_args),
+            Some("ultrafast"),
+            "expected ultrafast preset args, got: {proxy_args:?}"
+        );
+
+        let default_args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &std::collections::HashMap::new(),
+            &audio_info_map,
+            &ExportSettings::default(),
+        )
+        .expect("default settings should build export args");
+
+        assert_eq!(
+            preset_arg_value(&default_args),
+            None,
+            "default settings must not emit -preset, got: {default_args:?}"
+        );
+    }
+
+    /// Feature: Encoder speed serialization
+    /// Scenario: should stay absent from JSON when unset so stored settings are unchanged
+    #[test]
+    fn encoder_speed_should_be_omitted_from_serialization_when_unset() {
+        let settings = ExportSettings::default();
+
+        let json = serde_json::to_string(&settings).unwrap();
+
+        assert!(
+            !json.contains("encoderSpeed"),
+            "expected encoderSpeed to be omitted, got: {json}"
         );
     }
 

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -404,6 +404,8 @@ pub(super) fn build_sequence_ffmpeg_args(
         }
     }
 
+    args.extend(ctx.settings.encoder_speed_args(&video_encoder));
+
     args.extend(ctx.settings.hdr_args());
     append_output_time_range_args(&mut args, ctx.settings.start_time, ctx.settings.end_time);
     args.push("-y".to_string());

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -1233,6 +1233,8 @@ pub async fn export_frame(
         format: image_format,
         output_path: validated_output_path,
         quality,
+        // The GUI still exports stills at the source's native resolution.
+        max_width: None,
     };
 
     let result = engine

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -1238,7 +1238,7 @@ pub async fn export_frame(
     };
 
     let result = engine
-        .export_frame(&sequence, &assets, &settings)
+        .export_frame(&sequence, &assets, &project_path, &settings)
         .await
         .map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
## Description

Gives the headless CLI the primitives an external coding agent (Claude Code / Codex) needs to **see** media and **verify** its own edits: frame extraction (incl. VLM contact sheets), canvas-aware proxy renders, headless perception generation (shots/silence/audio/full analysis), and a deterministic QC `verify` command. All logic lives in Tauri-free core so the in-app agent and MCP server pick these up later at wrapper cost. Design doc: `docs/AGENT_PERCEPTION_CLI_PLAN.md`.

## Related Issue

Closes # (no linked issue — roadmap work from the agent-native strategy)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- **Unified FFmpeg resolution** (`resolve_ffmpeg`): explicit → env (`OPENREELIO_FFMPEG_PATH`, CLI-only) → bundled roots → managed install (previously invisible to the CLI) → dev → system; new `ffmpeg info` verb; transcription now resolves assets relative to the project.
- **QC module brought to life**: `QCContext`/`RenderMeasurements` threaded through all rules, real caption safe-area check, rule errors recorded in `QCReport.errored_rules` instead of masquerading as passes.
- **`frame extract`**: asset/timeline stills with max-width scaling, automatic composite fallback for text-only moments, `--times` batches, `--grid` contact sheets with cell→timecode JSON.
- **`render start --proxy`**: canvas-aspect 480p proxy, `--start/--end`, NDJSON `--progress` on stderr, Ctrl-C cancellation; plan hashes/caches unaffected.
- **Headless perception** `analysis shots|silence|audio|run`: triple-write persistence (index.db with SQLITE_BUSY retry / bundle / annotations) keeping GUI markers, CLI reports, and agent reads in sync; silence persists only at canonical thresholds; partial runs back-merge instead of clobbering.
- **`verify`**: single timed FFmpeg pass (blackdetect/freezedetect/ebur128/silencedetect/astats) + 8 structural rules (head/tail-aware gaps, orphans, missing assets, silent clips, caption overlap / CJK-aware reading rate / out-of-bounds, shot stats); exit codes 0/1/2; suggested fixes are executable EditScripts.
- **E2E test** driving the full agent loop: create → import → perceive → edit → proxy render → extract → verify.
- Pre-merge multi-agent review: 8 confirmed correctness findings fixed in `27a097b9`.

## Screenshots / Videos

N/A (headless CLI). Sample: `verify --file proxy.mp4` returns structural + rendered checks with measurements (I/LRA/true peak, black/freeze/silence ranges).

## Testing

### Test Environment

- OS: Windows 11 Pro (10.0.26200); CI covers ubuntu/windows/macos
- Node.js version: repo-pinned (CI)
- Rust version: repo-pinned toolchain (CI)

### Tests Performed

- [x] Unit tests pass (`pnpm test`) — CI 16 shards green
- [x] Rust tests pass (`cargo test`) — 3,500 lib + 96 CLI unit + 77 CLI integration (executed against real FFmpeg)
- [x] Manual testing performed — real renders, frame/grid extraction, verify fix-loop via `plan execute`
- [x] New tests added for changes — unit + integration per verb, full-loop e2e

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Known limitation (documented in the plan doc): interior holes between partially-overlapping single-clip video tracks are still invisible to `timeline.gap` (`find_gaps` needs ≥2 clips on one track); head/tail coverage is handled. Follow-ups queued: asset-import duration probing, bundle backfill protection in core, batched composite extraction, help-json param-name parity guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI tools for shot, silence, and audio analysis, including combined analysis runs.
  * Added still-frame extraction for assets, timelines, batches, and contact sheets.
  * Added proxy rendering, time-range rendering, progress output, and encoder speed presets.
  * Added FFmpeg inspection and deterministic project/render verification commands.
  * Expanded quality checks for timeline gaps, captions, audio loudness, black frames, freezes, and missing media.
* **Bug Fixes**
  * Improved FFmpeg discovery and reporting across supported installation locations.
  * Improved analysis result persistence and recovery during partial or concurrent runs.
* **Documentation**
  * Added comprehensive CLI planning and command help documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->