### PR TITLE
feat(api): agent distribution surface - MCP allow-write, npm packages, release assets, skills

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,9 +31,9 @@ name: npm Publish
 #       On npmjs.com, for `openreelio-cli` and each `@openreelio/cli-*`
 #       package: Settings -> Trusted publisher -> GitHub Actions, with
 #       repository `openreelio/openreelio` and workflow `npm-publish.yml`.
-#       Requires npm >= 11.5.1 on the runner (installed below) and
-#       `id-token: write` (granted below). Provenance is attached
-#       automatically.
+#       Requires Node.js >= 22.14.0 and npm >= 11.5.1 on the runner (both
+#       enforced below) and `id-token: write` (granted below). Provenance is
+#       attached automatically.
 #       Note: a trusted publisher must be configured per package, and a
 #       package must exist before it can be configured -- so the very first
 #       release of each of the five packages has to use path (b).
@@ -100,13 +100,14 @@ jobs:
             exit 1
           fi
 
-          case "${RELEASE_TAG}" in
-            v*) ;;
-            *)
-              echo "Refusing to publish from a non-tag ref: ${RELEASE_TAG}" >&2
-              exit 1
-              ;;
-          esac
+          # Strict semver, so the tag cannot carry shell metacharacters that a
+          # later step would have to defend against.
+          if ! printf '%s' "${RELEASE_TAG}" |
+            grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "Refusing to publish from a non-release ref: ${RELEASE_TAG}" >&2
+            echo "Expected a tag of the form vMAJOR.MINOR.PATCH[-PRERELEASE]." >&2
+            exit 1
+          fi
 
           if [ "${DRY_RUN}" != "true" ] && [ "${NPM_PUBLISH_ENABLED}" != "true" ]; then
             echo "npm publishing is disabled." >&2
@@ -129,6 +130,8 @@ jobs:
           persist-credentials: false
 
       - name: Verify npm sources exist at this tag
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -139,8 +142,8 @@ jobs:
           fi
 
           SHIM_VERSION="$(node -p "require('./npm/openreelio-cli/package.json').version")"
-          if [ "$SHIM_VERSION" != "${{ steps.release.outputs.version }}" ]; then
-            echo "Shim version ($SHIM_VERSION) does not match tag (${{ steps.release.outputs.version }})." >&2
+          if [ "$SHIM_VERSION" != "$VERSION" ]; then
+            echo "Shim version ($SHIM_VERSION) does not match tag ($VERSION)." >&2
             exit 1
           fi
 
@@ -148,12 +151,22 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
+          # Trusted Publishing needs Node.js >= 22.14.0; without this the action
+          # may pick an older 22.x already cached on the runner.
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for Trusted Publishing
-        # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.
+      - name: Verify Node.js and upgrade npm for Trusted Publishing
+        # Trusted Publishing (OIDC) requires Node.js >= 22.14.0 and npm >= 11.5.1;
+        # Node 22 ships npm 10.
         run: |
           set -euo pipefail
+
+          if [ "$(node -p 'const v = process.versions.node.split(".").map(Number); v[0] > 22 || (v[0] === 22 && v[1] >= 14)')" != "true" ]; then
+            echo "npm Trusted Publishing requires Node.js >= 22.14.0; got $(node --version)." >&2
+            exit 1
+          fi
+
           npm install -g npm@^11.5.1
           npm --version
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,276 @@
+name: npm Publish
+
+# Publishes the agent-facing CLI to npm as `openreelio-cli` plus four
+# `@openreelio/cli-*` platform packages built from the release assets.
+#
+# ---------------------------------------------------------------------------
+# Why this is a separate workflow (and not a job inside release.yml)
+# ---------------------------------------------------------------------------
+# The platform packages embed the standalone CLI archives that release.yml
+# attaches to a *draft* release. Their public download URLs only resolve after
+# the `publish-release` job flips the draft, so npm work has to happen strictly
+# afterwards.
+#
+# The trigger is `workflow_run`, not `release: published`, on purpose: GitHub
+# does not start new workflow runs from events raised with the built-in
+# GITHUB_TOKEN, and `publish-release` publishes the draft with exactly that
+# token. A `release: published` trigger would therefore never fire.
+#
+# ---------------------------------------------------------------------------
+# Setup required before this workflow can publish (neither is done yet)
+# ---------------------------------------------------------------------------
+# 1. Enable the workflow.
+#    Create repository variable `NPM_PUBLISH_ENABLED` = `true`
+#    (Settings -> Secrets and variables -> Actions -> Variables).
+#    Until then the automatic path is inert, so merging this file cannot
+#    publish anything by accident. Manual runs still require `dry_run: false`
+#    *and* the variable.
+#
+# 2. Authenticate to npm. Either:
+#    a. Trusted Publishing (preferred, no long-lived secret).
+#       On npmjs.com, for `openreelio-cli` and each `@openreelio/cli-*`
+#       package: Settings -> Trusted publisher -> GitHub Actions, with
+#       repository `openreelio/openreelio` and workflow `npm-publish.yml`.
+#       Requires npm >= 11.5.1 on the runner (installed below) and
+#       `id-token: write` (granted below). Provenance is attached
+#       automatically.
+#       Note: a trusted publisher must be configured per package, and a
+#       package must exist before it can be configured -- so the very first
+#       release of each of the five packages has to use path (b).
+#    b. Automation token fallback. Create a secret `NPM_TOKEN` holding an npm
+#       automation token. It is used only when present, so it can be deleted
+#       once trusted publishing is live.
+
+on:
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish from (e.g. v0.1.10)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Pack and validate only; do not publish'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    # Automatic path: only for a successful, tag-triggered Release run, and only
+    # when the maintainer has opted in via the repository variable.
+    # Manual path: always allowed to reach the job; the guard step below still
+    # blocks a real publish without the variable.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v') &&
+       vars.NPM_PUBLISH_ENABLED == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required by npm Trusted Publishing (OIDC) and by provenance.
+      id-token: write
+
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      NPM_PUBLISH_ENABLED: ${{ vars.NPM_PUBLISH_ENABLED }}
+
+    steps:
+      - name: Resolve and guard release version
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "Could not determine the release tag." >&2
+            exit 1
+          fi
+
+          case "${RELEASE_TAG}" in
+            v*) ;;
+            *)
+              echo "Refusing to publish from a non-tag ref: ${RELEASE_TAG}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "${DRY_RUN}" != "true" ] && [ "${NPM_PUBLISH_ENABLED}" != "true" ]; then
+            echo "npm publishing is disabled." >&2
+            echo "Set repository variable NPM_PUBLISH_ENABLED=true to enable it," >&2
+            echo "or re-run this workflow with dry_run: true." >&2
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version ${VERSION} from ${RELEASE_TAG} (dry_run=${DRY_RUN})."
+
+      - name: Checkout release tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # The npm packaging sources are taken from the tag being published, so
+          # the published shim always matches the released CLI.
+          ref: ${{ steps.release.outputs.tag }}
+          persist-credentials: false
+
+      - name: Verify npm sources exist at this tag
+        run: |
+          set -euo pipefail
+
+          if [ ! -f npm/openreelio-cli/package.json ]; then
+            echo "npm/openreelio-cli/package.json is missing at ${RELEASE_TAG}." >&2
+            echo "Only tags that contain the npm distribution sources can be published." >&2
+            exit 1
+          fi
+
+          SHIM_VERSION="$(node -p "require('./npm/openreelio-cli/package.json').version")"
+          if [ "$SHIM_VERSION" != "${{ steps.release.outputs.version }}" ]; then
+            echo "Shim version ($SHIM_VERSION) does not match tag (${{ steps.release.outputs.version }})." >&2
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for Trusted Publishing
+        # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.
+        run: |
+          set -euo pipefail
+          npm install -g npm@^11.5.1
+          npm --version
+
+      - name: Download release CLI assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist/cli-archives
+          gh release download "${RELEASE_TAG}" \
+            --repo "${{ github.repository }}" \
+            --dir dist/cli-archives \
+            --pattern 'openreelio-cli-*' \
+            --clobber
+
+          ls -la dist/cli-archives
+
+      - name: Extract CLI binaries
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Checksums are verified again by the generator (--archives); this
+          # early pass fails fast before anything is unpacked.
+          (cd dist/cli-archives && sha256sum --check --strict ./*.sha256)
+
+          extract() {
+            TRIPLE="$1"
+            EXTENSION="$2"
+            ARCHIVE="dist/cli-archives/openreelio-cli-${VERSION}-${TRIPLE}.${EXTENSION}"
+            DESTINATION="dist/cli-assets/${TRIPLE}"
+
+            mkdir -p "$DESTINATION"
+            if [ "$EXTENSION" = "zip" ]; then
+              unzip -o "$ARCHIVE" -d "$DESTINATION"
+            else
+              tar -xzf "$ARCHIVE" -C "$DESTINATION"
+            fi
+          }
+
+          extract x86_64-pc-windows-msvc zip
+          extract x86_64-apple-darwin tar.gz
+          extract aarch64-apple-darwin tar.gz
+          extract x86_64-unknown-linux-gnu tar.gz
+
+          find dist/cli-assets -type f -name 'openreelio-cli*' -print
+
+      - name: Assemble npm packages
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          node scripts/build-npm-platform-packages.mjs \
+            --version "${VERSION}" \
+            --input dist/cli-assets \
+            --archives dist/cli-archives \
+            --out dist/npm-packages \
+            --shim-out dist/npm-packages/openreelio-cli
+
+      - name: Pack packages (always runs)
+        run: |
+          set -euo pipefail
+
+          for PACKAGE_DIR in dist/npm-packages/cli-* dist/npm-packages/openreelio-cli; do
+            echo "::group::npm pack ${PACKAGE_DIR}"
+            npm pack --pack-destination dist/npm-tarballs "${PACKAGE_DIR}"
+            echo "::endgroup::"
+          done
+
+          ls -la dist/npm-tarballs
+
+      - name: Upload packed tarballs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: npm-tarballs-${{ steps.release.outputs.version }}
+          path: dist/npm-tarballs/*.tgz
+          if-no-files-found: error
+
+      - name: Publish platform packages
+        if: env.DRY_RUN != 'true'
+        env:
+          # Empty when trusted publishing is configured; npm then falls back to
+          # OIDC. Harmless to leave set once trusted publishing is live.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Platform packages first: the shim pins them as optionalDependencies,
+          # and npm resolves those at install time.
+          for PACKAGE_DIR in dist/npm-packages/cli-*; do
+            echo "Publishing ${PACKAGE_DIR}"
+            npm publish --access public "${PACKAGE_DIR}"
+          done
+
+      - name: Publish shim package
+        if: env.DRY_RUN != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          npm publish --access public dist/npm-packages/openreelio-cli
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          {
+            echo "## npm distribution"
+            echo
+            echo "- tag: \`${RELEASE_TAG}\`"
+            echo "- version: \`${VERSION}\`"
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "- mode: dry run (packed only, nothing published)"
+            else
+              echo "- mode: published"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,94 @@ jobs:
           echo "Bundled runtime tools:"
           ls -la src-tauri/binaries/
 
+      - name: Package standalone OpenReelio CLI
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
+          REPOSITORY: ${{ github.repository }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          STAGE_DIR="cli-package"
+
+          rm -rf "$STAGE_DIR"
+          mkdir -p "$STAGE_DIR"
+
+          # Asset names intentionally end with .zip/.tar.gz/.sha256 so they can
+          # never be picked up by the latest.json updater classifier, which only
+          # matches *.exe (setup/nsis), *.msi, *.app.tar.gz and *.appimage.
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            CLI_NAME="openreelio-cli.exe"
+            ASSET_NAME="openreelio-cli-${VERSION}-${TARGET}.zip"
+            ASSET_CONTENT_TYPE="application/zip"
+          else
+            CLI_NAME="openreelio-cli"
+            ASSET_NAME="openreelio-cli-${VERSION}-${TARGET}.tar.gz"
+            ASSET_CONTENT_TYPE="application/gzip"
+          fi
+
+          CLI_PATH="target/${TARGET}/release/${CLI_NAME}"
+          if [ ! -f "$CLI_PATH" ]; then
+            echo "Missing built CLI binary: $CLI_PATH" >&2
+            exit 1
+          fi
+
+          cp "$CLI_PATH" "${STAGE_DIR}/${CLI_NAME}"
+          cp LICENSE "${STAGE_DIR}/LICENSE"
+
+          rm -f "$ASSET_NAME" "${ASSET_NAME}.sha256"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            powershell -NoProfile -NonInteractive -Command \
+              "Compress-Archive -Path '${STAGE_DIR}/*' -DestinationPath '${ASSET_NAME}' -Force"
+          else
+            # COPYFILE_DISABLE keeps macOS bsdtar from adding ._ metadata entries.
+            COPYFILE_DISABLE=1 tar -czf "$ASSET_NAME" -C "$STAGE_DIR" "$CLI_NAME" LICENSE
+          fi
+
+          # macOS runners ship shasum instead of coreutils sha256sum.
+          if command -v sha256sum > /dev/null 2>&1; then
+            sha256sum "$ASSET_NAME" > "${ASSET_NAME}.sha256"
+          else
+            shasum -a 256 "$ASSET_NAME" > "${ASSET_NAME}.sha256"
+          fi
+
+          echo "Standalone CLI assets:"
+          ls -la "$ASSET_NAME" "${ASSET_NAME}.sha256"
+          cat "${ASSET_NAME}.sha256"
+
+          UPLOAD_URL="$(
+            gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.upload_url' |
+              sed 's/{.*//'
+          )"
+
+          upload_asset() {
+            ASSET_FILE="$1"
+            CONTENT_TYPE="$2"
+
+            EXISTING_ASSET_ID="$(
+              gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}/assets" \
+                --jq ".[] | select(.name == \"${ASSET_FILE}\") | .id" |
+                head -n 1
+            )"
+
+            if [ -n "$EXISTING_ASSET_ID" ]; then
+              gh api --method DELETE "repos/${REPOSITORY}/releases/assets/${EXISTING_ASSET_ID}"
+            fi
+
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --header "Content-Type: ${CONTENT_TYPE}" \
+              --data-binary "@${ASSET_FILE}" \
+              "${UPLOAD_URL}?name=${ASSET_FILE}"
+          }
+
+          upload_asset "$ASSET_NAME" "$ASSET_CONTENT_TYPE"
+          upload_asset "${ASSET_NAME}.sha256" "text/plain"
+
       - name: Install frontend dependencies
         run: npm ci
 
@@ -505,6 +593,14 @@ jobs:
           for (const asset of assets) {
             const name = asset.name.toLowerCase();
             if (name.endsWith('.sig')) {
+              continue;
+            }
+
+            // Standalone CLI archives (openreelio-cli-<version>-<target>.zip|.tar.gz
+            // and their .sha256 sidecars) are distribution assets, never updater
+            // artifacts. Their names already miss every classifier suffix below;
+            // this guard keeps that true if the naming scheme ever changes.
+            if (name.startsWith('openreelio-cli-')) {
               continue;
             }
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ npm run tauri build
 - [Data Models](docs/DATA_MODELS.md)
 - [Plugin Development](docs/PLUGIN_SPEC.md)
 
+## Using OpenReelio as a Tool (AI Agents)
+
+OpenReelio ships a headless CLI and MCP server so coding agents (Claude Code, Codex, Cursor) can edit, analyze, render, and verify video autonomously. Start with the [Agent Guide](docs/AGENT_GUIDE.md), or bootstrap directly:
+
+```bash
+npx openreelio-cli help-json                        # machine-readable command surface
+npx openreelio-cli mcp --project <dir> --stdio      # MCP server (read-only by default)
+```
+
 ## Project Structure
 
 ```

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -662,10 +662,11 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli verify --path ./project --file proxy.mp4 --target-lufs -14 --fail-on error"
             },
             "mcp": {
-                "description": "Serve read-only OpenReelio MCP tools for external AI agents",
+                "description": "Serve OpenReelio MCP tools for external AI agents. Read-only by default; mutating tools appear with a host-issued approval token or with --allow-write.",
                 "params": {
-                    "project": { "type": "string", "required": false, "desc": "Project directory path to expose through read-only tools" },
-                    "stdio": { "type": "boolean", "required": false, "desc": "Serve MCP JSON-RPC over stdio" }
+                    "project": { "type": "string", "required": false, "desc": "Project directory path to expose through the MCP tools" },
+                    "stdio": { "type": "boolean", "required": false, "desc": "Serve MCP JSON-RPC over stdio" },
+                    "allow-write": { "type": "boolean", "required": false, "desc": "Enable the mutating tools (media.insert, plan.apply) without a per-call approval token. For a locally trusted client only; every mutation still goes through the command log and stays undoable." }
                 },
                 "example": "openreelio-cli mcp --stdio --project ./project"
             },

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -1,7 +1,12 @@
-//! Read-only MCP server surface for external AI agents.
+//! MCP server surface for external AI agents.
+//!
+//! The server is read-only by default. Mutating tools appear either when the
+//! host supplies a single-use approval token through the environment, or when
+//! the operator starts the server with `--allow-write` — a local-trust switch
+//! that trades per-call approval for an unattended edit loop.
 
 use crate::{
-    commands::{help_json, plan, transcription},
+    commands::{help_json, plan, transcription, verify},
     output,
 };
 use clap::Args;
@@ -13,6 +18,14 @@ use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+/// Timeout for the rendered-file measurement pass of `openreelio.verify`,
+/// matching the `verify --timeout-sec` default.
+const VERIFY_MEASURE_TIMEOUT_SEC: u64 = 600;
+
+/// Severity threshold `openreelio.verify` applies when the caller names none,
+/// matching the `verify --fail-on` default.
+const DEFAULT_VERIFY_FAIL_ON: &str = "error";
+
 #[derive(Args)]
 pub struct McpAction {
     /// Project directory path to expose through read-only tools
@@ -22,11 +35,19 @@ pub struct McpAction {
     /// Serve MCP JSON-RPC over stdio
     #[arg(long)]
     pub stdio: bool,
+
+    /// Enable mutating tools without a per-call approval token
+    ///
+    /// Intended for a locally trusted client editing a local project; every
+    /// mutation still goes through the command log and stays undoable.
+    #[arg(long)]
+    pub allow_write: bool,
 }
 
 #[derive(Clone, Debug, Default)]
 struct McpServerState {
     project: Option<PathBuf>,
+    allow_write: bool,
     client_name: Option<String>,
     client_version: Option<String>,
     approval_token: Option<String>,
@@ -43,6 +64,7 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
     let (approval_expires_at_ms, approval_expiry_error) = read_approval_expiry_from_env();
     let state = McpServerState {
         project: action.project,
+        allow_write: action.allow_write,
         client_name: None,
         client_version: None,
         approval_token: std::env::var("OPENREELIO_MCP_APPROVAL_TOKEN").ok(),
@@ -56,6 +78,13 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
     };
 
     if action.stdio {
+        if state.allow_write {
+            // The operator gave up per-call approval, so the only remaining
+            // safeguard is who they let talk to this process. Say so once.
+            eprintln!(
+                "warning: --allow-write enables OpenReelio MCP mutations without per-call approval; use it only with a locally trusted client"
+            );
+        }
         serve_stdio(state)
     } else {
         output::print_json_pretty(&serde_json::json!({
@@ -67,15 +96,33 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
             "command": "openreelio-cli mcp --stdio --project <project-path>",
             "tools": build_tools(&state),
             "resources": build_resources(),
-            "policy": {
-                "mode": "read-only",
-                "mutations": "disabled"
-            }
+            "policy": build_discovery_policy(&state)
         }))
     }
 }
 
+/// Policy block of the non-stdio discovery payload.
+///
+/// This is what an operator reads before wiring the server into a client, so it
+/// has to name the write mode plainly rather than leave it to be inferred from
+/// the tool list.
+fn build_discovery_policy(state: &McpServerState) -> Value {
+    serde_json::json!({
+        "mode": if state.allow_write { "read-write-local" } else { "read-only" },
+        "mutations": if state.allow_write { "enabled" } else { "disabled" }
+    })
+}
+
 impl McpServerState {
+    /// Whether mutating tools are available at all.
+    ///
+    /// `--allow-write` and an approval token are alternatives, not layers: the
+    /// flag is an operator-level grant for the whole session, the token a
+    /// host-issued grant for a single call.
+    fn mutations_enabled(&self) -> bool {
+        self.allow_write || self.has_active_approval_token()
+    }
+
     fn has_active_approval_token(&self) -> bool {
         self.active_approval_token(None).is_ok()
     }
@@ -446,6 +493,44 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
             }),
         ),
         tool(
+            "openreelio.verify",
+            "OpenReelio verify",
+            "Run deterministic quality control over a sequence and, with 'file', over a rendered export. Every check that ran, was skipped, or errored is reported, so 'checked and clean' is distinguishable from 'never checked'. Violations carry an executable suggestedFix plan.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "sequenceId": {
+                        "type": "string",
+                        "description": "Sequence to verify. Defaults to the active sequence."
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": "Rendered file to measure for black/freeze/silence, EBU R128 loudness, and peaks. Without it only structural checks run and FFmpeg is never invoked. Measured times are file-relative and compared against timeline times, so pass a full-sequence render rather than a partial one."
+                    },
+                    "structuralOnly": {
+                        "type": "boolean",
+                        "description": "Run structural checks only and never touch FFmpeg. Cannot be combined with file."
+                    },
+                    "failOn": {
+                        "type": "string",
+                        "enum": ["info", "warning", "error", "critical"],
+                        "description": "Lowest severity that marks the run as failed. Defaults to error."
+                    },
+                    "checks": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Check IDs to run exclusively; asset.license and sequence.duration are opt-in and only run when named here."
+                    },
+                    "skip": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Check IDs to disable."
+                    }
+                },
+                "additionalProperties": false
+            }),
+        ),
+        tool(
             "openreelio.preview.describe",
             "OpenReelio preview state",
             "Read non-sensitive preview state.",
@@ -453,14 +538,14 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
         ),
     ];
 
-    if state.has_active_approval_token() {
+    if state.mutations_enabled() {
         tools.push(tool(
             "openreelio.media.insert",
             "OpenReelio media insert",
             "Insert a media asset through the drag-and-drop parity path: validates visible track placement, preserves source ranges, and creates linked audio for video assets.",
             serde_json::json!({
                 "type": "object",
-                "required": ["approvalToken", "sequenceId", "trackId", "assetId", "timelineStart"],
+                "required": required_fields(state, &["sequenceId", "trackId", "assetId", "timelineStart"]),
                 "properties": {
                     "approvalToken": { "type": "string" },
                     "sequenceId": { "type": "string" },
@@ -487,7 +572,7 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
             "Apply a validated edit plan, including text/caption commands, through the OpenReelio command log path using an approval token.",
             serde_json::json!({
                 "type": "object",
-                "required": ["approvalToken", "plan"],
+                "required": required_fields(state, &["plan"]),
                 "properties": {
                     "approvalToken": { "type": "string" },
                     "plan": { "type": "object" }
@@ -498,6 +583,20 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
     }
 
     tools
+}
+
+/// Builds a mutating tool's `required` list.
+///
+/// `--allow-write` removes the per-call approval requirement, so the token must
+/// also disappear from the schema; leaving it required would make every call an
+/// argument error for a client that has no token to send.
+fn required_fields(state: &McpServerState, fields: &[&str]) -> Vec<String> {
+    let mut required = Vec::with_capacity(fields.len() + 1);
+    if !state.allow_write {
+        required.push("approvalToken".to_string());
+    }
+    required.extend(fields.iter().map(|field| (*field).to_string()));
+    required
 }
 
 fn tool(name: &str, title: &str, description: &str, input_schema: Value) -> Value {
@@ -574,6 +673,7 @@ fn call_tool(state: &McpServerState, name: &str, arguments: Value) -> Result<Val
         "openreelio.command.schema" => Ok(build_command_schema()),
         "openreelio.command.validate" => validate_command(arguments),
         "openreelio.plan.validate" => validate_plan(arguments),
+        "openreelio.verify" => run_verify_tool(state, arguments),
         "openreelio.media.insert" => apply_media_insert(state, arguments),
         "openreelio.plan.apply" => apply_plan(state, arguments),
         "openreelio.preview.describe" => Ok(build_preview_state()),
@@ -665,14 +765,21 @@ fn build_host_context(state: &McpServerState) -> Value {
             "planValidate": true,
             "transcriptionGenerate": true,
             "transcriptionStatus": true,
-            "mediaInsertWithApproval": state.has_active_approval_token(),
-            "planApplyWithApproval": state.has_active_approval_token(),
+            "verify": true,
+            "mediaInsertWithApproval": state.mutations_enabled(),
+            "planApplyWithApproval": state.mutations_enabled(),
             "previewFrameRead": false,
             "diagnosticsRead": true,
             "renderControl": false
         },
         "policy": {
-            "approvalMode": if state.has_active_approval_token() { "approve-mutations" } else { "read-only" },
+            "approvalMode": if state.allow_write {
+                "allow-write-local"
+            } else if state.has_active_approval_token() {
+                "approve-mutations"
+            } else {
+                "read-only"
+            },
             "rawMediaAccess": if state.project.is_some() { "transcription-generate" } else { "none" },
             "filesystemAccess": if state.project.is_some() { "project-readonly" } else { "none" }
         },
@@ -1153,6 +1260,37 @@ fn optional_string_argument(arguments: &Value, key: &str) -> Result<Option<Strin
         })
 }
 
+fn optional_string_array_argument(
+    arguments: &Value,
+    key: &str,
+) -> Result<Option<Vec<String>>, ToolError> {
+    let Some(value) = arguments.get(key) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let items = value.as_array().ok_or_else(|| {
+        ToolError::InvalidArguments(format!("{key} must be an array of strings when provided"))
+    })?;
+
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| {
+                    ToolError::InvalidArguments(format!(
+                        "{key} must contain only non-empty strings"
+                    ))
+                })
+        })
+        .collect::<Result<Vec<String>, ToolError>>()
+        .map(Some)
+}
+
 fn optional_bool_argument(arguments: &Value, key: &str) -> Result<Option<bool>, ToolError> {
     let Some(value) = arguments.get(key) else {
         return Ok(None);
@@ -1198,22 +1336,70 @@ fn optional_non_negative_number(arguments: &Value, key: &str) -> Result<Option<f
     Ok(Some(number))
 }
 
-fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
-    let expected_token = state.active_approval_token(None)?;
-    let actual_token = arguments
-        .get("approvalToken")
-        .and_then(Value::as_str)
-        .ok_or_else(|| ToolError::PermissionDenied("approvalToken is required".to_string()))?;
-    if actual_token != expected_token {
-        return Err(ToolError::PermissionDenied(
-            "approvalToken is invalid".to_string(),
+/// Runs deterministic QC and returns the same document `openreelio-cli verify`
+/// prints.
+///
+/// Verify mutates nothing, so the tool is always registered. The rendered pass
+/// can run for minutes on a long export; the stdio loop handles one request at a
+/// time and imposes no deadline of its own, so the measurement timeout is the
+/// only bound and stays at the CLI default.
+fn run_verify_tool(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
+    let Some(project_path) = state.project.as_ref() else {
+        return Err(ToolError::InvalidArguments(
+            "openreelio.verify requires mcp --project <project-path>".to_string(),
+        ));
+    };
+
+    let file = optional_string_argument(&arguments, "file")?.map(PathBuf::from);
+    let structural_only = optional_bool_argument(&arguments, "structuralOnly")?.unwrap_or(false);
+    if file.is_some() && structural_only {
+        return Err(ToolError::InvalidArguments(
+            "file and structuralOnly cannot be combined".to_string(),
         ));
     }
 
-    if let Some(plan_id) = state.approval_plan_id.as_deref() {
-        return Err(ToolError::PermissionDenied(format!(
-            "approvalToken is scoped to plan '{plan_id}' and cannot be used for openreelio.media.insert"
-        )));
+    let args = verify::VerifyArgs {
+        path: project_path.clone(),
+        sequence: optional_string_argument(&arguments, "sequenceId")?,
+        file,
+        structural_only,
+        checks: optional_string_array_argument(&arguments, "checks")?,
+        skip: optional_string_array_argument(&arguments, "skip")?,
+        target_lufs: None,
+        max_true_peak: None,
+        fail_on: optional_string_argument(&arguments, "failOn")?
+            .unwrap_or_else(|| DEFAULT_VERIFY_FAIL_ON.to_string()),
+        timeout_sec: VERIFY_MEASURE_TIMEOUT_SEC,
+        json_pretty: false,
+    };
+
+    // The exit code is dropped on purpose: the report already carries `status`,
+    // `passed`, and the per-check outcomes an MCP client acts on, and a JSON-RPC
+    // result has nowhere honest to put a process code.
+    let (report, _exit_code) =
+        verify::run_verify(args).map_err(|error| ToolError::Execution(error.to_string()))?;
+    Ok(report)
+}
+
+fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
+    // `--allow-write` is the grant; there is no token to check, scope, or spend.
+    if !state.allow_write {
+        let expected_token = state.active_approval_token(None)?;
+        let actual_token = arguments
+            .get("approvalToken")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::PermissionDenied("approvalToken is required".to_string()))?;
+        if actual_token != expected_token {
+            return Err(ToolError::PermissionDenied(
+                "approvalToken is invalid".to_string(),
+            ));
+        }
+
+        if let Some(plan_id) = state.approval_plan_id.as_deref() {
+            return Err(ToolError::PermissionDenied(format!(
+                "approvalToken is scoped to plan '{plan_id}' and cannot be used for openreelio.media.insert"
+            )));
+        }
     }
 
     let sequence_id = required_string_argument(&arguments, "sequenceId")?;
@@ -1236,7 +1422,9 @@ fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value,
     })?;
     let mut project = super::load_project(project_path)
         .map_err(|error| ToolError::Execution(error.to_string()))?;
-    state.ensure_media_insert_token_scope(&project.state.meta.id)?;
+    if !state.allow_write {
+        state.ensure_media_insert_token_scope(&project.state.meta.id)?;
+    }
 
     // Validate the inputs against the canonical command schema, then run the
     // single canonical InsertMedia command. All linked-audio business logic now
@@ -1257,7 +1445,11 @@ fn apply_media_insert(state: &McpServerState, arguments: Value) -> Result<Value,
     )
     .map_err(ToolError::InvalidArguments)?;
 
-    state.consume_approval_token()?;
+    // Single-use consumption belongs to the token path only; spending it under
+    // `--allow-write` would let exactly one mutation through per session.
+    if !state.allow_write {
+        state.consume_approval_token()?;
+    }
 
     let command = InsertMediaCommand::new(&sequence_id, &track_id, &asset_id, timeline_start)
         .with_source_range(source_in, source_out)
@@ -1456,7 +1648,10 @@ fn validate_plan(arguments: Value) -> Result<Value, ToolError> {
 }
 
 fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolError> {
-    state.active_approval_token(None)?;
+    // `--allow-write` is the grant; there is no token to check, scope, or spend.
+    if !state.allow_write {
+        state.active_approval_token(None)?;
+    }
 
     let plan_value = arguments
         .get("plan")
@@ -1466,16 +1661,18 @@ fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolErr
         .get("id")
         .and_then(Value::as_str)
         .ok_or_else(|| ToolError::InvalidArguments("plan.id is required".to_string()))?;
-    let expected_token = state.active_approval_token(Some(plan_id))?;
-    let actual_token = arguments
-        .get("approvalToken")
-        .and_then(Value::as_str)
-        .ok_or_else(|| ToolError::PermissionDenied("approvalToken is required".to_string()))?;
+    if !state.allow_write {
+        let expected_token = state.active_approval_token(Some(plan_id))?;
+        let actual_token = arguments
+            .get("approvalToken")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::PermissionDenied("approvalToken is required".to_string()))?;
 
-    if actual_token != expected_token {
-        return Err(ToolError::PermissionDenied(
-            "approvalToken is invalid".to_string(),
-        ));
+        if actual_token != expected_token {
+            return Err(ToolError::PermissionDenied(
+                "approvalToken is invalid".to_string(),
+            ));
+        }
     }
 
     let project_path = state.project.as_ref().ok_or_else(|| {
@@ -1494,7 +1691,11 @@ fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolErr
         }));
     }
 
-    state.consume_approval_token()?;
+    // Single-use consumption belongs to the token path only; spending it under
+    // `--allow-write` would let exactly one plan through per session.
+    if !state.allow_write {
+        state.consume_approval_token()?;
+    }
 
     let mut project = super::load_project(project_path)
         .map_err(|error| ToolError::Execution(error.to_string()))?;
@@ -2323,6 +2524,297 @@ mod tests {
             .as_str()
             .expect("error message")
             .contains("already been consumed"));
+    }
+
+    #[test]
+    fn should_advertise_mutating_tools_without_a_token_when_allow_write_is_set() {
+        let state = McpServerState {
+            allow_write: true,
+            ..Default::default()
+        };
+        let response = handle_jsonrpc_request(&state, request("tools/list", serde_json::json!({})));
+        let tools = response["result"]["tools"].as_array().expect("tools array");
+
+        let find = |name: &str| {
+            tools
+                .iter()
+                .find(|tool| tool["name"] == name)
+                .unwrap_or_else(|| panic!("tool '{name}' must be advertised"))
+                .clone()
+        };
+
+        for name in ["openreelio.media.insert", "openreelio.plan.apply"] {
+            let required = find(name)["inputSchema"]["required"]
+                .as_array()
+                .expect("required array")
+                .clone();
+            assert!(
+                !required.iter().any(|field| field == "approvalToken"),
+                "{name} must not require approvalToken under --allow-write"
+            );
+        }
+
+        assert_eq!(
+            find("openreelio.media.insert")["inputSchema"]["required"],
+            serde_json::json!(["sequenceId", "trackId", "assetId", "timelineStart"])
+        );
+        assert_eq!(
+            find("openreelio.plan.apply")["inputSchema"]["required"],
+            serde_json::json!(["plan"])
+        );
+    }
+
+    #[test]
+    fn should_keep_the_approval_token_required_without_allow_write() {
+        let state = McpServerState {
+            approval_token: Some("token".to_string()),
+            ..Default::default()
+        };
+        let response = handle_jsonrpc_request(&state, request("tools/list", serde_json::json!({})));
+        let tools = response["result"]["tools"].as_array().expect("tools array");
+        let media_insert = tools
+            .iter()
+            .find(|tool| tool["name"] == "openreelio.media.insert")
+            .expect("media insert tool");
+
+        assert_eq!(
+            media_insert["inputSchema"]["required"],
+            serde_json::json!([
+                "approvalToken",
+                "sequenceId",
+                "trackId",
+                "assetId",
+                "timelineStart"
+            ])
+        );
+    }
+
+    #[test]
+    fn should_report_local_write_policy_when_allow_write_is_set() {
+        let state = McpServerState {
+            allow_write: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_discovery_policy(&state),
+            serde_json::json!({ "mode": "read-write-local", "mutations": "enabled" })
+        );
+        assert_eq!(
+            build_discovery_policy(&McpServerState::default()),
+            serde_json::json!({ "mode": "read-only", "mutations": "disabled" })
+        );
+
+        let context = build_host_context(&state);
+        assert_eq!(context["policy"]["approvalMode"], "allow-write-local");
+        assert_eq!(context["capabilities"]["planApplyWithApproval"], true);
+        assert_eq!(context["capabilities"]["mediaInsertWithApproval"], true);
+    }
+
+    #[test]
+    fn should_apply_two_plans_in_a_row_when_allow_write_is_set() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let project_path = temp_dir.path().join("allow_write_plan_project");
+        let project = openreelio_core::ActiveProject::create("Allow Write", project_path.clone())
+            .expect("project");
+        let sequence_id = project.state.active_sequence_id.clone().expect("sequence");
+        let initial_track_count = project
+            .state
+            .sequences
+            .get(&sequence_id)
+            .expect("sequence state")
+            .tracks
+            .len();
+        drop(project);
+
+        let state = McpServerState {
+            project: Some(project_path.clone()),
+            allow_write: true,
+            ..Default::default()
+        };
+
+        let apply = |track_name: &str| {
+            handle_jsonrpc_request(
+                &state,
+                request(
+                    "tools/call",
+                    serde_json::json!({
+                        "name": "openreelio.plan.apply",
+                        "arguments": {
+                            "plan": {
+                                "id": format!("allow-write-{track_name}"),
+                                "steps": [{
+                                    "id": "step-1",
+                                    "commandType": "AddTrack",
+                                    "payload": {
+                                        "sequenceId": sequence_id,
+                                        "name": track_name,
+                                        "kind": "video"
+                                    },
+                                    "dependsOn": []
+                                }]
+                            }
+                        }
+                    }),
+                ),
+            )
+        };
+
+        for track_name in ["First Track", "Second Track"] {
+            let response = apply(track_name);
+            let text = response["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap_or_else(|| panic!("apply '{track_name}' failed: {response}"));
+            let result: Value = serde_json::from_str(text).expect("apply result JSON");
+            assert_eq!(result["status"], "ok", "apply '{track_name}': {result}");
+        }
+
+        let reopened = openreelio_core::ActiveProject::open(project_path).expect("reopen");
+        let sequence = reopened
+            .state
+            .sequences
+            .get(&sequence_id)
+            .expect("sequence after apply");
+        assert_eq!(sequence.tracks.len(), initial_track_count + 2);
+    }
+
+    #[test]
+    fn should_insert_media_twice_when_allow_write_is_set() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let project_path = temp_dir.path().join("allow_write_media_project");
+        let media_path = temp_dir.path().join("clip.mp4");
+        std::fs::write(&media_path, b"fake video bytes").expect("media fixture");
+
+        let mut project =
+            openreelio_core::ActiveProject::create("Allow Write Media", project_path.clone())
+                .expect("project");
+        let sequence_id = project.state.active_sequence_id.clone().expect("sequence");
+        let track_id = project.state.sequences[&sequence_id]
+            .tracks
+            .iter()
+            .find(|track| matches!(track.kind, TrackKind::Video | TrackKind::Overlay))
+            .expect("video track")
+            .id
+            .clone();
+        let import_command = ImportAssetCommand::new("clip.mp4", &media_path.to_string_lossy())
+            .with_duration(8.0)
+            .with_audio_info(AudioInfo::default());
+        let asset_id = import_command.asset_id().to_string();
+        project
+            .executor
+            .execute(Box::new(import_command), &mut project.state)
+            .expect("import video asset");
+        project.save().expect("save project");
+        drop(project);
+
+        let state = McpServerState {
+            project: Some(project_path.clone()),
+            allow_write: true,
+            ..Default::default()
+        };
+
+        let mut clip_ids = Vec::new();
+        for timeline_start in [0.0, 10.0] {
+            let result = apply_media_insert(
+                &state,
+                serde_json::json!({
+                    "sequenceId": sequence_id,
+                    "trackId": track_id,
+                    "assetId": asset_id,
+                    "timelineStart": timeline_start
+                }),
+            )
+            .unwrap_or_else(|error| panic!("media insert at {timeline_start} failed: {error}"));
+            clip_ids.push(result["clipId"].as_str().expect("clip id").to_string());
+        }
+
+        let reopened = openreelio_core::ActiveProject::open(project_path).expect("reopen");
+        let track = reopened.state.sequences[&sequence_id]
+            .tracks
+            .iter()
+            .find(|track| track.id == track_id)
+            .expect("video track after insert");
+        for clip_id in &clip_ids {
+            assert!(
+                track.clips.iter().any(|clip| &clip.id == clip_id),
+                "clip '{clip_id}' must survive the second insert"
+            );
+        }
+    }
+
+    #[test]
+    fn should_always_advertise_the_verify_tool() {
+        for state in [
+            McpServerState::default(),
+            McpServerState {
+                allow_write: true,
+                ..Default::default()
+            },
+        ] {
+            let response =
+                handle_jsonrpc_request(&state, request("tools/list", serde_json::json!({})));
+            let tools = response["result"]["tools"].as_array().expect("tools array");
+            assert!(
+                tools.iter().any(|tool| tool["name"] == "openreelio.verify"),
+                "verify is read-only-safe and must always be advertised"
+            );
+        }
+    }
+
+    #[test]
+    fn should_run_structural_checks_through_the_verify_tool() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let project_path = temp_dir.path().join("verify_tool_project");
+        let project = openreelio_core::ActiveProject::create("Verify Tool", project_path.clone())
+            .expect("project");
+        let sequence_id = project.state.active_sequence_id.clone().expect("sequence");
+        drop(project);
+
+        let state = McpServerState {
+            project: Some(project_path),
+            ..Default::default()
+        };
+        let response = handle_jsonrpc_request(
+            &state,
+            request(
+                "tools/call",
+                serde_json::json!({
+                    "name": "openreelio.verify",
+                    "arguments": { "structuralOnly": true }
+                }),
+            ),
+        );
+
+        let text = response["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("verify tool failed: {response}"));
+        let report: Value = serde_json::from_str(text).expect("verify report JSON");
+
+        assert_eq!(report["target"]["sequenceId"], sequence_id);
+        // Structural-only never invokes FFmpeg, so the tool works on a machine
+        // that has none installed.
+        assert_eq!(report["measurements"]["measured"], false);
+        assert!(!report["checks"]
+            .as_array()
+            .expect("checks array")
+            .is_empty());
+    }
+
+    #[test]
+    fn should_reject_verify_arguments_that_contradict_each_other() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let state = McpServerState {
+            project: Some(temp_dir.path().join("verify_conflict_project")),
+            ..Default::default()
+        };
+
+        let error = run_verify_tool(
+            &state,
+            serde_json::json!({ "file": "render.mp4", "structuralOnly": true }),
+        )
+        .expect_err("file and structuralOnly must conflict");
+
+        assert!(error.to_string().contains("structuralOnly"));
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -93,7 +93,7 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
                 "version": env!("CARGO_PKG_VERSION"),
                 "transport": "stdio"
             },
-            "command": "openreelio-cli mcp --stdio --project <project-path>",
+            "command": build_discovery_command(&state),
             "tools": build_tools(&state),
             "resources": build_resources(),
             "policy": build_discovery_policy(&state)
@@ -101,15 +101,34 @@ pub fn execute(action: McpAction) -> anyhow::Result<()> {
     }
 }
 
+/// Command line an operator copies into a client config.
+///
+/// It has to reproduce the mode this discovery run reported, otherwise copying
+/// it silently downgrades a local-write server to read-only.
+fn build_discovery_command(state: &McpServerState) -> &'static str {
+    if state.allow_write {
+        "openreelio-cli mcp --stdio --project <project-path> --allow-write"
+    } else {
+        "openreelio-cli mcp --stdio --project <project-path>"
+    }
+}
+
 /// Policy block of the non-stdio discovery payload.
 ///
 /// This is what an operator reads before wiring the server into a client, so it
 /// has to name the write mode plainly rather than leave it to be inferred from
-/// the tool list.
+/// the tool list. The mode names match `policy.approvalMode` in the stdio host
+/// context, and `mutations` tracks the same predicate that gates the tool list.
 fn build_discovery_policy(state: &McpServerState) -> Value {
     serde_json::json!({
-        "mode": if state.allow_write { "read-write-local" } else { "read-only" },
-        "mutations": if state.allow_write { "enabled" } else { "disabled" }
+        "mode": if state.allow_write {
+            "read-write-local"
+        } else if state.has_active_approval_token() {
+            "approve-mutations"
+        } else {
+            "read-only"
+        },
+        "mutations": if state.mutations_enabled() { "enabled" } else { "disabled" }
     })
 }
 
@@ -2601,14 +2620,47 @@ mod tests {
             serde_json::json!({ "mode": "read-write-local", "mutations": "enabled" })
         );
         assert_eq!(
+            build_discovery_command(&state),
+            "openreelio-cli mcp --stdio --project <project-path> --allow-write"
+        );
+        assert_eq!(
             build_discovery_policy(&McpServerState::default()),
             serde_json::json!({ "mode": "read-only", "mutations": "disabled" })
+        );
+        assert_eq!(
+            build_discovery_command(&McpServerState::default()),
+            "openreelio-cli mcp --stdio --project <project-path>"
         );
 
         let context = build_host_context(&state);
         assert_eq!(context["policy"]["approvalMode"], "allow-write-local");
         assert_eq!(context["capabilities"]["planApplyWithApproval"], true);
         assert_eq!(context["capabilities"]["mediaInsertWithApproval"], true);
+    }
+
+    #[test]
+    fn should_report_token_authorized_policy_when_an_approval_token_is_active() {
+        let state = McpServerState {
+            approval_token: Some("token".to_string()),
+            ..Default::default()
+        };
+
+        // The tool list already exposes the mutating tools here, so the policy
+        // block must not claim the server is read-only.
+        assert_eq!(
+            build_discovery_policy(&state),
+            serde_json::json!({ "mode": "approve-mutations", "mutations": "enabled" })
+        );
+        assert_eq!(
+            build_discovery_command(&state),
+            "openreelio-cli mcp --stdio --project <project-path>"
+        );
+
+        let response = handle_jsonrpc_request(&state, request("tools/list", serde_json::json!({})));
+        let tools = response["result"]["tools"].as_array().expect("tools array");
+        assert!(tools
+            .iter()
+            .any(|tool| tool["name"] == "openreelio.plan.apply"));
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/verify.rs
+++ b/crates/openreelio-cli/src/commands/verify.rs
@@ -115,11 +115,32 @@ pub fn execute(args: VerifyArgs) -> anyhow::Result<()> {
     }
 }
 
-/// Runs the verification and returns the process exit code.
+/// Runs the verification, prints the report, and returns the process exit code.
 ///
 /// Returning `Err` means the tool failed before it could produce a report; a
 /// report that merely found problems returns `Ok` with a non-zero code.
 fn run(args: VerifyArgs) -> anyhow::Result<i32> {
+    let json_pretty = args.json_pretty;
+    let (output_value, exit_code) = run_verify(args)?;
+
+    if json_pretty {
+        output::print_json_pretty(&output_value)?;
+    } else {
+        output::print_json(&output_value)?;
+    }
+
+    Ok(exit_code)
+}
+
+/// Runs the verification and returns the report document plus the exit code.
+///
+/// This is the print-free seam for in-process callers, which hand the returned
+/// document straight to their own client. The document is exactly what the CLI
+/// prints, so the two surfaces can never drift.
+///
+/// Returning `Err` means the tool failed before it could produce a report; a
+/// report that merely found problems returns `Ok` with a non-zero code.
+pub(crate) fn run_verify(args: VerifyArgs) -> anyhow::Result<(Value, i32)> {
     let fail_on = parse_severity(&args.fail_on)?;
     if args.timeout_sec == 0 {
         return Err(anyhow::anyhow!(
@@ -225,25 +246,20 @@ fn run(args: VerifyArgs) -> anyhow::Result<i32> {
         errors,
     );
 
-    if args.json_pretty {
-        output::print_json_pretty(&output_value)?;
-    } else {
-        output::print_json(&output_value)?;
-    }
-
     let breached = report
         .violations
         .iter()
         .any(|violation| violation.severity.meets_threshold(fail_on));
 
-    if breached {
-        return Ok(EXIT_THRESHOLD_BREACHED);
-    }
-    if measurement_failed || !report.errored_rules.is_empty() {
-        return Ok(EXIT_TOOL_FAILURE);
-    }
+    let exit_code = if breached {
+        EXIT_THRESHOLD_BREACHED
+    } else if measurement_failed || !report.errored_rules.is_empty() {
+        EXIT_TOOL_FAILURE
+    } else {
+        0
+    };
 
-    Ok(0)
+    Ok((output_value, exit_code))
 }
 
 // ── Configuration ───────────────────────────────────────────────────────

--- a/distribution/skills/.claude-plugin/plugin.json
+++ b/distribution/skills/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "openreelio",
+  "description": "Headless video editing, analysis and rendering with the openreelio CLI — timeline edits on an event-sourced project, shot/silence detection, frame inspection, proxy renders and deterministic QC.",
+  "version": "0.1.10",
+  "author": {
+    "name": "Junseo5",
+    "url": "https://github.com/Junseo5"
+  },
+  "homepage": "https://github.com/openreelio/openreelio",
+  "repository": "https://github.com/openreelio/openreelio",
+  "license": "MIT",
+  "keywords": [
+    "video",
+    "video-editing",
+    "ffmpeg",
+    "timeline",
+    "captions",
+    "render",
+    "mcp"
+  ]
+}

--- a/distribution/skills/.mcp.json
+++ b/distribution/skills/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "openreelio": {
+      "command": "openreelio-cli",
+      "args": ["mcp", "--stdio", "--project", "${CLAUDE_PROJECT_DIR}"],
+      "env": {}
+    }
+  }
+}

--- a/distribution/skills/README.md
+++ b/distribution/skills/README.md
@@ -11,7 +11,7 @@ repository root, so this repo is not itself a plugin or a skills container.
 
 ## Layout
 
-```
+```text
 distribution/skills/
 ├── .claude-plugin/plugin.json     plugin manifest (name, version, author, license)
 ├── .mcp.json                      MCP server wiring for openreelio-cli
@@ -45,7 +45,11 @@ These are structural requirements, not style preferences.
 5. **Every command and flag must exist.** Cross-check against
    `openreelio-cli help-json` or `openreelio-cli <verb> --help` before writing it
    down. The CLI is self-describing; this package exists to orient an agent, not
-   to replace the binary's own help.
+   to replace the binary's own help. Never copy a `help-json` *example*
+   verbatim: they carry placeholder IDs (`asset_001`) rather than the ULIDs the
+   CLI returns, and some spell a negative option in the spaced form
+   (`--target-lufs -14`) that argument parsing rejects. Take flags from per-verb
+   `--help`, and run an example before writing it down.
 6. **Keep each `REFERENCE.md` under about 150 lines.** If a topic outgrows that,
    split it into a new topic and add a router entry.
 
@@ -55,7 +59,9 @@ These are structural requirements, not style preferences.
 `--stdio` is required — without it the command prints a discovery payload and
 exits instead of serving.
 
-The server is **read-only by default**. Mutating tools (`openreelio.media.insert`,
+The server is **read-only by default**. The read tools are always registered,
+including `openreelio.verify`, so deterministic QC is available without any
+write grant. Mutating tools (`openreelio.media.insert`,
 `openreelio.plan.apply`) appear only when the operator adds `--allow-write` — a
 local-trust switch that drops the per-call approval requirement — or when the
 host supplies `OPENREELIO_MCP_APPROVAL_TOKEN` for a single call. Editing through

--- a/distribution/skills/README.md
+++ b/distribution/skills/README.md
@@ -1,0 +1,75 @@
+# OpenReelio agent skill package
+
+This directory is the **authoring source** for the `openreelio` agent skill and
+plugin. It is written and reviewed here, alongside the CLI it documents, and then
+synced to the standalone [`openreelio/skills`](https://github.com/openreelio/skills)
+repository, which is what users actually install from.
+
+Nothing here is auto-installed by checking out this repository. The plugin
+manifest lives at `distribution/skills/.claude-plugin/plugin.json`, not at the
+repository root, so this repo is not itself a plugin or a skills container.
+
+## Layout
+
+```
+distribution/skills/
+├── .claude-plugin/plugin.json     plugin manifest (name, version, author, license)
+├── .mcp.json                      MCP server wiring for openreelio-cli
+├── README.md                      this file
+└── skills/
+    └── openreelio/
+        ├── SKILL.md               the installable unit — a router, nothing more
+        ├── setup/REFERENCE.md
+        ├── perception/REFERENCE.md
+        ├── editing/REFERENCE.md
+        ├── captions/REFERENCE.md
+        ├── render/REFERENCE.md
+        └── verify/REFERENCE.md
+```
+
+## Authoring rules
+
+These are structural requirements, not style preferences.
+
+1. **`SKILL.md` frontmatter has exactly two fields**: `name` and `description`.
+   `name` must equal the containing directory name and match
+   `^[a-z0-9]+(-[a-z0-9]+)*$`.
+2. **`description` is one capability sentence plus a trigger clause.** It is the
+   only thing a host model sees when deciding whether to load the skill.
+3. **Sub-topic files are named `REFERENCE.md`, never `SKILL.md`.** A nested
+   `SKILL.md` would be discovered as a separate skill (or, worse, silently
+   ignored), which is not what a router-and-topics layout means.
+4. **`SKILL.md` is a router.** Each topic gets an `## Heading`, one sentence
+   naming the trigger, and a link to its `REFERENCE.md`. Detail belongs in the
+   reference file, which is loaded only when the topic is relevant.
+5. **Every command and flag must exist.** Cross-check against
+   `openreelio-cli help-json` or `openreelio-cli <verb> --help` before writing it
+   down. The CLI is self-describing; this package exists to orient an agent, not
+   to replace the binary's own help.
+6. **Keep each `REFERENCE.md` under about 150 lines.** If a topic outgrows that,
+   split it into a new topic and add a router entry.
+
+## MCP server
+
+`.mcp.json` starts `openreelio-cli mcp --stdio` against `${CLAUDE_PROJECT_DIR}`.
+`--stdio` is required — without it the command prints a discovery payload and
+exits instead of serving.
+
+The server is **read-only by default**. Mutating tools (`openreelio.media.insert`,
+`openreelio.plan.apply`) appear only when the operator adds `--allow-write` — a
+local-trust switch that drops the per-call approval requirement — or when the
+host supplies `OPENREELIO_MCP_APPROVAL_TOKEN` for a single call. Editing through
+the CLI verbs described in the skill needs neither.
+
+If your host does not substitute `${CLAUDE_PROJECT_DIR}`, replace it with an
+absolute project directory, or drop `--project` and pass the project path to each
+CLI call instead.
+
+## Sync
+
+Changes here are mirrored to `openreelio/skills` as part of a release. Edit here;
+do not edit the published copy directly.
+
+## License
+
+MIT © 2026 Junseo5

--- a/distribution/skills/skills/openreelio/SKILL.md
+++ b/distribution/skills/skills/openreelio/SKILL.md
@@ -35,6 +35,13 @@ Treat the binary as the source of truth, not this skill.
 is roughly 58 KB — fetch per-verb help instead of loading all of it. Use
 `openreelio-cli command schema` for the 79 backend command types.
 
+Its *examples* are not copy-paste ready: IDs are readable placeholders
+(`asset_001`) rather than the ULIDs the CLI actually returns, and some spell a
+negative option in the spaced form (`--target-lufs -14`) that argument parsing
+rejects. Check an example against
+[the conventions](./setup/REFERENCE.md#conventions-that-apply-everywhere) and the
+verb's own `--help` before running it.
+
 ## Never full-render to check your work
 
 A full export is the most expensive way to answer "did that cut land?". Use

--- a/distribution/skills/skills/openreelio/SKILL.md
+++ b/distribution/skills/skills/openreelio/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: openreelio
+description: Edit, analyze, and render video from the command line with the openreelio CLI — import media, cut/trim/split a timeline, add captions and text, detect shots and silence, extract frames to inspect results, and render. Use for any video editing, video analysis, or video rendering task.
+---
+
+# OpenReelio
+
+`openreelio-cli` is a headless non-linear editor. It keeps a real project on disk
+and exposes editing, media analysis, captioning, rendering, and deterministic
+quality control as subcommands that print a single JSON object on stdout.
+
+## Why openreelio rather than raw ffmpeg
+
+- **The project is editable, not baked.** Every edit is a command appended to an
+  event-sourced op log; project state is a replayable snapshot of that log. You
+  can revise a decision from ten steps ago instead of rebuilding a filtergraph.
+- **Undo and replay are first-class.** `timeline undo` / `timeline redo` walk the
+  log, and `state ops` shows exactly what happened.
+- **Validation happens before the render.** `command validate` and
+  `plan validate` reject a bad edit up front, and `plan execute` is atomic —
+  a failing step rolls the whole batch back.
+- **There is a QC loop.** `verify` measures the sequence and the rendered file
+  (gaps, black frames, freezes, caption overlaps, EBU R128 loudness, true peak)
+  and returns executable fixes, so "is this deliverable?" is a command rather
+  than a judgement call.
+
+Reach for ffmpeg directly only for one-off transcodes with no editorial decisions
+in them.
+
+## The CLI is self-describing
+
+Treat the binary as the source of truth, not this skill.
+`openreelio-cli help-json` prints the entire command schema as JSON, and
+`openreelio-cli <verb> --help` is authoritative for any single verb. `help-json`
+is roughly 58 KB — fetch per-verb help instead of loading all of it. Use
+`openreelio-cli command schema` for the 79 backend command types.
+
+## Never full-render to check your work
+
+A full export is the most expensive way to answer "did that cut land?". Use
+`frame extract` for stills and contact sheets, or `render start --proxy
+--start/--end` for a 480p draft of just the range under review. Full-quality
+renders are for delivery.
+
+## Setup
+
+Install the CLI, point it at a project, and confirm the media toolchain.
+Load [Setup](./setup/REFERENCE.md).
+
+## Perception
+
+Find out what is actually in the footage: shots, silence, loudness, and frames
+you can look at. Load [Perception](./perception/REFERENCE.md).
+
+## Editing
+
+Place, trim, split, move, and speed-change clips; reach every backend command;
+run atomic batches. Load [Editing](./editing/REFERENCE.md).
+
+## Captions and text
+
+Add subtitles and styled text overlays, import/export SRT and VTT, and generate
+transcripts locally. Load [Captions](./captions/REFERENCE.md).
+
+## Render
+
+List presets, render a fast proxy or a delivery file, stream progress, and limit
+the render to a range. Load [Render](./render/REFERENCE.md).
+
+## Verify
+
+Run deterministic quality control over the sequence and the rendered file, then
+feed the suggested fixes back as an edit plan. Load [Verify](./verify/REFERENCE.md).

--- a/distribution/skills/skills/openreelio/captions/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/captions/REFERENCE.md
@@ -1,0 +1,76 @@
+# Captions and text
+
+Captions are timed subtitle entries on a caption track. Text clips are styled
+overlays with position, transform, and effects. Both are ordinary commands in the
+op log, so both are undoable.
+
+## Captions
+
+```bash
+openreelio-cli caption add    --path ./demo --text "Hello" --start 0.5 --end 3.0 \
+                              [--track <TRACK_ID>] [--position <POS>] [--style-json '{…}']
+openreelio-cli caption update --path ./demo --id <CAPTION_ID> [--text "Updated"] \
+                              [--start 1.0] [--end 4.0] [--style-json '{…}']
+openreelio-cli caption list   --path ./demo
+openreelio-cli caption remove --path ./demo --id <CAPTION_ID>
+```
+
+`caption add` returns `{"status","opId","createdIds":[<CAPTION_ID>],"trackId"}`
+and creates a caption track if none exists. `caption list` returns
+`captions[{id,trackId,text,startSec,endSec,durationSec,position,style}]`.
+
+Import and export:
+
+```bash
+openreelio-cli caption import --path ./demo --file subs.srt \
+                              [--format srt|vtt|transcript-json] [--language en]
+openreelio-cli caption export --path ./demo --format srt --output subs.srt
+```
+
+`--format` is auto-detected from the file extension on import when omitted.
+Export supports `srt` and `vtt`.
+
+## Text overlays
+
+```bash
+openreelio-cli text add       --path ./demo --text "Title" --start 0 --duration 3 \
+                              [--preset credits] [--font-size 72] [--color "#ffffff"] \
+                              [--x 0.5] [--y 0.5] [--align center] [--bold]
+openreelio-cli text update    --path ./demo --id <CLIP_ID> --text "New" [--font-weight 600]
+openreelio-cli text transform --path ./demo --id <CLIP_ID> --x 0.38 --y 0.42 \
+                              --scale-x 1.2 --scale-y 1.2 --rotation 8
+openreelio-cli text list      --path ./demo
+openreelio-cli text remove    --path ./demo --id <CLIP_ID>
+```
+
+`text add` and `text update` accept a long list of styling flags plus escape
+hatches (`--style-json`, `--text-json`, `--position-json`, `--outline-json`,
+`--shadow-json`). Run `openreelio-cli text add --help` for the current set rather
+than guessing — the flag list is the largest in the CLI.
+
+Positions are normalized (`0.0`–`1.0`) fractions of the canvas.
+
+## Transcription
+
+Speech-to-text runs locally with Whisper. Check readiness first; the model is a
+multi-hundred-megabyte download.
+
+```bash
+openreelio-cli transcription status
+openreelio-cli transcription install --model large-v3-turbo [--force]
+openreelio-cli transcription generate --path ./demo --asset <ASSET_ID> \
+                                      [--language auto] [--model auto] [--import] \
+                                      [--track <TRACK_ID>] [--replace-existing] [--translate]
+openreelio-cli transcription generate-sequence --path ./demo [--sequence <SEQ_ID>] --import
+```
+
+`transcription status` returns `{featureAvailable, ready, modelsDir,
+defaultModel, installedCount, models[…]}`. `--import` writes the result straight
+into a caption track; without it, use `--output <FILE>` and import later.
+`generate-sequence` transcribes the audible mix of a sequence instead of a single
+asset.
+
+After generating captions, run `verify` — `caption.overlap`,
+`caption.out_of_bounds`, `caption.reading_rate`, and `caption.safe_area` catch
+the failures auto-generated subtitles actually produce. See
+[Verify](../verify/REFERENCE.md).

--- a/distribution/skills/skills/openreelio/editing/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/editing/REFERENCE.md
@@ -1,0 +1,92 @@
+# Editing
+
+Every edit is a command appended to the project's op log. Nothing mutates state
+outside that path, which is why undo and replay always work.
+
+## Timeline verbs
+
+```bash
+openreelio-cli timeline info    --path ./demo
+openreelio-cli timeline tracks  --path ./demo
+openreelio-cli timeline clips   --path ./demo [--track <TRACK_ID>]
+
+openreelio-cli timeline insert  --path ./demo --asset <ASSET_ID> --track <TRACK_ID> --at 0.0
+openreelio-cli timeline trim    --path ./demo --clip <CLIP_ID> --track <TRACK_ID> \
+                                --source-in 0 --source-out 12
+openreelio-cli timeline split   --path ./demo --clip <CLIP_ID> --track <TRACK_ID> --at 6.0
+openreelio-cli timeline move    --path ./demo --clip <CLIP_ID> --track <TRACK_ID> --to 10.0 \
+                                [--new-track <TRACK_ID>]
+openreelio-cli timeline speed   --path ./demo --clip <CLIP_ID> --track <TRACK_ID> \
+                                --speed 2.0 [--reverse]
+openreelio-cli timeline remove  --path ./demo --clip <CLIP_ID> --track <TRACK_ID>
+
+openreelio-cli timeline add-track    --path ./demo --kind video --name "Video 2"
+openreelio-cli timeline remove-track --path ./demo --track <TRACK_ID>
+```
+
+The trim flags are `--source-in` and `--source-out` (source-media in/out points),
+not `--in` / `--out`.
+
+`timeline clips` returns each clip's `id`, `trackId`, `assetId`,
+`timelineInSec`, `durationSec`, `sourceInSec`, `sourceOutSec`, and `speed` —
+enough to plan the next edit without dumping full state.
+
+## Every backend command: `command execute`
+
+The convenience verbs cover the common cuts. The full editor surface — 79
+command types including effects, masks, keyframes, compound clips, adjustment
+layers, audio ducking, blend modes, markers, freeze frames, time remapping — is
+reachable directly.
+
+```bash
+openreelio-cli command schema                                    # list all 79 types
+openreelio-cli command validate --type RenameTrack --payload '{…}'
+openreelio-cli command execute  --path ./demo --type SplitClip \
+  --payload '{"sequenceId":"…","trackId":"…","clipId":"…","splitTime":5}'
+```
+
+Payloads are camelCase JSON objects matching the IPC payload format. Use
+`--payload-file <FILE>` when the JSON is large or shell quoting is awkward.
+`command validate` runs the same strict parser without touching the project —
+check before you execute.
+
+## Atomic batches: `plan execute`
+
+An edit plan is:
+
+```json
+{
+  "id": "plan_001",
+  "steps": [
+    { "id": "step_1", "commandType": "SplitClip", "payload": { }, "dependsOn": [] },
+    { "id": "step_2", "commandType": "MoveClip",  "payload": { }, "dependsOn": ["step_1"] }
+  ]
+}
+```
+
+Steps run in dependency order, and the whole plan rolls back if any step fails.
+
+```bash
+openreelio-cli plan template --template-type split-and-move
+openreelio-cli plan validate --path ./demo --file plan.json
+openreelio-cli plan execute  --path ./demo --file plan.json
+```
+
+`plan template` takes `--template-type`, not `--type`. `plan execute` returns
+`{"status","planId","stepsExecuted","stepResults":[…]}`.
+
+Prefer a plan over a sequence of individual commands whenever the steps only make
+sense together — a half-applied multi-step edit is worse than none.
+
+## Undo and history
+
+```bash
+openreelio-cli timeline undo --path ./demo
+openreelio-cli timeline redo --path ./demo
+openreelio-cli state ops     --path ./demo --last 20
+openreelio-cli state dump    --path ./demo [--sequence <SEQUENCE_ID>]
+openreelio-cli state snapshot --path ./demo
+```
+
+`state ops` is the cheapest way to see what actually happened; `state dump` is
+the full derived state and can be large.

--- a/distribution/skills/skills/openreelio/perception/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/perception/REFERENCE.md
@@ -1,0 +1,81 @@
+# Perception
+
+Find out what is in the footage before cutting it. Results are cached in the
+project's shared analysis bundle, so the desktop app sees whatever you computed.
+
+## Analysis verbs
+
+```bash
+openreelio-cli analysis shots   --path ./demo --id <ASSET_ID> \
+  [--threshold 0.3] [--min-shot-duration 0.5] [--timeout-sec 600] [--no-persist]
+openreelio-cli analysis silence --path ./demo --id <ASSET_ID> \
+  [--threshold-db -40] [--min-duration 0.5]
+openreelio-cli analysis audio   --path ./demo --id <ASSET_ID>
+openreelio-cli analysis run     --path ./demo --id <ASSET_ID> \
+  [--all | --shots --audio --segments --visual --transcript] [--progress]
+openreelio-cli analysis report  --path ./demo --id <ASSET_ID>
+```
+
+**`analysis shots`** returns `totalDurationSec`, `shotCount`, and
+`shots[{index,startSec,endSec,durationSec,confidence}]`. `persisted` is an array
+naming the stores written, e.g. `["indexDb","bundle","annotations"]`. Cut on shot
+boundaries, not round numbers.
+
+> `asset import` does not probe media duration, so a clip placed by
+> `timeline insert` gets the 10-second default length. `totalDurationSec` from
+> `analysis shots` (or `durationSec` from `analysis audio`) is how you learn the
+> real length; then `timeline trim --source-in 0 --source-out <duration>`.
+
+**`analysis silence`** returns `regions[{startSec,endSec,durationSec}]`,
+`totalSilenceSec`, and a boolean `persisted`. Results reach the shared cache only
+at the default thresholds (`-40` dB, `0.5` s) *and* only when an audio profile
+already exists. Otherwise the run is output-only: `"persisted": false` with a
+`reason` of `"non-default threshold"`, `"non-default min-duration"`, or
+``"no audio profile in bundle; run `analysis audio` first"``. The numbers are
+still correct — they just do not update the cache.
+
+**`analysis audio`** runs the full profiler (silence, loudness curve, peak, BPM,
+speech regions) and always persists into the bundle.
+
+**`analysis run`** drives the job runner with local-only providers. Transcript is
+off unless `--transcript` is passed and fails fast with a
+`transcription install` hint when no Whisper model is present. `--progress`
+streams `{"type":"progress","job","status","detail"}` to stderr. Per-job failures
+land in `errors`; the exit is non-zero only if every enabled sub-job failed.
+
+Semantic search over cached analysis (needs transcript/segments):
+
+```bash
+openreelio-cli analysis search         --path ./demo --id <ASSET_ID> --query "host question"
+openreelio-cli analysis search-library --path ./demo --query "crowd cheer" --limit 8
+openreelio-cli analysis build-selects  --path ./demo --query "crowd cheer" \
+  --track-name "Source Selects" --limit 6 --apply
+```
+
+## Look at frames
+
+```bash
+openreelio-cli frame extract --path ./demo --time 12.5 --out frame.png
+openreelio-cli frame extract --path ./demo --times 2,8,14 --out ./stills/
+openreelio-cli frame extract --path ./demo --asset <ASSET_ID> --source-time 3.0 --out src.png
+openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30 --out sheet.jpg
+```
+
+- `--time` is a timeline position; `--asset` + `--source-time` reads the asset's
+  own media timebase; `--times a,b,c` writes a batch and needs `--out` to be a
+  directory.
+- `--mode fast` (default) renders the topmost file-backed clip only — no
+  effects, text, or compositing. Cheap, and right for "what footage is here". It
+  auto-falls back to composite when there is no such clip (a title card, say) and
+  reports `fellBackToComposite: true`.
+- `--mode composite` renders a minimal window through the full stack, so effects
+  and overlays appear. Range renders decode from zero, so it costs more.
+- `--max-width` caps output size (default 1280 px, aspect preserved, never
+  upscaled). `--format png|jpeg`.
+
+**Contact sheets.** `--grid COLSxROWS --between START END [--count N]` writes one
+sheet and returns `sheet.cells[{index,row,col,timelineSec}]`, mapping every cell
+a vision model comments on back to a timecode. Capped at 100 cells.
+
+Single and batch extraction return
+`frames[{index,timeSec,sourceTimeSec,clipId,assetId,path,width,height}]`.

--- a/distribution/skills/skills/openreelio/render/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/render/REFERENCE.md
@@ -1,0 +1,72 @@
+# Render
+
+## Presets
+
+```bash
+openreelio-cli render presets
+```
+
+| ID               | Label                                | Container |
+| ---------------- | ------------------------------------ | --------- |
+| `mp4_h264_1080p` | MP4 H.264 1080p (default)            | mp4       |
+| `mp4_h264_4k`    | MP4 H.264 4K                         | mp4       |
+| `mp4_h265_1080p` | MP4 H.265 1080p                      | mp4       |
+| `mp4_draft`      | MP4 H.264 720p Draft                 | mp4       |
+| `proxy_480p`     | Proxy 480p (fast, agent inspection)  | mp4       |
+| `webm_vp9_1080p` | WebM VP9 1080p                       | webm      |
+| `prores_422`     | ProRes 422                           | mov       |
+
+## Start a render
+
+```bash
+openreelio-cli render start --path ./demo --output out.mp4 \
+  [--preset mp4_h264_1080p | --proxy] [--sequence <SEQ_ID>] \
+  [--start 0] [--end 30] [--progress]
+```
+
+`--output` is required. `--preset` and `--proxy` conflict.
+
+**`--proxy` is the inspection render.** It is an alias for the `proxy_480p`
+preset: 854x480, CRF 30, H.264 + AAC, `ultrafast`. Use it whenever you are
+checking your own work rather than delivering.
+
+**`--start` / `--end`** limit the rendered range to timeline seconds. Combine
+with `--proxy` to review just the section you changed. Note that a partial render
+starts its own timebase at the range start, so `verify --file` on it will not
+line up with timeline timecodes — pass a full-sequence render to `verify`.
+
+**`--progress`** streams NDJSON to stderr:
+
+```json
+{"type":"progress","percent":42.0,"frame":151,"totalFrames":360,"fps":98.2,"etaSeconds":2,"message":"Encoding frame 151"}
+```
+
+The result on stdout:
+
+```json
+{"status":"ok","sequenceId":"…","preset":"proxy_480p","outputPath":"…",
+ "durationSec":12.0,"fileSize":408445,"encodingTimeSec":0.27,
+ "planHash":"c2b33fc72122ba67","warnings":[]}
+```
+
+## Inspect without encoding
+
+```bash
+openreelio-cli render graph --path ./demo [--sequence <SEQ_ID>]
+```
+
+Prints the renderer-agnostic graph so you can see what would be rendered — no
+FFmpeg process, no output file.
+
+## Cost discipline
+
+Do not full-render to check an edit. In order of cost:
+
+1. `frame extract --time` / `--grid` — stills, near-instant, no encode.
+2. `render start --proxy --start A --end B` — 480p draft of just the range.
+3. `render start --proxy` — 480p draft of the whole sequence, and what
+   `verify --file` wants.
+4. `render start --preset <delivery>` — only when you are actually delivering.
+
+Renders honour Ctrl-C: the CLI wires the interrupt to the export engine's cancel
+path rather than leaving an orphaned FFmpeg process.

--- a/distribution/skills/skills/openreelio/setup/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/setup/REFERENCE.md
@@ -1,0 +1,77 @@
+# Setup
+
+## Install
+
+```bash
+npm install -g openreelio-cli     # global install
+npx openreelio-cli --help         # or run without installing
+```
+
+The npm package downloads nothing at install time. The binary ships in a
+platform-specific optional dependency (`@openreelio/cli-win32-x64`,
+`@openreelio/cli-darwin-x64`, `@openreelio/cli-darwin-arm64`,
+`@openreelio/cli-linux-x64`) that npm resolves from `os`/`cpu`, so installs work
+with lifecycle scripts disabled. Linux builds are glibc only.
+
+**Standalone archive.** Releases publish
+`openreelio-cli-<version>-<target-triple>.zip` (Windows) and
+`openreelio-cli-<version>-<target-triple>.tar.gz` (macOS, Linux) at
+<https://github.com/openreelio/openreelio/releases>. On macOS, clear the
+quarantine attribute before running the extracted binary:
+
+```bash
+xattr -d com.apple.quarantine ./openreelio-cli
+```
+
+**App-bundled sidecar.** The OpenReelio desktop app ships the same binary at
+`<app-dir>/binaries/openreelio-cli[.exe]` (Windows, Linux) or
+`OpenReelio.app/Contents/Resources/binaries/openreelio-cli` (macOS).
+
+**`OPENREELIO_CLI_BINARY`** — set this to an absolute path and the npm launcher
+uses that binary verbatim, bypassing package lookup. Use it to run a standalone
+or app-bundled build through `npx openreelio-cli`.
+
+## Confirm the media toolchain
+
+```bash
+openreelio-cli ffmpeg info
+```
+
+Returns `{status, ffmpegPath, ffprobePath, version, source}`. `source` is one of
+`explicit`, `env`, `bundled`, `managed`, `dev`, `system` — that is also the
+resolution order. Run this first whenever a media verb fails for no obvious
+reason.
+
+Override the toolchain with `OPENREELIO_FFMPEG_PATH` and
+`OPENREELIO_FFPROBE_PATH`; both outrank every bundled or system install.
+
+## Create or open a project
+
+```bash
+openreelio-cli project create --name "Demo" --path ./demo
+openreelio-cli project info   --path ./demo
+openreelio-cli asset import   --path ./demo --file ./footage.mp4 [--name "A-roll"]
+openreelio-cli asset list     --path ./demo
+```
+
+`project create` makes the directory and a default sequence with one video and
+one audio track. `asset import` returns
+`{"status","opId","createdIds":[<ASSET_ID>],"assetName","uri"}`.
+
+## Conventions that apply everywhere
+
+- **stdout is one JSON object.** Parse stdout; never parse stderr.
+- **stderr carries progress and diagnostics.** `--progress` streams NDJSON there.
+- **`--path <PROJECT_DIR>` is required on every project verb.** There is no
+  ambient current project. Only `help-json`, `command schema`, `plan template`,
+  `render presets`, `ffmpeg info`, `transcription status` and
+  `transcription install` omit it.
+- **`--sequence` is always optional** and defaults to the active sequence.
+- **IDs are ULIDs** like `01KZW64VJ4JPBS5B9YZEA335J8`, not `asset_001`. Read them
+  from `createdIds` in a command result, or from `asset list`,
+  `timeline tracks`, `timeline clips`.
+- **Negative numbers need `=`**: write `--target-lufs=-14`, not
+  `--target-lufs -14`. (`analysis silence --threshold-db -40` is the one option
+  that accepts the spaced form.)
+- **Exit codes**: `0` success, `1` failure. `verify` is the exception — see
+  [Verify](../verify/REFERENCE.md).

--- a/distribution/skills/skills/openreelio/verify/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/verify/REFERENCE.md
@@ -1,0 +1,85 @@
+# Verify
+
+Deterministic quality control. `verify` is how you answer "is this deliverable?"
+with a measurement instead of a guess.
+
+```bash
+openreelio-cli verify --path ./demo                       # structural only
+openreelio-cli verify --path ./demo --file ./proxy.mp4    # + rendered measurements
+openreelio-cli verify --path ./demo --file ./proxy.mp4 \
+  --target-lufs=-14 --max-true-peak=-1 --fail-on error [--json-pretty]
+```
+
+Without `--file`, only structural checks run and FFmpeg is never invoked.
+`--structural-only` states that explicitly and conflicts with `--file`.
+
+Negative numbers need the `=` form: `--target-lufs=-14`, `--max-true-peak=-1`.
+
+Measured times are file-relative while structural findings are
+timeline-relative, so `--file` expects a render of the whole sequence from zero.
+
+## Exit codes
+
+| Code | Meaning                                                              |
+| ---- | -------------------------------------------------------------------- |
+| `0`  | Ran and did not breach the `--fail-on` threshold                      |
+| `1`  | Ran and breached the threshold                                        |
+| `2`  | The tool itself failed (bad arguments, unreadable file, FFmpeg error) |
+
+`--fail-on info|warning|error|critical` defaults to `error`. Taste-adjacent
+findings stay at warning/info; `error` is reserved for objectively broken output.
+Exit `2` is never "the video is bad" — it means the verdict is unknown.
+
+## Checks
+
+**structural** — `timeline.gap`, `clip.orphan`, `clip.missing_asset`,
+`clip.aspect_ratio`, `audio.silent_clip`, `caption.overlap`,
+`caption.reading_rate`, `caption.out_of_bounds`, `caption.safe_area`,
+`shot.length_stats`, `shot.cut_rhythm`, plus opt-in `asset.license` and
+`sequence.duration`.
+
+**rendered** (require `--file`) — `render.black_frames`, `audio.peak`,
+`audio.loudness`.
+
+`asset.license` and `sequence.duration` run only when named in `--checks`.
+Narrow any run with `--checks a,b` or `--skip a,b`.
+
+## Report shape
+
+```json
+{
+  "status": "warning", "passed": true, "checkedAt": "…", "durationMs": 812,
+  "target": { "sequenceId": "…", "renderedFile": "…", "measured": true, "selectedChecks": ["…"] },
+  "summary": { "critical": 0, "error": 0, "warning": 1, "info": 1, "skipped": 2 },
+  "checks": [ { "id": "audio.loudness", "category": "rendered", "status": "failed",
+                "severity": "warning", "violationCount": 1, "timeRanges": [],
+                "metrics": { }, "autoFixable": true, "suggestedFix": { } } ],
+  "measurements": { "measured": true, "durationSec": 12.0,
+                    "blackRanges": [], "freezeRanges": [], "silenceRanges": [],
+                    "integratedLufs": -21.8, "loudnessRangeLu": 0.0,
+                    "truePeakDbtp": -13.4, "samplePeakDb": -13.4, "flatFactor": 0.0 },
+  "warnings": [], "errors": []
+}
+```
+
+Every check that ran, was skipped, or errored appears in `checks` — so "checked
+and clean" is distinguishable from "never looked". `status` per check is
+`passed`, `failed`, `skipped`, or `errored`, with `skipReason` when skipped.
+
+## The fix loop
+
+`suggestedFix` is `{"description","confidence","steps":[…]}`, and the steps are
+already in edit-plan shape. Wrap them in a plan envelope and execute:
+
+```bash
+openreelio-cli verify --path ./demo --file ./proxy.mp4 --fail-on warning > report.json
+# build fix.json as {"id":"fix_plan","steps": <report.checks[].suggestedFix.steps>}
+openreelio-cli plan validate --path ./demo --file fix.json
+openreelio-cli plan execute  --path ./demo --file fix.json
+openreelio-cli render start  --path ./demo --proxy --output proxy.mp4
+openreelio-cli verify --path ./demo --file ./proxy.mp4 --fail-on warning
+```
+
+That is the whole loop: **analyze → edit → proxy render → look at frames →
+verify → fix → verify again.** Do not declare a job done until `verify` passes at
+the threshold you chose.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,392 @@
+# OpenReelio Agent Guide
+
+The canonical reference for driving OpenReelio from an AI agent or a script.
+
+`openreelio-cli` is a headless non-linear editor. It keeps a real project on
+disk — an append-only command log plus a derived state snapshot — and exposes
+media analysis, editing, captioning, rendering and deterministic QC as
+subcommands that print JSON. Every edit is a command in the log, so a session is
+inspectable, undoable and replayable. Everything below was cross-checked against
+the CLI; when this document and `openreelio-cli <verb> --help` disagree, the
+binary wins.
+
+## 1. Install
+
+### npm (recommended for agents)
+
+```bash
+npm install -g openreelio-cli
+# or, without installing:
+npx openreelio-cli --help
+```
+
+The package downloads nothing at install time. The binary ships in a
+platform-specific optional dependency (`@openreelio/cli-win32-x64`,
+`-darwin-x64`, `-darwin-arm64`, `-linux-x64`) that npm resolves from `os`/`cpu`,
+so installs work with lifecycle scripts disabled. Linux builds are glibc only;
+there is no musl variant.
+
+### Standalone release archive
+
+Every release publishes standalone CLI archives named
+`openreelio-cli-<version>-<target-triple>.zip` (Windows) or
+`openreelio-cli-<version>-<target-triple>.tar.gz` (macOS, Linux) on the
+[releases page](https://github.com/openreelio/openreelio/releases). macOS marks
+downloaded archives with a quarantine attribute; clear it before running the
+extracted binary:
+
+```bash
+xattr -d com.apple.quarantine ./openreelio-cli
+```
+
+### App-bundled sidecar
+
+The desktop app ships the same binary next to the app executable:
+`<app-dir>/binaries/openreelio-cli[.exe]` on Windows and Linux,
+`OpenReelio.app/Contents/Resources/binaries/openreelio-cli` on macOS
+(`<app-dir>/resources/binaries/` is also searched).
+
+Point the npm shim at any binary with `OPENREELIO_CLI_BINARY=<absolute path>`;
+the launcher then uses it verbatim.
+
+## 2. The machine contract
+
+**stdout is one JSON object.** Every successful command prints a single JSON
+document to stdout and nothing else.
+
+**stderr carries progress and diagnostics.** Long-running verbs
+(`render start --progress`, `analysis run --progress`) stream NDJSON progress
+lines to stderr. Log output (`--verbose`, `--quiet`) also goes to stderr. Never
+parse stderr as the result.
+
+**Exit codes.** Most verbs exit `0` on success and `1` on failure, with the
+error text on stderr. `verify` is the exception: `0` ran without breaching the
+`--fail-on` threshold, `1` breached it, `2` the tool itself failed (bad
+arguments, unreadable file, FFmpeg error).
+
+**`--path <PROJECT_DIR>` on every project verb.** There is no ambient "current
+project". Only `help-json`, `command schema`, `plan template`, `render presets`,
+`ffmpeg info`, `transcription status` and `transcription install` omit it.
+`--sequence` is always optional and defaults to the active sequence.
+
+**IDs are ULIDs, not `asset_001`.** The examples in `help-json` use readable
+placeholders. Real IDs look like `01KZW64VJ4JPBS5B9YZEA335J8`. Read them from
+`createdIds` in the command result, or from `asset list` / `timeline tracks` /
+`timeline clips`.
+
+**Negative numbers need `=`.** `--target-lufs -14` is parsed as a flag and
+errors. Write `--target-lufs=-14` and `--max-true-peak=-1`.
+(`analysis silence --threshold-db -40` is the one option that accepts the
+spaced form.)
+
+### Discovering the surface
+
+`help-json` prints the whole command schema, but it is ~58 KB — do not preload
+it into a context window. Fetch help per verb instead
+(`openreelio-cli verify --help`, `openreelio-cli frame extract --help`), and use
+`openreelio-cli command schema` for the 79 backend command types.
+
+### Self-diagnosis
+
+`openreelio-cli ffmpeg info` returns
+`{status, ffmpegPath, ffprobePath, version, source}`, where `source` is one of
+`explicit`, `env`, `bundled`, `managed`, `dev`, `system` — the resolution order.
+Override the toolchain with `OPENREELIO_FFMPEG_PATH` and
+`OPENREELIO_FFPROBE_PATH`; both outrank every bundled or system install. Run
+this first when a media verb fails for no obvious reason.
+
+## 3. Project lifecycle
+
+`project create` makes the directory and a default sequence with one video and
+one audio track. `asset import` returns
+`{"status","opId","createdIds":[<ASSET_ID>],"assetName","uri"}`.
+
+```bash
+openreelio-cli project create --name "Demo" --path ./demo
+openreelio-cli project open   --path ./demo
+openreelio-cli project info   --path ./demo
+openreelio-cli project save   --path ./demo
+openreelio-cli asset import   --path ./demo --file ./footage.mp4 [--name "A-roll"]
+openreelio-cli asset list     --path ./demo
+openreelio-cli asset info     --path ./demo --id <ASSET_ID>
+openreelio-cli asset remove   --path ./demo --id <ASSET_ID>
+```
+
+> **Duration gap.** `asset import` does not probe media duration. A clip placed
+> with `timeline insert` therefore gets the 10-second default length regardless
+> of how long the file actually is. The reliable source of real duration is
+> perception: `analysis shots` returns `totalDurationSec`, and `analysis audio`
+> returns `durationSec`. Insert, then `timeline trim --source-in 0
+> --source-out <totalDurationSec>` to make the clip match the media.
+
+## 4. Editing
+
+### Timeline verbs
+
+```bash
+openreelio-cli timeline info    --path ./demo
+openreelio-cli timeline tracks  --path ./demo
+openreelio-cli timeline clips   --path ./demo [--track <TRACK_ID>]
+
+openreelio-cli timeline insert  --path ./demo --asset <ASSET_ID> --track <TRACK_ID> --at 0.0
+openreelio-cli timeline trim    --path ./demo --clip <CLIP_ID> --track <TRACK_ID> --source-in 0 --source-out 12
+openreelio-cli timeline split   --path ./demo --clip <CLIP_ID> --track <TRACK_ID> --at 6.0
+openreelio-cli timeline move    --path ./demo --clip <CLIP_ID> --track <TRACK_ID> --to 10.0 [--new-track <TRACK_ID>]
+openreelio-cli timeline speed   --path ./demo --clip <CLIP_ID> --track <TRACK_ID> --speed 2.0 [--reverse]
+openreelio-cli timeline remove  --path ./demo --clip <CLIP_ID> --track <TRACK_ID>
+
+openreelio-cli timeline add-track    --path ./demo --kind video --name "Video 2"
+openreelio-cli timeline remove-track --path ./demo --track <TRACK_ID>
+
+openreelio-cli timeline undo --path ./demo
+openreelio-cli timeline redo --path ./demo
+```
+
+The trim flags are `--source-in` / `--source-out` (source-media in/out points),
+not `--in` / `--out`.
+
+`timeline clips` returns each clip's `id`, `trackId`, `assetId`,
+`timelineInSec`, `durationSec`, `sourceInSec`, `sourceOutSec` and `speed` —
+enough to compute any subsequent edit without dumping full state.
+
+### The escape hatch: `command execute`
+
+The convenience verbs cover the common cuts. Everything the editor can do —
+79 command types including effects, masks, keyframes, compound clips,
+adjustment layers, audio ducking, blend modes — is reachable directly:
+
+```bash
+openreelio-cli command schema                       # list all 79 types
+openreelio-cli command validate --type RenameTrack --payload '{…}'
+openreelio-cli command execute  --path ./demo --type SplitClip \
+  --payload '{"sequenceId":"…","trackId":"…","clipId":"…","splitTime":5}'
+```
+
+Payloads are camelCase JSON objects. Use `--payload-file <FILE>` instead of
+`--payload` when the JSON is large or shell quoting is awkward. `command
+validate` runs the same strict parser without touching the project.
+
+### Atomic batches: `plan execute`
+
+An edit plan is `{"id": "...", "steps": [{"id","commandType","payload","dependsOn"}]}`.
+Steps run in dependency order and the whole plan rolls back if any step fails.
+`plan execute` returns `{"status","planId","stepsExecuted","stepResults":[…]}`.
+
+```bash
+openreelio-cli plan template --template-type split-and-move   # note: --template-type
+openreelio-cli plan validate --path ./demo --file plan.json
+openreelio-cli plan execute  --path ./demo --file plan.json
+```
+
+### Undo and history
+
+`timeline undo` / `timeline redo` walk the op log. `state ops --last N` shows
+recent operations, `state dump` the full derived state, `state snapshot` forces
+a snapshot write.
+
+## 5. The perception loop
+
+An agent that cannot see the footage is guessing. These verbs produce the facts.
+
+```bash
+openreelio-cli analysis shots   --path ./demo --id <ASSET_ID> \
+  [--threshold 0.3] [--min-shot-duration 0.5] [--timeout-sec 600] [--no-persist]
+openreelio-cli analysis silence --path ./demo --id <ASSET_ID> \
+  [--threshold-db -40] [--min-duration 0.5]
+openreelio-cli analysis audio   --path ./demo --id <ASSET_ID>
+openreelio-cli analysis run     --path ./demo --id <ASSET_ID> \
+  [--all | --shots --audio --segments --visual --transcript] [--progress]
+openreelio-cli analysis report  --path ./demo --id <ASSET_ID>
+```
+
+- **`analysis shots`** returns `totalDurationSec`, `shotCount` and
+  `shots[{index,startSec,endSec,durationSec,confidence}]`. `persisted` is an
+  array naming the stores written: `["indexDb","bundle","annotations"]`. Cut on
+  shot boundaries instead of round numbers.
+- **`analysis silence`** returns `regions[{startSec,endSec,durationSec}]`,
+  `totalSilenceSec` and a boolean `persisted`. **Persistence contract:** results
+  reach the shared analysis cache only at the default thresholds (`-40` dB,
+  `0.5` s) *and* only when an audio profile already exists. Otherwise the run is
+  output-only, returning `"persisted": false` with a `reason` of
+  `"non-default threshold"`, `"non-default min-duration"`, or
+  ``"no audio profile in bundle; run `analysis audio` first"``. The numbers are
+  still correct — they just do not update the cache the GUI reads.
+- **`analysis audio`** runs the full profiler (silence, loudness curve, peak,
+  BPM, speech regions) and always persists into the bundle.
+- **`analysis run`** drives the job runner with local-only providers.
+  Transcript is off unless `--transcript` is passed, and fails fast with an
+  `openreelio-cli transcription install` hint when no Whisper model is present.
+  `--progress` streams `{"type":"progress","job","status","detail"}` NDJSON to
+  stderr. Per-job failures appear in the `errors` object; the exit is non-zero
+  only if every enabled sub-job failed.
+
+Results land in the project's shared analysis bundle (`analysis report` reads it
+back), so the desktop app sees whatever the CLI computed.
+
+### Looking at frames
+
+```bash
+openreelio-cli frame extract --path ./demo --time 12.5 --out frame.png      # one still
+openreelio-cli frame extract --path ./demo --times 2,8,14 --out ./stills/   # batch (dir)
+openreelio-cli frame extract --path ./demo --asset <ASSET_ID> --source-time 3.0 --out src.png
+openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30 --out sheet.jpg
+```
+
+- `--mode fast` (default) renders the topmost file-backed clip only: no
+  effects, text or compositing. Cheap, and right for "what footage is here". It
+  auto-falls back to composite when there is no such clip (a title card, for
+  example) and reports `fellBackToComposite: true`.
+- `--mode composite` renders a minimal window through the full stack, so
+  effects and overlays appear. Range renders decode from zero, so it costs more.
+- `--max-width` caps the output (default 1280 px, aspect preserved, never
+  upscaled); `--format png|jpeg`.
+- `--grid COLSxROWS --between START END [--count N]` writes one contact sheet
+  and returns `sheet.cells[{index,row,col,timelineSec}]`, which maps every cell
+  a vision model comments on back to a timecode. Grids are capped at 100 cells.
+
+Single and batch extraction return
+`frames[{index,timeSec,sourceTimeSec,clipId,assetId,path,width,height}]`.
+
+### Draft renders
+
+```bash
+openreelio-cli render start --path ./demo --proxy --output proxy.mp4 \
+  --start 0 --end 30 --progress
+```
+
+`--proxy` is an alias for the `proxy_480p` preset: 854x480, CRF 30, H.264 +
+AAC, `ultrafast`. Combine it with `--start` / `--end` to render only the range
+under review. `--output` is required. `--progress` streams
+`{"type":"progress","percent","frame","totalFrames","fps","etaSeconds","message"}`
+to stderr. The result carries `outputPath`, `durationSec`, `fileSize`,
+`encodingTimeSec`, `planHash` and `warnings`. `render presets` lists the
+presets; `render graph` prints the render graph without encoding anything.
+
+## 6. The verify loop
+
+```bash
+openreelio-cli verify --path ./demo                          # structural only
+openreelio-cli verify --path ./demo --file ./proxy.mp4       # + rendered measurements
+openreelio-cli verify --path ./demo --file ./proxy.mp4 \
+  --target-lufs=-14 --max-true-peak=-1 --fail-on error
+```
+
+Without `--file`, only structural checks run and FFmpeg is never invoked.
+`--structural-only` makes that explicit and conflicts with `--file`.
+
+Sixteen checks in two categories. **structural**: `timeline.gap`,
+`clip.orphan`, `clip.missing_asset`, `clip.aspect_ratio`, `audio.silent_clip`,
+`caption.overlap`, `caption.reading_rate`, `caption.out_of_bounds`,
+`caption.safe_area`, `shot.length_stats`, `shot.cut_rhythm`, plus the opt-in
+`asset.license` and `sequence.duration`. **rendered**: `render.black_frames`,
+`audio.peak`, `audio.loudness`. The two opt-ins run only when named in
+`--checks`; narrow any run with `--checks a,b` or `--skip a,b`.
+
+The report always lists every check that ran, was skipped, or errored — so
+"checked and clean" is distinguishable from "never looked". Each entry carries
+`id`, `category`, `status` (`passed`/`failed`/`skipped`/`errored`),
+`violationCount`, `timeRanges`, `metrics`, `autoFixable` and, when the rule
+knows the repair, `suggestedFix`. `measurements` holds the file-level numbers:
+`blackRanges`, `freezeRanges`, `silenceRanges`, `integratedLufs`,
+`loudnessRangeLu`, `truePeakDbtp`, `samplePeakDb`, `flatFactor`.
+
+`--fail-on info|warning|error|critical` (default `error`) sets which severity
+turns exit `0` into exit `1`. Taste-adjacent findings stay at warning/info;
+`error` is reserved for objectively broken output.
+
+Measured times are file-relative while structural findings are
+timeline-relative, so `--file` expects a render of the whole sequence from zero.
+A partial render still measures correctly, but its timestamps no longer line up.
+
+### Feeding a fix back
+
+`suggestedFix` is `{"description","confidence","steps":[…]}` and the steps are
+already in plan shape. Wrap them in a plan envelope and execute:
+
+```bash
+openreelio-cli verify --path ./demo --file ./proxy.mp4 --fail-on warning > report.json
+# take report.checks[].suggestedFix.steps → {"id":"fix_plan","steps":[…]} → fix.json
+openreelio-cli plan validate --path ./demo --file fix.json
+openreelio-cli plan execute  --path ./demo --file fix.json
+openreelio-cli verify --path ./demo --file ./proxy.mp4 --fail-on warning
+```
+
+That is the whole loop: **analyze → edit → proxy render → look at frames →
+verify → fix → verify again.**
+
+## 7. Captions and text
+
+Captions are timed subtitle entries; text clips are styled overlays with
+position, transform and effects. Both are ordinary commands in the op log.
+
+```bash
+openreelio-cli caption add    --path ./demo --text "Hello" --start 0.5 --end 3.0
+openreelio-cli caption update --path ./demo --id <CAPTION_ID> --text "Updated"
+openreelio-cli caption list   --path ./demo
+openreelio-cli caption remove --path ./demo --id <CAPTION_ID>
+openreelio-cli caption import --path ./demo --file subs.srt [--format srt|vtt|transcript-json]
+openreelio-cli caption export --path ./demo --format srt --output subs.srt
+
+openreelio-cli text add       --path ./demo --text "Title" --start 0 --duration 3 [--preset credits]
+openreelio-cli text update    --path ./demo --id <CLIP_ID> --text "New"
+openreelio-cli text transform --path ./demo --id <CLIP_ID> --x 0.38 --y 0.42 --scale-x 1.2
+openreelio-cli text list      --path ./demo
+openreelio-cli text remove    --path ./demo --id <CLIP_ID>
+```
+
+Speech-to-text is local (Whisper); `--import` writes the result straight into a
+caption track.
+
+```bash
+openreelio-cli transcription status
+openreelio-cli transcription install --model large-v3-turbo
+openreelio-cli transcription generate --path ./demo --asset <ASSET_ID> --import
+openreelio-cli transcription generate-sequence --path ./demo --import
+```
+
+## 8. MCP server
+
+The same binary is an MCP server over stdio. `--stdio` is required to actually
+serve; without it the command prints the tool list, resources and policy as JSON
+so you can inspect the surface first.
+
+```bash
+openreelio-cli mcp --project ./demo             # prints the discovery payload
+openreelio-cli mcp --stdio --project ./demo     # serves JSON-RPC on stdio
+openreelio-cli mcp --stdio --project ./demo --allow-write
+```
+
+**Read-only by default.** Fourteen tools are advertised: `host.context`,
+`project.info`, `selection.read`, `diagnostics.read`, `timeline.snapshot`,
+`assets.list`, `annotation.read`, `command.schema`, `command.validate`,
+`plan.validate`, `preview.describe`, `transcription.status`,
+`transcription.generate` and `verify` — each prefixed `openreelio.`.
+
+**`--allow-write` is a local-trust switch.** It adds `openreelio.media.insert`
+and `openreelio.plan.apply` and drops the per-call approval token those tools
+otherwise require; the policy block then reports `"mode": "read-write-local"`.
+Every mutation still goes through the command log and stays undoable, but use it
+only with a locally trusted client. Without the flag, a host can still authorize
+a single call by supplying `OPENREELIO_MCP_APPROVAL_TOKEN`.
+
+**`openreelio.verify`** is read-only-safe and always advertised. It accepts
+`{sequenceId?, file?, structuralOnly?, checks?[], skip?[], failOn?}` and returns
+the same report document the CLI prints — so an MCP client gets the fix loop
+without shelling out.
+
+## 9. Environment variables
+
+| Variable                        | Purpose                                                      |
+| ------------------------------- | ------------------------------------------------------------ |
+| `OPENREELIO_CLI_BINARY`         | Absolute path to a CLI binary; bypasses npm package lookup   |
+| `OPENREELIO_FFMPEG_PATH`        | Explicit FFmpeg binary (highest precedence)                  |
+| `OPENREELIO_FFPROBE_PATH`       | Explicit FFprobe binary                                      |
+| `OPENREELIO_MCP_APPROVAL_TOKEN` | Host-issued single-call write approval for the MCP server    |
+
+## 10. See also
+
+- [`AGENT_PERCEPTION_CLI_PLAN.md`](./AGENT_PERCEPTION_CLI_PLAN.md) — design
+  rationale and accepted deviations for the perception and verify surfaces
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — system architecture
+- [`COMMAND_REFERENCE.md`](./COMMAND_REFERENCE.md) — backend edit commands
+- [`API_SPEC.md`](./API_SPEC.md) — IPC/API specifications

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -12,7 +12,8 @@ This document explains distribution options for OpenReelio releases.
 6. [macOS Code Signing & Notarization](#macos-code-signing--notarization)
 7. [Tauri Updater Signing](#tauri-updater-signing)
 8. [Release Process](#release-process)
-9. [Troubleshooting](#troubleshooting)
+9. [npm Distribution (CLI)](#npm-distribution-cli)
+10. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -312,6 +313,125 @@ The GitHub Actions workflow will automatically:
 2. Review the draft release
 3. Edit release notes
 4. Click "Publish release"
+
+---
+
+## npm Distribution (CLI)
+
+The headless CLI is also published to npm so agents and CI can reach it with a
+single `npx openreelio-cli`. The installers are unaffected; this is a second
+delivery path for the same binary.
+
+### Published packages
+
+| Package                        | Contents                                      |
+| ------------------------------ | --------------------------------------------- |
+| `openreelio-cli`               | Launcher only (`bin/openreelio-cli.mjs`)      |
+| `@openreelio/cli-win32-x64`    | `x86_64-pc-windows-msvc` binary               |
+| `@openreelio/cli-darwin-x64`   | `x86_64-apple-darwin` binary                  |
+| `@openreelio/cli-darwin-arm64` | `aarch64-apple-darwin` binary                 |
+| `@openreelio/cli-linux-x64`    | `x86_64-unknown-linux-gnu` binary             |
+
+The shim lists all four platform packages as `optionalDependencies`; npm
+installs only the one whose `os`/`cpu` matches the host, and the launcher
+resolves its binary through `require.resolve`. `OPENREELIO_CLI_BINARY`
+overrides that lookup with an explicit path.
+
+### Why there is no postinstall download
+
+npm v12 disables dependency lifecycle scripts by default, so the classic
+"postinstall downloads a binary" pattern now fails silently for a growing share
+of installs. The binary therefore has to arrive as package *content*. This is
+the same shape esbuild, Biome and turbo use.
+
+Consequences worth remembering:
+
+- Neither the shim nor the platform packages define **any** install script.
+- Platform packages declare no `bin` and no `exports` field: the shim owns the
+  command name, and an `exports` map would block resolution of
+  `@openreelio/cli-<platform>/package.json`.
+- Installs that pass `--omit=optional` / `--no-optional` get a clear error
+  naming the missing package instead of a mystery `ENOENT`.
+
+**Known limitation:** Linux is glibc only. The release matrix builds no musl
+target, so Alpine users must download a standalone archive and set
+`OPENREELIO_CLI_BINARY`. Adding a musl package means adding a musl target to
+`release.yml` first, then registering it in the generator's `TARGETS` table.
+
+### Assets to packages: the flow
+
+```
+release.yml (build-tauri)
+  └─ openreelio-cli-<version>-<triple>.zip|.tar.gz  + .sha256   (draft release)
+release.yml (publish-release)
+  └─ draft flipped to published -> download URLs resolve
+npm-publish.yml (workflow_run: Release completed)
+  ├─ gh release download 'openreelio-cli-*'
+  ├─ sha256sum --check, then extract to dist/cli-assets/<triple>/
+  ├─ node scripts/build-npm-platform-packages.mjs   (verifies .sha256 again,
+  │    stamps versions, writes 4 platform packages + a stamped shim copy)
+  ├─ npm publish each @openreelio/cli-* package
+  └─ npm publish openreelio-cli
+```
+
+Platform packages are published **before** the shim, because the shim pins them
+exactly.
+
+Run the generator locally to inspect what would be published:
+
+```bash
+cargo build --release -p openreelio-cli
+node scripts/build-npm-platform-packages.mjs \
+  --only win32-x64 \
+  --binary win32-x64=target/release/openreelio-cli.exe \
+  --shim-out npm/platform-packages/generated/openreelio-cli
+```
+
+Generate the non-Windows packages on Linux or macOS: `npm pack` records the file
+mode, and a Windows host cannot set the executable bit.
+
+### Why npm publishing is a separate workflow
+
+The platform packages embed assets from the release, which only become
+downloadable once `publish-release` flips the draft. npm work must run strictly
+afterwards.
+
+The trigger is `workflow_run` on the **Release** workflow rather than
+`release: published`, because GitHub does not start new workflow runs from
+events raised with the built-in `GITHUB_TOKEN` — and `publish-release`
+publishes the draft with exactly that token.
+
+### Setup TODO (not done yet)
+
+npm publishing is **inert until both steps below are completed**. Merging the
+workflow cannot publish anything.
+
+1. **Enable the workflow.** Create repository variable
+   `NPM_PUBLISH_ENABLED = true` (Settings → Secrets and variables → Actions →
+   Variables). Without it, the automatic path is skipped and a manual run
+   refuses to publish (`dry_run: true` still packs and uploads tarballs as a
+   build artifact, which is the safe way to inspect output).
+
+2. **Set up authentication.** Preferred: **Trusted Publishing (OIDC)** — on
+   npmjs.com, configure a GitHub Actions trusted publisher for each of the five
+   packages, pointing at repository `openreelio/openreelio` and workflow
+   `npm-publish.yml`. It needs npm ≥ 11.5.1 (the workflow installs it) and
+   `id-token: write` (already granted), and attaches provenance automatically.
+
+   Chicken-and-egg caveat: a trusted publisher can only be configured on a
+   package that already exists, so the **first** publish of each package must
+   use the fallback — an npm automation token stored as secret `NPM_TOKEN`. The
+   workflow uses it only when present, so it can be deleted once trusted
+   publishing is live.
+
+### Version discipline
+
+`npm/openreelio-cli/package.json` is a `version:check` target, so the shim
+version is enforced against `package.json` in CI. `npm run version:sync` also
+repins the shim's `@openreelio/*` `optionalDependencies` to the new version, and
+the publish workflow re-stamps both the shim and the platform packages from the
+release tag, so a published shim can never point at platform versions that were
+never released.
 
 ---
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -339,10 +339,13 @@ overrides that lookup with an explicit path.
 
 ### Why there is no postinstall download
 
-npm v12 disables dependency lifecycle scripts by default, so the classic
-"postinstall downloads a binary" pattern now fails silently for a growing share
-of installs. The binary therefore has to arrive as package *content*. This is
-the same shape esbuild, Biome and turbo use.
+npm still runs lifecycle scripts by default (`ignore-scripts` is `false` in npm
+v12), but a growing share of installs turn them off — `--ignore-scripts`,
+a hardened CI image, or an organization-wide policy — and the classic
+"postinstall downloads a binary" pattern then fails silently. The binary
+therefore has to arrive as package *content*, so the package stays fully
+functional with lifecycle scripts disabled. This is the same shape esbuild,
+Biome and turbo use.
 
 Consequences worth remembering:
 
@@ -360,7 +363,7 @@ target, so Alpine users must download a standalone archive and set
 
 ### Assets to packages: the flow
 
-```
+```text
 release.yml (build-tauri)
   └─ openreelio-cli-<version>-<triple>.zip|.tar.gz  + .sha256   (draft release)
 release.yml (publish-release)
@@ -415,7 +418,8 @@ workflow cannot publish anything.
 2. **Set up authentication.** Preferred: **Trusted Publishing (OIDC)** — on
    npmjs.com, configure a GitHub Actions trusted publisher for each of the five
    packages, pointing at repository `openreelio/openreelio` and workflow
-   `npm-publish.yml`. It needs npm ≥ 11.5.1 (the workflow installs it) and
+   `npm-publish.yml`. It needs Node.js ≥ 22.14.0 and npm ≥ 11.5.1 (the workflow
+   resolves the latest Node 22, asserts that minimum, then installs npm 11) and
    `id-token: write` (already granted), and attaches provenance automatically.
 
    Chicken-and-egg caveat: a trusted publisher can only be configured on a

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,7 @@ export default tseslint.config(
       'tailwind.config.js',
       'postcss.config.js',
       'scripts/**/*.{js,mjs}',
+      'npm/**/*.mjs',
     ],
     languageOptions: {
       globals: {

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,35 @@
+# OpenReelio
+
+> OpenReelio is an open-source, AI agent-driven video editing IDE with a headless
+> CLI and MCP server (`openreelio-cli`). It gives an agent a real non-linear
+> editor: import media, cut/trim/split a timeline, add captions and text overlays,
+> detect shots and silence, extract frames to inspect the result, render, and run
+> deterministic quality control. Projects are event-sourced — every edit is a
+> command appended to an append-only op log, and the project state is a replayable
+> snapshot of that log — so edits stay inspectable, undoable and reproducible
+> rather than baked into a one-shot output file.
+
+Every CLI command prints a single JSON object on stdout; progress and diagnostics
+go to stderr. Long-running verbs stream NDJSON progress under `--progress`. The
+CLI is self-describing: `openreelio-cli help-json` emits the full command schema,
+and `openreelio-cli <verb> --help` is authoritative for any single verb.
+
+Install with `npm install -g openreelio-cli` (or run `npx openreelio-cli --help`).
+FFmpeg and FFprobe are resolved at runtime; `openreelio-cli ffmpeg info` reports
+which binaries were picked and from where.
+
+## Docs
+
+- [Agent Guide](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/AGENT_GUIDE.md): The canonical agent-facing reference — install, the JSON/exit-code contract, project lifecycle, editing verbs, the perception loop (analysis, frame extraction, proxy renders), the verify QC loop, and the MCP server.
+- [Agent Perception CLI Plan](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/AGENT_PERCEPTION_CLI_PLAN.md): Design rationale for the perception and verify surfaces, including accepted deviations such as the `analysis silence` cache-persistence contract and the proxy render preset.
+- [Architecture](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/ARCHITECTURE.md): System architecture — event sourcing, worker separation, the Rust core, and the Tauri/React frontend.
+- [Command Reference](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/COMMAND_REFERENCE.md): The backend edit commands that `command execute` and `plan execute` accept.
+
+## Optional
+
+- [README](https://raw.githubusercontent.com/openreelio/openreelio/main/README.md): Project overview, features, and desktop app installation.
+- [API Spec](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/API_SPEC.md): IPC and API specifications for the desktop app boundary.
+- [Data Models](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/DATA_MODELS.md): Project, sequence, track, clip, asset and analysis schemas.
+- [Plugin Spec](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/PLUGIN_SPEC.md): The WASM-based plugin sandbox.
+- [Roadmap](https://raw.githubusercontent.com/openreelio/openreelio/main/docs/ROADMAP.md): Development roadmap from v0.1.0 to v1.0.0.
+- [Contributing](https://raw.githubusercontent.com/openreelio/openreelio/main/CONTRIBUTING.md): How to contribute code, and the project conventions.

--- a/npm/openreelio-cli/LICENSE
+++ b/npm/openreelio-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Junseo5
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/openreelio-cli/README.md
+++ b/npm/openreelio-cli/README.md
@@ -1,0 +1,117 @@
+<!-- mcp-name: io.github.openreelio/openreelio -->
+
+# openreelio-cli
+
+Headless, agent-native video editing. `openreelio-cli` gives an AI agent (or a
+script) a real non-linear editor over the command line: an event-sourced
+timeline, media analysis, captions, deterministic QC and rendering — instead of
+hand-assembling `ffmpeg` filtergraphs and hoping the result is watchable.
+
+Every command prints a single JSON object on stdout. Progress and diagnostics go
+to stderr. Every edit is a command appended to an append-only op log, so the
+whole session is inspectable, undoable and replayable.
+
+## Install
+
+```bash
+npm install -g openreelio-cli
+# or, without installing:
+npx openreelio-cli --help
+```
+
+The package downloads nothing at install time. The binary ships in a
+platform-specific optional dependency that npm resolves from `os`/`cpu`, so
+installs work with lifecycle scripts disabled (the npm v12 default).
+
+| Platform          | Package                        | Release target             |
+| ----------------- | ------------------------------ | -------------------------- |
+| Windows x64       | `@openreelio/cli-win32-x64`    | `x86_64-pc-windows-msvc`   |
+| macOS Intel       | `@openreelio/cli-darwin-x64`   | `x86_64-apple-darwin`      |
+| macOS Apple Sili. | `@openreelio/cli-darwin-arm64` | `aarch64-apple-darwin`     |
+| Linux x64 (glibc) | `@openreelio/cli-linux-x64`    | `x86_64-unknown-linux-gnu` |
+
+Linux builds are glibc only; there is no musl variant yet. On any unlisted
+platform, download a standalone archive from the
+[releases page](https://github.com/openreelio/openreelio/releases) and set
+`OPENREELIO_CLI_BINARY` to its path — the launcher will use it verbatim.
+
+FFmpeg and FFprobe are resolved at runtime (bundled, managed, or from `PATH`).
+Run `openreelio-cli ffmpeg info` to see exactly which binaries were picked and
+where they came from.
+
+## Quickstart
+
+```bash
+# 1. Create a project and import media
+openreelio-cli project create --name "Demo" --path ./demo
+openreelio-cli asset import --path ./demo --file ./footage.mp4
+
+# 2. Look before you cut: shots, silence, loudness
+openreelio-cli analysis run --path ./demo --progress
+
+# 3. Edit through commands (append-only, undoable)
+openreelio-cli timeline insert --path ./demo --asset asset_001 --track track_v1 --at 0.0
+openreelio-cli timeline split  --path ./demo --clip clip_001 --at 5.0
+openreelio-cli timeline undo   --path ./demo
+
+# 4. See the result, not just the JSON
+openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30
+openreelio-cli render start --path ./demo --proxy --start 0 --end 30 --progress
+
+# 5. Prove it is deliverable
+openreelio-cli verify --path ./demo --file ./out/proxy.mp4
+```
+
+`verify` exits `0` when checks pass, `1` when a `--fail-on` threshold is
+breached, and `2` when it could not run. Violations carry a `suggestedFix`
+EditScript that can be fed straight back into `plan execute`.
+
+## Use it from an agent
+
+Start with the machine-readable command schema, then drive the loop:
+
+```bash
+openreelio-cli help-json          # full command surface as JSON
+openreelio-cli ffmpeg info        # self-diagnosis
+```
+
+The perception loop that makes autonomous editing work is: **analyze → edit →
+render → look at frames → verify → fix**. `analysis`, `frame extract`,
+`render start --proxy` and `verify` exist specifically to close it.
+
+### MCP server
+
+`openreelio-cli` is also an MCP server over stdio, so MCP-capable agents can use
+it as a tool provider:
+
+```bash
+openreelio-cli mcp                 # read-only tools
+openreelio-cli mcp --allow-write   # also expose mutating tools (local trust)
+```
+
+`--allow-write` drops the per-call approval requirement for mutating tools. Use
+it only with a locally trusted client; every mutation still goes through the
+command log and stays undoable.
+
+MCP registry identifier:
+
+```
+mcp-name: io.github.openreelio/openreelio
+```
+
+## Environment
+
+| Variable                 | Purpose                                                 |
+| ------------------------ | ------------------------------------------------------- |
+| `OPENREELIO_CLI_BINARY`  | Absolute path to a CLI binary; bypasses package lookup   |
+| `OPENREELIO_FFMPEG_PATH` | Explicit FFmpeg binary (highest precedence)              |
+| `OPENREELIO_FFPROBE_PATH`| Explicit FFprobe binary (highest precedence)             |
+
+## Links
+
+- Source and issues: <https://github.com/openreelio/openreelio>
+- Full command reference: `openreelio-cli help-json`
+
+## License
+
+MIT © 2026 Junseo5

--- a/npm/openreelio-cli/README.md
+++ b/npm/openreelio-cli/README.md
@@ -19,9 +19,10 @@ npm install -g openreelio-cli
 npx openreelio-cli --help
 ```
 
-The package downloads nothing at install time. The binary ships in a
-platform-specific optional dependency that npm resolves from `os`/`cpu`, so
-installs work with lifecycle scripts disabled (the npm v12 default).
+npm downloads this package and the one platform package matching your `os`/`cpu`;
+no install script downloads the binary. It ships as content of that
+platform-specific optional dependency, so installs also work with lifecycle
+scripts disabled (`--ignore-scripts`).
 
 | Platform          | Package                        | Release target             |
 | ----------------- | ------------------------------ | -------------------------- |
@@ -95,7 +96,7 @@ command log and stays undoable.
 
 MCP registry identifier:
 
-```
+```text
 mcp-name: io.github.openreelio/openreelio
 ```
 

--- a/npm/openreelio-cli/README.md
+++ b/npm/openreelio-cli/README.md
@@ -47,7 +47,7 @@ openreelio-cli project create --name "Demo" --path ./demo
 openreelio-cli asset import --path ./demo --file ./footage.mp4
 
 # 2. Look before you cut: shots, silence, loudness
-openreelio-cli analysis run --path ./demo --progress
+openreelio-cli analysis run --path ./demo --id <ASSET_ID> --progress
 
 # 3. Edit through commands (append-only, undoable)
 openreelio-cli timeline insert --path ./demo --asset asset_001 --track track_v1 --at 0.0
@@ -55,8 +55,8 @@ openreelio-cli timeline split  --path ./demo --clip clip_001 --at 5.0
 openreelio-cli timeline undo   --path ./demo
 
 # 4. See the result, not just the JSON
-openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30
-openreelio-cli render start --path ./demo --proxy --start 0 --end 30 --progress
+openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30 --out ./frames/sheet.jpg
+openreelio-cli render start --path ./demo --proxy --output ./out/proxy.mp4 --start 0 --end 30 --progress
 
 # 5. Prove it is deliverable
 openreelio-cli verify --path ./demo --file ./out/proxy.mp4
@@ -85,8 +85,8 @@ render → look at frames → verify → fix**. `analysis`, `frame extract`,
 it as a tool provider:
 
 ```bash
-openreelio-cli mcp                 # read-only tools
-openreelio-cli mcp --allow-write   # also expose mutating tools (local trust)
+openreelio-cli mcp --project ./demo --stdio                 # read-only tools
+openreelio-cli mcp --project ./demo --stdio --allow-write   # also expose mutating tools (local trust)
 ```
 
 `--allow-write` drops the per-call approval requirement for mutating tools. Use

--- a/npm/openreelio-cli/bin/openreelio-cli.mjs
+++ b/npm/openreelio-cli/bin/openreelio-cli.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview `openreelio-cli` npm launcher.
+ *
+ * This package ships no binary of its own. The platform binary arrives through
+ * one of the `@openreelio/cli-*` optional dependencies, which npm installs only
+ * when their `os`/`cpu` fields match the host. This launcher locates that
+ * sibling package and execs the binary inside it.
+ *
+ * Deliberately there is no install script: npm v12 disables lifecycle scripts
+ * for dependencies by default, so a postinstall download would silently fail
+ * for a growing share of users.
+ *
+ * Contract:
+ * - stdout/stderr belong entirely to the CLI. This launcher prints nothing on
+ *   the happy path, because callers parse stdout as a single JSON object.
+ * - The child's exit code is propagated verbatim. `openreelio-cli verify` uses
+ *   0 (passed), 1 (threshold breached) and 2 (could not run), and agents branch
+ *   on those values.
+ * - Failures inside the launcher itself exit with 2 ("the tool could not run").
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, writeSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { constants as osConstants } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** Exit code used when the launcher cannot start the real CLI. */
+const EXIT_LAUNCH_FAILURE = 2;
+
+/** Environment variable that overrides platform package resolution. */
+const BINARY_OVERRIDE_ENV = 'OPENREELIO_CLI_BINARY';
+
+/** Release targets published to npm, keyed by `${process.platform}-${process.arch}`. */
+const PLATFORM_PACKAGES = {
+  'win32-x64': { packageName: '@openreelio/cli-win32-x64', binaryName: 'openreelio-cli.exe' },
+  'darwin-x64': { packageName: '@openreelio/cli-darwin-x64', binaryName: 'openreelio-cli' },
+  'darwin-arm64': { packageName: '@openreelio/cli-darwin-arm64', binaryName: 'openreelio-cli' },
+  'linux-x64': { packageName: '@openreelio/cli-linux-x64', binaryName: 'openreelio-cli' },
+};
+
+const RELEASES_URL = 'https://github.com/openreelio/openreelio/releases';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Fails the process with a message on stderr, never stdout.
+ *
+ * @param {string[]} lines Message lines, printed in order.
+ * @returns {never}
+ */
+function fail(lines) {
+  // writeSync, not process.stderr.write: stderr is async when it is a pipe, and
+  // process.exit() would discard a buffered message.
+  writeSync(process.stderr.fd, `${lines.join('\n')}\n`);
+  process.exit(EXIT_LAUNCH_FAILURE);
+}
+
+/**
+ * Detects a musl-based Linux host. Release builds are glibc (gnu) only, so this
+ * turns an opaque "package not found" into an actionable message.
+ *
+ * @returns {boolean} True when the host looks like musl libc.
+ */
+function isLikelyMuslLinux() {
+  if (process.platform !== 'linux') {
+    return false;
+  }
+
+  try {
+    const report = process.report?.getReport();
+    const header = typeof report === 'object' && report !== null ? report.header : undefined;
+    // glibcVersionRuntime is absent on musl builds of Node.
+    return Boolean(header) && !('glibcVersionRuntime' in header);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Builds the diagnostic shown when the platform package cannot be resolved.
+ *
+ * @param {string} packageName Expected optional dependency.
+ * @returns {string[]} Message lines.
+ */
+function missingPlatformPackageMessage(packageName) {
+  const lines = [
+    `openreelio-cli: the platform package "${packageName}" is not installed.`,
+    `  host: ${process.platform}-${process.arch}`,
+    '',
+    'This package resolves its binary from an optional dependency, so the most',
+    'common causes are:',
+    '  - the install disabled optional dependencies',
+    '    (npm --omit=optional / --no-optional, yarn --ignore-optional,',
+    '     pnpm --no-optional, or NPM_CONFIG_OPTIONAL=false in CI)',
+    '  - a lockfile generated on a different OS or CPU was installed verbatim',
+    '  - the package was vendored or copied without its dependencies',
+  ];
+
+  if (isLikelyMuslLinux()) {
+    lines.push(
+      '  - this host appears to use musl libc; published builds are glibc (gnu) only',
+    );
+  }
+
+  lines.push(
+    '',
+    'Fixes:',
+    '  - reinstall with optional dependencies enabled: npm install openreelio-cli',
+    `  - or download a standalone build from ${RELEASES_URL}`,
+    `    and point ${BINARY_OVERRIDE_ENV} at it`,
+  );
+
+  return lines;
+}
+
+/**
+ * Resolves the absolute path of the OpenReelio CLI binary for this host.
+ *
+ * @returns {string} Absolute path to the executable.
+ */
+function resolveBinaryPath() {
+  const override = process.env[BINARY_OVERRIDE_ENV];
+  if (override) {
+    if (!existsSync(override)) {
+      fail([
+        `openreelio-cli: ${BINARY_OVERRIDE_ENV} points at a missing file.`,
+        `  ${override}`,
+      ]);
+    }
+    return override;
+  }
+
+  const hostKey = `${process.platform}-${process.arch}`;
+  const target = PLATFORM_PACKAGES[hostKey];
+  if (!target) {
+    fail([
+      `openreelio-cli: unsupported platform/arch "${hostKey}".`,
+      `  supported: ${Object.keys(PLATFORM_PACKAGES).join(', ')}`,
+      '',
+      `Build from source or download a standalone archive from ${RELEASES_URL},`,
+      `then point ${BINARY_OVERRIDE_ENV} at the binary.`,
+    ]);
+  }
+
+  let packageJsonPath;
+  try {
+    packageJsonPath = require.resolve(`${target.packageName}/package.json`);
+  } catch {
+    fail(missingPlatformPackageMessage(target.packageName));
+  }
+
+  const binaryPath = join(dirname(packageJsonPath), 'bin', target.binaryName);
+  if (!existsSync(binaryPath)) {
+    fail([
+      `openreelio-cli: "${target.packageName}" is installed but its binary is missing.`,
+      `  expected: ${binaryPath}`,
+      '',
+      'Reinstall the package, or download a standalone build from',
+      `${RELEASES_URL} and point ${BINARY_OVERRIDE_ENV} at it.`,
+    ]);
+  }
+
+  return binaryPath;
+}
+
+const binaryPath = resolveBinaryPath();
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: 'inherit',
+  // shell: false keeps arguments verbatim; edit commands routinely carry
+  // quotes, spaces and filter expressions that a shell would mangle.
+  shell: false,
+});
+
+if (result.error) {
+  fail([
+    `openreelio-cli: failed to start ${binaryPath}`,
+    `  ${result.error.message}`,
+  ]);
+}
+
+if (typeof result.status === 'number') {
+  process.exit(result.status);
+}
+
+if (result.signal) {
+  // Mirror the shell convention so callers can tell a signal from a normal exit.
+  const signalNumber = osConstants.signals[result.signal] ?? 0;
+  process.exit(128 + signalNumber);
+}
+
+process.exit(EXIT_LAUNCH_FAILURE);

--- a/npm/openreelio-cli/package.json
+++ b/npm/openreelio-cli/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "openreelio-cli",
+  "version": "0.1.10",
+  "description": "Headless, agent-native video editing CLI and MCP server. Cut, trim, caption, analyze and render real timelines from natural language or scripts instead of hand-writing ffmpeg filtergraphs.",
+  "keywords": [
+    "video-editing",
+    "video",
+    "ai-agent",
+    "agent",
+    "mcp",
+    "mcp-server",
+    "ffmpeg",
+    "ffmpeg-alternative",
+    "nle",
+    "timeline",
+    "captions",
+    "transcription",
+    "render",
+    "headless",
+    "cli"
+  ],
+  "homepage": "https://github.com/openreelio/openreelio#readme",
+  "bugs": {
+    "url": "https://github.com/openreelio/openreelio/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openreelio/openreelio.git",
+    "directory": "npm/openreelio-cli"
+  },
+  "license": "MIT",
+  "author": "Junseo5",
+  "mcpName": "io.github.openreelio/openreelio",
+  "type": "module",
+  "bin": {
+    "openreelio-cli": "bin/openreelio-cli.mjs"
+  },
+  "files": [
+    "bin/openreelio-cli.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@openreelio/cli-darwin-arm64": "0.1.10",
+    "@openreelio/cli-darwin-x64": "0.1.10",
+    "@openreelio/cli-linux-x64": "0.1.10",
+    "@openreelio/cli-win32-x64": "0.1.10"
+  }
+}

--- a/npm/platform-packages/.gitignore
+++ b/npm/platform-packages/.gitignore
@@ -1,0 +1,2 @@
+# Platform packages are assembled at publish time from release binaries.
+generated/

--- a/npm/platform-packages/README.md
+++ b/npm/platform-packages/README.md
@@ -1,0 +1,60 @@
+# Platform packages (`@openreelio/cli-*`)
+
+These packages are **generated, not committed**. Each one carries a single
+prebuilt `openreelio-cli` binary for one release target, plus `os`/`cpu` fields
+so npm installs exactly one of them per host. The `openreelio-cli` shim in
+`../openreelio-cli` lists all four as `optionalDependencies` and resolves the
+binary at run time.
+
+The binaries only exist as release assets, so the packages are assembled during
+the publish workflow by `scripts/build-npm-platform-packages.mjs` and written to
+`generated/` (git-ignored).
+
+| Package                        | `os`     | `cpu`   | Release target             | Archive  |
+| ------------------------------ | -------- | ------- | -------------------------- | -------- |
+| `@openreelio/cli-win32-x64`    | `win32`  | `x64`   | `x86_64-pc-windows-msvc`   | `.zip`   |
+| `@openreelio/cli-darwin-x64`   | `darwin` | `x64`   | `x86_64-apple-darwin`      | `.tar.gz`|
+| `@openreelio/cli-darwin-arm64` | `darwin` | `arm64` | `aarch64-apple-darwin`     | `.tar.gz`|
+| `@openreelio/cli-linux-x64`    | `linux`  | `x64`   | `x86_64-unknown-linux-gnu` | `.tar.gz`|
+
+## Known limitation: glibc only
+
+There is no `linux-x64-musl` package. The release matrix builds
+`x86_64-unknown-linux-gnu` only, so Alpine and other musl distributions must
+download a standalone archive and point `OPENREELIO_CLI_BINARY` at it. Adding a
+musl variant means adding a musl target to the release matrix first; the
+generator's `TARGETS` table is then the single place to register it.
+
+## Generating locally
+
+```bash
+# From a real local build (Windows example)
+cargo build --release -p openreelio-cli
+node scripts/build-npm-platform-packages.mjs \
+  --only win32-x64 \
+  --binary win32-x64=target/release/openreelio-cli.exe
+
+# From downloaded release assets, verifying checksums
+node scripts/build-npm-platform-packages.mjs \
+  --version 0.1.10 \
+  --input dist/cli-assets \
+  --archives dist/cli-archives \
+  --shim-out npm/platform-packages/generated/shim
+```
+
+`--input` expects the archives already unpacked, one directory per target
+triple. `--archives` is optional and verifies each archive against its `.sha256`
+sidecar before the package is written.
+
+Generate the non-Windows packages on Linux or macOS: `npm pack` records the
+file mode, and a Windows host cannot set the executable bit.
+
+## Design notes
+
+- **No install scripts anywhere.** npm v12 disables dependency lifecycle
+  scripts by default, so a `postinstall` downloader would silently fail. The
+  binary must arrive as package content.
+- **No `bin` field in the platform packages.** Only the shim declares a command;
+  a second `bin` entry would fight it for the same name.
+- **No `exports` field either.** The shim resolves
+  `@openreelio/cli-<platform>/package.json`, which an `exports` map would block.

--- a/scripts/build-npm-platform-packages.mjs
+++ b/scripts/build-npm-platform-packages.mjs
@@ -1,0 +1,513 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview Assembles the `@openreelio/cli-*` npm platform packages.
+ *
+ * The published npm surface is a shim package (`npm/openreelio-cli`) plus one
+ * binary-carrying package per release target. The binaries only exist as
+ * release assets, so the platform packages are generated at publish time rather
+ * than committed. This script is that generator.
+ *
+ * It never downloads anything: give it a directory of already-unpacked release
+ * binaries (the publish workflow extracts the release archives into it), and
+ * optionally the directory holding the archives plus their `.sha256` sidecars
+ * so the payload can be verified before it is republished to npm.
+ *
+ * Usage:
+ *   node scripts/build-npm-platform-packages.mjs [options]
+ *
+ * Options:
+ *   --input <dir>          Directory of unpacked release binaries.
+ *                          Default: dist/cli-assets
+ *                          Looked up per target, first match wins:
+ *                            <input>/<target-triple>/openreelio-cli[.exe]
+ *                            <input>/<platform>/openreelio-cli[.exe]
+ *                            <input>/openreelio-cli-<version>-<triple>/openreelio-cli[.exe]
+ *                            <input>/openreelio-cli-<platform>[.exe]
+ *   --binary <plat>=<path> Explicit binary for one platform (repeatable).
+ *                          Overrides --input resolution for that platform.
+ *   --archives <dir>       Directory holding the release archives and their
+ *                          .sha256 sidecars. When given, each selected target's
+ *                          archive is verified before its package is written.
+ *   --out <dir>            Output directory.
+ *                          Default: npm/platform-packages/generated (git-ignored)
+ *   --shim-out <dir>       Also write a version-stamped copy of the shim package
+ *                          (npm/openreelio-cli) here, with optionalDependencies
+ *                          pinned to --version.
+ *   --version <semver>     Version to stamp. Default: the shim package version.
+ *   --only <a,b>           Restrict to a comma-separated list of platforms.
+ *   --help                 Print this help.
+ *
+ * Exit codes:
+ *   0 - packages written
+ *   1 - bad arguments, missing binary, or checksum mismatch
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  copyFileSync,
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..');
+const SHIM_DIR = join(PROJECT_ROOT, 'npm', 'openreelio-cli');
+const SCOPE = '@openreelio';
+
+/**
+ * Release targets published to npm. Kept deliberately in lockstep with the
+ * matrix in .github/workflows/release.yml and the table in the shim launcher.
+ *
+ * Linux is glibc (gnu) only: the release matrix builds no musl target, so a
+ * `linux-x64-musl` package would ship a binary that cannot run.
+ */
+const TARGETS = [
+  {
+    platform: 'win32-x64',
+    triple: 'x86_64-pc-windows-msvc',
+    os: 'win32',
+    cpu: 'x64',
+    binaryName: 'openreelio-cli.exe',
+    archiveExtension: 'zip',
+  },
+  {
+    platform: 'darwin-x64',
+    triple: 'x86_64-apple-darwin',
+    os: 'darwin',
+    cpu: 'x64',
+    binaryName: 'openreelio-cli',
+    archiveExtension: 'tar.gz',
+  },
+  {
+    platform: 'darwin-arm64',
+    triple: 'aarch64-apple-darwin',
+    os: 'darwin',
+    cpu: 'arm64',
+    binaryName: 'openreelio-cli',
+    archiveExtension: 'tar.gz',
+  },
+  {
+    platform: 'linux-x64',
+    triple: 'x86_64-unknown-linux-gnu',
+    os: 'linux',
+    cpu: 'x64',
+    binaryName: 'openreelio-cli',
+    archiveExtension: 'tar.gz',
+  },
+];
+
+const SEMVER_REGEX =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Aborts with a message on stderr.
+ *
+ * @param {string} message Reason for the failure.
+ * @returns {never}
+ */
+function fail(message) {
+  console.error(`build-npm-platform-packages: ${message}`);
+  process.exit(1);
+}
+
+/**
+ * Parses argv into a flat option object.
+ *
+ * @param {string[]} argv Raw arguments (without node/script).
+ * @returns {{input?: string, archives?: string, out?: string, shimOut?: string,
+ *   version?: string, only?: string, help: boolean, binaries: Map<string,string>}}
+ */
+function parseArgs(argv) {
+  const options = { help: false, binaries: new Map() };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+    if (!raw.startsWith('--')) {
+      fail(`unexpected argument "${raw}"`);
+    }
+
+    const equalsAt = raw.indexOf('=');
+    const key = equalsAt === -1 ? raw.slice(2) : raw.slice(2, equalsAt);
+    const inlineValue = equalsAt === -1 ? undefined : raw.slice(equalsAt + 1);
+
+    const readValue = () => {
+      if (inlineValue !== undefined) {
+        return inlineValue;
+      }
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith('--')) {
+        fail(`option --${key} requires a value`);
+      }
+      index += 1;
+      return next;
+    };
+
+    switch (key) {
+      case 'help':
+        options.help = true;
+        break;
+      case 'input':
+        options.input = readValue();
+        break;
+      case 'archives':
+        options.archives = readValue();
+        break;
+      case 'out':
+        options.out = readValue();
+        break;
+      case 'shim-out':
+        options.shimOut = readValue();
+        break;
+      case 'version':
+        options.version = readValue();
+        break;
+      case 'only':
+        options.only = readValue();
+        break;
+      case 'binary': {
+        const value = readValue();
+        const separatorAt = value.indexOf('=');
+        if (separatorAt === -1) {
+          fail('--binary expects <platform>=<path>');
+        }
+        options.binaries.set(value.slice(0, separatorAt), value.slice(separatorAt + 1));
+        break;
+      }
+      default:
+        fail(`unknown option --${key}`);
+    }
+  }
+
+  return options;
+}
+
+/** Prints the usage block extracted from this file's header comment. */
+function printHelp() {
+  const source = readFileSync(fileURLToPath(import.meta.url), 'utf-8');
+  const usageAt = source.indexOf(' * Usage:');
+  const endAt = source.indexOf(' */', usageAt);
+  const usage = source
+    .slice(usageAt, endAt)
+    .split('\n')
+    .map((line) => line.replace(/^ \* ?/, ''))
+    .join('\n')
+    .trimEnd();
+  console.log(usage);
+}
+
+/**
+ * Reads and validates the shim package manifest.
+ *
+ * @returns {Record<string, unknown>} Parsed package.json of the shim.
+ */
+function readShimManifest() {
+  const manifestPath = join(SHIM_DIR, 'package.json');
+  if (!existsSync(manifestPath)) {
+    fail(`shim package not found: ${manifestPath}`);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  const declared = Object.keys(manifest.optionalDependencies ?? {}).sort();
+  const expected = TARGETS.map((target) => `${SCOPE}/cli-${target.platform}`).sort();
+
+  if (declared.join(',') !== expected.join(',')) {
+    fail(
+      'shim optionalDependencies drifted from the release targets.\n' +
+        `  declared: ${declared.join(', ') || '(none)'}\n` +
+        `  expected: ${expected.join(', ')}`,
+    );
+  }
+
+  return manifest;
+}
+
+/**
+ * Computes the SHA-256 of a file.
+ *
+ * @param {string} filePath Absolute path.
+ * @returns {Promise<string>} Lowercase hex digest.
+ */
+function sha256OfFile(filePath) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+    stream.on('error', rejectPromise);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolvePromise(hash.digest('hex')));
+  });
+}
+
+/**
+ * Verifies one target's release archive against its `.sha256` sidecar.
+ *
+ * @param {typeof TARGETS[number]} target Release target.
+ * @param {string} archivesDir Directory holding archives and sidecars.
+ * @param {string} version Version being published.
+ * @returns {Promise<string>} The archive file name that was verified.
+ */
+async function verifyArchive(target, archivesDir, version) {
+  const archiveName = `openreelio-cli-${version}-${target.triple}.${target.archiveExtension}`;
+  const archivePath = join(archivesDir, archiveName);
+  const checksumPath = `${archivePath}.sha256`;
+
+  if (!existsSync(archivePath)) {
+    fail(`missing release archive for ${target.platform}: ${archivePath}`);
+  }
+  if (!existsSync(checksumPath)) {
+    fail(`missing checksum sidecar for ${target.platform}: ${checksumPath}`);
+  }
+
+  // sha256sum/shasum sidecar format: "<hex>  <filename>".
+  const expected = readFileSync(checksumPath, 'utf-8').trim().split(/\s+/)[0]?.toLowerCase();
+  if (!expected || !/^[0-9a-f]{64}$/.test(expected)) {
+    fail(`unreadable checksum sidecar for ${target.platform}: ${checksumPath}`);
+  }
+
+  const actual = await sha256OfFile(archivePath);
+  if (actual !== expected) {
+    fail(
+      `checksum mismatch for ${archiveName}\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${actual}`,
+    );
+  }
+
+  return archiveName;
+}
+
+/**
+ * Locates the unpacked binary for a target.
+ *
+ * @param {typeof TARGETS[number]} target Release target.
+ * @param {string|undefined} explicitPath Value of a matching --binary option.
+ * @param {string} inputDir Directory of unpacked binaries.
+ * @param {string} version Version being published.
+ * @returns {string} Absolute path to the binary.
+ */
+function resolveBinary(target, explicitPath, inputDir, version) {
+  if (explicitPath) {
+    const absolute = resolve(PROJECT_ROOT, explicitPath);
+    if (!existsSync(absolute)) {
+      fail(`--binary ${target.platform} points at a missing file: ${absolute}`);
+    }
+    return absolute;
+  }
+
+  const candidates = [
+    join(inputDir, target.triple, target.binaryName),
+    join(inputDir, target.platform, target.binaryName),
+    join(inputDir, `openreelio-cli-${version}-${target.triple}`, target.binaryName),
+    join(inputDir, `openreelio-cli-${target.platform}${target.os === 'win32' ? '.exe' : ''}`),
+  ];
+
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) {
+    fail(
+      `no binary found for ${target.platform}. Looked in:\n` +
+        candidates.map((candidate) => `  ${candidate}`).join('\n') +
+        `\nPass --binary ${target.platform}=<path> to point at it directly.`,
+    );
+  }
+
+  return found;
+}
+
+/**
+ * Writes one platform package directory.
+ *
+ * @param {typeof TARGETS[number]} target Release target.
+ * @param {string} binaryPath Source binary.
+ * @param {string} version Version to stamp.
+ * @param {string} outDir Output root.
+ * @returns {string} The package directory that was written.
+ */
+function writePlatformPackage(target, binaryPath, version, outDir) {
+  const packageName = `${SCOPE}/cli-${target.platform}`;
+  const packageDir = join(outDir, `cli-${target.platform}`);
+
+  rmSync(packageDir, { recursive: true, force: true });
+  mkdirSync(join(packageDir, 'bin'), { recursive: true });
+
+  // No "bin" field and no "exports": the shim resolves this package's
+  // package.json and joins bin/<binary> itself. Declaring a bin here would
+  // create a second, conflicting command link.
+  const manifest = {
+    name: packageName,
+    version,
+    description: `OpenReelio CLI binary for ${target.os} ${target.cpu} (${target.triple}).`,
+    homepage: 'https://github.com/openreelio/openreelio#readme',
+    bugs: { url: 'https://github.com/openreelio/openreelio/issues' },
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/openreelio/openreelio.git',
+    },
+    license: 'MIT',
+    author: 'Junseo5',
+    os: [target.os],
+    cpu: [target.cpu],
+    engines: { node: '>=18' },
+    files: [`bin/${target.binaryName}`, 'README.md', 'LICENSE'],
+    preferUnplugged: true,
+  };
+
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf-8',
+  );
+
+  const readme = [
+    `# ${packageName}`,
+    '',
+    `Prebuilt OpenReelio CLI binary for **${target.os} ${target.cpu}** (\`${target.triple}\`).`,
+    '',
+    'This package is an implementation detail of',
+    '[`openreelio-cli`](https://www.npmjs.com/package/openreelio-cli). Install that',
+    'package instead; npm selects the right binary package from `os`/`cpu`.',
+    '',
+    '```bash',
+    'npm install openreelio-cli',
+    '```',
+    '',
+    '## License',
+    '',
+    'MIT (c) 2026 Junseo5',
+    '',
+  ].join('\n');
+  writeFileSync(join(packageDir, 'README.md'), readme, 'utf-8');
+
+  copyFileSync(join(PROJECT_ROOT, 'LICENSE'), join(packageDir, 'LICENSE'));
+
+  const destinationBinary = join(packageDir, 'bin', target.binaryName);
+  copyFileSync(binaryPath, destinationBinary);
+  if (target.os !== 'win32') {
+    // npm pack preserves the mode bit; without it the installed binary is not
+    // executable. Windows hosts cannot set it, hence the warning below.
+    chmodSync(destinationBinary, 0o755);
+    if (process.platform === 'win32') {
+      console.warn(
+        `  warning: generated ${packageName} on Windows; the executable bit may not survive npm pack.`,
+      );
+    }
+  }
+
+  return packageDir;
+}
+
+/**
+ * Writes a version-stamped copy of the shim package.
+ *
+ * @param {Record<string, unknown>} shimManifest Parsed shim package.json.
+ * @param {string} version Version to stamp.
+ * @param {string} shimOutDir Destination directory.
+ * @returns {string} The directory that was written.
+ */
+function writeStampedShim(shimManifest, version, shimOutDir) {
+  rmSync(shimOutDir, { recursive: true, force: true });
+  mkdirSync(join(shimOutDir, 'bin'), { recursive: true });
+
+  const manifest = { ...shimManifest, version };
+  manifest.optionalDependencies = Object.fromEntries(
+    TARGETS.map((target) => [`${SCOPE}/cli-${target.platform}`, version]),
+  );
+
+  writeFileSync(
+    join(shimOutDir, 'package.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf-8',
+  );
+
+  for (const file of ['README.md', 'LICENSE']) {
+    copyFileSync(join(SHIM_DIR, file), join(shimOutDir, file));
+  }
+  copyFileSync(
+    join(SHIM_DIR, 'bin', 'openreelio-cli.mjs'),
+    join(shimOutDir, 'bin', 'openreelio-cli.mjs'),
+  );
+
+  return shimOutDir;
+}
+
+/** Entry point. */
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const shimManifest = readShimManifest();
+  const version = options.version ?? shimManifest.version;
+  if (typeof version !== 'string' || !SEMVER_REGEX.test(version)) {
+    fail(`invalid version: ${String(version)}`);
+  }
+
+  const knownPlatforms = new Set(TARGETS.map((target) => target.platform));
+  for (const platform of options.binaries.keys()) {
+    if (!knownPlatforms.has(platform)) {
+      fail(`--binary references unknown platform "${platform}"`);
+    }
+  }
+
+  let selected = TARGETS;
+  if (options.only) {
+    const requested = options.only
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    for (const platform of requested) {
+      if (!knownPlatforms.has(platform)) {
+        fail(`--only references unknown platform "${platform}"`);
+      }
+    }
+    selected = TARGETS.filter((target) => requested.includes(target.platform));
+    if (selected.length === 0) {
+      fail('--only selected no targets');
+    }
+  }
+
+  const inputDir = resolve(PROJECT_ROOT, options.input ?? join('dist', 'cli-assets'));
+  const outDir = resolve(
+    PROJECT_ROOT,
+    options.out ?? join('npm', 'platform-packages', 'generated'),
+  );
+  const archivesDir = options.archives ? resolve(PROJECT_ROOT, options.archives) : undefined;
+
+  mkdirSync(outDir, { recursive: true });
+
+  console.log(`Assembling ${selected.length} platform package(s) at version ${version}`);
+
+  for (const target of selected) {
+    if (archivesDir) {
+      const archiveName = await verifyArchive(target, archivesDir, version);
+      console.log(`  verified ${archiveName}`);
+    }
+
+    const binaryPath = resolveBinary(
+      target,
+      options.binaries.get(target.platform),
+      inputDir,
+      version,
+    );
+    const packageDir = writePlatformPackage(target, binaryPath, version, outDir);
+    console.log(`  ${SCOPE}/cli-${target.platform} -> ${packageDir}`);
+  }
+
+  if (options.shimOut) {
+    const shimOutDir = resolve(PROJECT_ROOT, options.shimOut);
+    writeStampedShim(shimManifest, version, shimOutDir);
+    console.log(`  openreelio-cli -> ${shimOutDir}`);
+  }
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.message : String(error));
+});

--- a/scripts/sync-version.test.ts
+++ b/scripts/sync-version.test.ts
@@ -425,5 +425,43 @@ edition = "2021"
         'unrelated-package': '^2.0.0',
       });
     });
+
+    it('should repin a stale lockstep dependency when the manifest version already matches', () => {
+      mkdirSync(dirname(TEST_MISSING_PACKAGE_JSON), { recursive: true });
+      writeFileSync(
+        TEST_MISSING_PACKAGE_JSON,
+        JSON.stringify(
+          {
+            name: 'demo',
+            version: '1.2.3',
+            optionalDependencies: {
+              '@openreelio/cli-linux-x64': '1.2.3',
+              '@openreelio/cli-win32-x64': '1.1.0',
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const checkResult = checkVersionSync({
+        packageJson: TEST_PACKAGE_JSON, // version: 1.2.3
+        targets: [optionalMissingTarget],
+      });
+
+      expect(checkResult.synced).toBe(false);
+
+      const result = syncVersions({
+        packageJson: TEST_PACKAGE_JSON,
+        targets: [optionalMissingTarget],
+      });
+
+      expect(result.updatedFiles).toEqual(['npm/demo/package.json']);
+      const updated = JSON.parse(readFileSync(TEST_MISSING_PACKAGE_JSON, 'utf-8'));
+      expect(updated.optionalDependencies).toEqual({
+        '@openreelio/cli-linux-x64': '1.2.3',
+        '@openreelio/cli-win32-x64': '1.2.3',
+      });
+    });
   });
 });

--- a/scripts/sync-version.test.ts
+++ b/scripts/sync-version.test.ts
@@ -21,6 +21,7 @@ import {
   checkVersionSync,
   syncVersions,
   validateSemver,
+  type VersionTarget,
 } from './sync-version';
 
 // Test fixtures directory
@@ -28,6 +29,23 @@ const TEST_DIR = join(__dirname, '__test_fixtures__');
 const TEST_PACKAGE_JSON = join(TEST_DIR, 'package.json');
 const TEST_CARGO_TOML = join(TEST_DIR, 'Cargo.toml');
 const TEST_TAURI_CONF = join(TEST_DIR, 'tauri.conf.json');
+const TEST_CRATE_CARGO_TOML = join(TEST_DIR, 'crate-Cargo.toml');
+const TEST_MISSING_PACKAGE_JSON = join(TEST_DIR, 'missing', 'package.json');
+
+/** Targets mirroring the production descriptor list, minus the optional entry */
+const requiredTargets: VersionTarget[] = [
+  { file: 'Cargo.toml', path: TEST_CARGO_TOML, kind: 'cargo-toml' },
+  { file: 'tauri.conf.json', path: TEST_TAURI_CONF, kind: 'tauri-conf' },
+  { file: 'crates/demo/Cargo.toml', path: TEST_CRATE_CARGO_TOML, kind: 'cargo-toml' },
+];
+
+/** Optional target that does not exist on disk */
+const optionalMissingTarget: VersionTarget = {
+  file: 'npm/demo/package.json',
+  path: TEST_MISSING_PACKAGE_JSON,
+  kind: 'package-json',
+  optional: true,
+};
 
 describe('Version Sync Script', () => {
   beforeEach(() => {
@@ -47,6 +65,16 @@ describe('Version Sync Script', () => {
       TEST_CARGO_TOML,
       `[package]
 name = "test"
+version = "1.0.0"
+edition = "2021"
+`
+    );
+
+    // Create test crate Cargo.toml
+    writeFileSync(
+      TEST_CRATE_CARGO_TOML,
+      `[package]
+name = "demo-crate"
 version = "1.0.0"
 edition = "2021"
 `
@@ -199,30 +227,111 @@ edition = "2021"
 
       const result = checkVersionSync({
         packageJson: TEST_PACKAGE_JSON,
-        cargoToml: TEST_CARGO_TOML,
-        tauriConf: TEST_TAURI_CONF,
+        targets: requiredTargets,
       });
 
       expect(result.synced).toBe(true);
       expect(result.mismatches).toEqual([]);
+      expect(result.skipped).toEqual([]);
     });
 
     it('should return mismatches when versions differ', () => {
       const result = checkVersionSync({
         packageJson: TEST_PACKAGE_JSON, // version: 1.2.3
-        cargoToml: TEST_CARGO_TOML, // version: 1.0.0
-        tauriConf: TEST_TAURI_CONF, // version: 1.0.0
+        targets: requiredTargets, // all fixtures: 1.0.0
       });
 
       expect(result.synced).toBe(false);
       expect(result.sourceVersion).toBe('1.2.3');
-      expect(result.mismatches).toHaveLength(2);
+      expect(result.mismatches).toHaveLength(3);
       expect(result.mismatches).toContainEqual({
         file: 'Cargo.toml',
         path: TEST_CARGO_TOML,
+        kind: 'cargo-toml',
         currentVersion: '1.0.0',
         expectedVersion: '1.2.3',
       });
+    });
+
+    it('should report a workspace crate Cargo.toml as mismatched when it lags behind', () => {
+      writeFileSync(
+        TEST_PACKAGE_JSON,
+        JSON.stringify({ name: 'test', version: '1.0.0' }, null, 2)
+      );
+      updateCargoVersion(TEST_CRATE_CARGO_TOML, '0.9.0');
+
+      const result = checkVersionSync({
+        packageJson: TEST_PACKAGE_JSON,
+        targets: requiredTargets,
+      });
+
+      expect(result.synced).toBe(false);
+      expect(result.mismatches).toEqual([
+        {
+          file: 'crates/demo/Cargo.toml',
+          path: TEST_CRATE_CARGO_TOML,
+          kind: 'cargo-toml',
+          currentVersion: '0.9.0',
+          expectedVersion: '1.0.0',
+        },
+      ]);
+    });
+
+    it('should skip an optional target that does not exist yet', () => {
+      writeFileSync(
+        TEST_PACKAGE_JSON,
+        JSON.stringify({ name: 'test', version: '1.0.0' }, null, 2)
+      );
+
+      const result = checkVersionSync({
+        packageJson: TEST_PACKAGE_JSON,
+        targets: [...requiredTargets, optionalMissingTarget],
+      });
+
+      expect(result.synced).toBe(true);
+      expect(result.skipped).toEqual([
+        {
+          file: 'npm/demo/package.json',
+          path: TEST_MISSING_PACKAGE_JSON,
+          reason: 'file not present',
+        },
+      ]);
+    });
+
+    it('should check an optional target once the file exists', () => {
+      mkdirSync(dirname(TEST_MISSING_PACKAGE_JSON), { recursive: true });
+      writeFileSync(
+        TEST_MISSING_PACKAGE_JSON,
+        JSON.stringify({ name: 'demo', version: '0.9.0' }, null, 2)
+      );
+      writeFileSync(
+        TEST_PACKAGE_JSON,
+        JSON.stringify({ name: 'test', version: '1.0.0' }, null, 2)
+      );
+
+      const result = checkVersionSync({
+        packageJson: TEST_PACKAGE_JSON,
+        targets: [optionalMissingTarget],
+      });
+
+      expect(result.synced).toBe(false);
+      expect(result.skipped).toEqual([]);
+      expect(result.mismatches).toContainEqual({
+        file: 'npm/demo/package.json',
+        path: TEST_MISSING_PACKAGE_JSON,
+        kind: 'package-json',
+        currentVersion: '0.9.0',
+        expectedVersion: '1.0.0',
+      });
+    });
+
+    it('should throw when a required target is missing', () => {
+      expect(() =>
+        checkVersionSync({
+          packageJson: TEST_PACKAGE_JSON,
+          targets: [{ ...optionalMissingTarget, optional: false }],
+        })
+      ).toThrow('File not found');
     });
   });
 
@@ -230,16 +339,16 @@ edition = "2021"
     it('should sync all versions to match package.json', () => {
       const result = syncVersions({
         packageJson: TEST_PACKAGE_JSON, // version: 1.2.3
-        cargoToml: TEST_CARGO_TOML,
-        tauriConf: TEST_TAURI_CONF,
+        targets: requiredTargets,
       });
 
       expect(result.success).toBe(true);
-      expect(result.updatedFiles).toHaveLength(2);
+      expect(result.updatedFiles).toHaveLength(3);
 
       // Verify the files were updated
       expect(readCargoVersion(TEST_CARGO_TOML)).toBe('1.2.3');
       expect(readTauriVersion(TEST_TAURI_CONF)).toBe('1.2.3');
+      expect(readCargoVersion(TEST_CRATE_CARGO_TOML)).toBe('1.2.3');
     });
 
     it('should return success with no updates when already synced', () => {
@@ -250,12 +359,39 @@ edition = "2021"
 
       const result = syncVersions({
         packageJson: TEST_PACKAGE_JSON,
-        cargoToml: TEST_CARGO_TOML,
-        tauriConf: TEST_TAURI_CONF,
+        targets: requiredTargets,
       });
 
       expect(result.success).toBe(true);
       expect(result.updatedFiles).toHaveLength(0);
+    });
+
+    it('should not create an optional target that does not exist yet', () => {
+      const result = syncVersions({
+        packageJson: TEST_PACKAGE_JSON, // version: 1.2.3
+        targets: [...requiredTargets, optionalMissingTarget],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.updatedFiles).not.toContain('npm/demo/package.json');
+      expect(result.skipped).toHaveLength(1);
+      expect(existsSync(TEST_MISSING_PACKAGE_JSON)).toBe(false);
+    });
+
+    it('should sync an optional target once the file exists', () => {
+      mkdirSync(dirname(TEST_MISSING_PACKAGE_JSON), { recursive: true });
+      writeFileSync(
+        TEST_MISSING_PACKAGE_JSON,
+        JSON.stringify({ name: 'demo', version: '0.9.0' }, null, 2)
+      );
+
+      const result = syncVersions({
+        packageJson: TEST_PACKAGE_JSON, // version: 1.2.3
+        targets: [optionalMissingTarget],
+      });
+
+      expect(result.updatedFiles).toEqual(['npm/demo/package.json']);
+      expect(readPackageVersion(TEST_MISSING_PACKAGE_JSON)).toBe('1.2.3');
     });
   });
 });

--- a/scripts/sync-version.test.ts
+++ b/scripts/sync-version.test.ts
@@ -393,5 +393,37 @@ edition = "2021"
       expect(result.updatedFiles).toEqual(['npm/demo/package.json']);
       expect(readPackageVersion(TEST_MISSING_PACKAGE_JSON)).toBe('1.2.3');
     });
+
+    it('should repin lockstep optional dependencies when syncing a package manifest', () => {
+      mkdirSync(dirname(TEST_MISSING_PACKAGE_JSON), { recursive: true });
+      writeFileSync(
+        TEST_MISSING_PACKAGE_JSON,
+        JSON.stringify(
+          {
+            name: 'demo',
+            version: '0.9.0',
+            optionalDependencies: {
+              '@openreelio/cli-linux-x64': '0.9.0',
+              '@openreelio/cli-win32-x64': '0.9.0',
+              'unrelated-package': '^2.0.0',
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      syncVersions({
+        packageJson: TEST_PACKAGE_JSON, // version: 1.2.3
+        targets: [optionalMissingTarget],
+      });
+
+      const updated = JSON.parse(readFileSync(TEST_MISSING_PACKAGE_JSON, 'utf-8'));
+      expect(updated.optionalDependencies).toEqual({
+        '@openreelio/cli-linux-x64': '1.2.3',
+        '@openreelio/cli-win32-x64': '1.2.3',
+        'unrelated-package': '^2.0.0',
+      });
+    });
   });
 });

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -130,6 +130,30 @@ function repinLockstepOptionalDependencies(
 }
 
 /**
+ * Lists `@openreelio/*` optional dependencies of a package manifest that are not
+ * pinned to the given version.
+ *
+ * The version field and the lockstep pins can drift apart — a manual edit, or a
+ * pin added after the last bump — so a manifest whose version already matches
+ * can still ship stale pins. Checking must catch that, not just fixing.
+ */
+export function findStaleLockstepPins(filePath: string, expectedVersion: string): string[] {
+  const json = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+  const optionalDependencies = json.optionalDependencies;
+
+  if (typeof optionalDependencies !== 'object' || optionalDependencies === null) {
+    return [];
+  }
+
+  return Object.entries(optionalDependencies as Record<string, string>)
+    .filter(
+      ([name, range]) =>
+        name.startsWith(LOCKSTEP_DEPENDENCY_SCOPE) && range !== expectedVersion
+    )
+    .map(([name]) => name);
+}
+
+/**
  * Updates version in Cargo.toml
  */
 export function updateCargoVersion(filePath: string, newVersion: string): void {
@@ -218,6 +242,11 @@ export interface VersionMismatch {
   kind: VersionFileKind;
   currentVersion: string;
   expectedVersion: string;
+  /**
+   * Set when the version field itself matches but something else in the file is
+   * out of sync, so reports can say what actually has to change.
+   */
+  detail?: string;
 }
 
 export interface SkippedTarget {
@@ -260,6 +289,24 @@ export function checkVersionSync(config: VersionSyncConfig): CheckResult {
         currentVersion,
         expectedVersion: sourceVersion,
       });
+      continue;
+    }
+
+    // A manifest can carry the right version and still pin its lockstep
+    // siblings at an older one; the writer repins them, so report it as a
+    // mismatch to get the writer invoked.
+    if (target.kind === 'package-json') {
+      const stalePins = findStaleLockstepPins(target.path, sourceVersion);
+      if (stalePins.length > 0) {
+        mismatches.push({
+          file: target.file,
+          path: target.path,
+          kind: target.kind,
+          currentVersion,
+          expectedVersion: sourceVersion,
+          detail: `stale ${LOCKSTEP_DEPENDENCY_SCOPE}* pins: ${stalePins.join(', ')}`,
+        });
+      }
     }
   }
 
@@ -371,7 +418,11 @@ function main(): void {
       } else {
         console.log('\n✗ Version mismatch detected:\n');
         for (const m of result.mismatches) {
-          console.log(`  ${m.file}: ${m.currentVersion} (expected ${m.expectedVersion})`);
+          console.log(
+            m.detail
+              ? `  ${m.file}: ${m.detail} (expected ${m.expectedVersion})`
+              : `  ${m.file}: ${m.currentVersion} (expected ${m.expectedVersion})`
+          );
         }
         console.log('\nRun with --fix to sync versions.');
         process.exit(1);

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -4,7 +4,9 @@
  * @fileoverview Version Sync Script for OpenReelio
  *
  * Single Source of Truth: package.json
- * Sync Targets: Cargo.toml, tauri.conf.json
+ * Sync Targets: every entry in the target descriptor list (see getDefaultConfig),
+ * currently the Tauri app manifests plus the openreelio-core / openreelio-cli
+ * crates and the published npm shim package.
  *
  * Usage:
  *   npx tsx scripts/sync-version.ts --check   # Verify versions are synced (CI mode)
@@ -80,18 +82,23 @@ export function readCargoVersion(filePath: string): string {
  * Reads version from tauri.conf.json
  */
 export function readTauriVersion(filePath: string): string {
-  if (!existsSync(filePath)) {
-    throw new Error(`File not found: ${filePath}`);
+  return readPackageVersion(filePath);
+}
+
+/**
+ * Updates the version field of a JSON manifest, preserving 2-space indentation
+ */
+function updateJsonVersion(filePath: string, newVersion: string): void {
+  if (!validateSemver(newVersion)) {
+    throw new Error(`Invalid semver: ${newVersion}`);
   }
 
   const content = readFileSync(filePath, 'utf-8');
-  const json = JSON.parse(content) as { version?: string };
+  const json = JSON.parse(content) as Record<string, unknown>;
 
-  if (!json.version) {
-    throw new Error(`version field not found in ${filePath}`);
-  }
+  json.version = newVersion;
 
-  return json.version;
+  writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n', 'utf-8');
 }
 
 /**
@@ -117,71 +124,112 @@ export function updateCargoVersion(filePath: string, newVersion: string): void {
  * Updates version in tauri.conf.json
  */
 export function updateTauriVersion(filePath: string, newVersion: string): void {
-  if (!validateSemver(newVersion)) {
-    throw new Error(`Invalid semver: ${newVersion}`);
-  }
+  updateJsonVersion(filePath, newVersion);
+}
 
-  const content = readFileSync(filePath, 'utf-8');
-  const json = JSON.parse(content) as Record<string, unknown>;
+/**
+ * Updates version in a package.json manifest
+ */
+export function updatePackageVersion(filePath: string, newVersion: string): void {
+  updateJsonVersion(filePath, newVersion);
+}
 
-  json.version = newVersion;
+/** Manifest formats the sync script knows how to read and write */
+export type VersionFileKind = 'package-json' | 'cargo-toml' | 'tauri-conf';
 
-  // Preserve formatting with 2-space indentation
-  writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n', 'utf-8');
+const VERSION_READERS: Record<VersionFileKind, (filePath: string) => string> = {
+  'package-json': readPackageVersion,
+  'cargo-toml': readCargoVersion,
+  'tauri-conf': readTauriVersion,
+};
+
+const VERSION_WRITERS: Record<
+  VersionFileKind,
+  (filePath: string, newVersion: string) => void
+> = {
+  'package-json': updatePackageVersion,
+  'cargo-toml': updateCargoVersion,
+  'tauri-conf': updateTauriVersion,
+};
+
+/** A single file that must carry the same version as package.json */
+export interface VersionTarget {
+  /** Human-readable label used in reports (repo-relative path is clearest) */
+  file: string;
+  /** Absolute path to the manifest */
+  path: string;
+  /** Manifest format, selects the reader/writer pair */
+  kind: VersionFileKind;
+  /**
+   * When true, a missing file is reported as skipped instead of failing.
+   * Used for manifests that are generated or land in a later change.
+   */
+  optional?: boolean;
+}
+
+export interface VersionSyncConfig {
+  /** Single source of truth */
+  packageJson: string;
+  /** Files that must match the source version */
+  targets: VersionTarget[];
 }
 
 export interface VersionMismatch {
   file: string;
   path: string;
+  kind: VersionFileKind;
   currentVersion: string;
   expectedVersion: string;
+}
+
+export interface SkippedTarget {
+  file: string;
+  path: string;
+  reason: string;
 }
 
 export interface CheckResult {
   synced: boolean;
   sourceVersion: string;
   mismatches: VersionMismatch[];
-}
-
-export interface FilePaths {
-  packageJson: string;
-  cargoToml: string;
-  tauriConf: string;
+  skipped: SkippedTarget[];
 }
 
 /**
  * Checks if all version files are in sync with package.json
  */
-export function checkVersionSync(paths: FilePaths): CheckResult {
-  const sourceVersion = readPackageVersion(paths.packageJson);
+export function checkVersionSync(config: VersionSyncConfig): CheckResult {
+  const sourceVersion = readPackageVersion(config.packageJson);
   const mismatches: VersionMismatch[] = [];
+  const skipped: SkippedTarget[] = [];
 
-  // Check Cargo.toml
-  const cargoVersion = readCargoVersion(paths.cargoToml);
-  if (cargoVersion !== sourceVersion) {
-    mismatches.push({
-      file: 'Cargo.toml',
-      path: paths.cargoToml,
-      currentVersion: cargoVersion,
-      expectedVersion: sourceVersion,
-    });
-  }
+  for (const target of config.targets) {
+    if (target.optional && !existsSync(target.path)) {
+      skipped.push({
+        file: target.file,
+        path: target.path,
+        reason: 'file not present',
+      });
+      continue;
+    }
 
-  // Check tauri.conf.json
-  const tauriVersion = readTauriVersion(paths.tauriConf);
-  if (tauriVersion !== sourceVersion) {
-    mismatches.push({
-      file: 'tauri.conf.json',
-      path: paths.tauriConf,
-      currentVersion: tauriVersion,
-      expectedVersion: sourceVersion,
-    });
+    const currentVersion = VERSION_READERS[target.kind](target.path);
+    if (currentVersion !== sourceVersion) {
+      mismatches.push({
+        file: target.file,
+        path: target.path,
+        kind: target.kind,
+        currentVersion,
+        expectedVersion: sourceVersion,
+      });
+    }
   }
 
   return {
     synced: mismatches.length === 0,
     sourceVersion,
     mismatches,
+    skipped,
   };
 }
 
@@ -189,30 +237,18 @@ export interface SyncResult {
   success: boolean;
   version: string;
   updatedFiles: string[];
+  skipped: SkippedTarget[];
 }
 
 /**
  * Syncs all version files to match package.json
  */
-export function syncVersions(paths: FilePaths): SyncResult {
-  const checkResult = checkVersionSync(paths);
+export function syncVersions(config: VersionSyncConfig): SyncResult {
+  const checkResult = checkVersionSync(config);
   const updatedFiles: string[] = [];
 
-  if (checkResult.synced) {
-    return {
-      success: true,
-      version: checkResult.sourceVersion,
-      updatedFiles,
-    };
-  }
-
-  // Update mismatched files
   for (const mismatch of checkResult.mismatches) {
-    if (mismatch.file === 'Cargo.toml') {
-      updateCargoVersion(mismatch.path, checkResult.sourceVersion);
-    } else if (mismatch.file === 'tauri.conf.json') {
-      updateTauriVersion(mismatch.path, checkResult.sourceVersion);
-    }
+    VERSION_WRITERS[mismatch.kind](mismatch.path, checkResult.sourceVersion);
     updatedFiles.push(mismatch.file);
   }
 
@@ -220,18 +256,47 @@ export function syncVersions(paths: FilePaths): SyncResult {
     success: true,
     version: checkResult.sourceVersion,
     updatedFiles,
+    skipped: checkResult.skipped,
   };
 }
 
 /**
- * Gets default file paths relative to project root
+ * Gets the default sync configuration relative to project root
  */
-function getDefaultPaths(): FilePaths {
+function getDefaultConfig(): VersionSyncConfig {
   const projectRoot = resolve(__dirname, '..');
   return {
     packageJson: resolve(projectRoot, 'package.json'),
-    cargoToml: resolve(projectRoot, 'src-tauri', 'Cargo.toml'),
-    tauriConf: resolve(projectRoot, 'src-tauri', 'tauri.conf.json'),
+    targets: [
+      {
+        file: 'src-tauri/Cargo.toml',
+        path: resolve(projectRoot, 'src-tauri', 'Cargo.toml'),
+        kind: 'cargo-toml',
+      },
+      {
+        file: 'src-tauri/tauri.conf.json',
+        path: resolve(projectRoot, 'src-tauri', 'tauri.conf.json'),
+        kind: 'tauri-conf',
+      },
+      {
+        file: 'crates/openreelio-core/Cargo.toml',
+        path: resolve(projectRoot, 'crates', 'openreelio-core', 'Cargo.toml'),
+        kind: 'cargo-toml',
+      },
+      {
+        file: 'crates/openreelio-cli/Cargo.toml',
+        path: resolve(projectRoot, 'crates', 'openreelio-cli', 'Cargo.toml'),
+        kind: 'cargo-toml',
+      },
+      {
+        // The npm distribution shim is optional so version:check stays green
+        // both before and after that package lands.
+        file: 'npm/openreelio-cli/package.json',
+        path: resolve(projectRoot, 'npm', 'openreelio-cli', 'package.json'),
+        kind: 'package-json',
+        optional: true,
+      },
+    ],
   };
 }
 
@@ -242,18 +307,25 @@ function main(): void {
   const args = process.argv.slice(2);
   const mode = args.includes('--fix') ? 'fix' : 'check';
 
-  const paths = getDefaultPaths();
+  const config = getDefaultConfig();
 
   console.log('OpenReelio Version Sync');
   console.log('========================');
   console.log(`Source: package.json`);
   console.log(`Mode: ${mode}\n`);
 
+  const reportSkipped = (skipped: SkippedTarget[]): void => {
+    for (const target of skipped) {
+      console.log(`  - Skipped ${target.file} (${target.reason})`);
+    }
+  };
+
   try {
     if (mode === 'check') {
-      const result = checkVersionSync(paths);
+      const result = checkVersionSync(config);
 
       console.log(`Source version: ${result.sourceVersion}`);
+      reportSkipped(result.skipped);
 
       if (result.synced) {
         console.log('\n✓ All versions are in sync!');
@@ -268,9 +340,10 @@ function main(): void {
       }
     } else {
       // Fix mode
-      const result = syncVersions(paths);
+      const result = syncVersions(config);
 
       console.log(`Target version: ${result.version}`);
+      reportSkipped(result.skipped);
 
       if (result.updatedFiles.length === 0) {
         console.log('\n✓ All versions already in sync!');

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -85,6 +85,9 @@ export function readTauriVersion(filePath: string): string {
   return readPackageVersion(filePath);
 }
 
+/** Scope whose sibling packages are released in lockstep with the app version */
+const LOCKSTEP_DEPENDENCY_SCOPE = '@openreelio/';
+
 /**
  * Updates the version field of a JSON manifest, preserving 2-space indentation
  */
@@ -99,6 +102,31 @@ function updateJsonVersion(filePath: string, newVersion: string): void {
   json.version = newVersion;
 
   writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Repins `@openreelio/*` optional dependencies to the given version.
+ *
+ * The npm shim pins its platform packages exactly, and those packages are
+ * published from the same tag. Left alone, a version bump would ship a shim
+ * pointing at platform packages that do not exist yet; npm treats a missing
+ * optional dependency as a soft failure, so the breakage would only surface
+ * when a user runs the command.
+ */
+function repinLockstepOptionalDependencies(
+  json: Record<string, unknown>,
+  newVersion: string
+): void {
+  const optionalDependencies = json.optionalDependencies;
+  if (typeof optionalDependencies !== 'object' || optionalDependencies === null) {
+    return;
+  }
+
+  for (const name of Object.keys(optionalDependencies)) {
+    if (name.startsWith(LOCKSTEP_DEPENDENCY_SCOPE)) {
+      (optionalDependencies as Record<string, string>)[name] = newVersion;
+    }
+  }
 }
 
 /**
@@ -128,10 +156,20 @@ export function updateTauriVersion(filePath: string, newVersion: string): void {
 }
 
 /**
- * Updates version in a package.json manifest
+ * Updates version in a package.json manifest, keeping `@openreelio/*` optional
+ * dependencies pinned to the same version
  */
 export function updatePackageVersion(filePath: string, newVersion: string): void {
-  updateJsonVersion(filePath, newVersion);
+  if (!validateSemver(newVersion)) {
+    throw new Error(`Invalid semver: ${newVersion}`);
+  }
+
+  const json = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+
+  json.version = newVersion;
+  repinLockstepOptionalDependencies(json, newVersion);
+
+  writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n', 'utf-8');
 }
 
 /** Manifest formats the sync script knows how to read and write */


### PR DESCRIPTION
### **User description**
## Description

Makes the headless CLI reachable and usable by external coding agents (Claude Code, Codex, Cursor): a local-trust MCP write mode, standalone CLI release assets, an npm distribution (script-free, npm-v12-safe), agent bootstrap docs, and the installable skill package content. Follows the merged perception/verify primitives from #785. Design: `docs/AGENT_PERCEPTION_CLI_PLAN.md` + the P2 distribution plan.

## Related Issue

Closes # (roadmap work — agent-native distribution phase)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- **MCP `--allow-write`**: mutating tools work without the per-call approval-token handshake for local-trust sessions (`mode: read-write-local`, startup stderr warning); read-only stays the default and the token path is byte-identical. New always-registered `openreelio.verify` MCP tool reusing the verify pipeline via a new print-seam refactor.
- **Release assets**: `openreelio-cli-{ver}-{triple}.zip|tar.gz` + `.sha256` uploaded per target; latest.json classifier proven safe against the new names and hardened with an explicit `openreelio-cli-` skip.
- **Version sync**: generalized to a descriptor list now enforcing `crates/openreelio-cli` and `crates/openreelio-core` versions (previously unchecked at release time) plus the npm shim, which also repins its platform dependencies on bump.
- **npm distribution**: `openreelio-cli` shim (no install scripts — npm v12 blocks them) + 4 `@openreelio/cli-*` platform packages assembled by a stdlib-only generator with sha256 verification; publish workflow is doubly gated (repository variable + dry-run default) and runs only after the release is published; Trusted Publishing with token fallback documented.
- **Agent docs**: `docs/AGENT_GUIDE.md` (canonical agent-facing doc), root `llms.txt`, README "Using OpenReelio as a Tool" section.
- **Skill package** under `distribution/skills/`: Remotion-style router `SKILL.md` + six topic `REFERENCE.md` files + Claude Code plugin manifest and `.mcp.json`, authored for later sync to a public skills repo; every documented flag cross-checked against the live CLI (190 flag mentions, zero mismatches).

## Screenshots / Videos

N/A (headless CLI + CI + docs).

## Testing

### Test Environment

- OS: Windows 11 Pro (10.0.26200); CI covers ubuntu/windows/macos
- Node.js version: repo-pinned (CI)
- Rust version: repo-pinned toolchain (CI)

### Tests Performed

- [x] Unit tests pass (`pnpm test`) — sync-version suite extended to 28 cases
- [x] Rust tests pass (`cargo test`) — 110 CLI unit + 77 integration (8 new MCP tests incl. double-mutation under allow-write)
- [x] Manual testing performed — real-binary npm smoke test (shim resolution, exit codes 0/1/2, checksum tamper detection, missing-platform-package path); full agent loop run live to validate docs
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Publishing is deliberately inert until the maintainer acts: npm publish requires setting the `NPM_PUBLISH_ENABLED` repository variable (and npm Trusted Publishing / token setup, documented in `docs/DISTRIBUTION.md`); the skills content ships in-repo under `distribution/` and is not auto-installable from this repository. Known follow-up (chipped): three pre-existing help-json entries advertise wrong flag names (`timeline.trim`, `plan.template`, `verify` example) — agent docs use the verified forms.


___

### **PR Type**
Enhancement, Documentation, Other


___

### **Description**
- Adds an MCP server mode with `--allow-write` for unattended agent edits.

- Implements a multi-package npm distribution strategy for the headless CLI.

- Introduces a comprehensive `AGENT_GUIDE.md` and LLM-optimized skill documentation.

- Automates version synchronization across workspace crates and npm manifests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["openreelio-cli"] -- "MCP stdio" --> Agent["AI Agent"]
  CLI -- "npm publish" --> NPM["npm Registry"]
  NPM -- "install" --> User["Developer/Agent"]
  CLI -- "verify" --> QC["QC Report"]
  QC -- "suggestedFix" --> CLI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>mcp.rs</strong><dd><code>Add allow-write mode and verify tool to MCP server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+530/-38</a></td>

</tr>

<tr>
  <td><strong>openreelio-cli.mjs</strong><dd><code>Platform-aware binary launcher for npm distribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-d5ff3546d52bc60c219fcdb0089cc2c4f03eefcd80fdc691624b12c24fe204b3">+194/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>sync-version.ts</strong><dd><code>Generalize version syncing for workspace crates and npm</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-f44ff477aaa87d693b7fb08f8f4d1c6b71731d6b923a1b12442e8e79421bede8">+172/-61</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AGENT_GUIDE.md</strong><dd><code>Comprehensive guide for AI agents using the CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-609f4b6b6395bee5b56f2cb041c6803bc2afd043dbb10d33c31349b6e8c96a26">+392/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>help_json.rs</strong><dd><code>Update CLI schema with MCP write mode parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>llms.txt</strong><dd><code>Add LLM-optimized index for project documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>npm-publish.yml</strong><dd><code>Automated workflow for publishing platform-specific npm packages</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240">+276/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>build-npm-platform-packages.mjs</strong><dd><code>Generator for platform-specific npm binary packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-3511003973bb5ee0e98d091c448228731b1a841ae0084e074cdbfa31cac63635">+513/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>verify.rs</strong><dd><code>Refactor verify command for in-process reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-6230a47e8099d60c3f943e67c7aa6969829e0e53bbca8aca67c7820c956c75f6">+30/-14</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>sync-version.test.ts</strong><dd><code>Tests for enhanced version synchronization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-17d22dcba60964477901cd83641c9a10160195e24b09f0204b435d8afe571dda">+178/-10</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>release.yml</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin.json</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-08805669a98d5ea7dc05b2043a618118fcd16a63f4f9c1aedb70557ab161f811">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.mcp.json</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-ffc1dc51f99ec90c6ebdba4a53bad5acd1eae51b9e453ca8600ba72221b956fb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-c8977104f016771da02a4901cada7633c559e76da9e8402899a63726fe663aa5">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-4847e139fc42c0e90126f03bf18157a06f87f753f4f196fc25f670c7733b598f">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-3108771c2d44e2b7db9e9097acfa4590082bf896c1561d2cc81899e9fbbfb0f3">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-cc3496de9305713d70667351fab7c5a60539b3fbb1dd4940b15419d868b1f1bb">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-09f1fbcec2ba7a75b725e8485fb6f7b13ba4ab79c79bb96279303767f681c4b2">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-40f74bdcd5d6950bc452545f551fa24eb3a4a375d6bb00eaaff5412a802d6d8f">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-9d8457ac11b1c3b848ebe643ab385eaeac45387b40150482366f62e4039c82e1">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-e552a036d77c2c0d3794d51139a09c338cf087ea9830d52cfa07fa01fd93339d">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DISTRIBUTION.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-9be3330c309d8e0483351ebde7db2ffa3e0106e0cd9bc245ada40a06dc69261c">+121/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>eslint.config.js</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LICENSE</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-d768745f9fbf945c4821b743eef5c78640ade20e73bab8eddb93da43b953514c">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-a5e230bf6c8c060f68b97daa5a06791487834633bd2f588ecc39f7a53327d551">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-458edbef8655d0312cfc205dd78a0b5596ff0ea83f3a5b8fb9626cdb9199c957">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/786/files#diff-a589318adf0cfecc85dcbc8a529d0079e5ac292995a2087f8d20cbdc355c77c1">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added npm distribution for the CLI with platform-specific packages and standalone binary support.
  - Added MCP write mode with optional local approval bypass and the read-only `verify` tool.
  - Added automated release packaging with checksums and downloadable platform archives.

- **Documentation**
  - Added comprehensive guides for CLI, MCP, agent workflows, setup, editing, rendering, captions, perception, and verification.
  - Added npm installation, troubleshooting, and platform support documentation.

- **Improvements**
  - Enhanced version synchronization across CLI and npm packages.
  - Added clearer launcher diagnostics for unsupported platforms and missing binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->