### PR TITLE
ci(release): create the tarball destination before npm pack

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -233,6 +233,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          mkdir -p dist/npm-tarballs
           for PACKAGE_DIR in dist/npm-packages/cli-* dist/npm-packages/openreelio-cli; do
             echo "::group::npm pack ${PACKAGE_DIR}"
             npm pack --pack-destination dist/npm-tarballs "${PACKAGE_DIR}"


### PR DESCRIPTION
### **User description**
## Description

The npm-publish workflow's pack step failed on a fresh runner because `npm pack --pack-destination` does not create the destination directory. Caught by the first CI dry run of the v0.1.11 publish (run 31666937096).

## Related Issue

Closes # (found via npm-publish dry run)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `mkdir -p dist/npm-tarballs` before the pack loop in `.github/workflows/npm-publish.yml` (one line).

## Screenshots / Videos

N/A

## Testing

### Test Environment

- OS: CI ubuntu-latest (workflow-only change)
- Node.js version: workflow-pinned
- Rust version: N/A

### Tests Performed

- [x] Unit tests pass (`pnpm test`) — unaffected, CI validates
- [x] Rust tests pass (`cargo test`) — unaffected, CI validates
- [x] Manual testing performed — failure reproduced and diagnosed from the dry-run logs; will re-run the dry run after merge
- [ ] New tests added for changes (workflow-only)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

After merge the npm-publish dry run will be re-triggered for v0.1.11 to validate the full pack path before the first real publish.


___

### **PR Type**
Bug fix


___

### **Description**
- Create the tarball destination directory before packing.

- Fixes `ENOENT` errors in the npm-publish workflow.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Runner"] -- "mkdir -p" --> B["dist/npm-tarballs"]
  B -- "destination for" --> C["npm pack"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npm-publish.yml</strong><dd><code>Ensure npm pack destination directory exists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/npm-publish.yml

<ul><li>Added a <code>mkdir -p dist/npm-tarballs</code> command before the <code>npm pack</code> loop.<br> <li> Ensures the destination directory exists to prevent <code>npm pack</code> from <br>failing with a missing directory error.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/787/files#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the npm packaging workflow to reliably create the required output directory before generating package archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->