### PR TITLE
feat(core): detect external project edits and reload safely

### DIFF
--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -162,6 +162,17 @@ use openreelio_core::ActiveProject;
 use std::path::PathBuf;
 
 /// Load an existing project from the given path.
+///
+/// Opening installs the external-edit guard: the session records the revision of
+/// `ops.jsonl` and `history.json` it replayed, and refuses to write on top of
+/// another process's changes. The CLI is not exempt from it, and does not need
+/// to be — an invocation opens, mutates, saves and exits, so a command that runs
+/// after another writer baselines against the current tail and appends onto it.
+///
+/// A command that runs *while* another process is editing the same project is
+/// refused with `ExternalChangeDetected` instead of interleaving; re-run it and
+/// the fresh open picks up the other writer's work. Serialize concurrent
+/// automation on a project rather than racing it.
 pub(crate) fn load_project(path: &PathBuf) -> anyhow::Result<ActiveProject> {
     let canonical = std::fs::canonicalize(path)
         .map_err(|e| anyhow::anyhow!("Project path '{}' not found: {}", path.display(), e))?;

--- a/src-tauri/src/core/commands/asset.rs
+++ b/src-tauri/src/core/commands/asset.rs
@@ -42,6 +42,15 @@ fn validate_asset_relative_path(relative_path: &str, label: &str) -> Result<(), 
     if trimmed.contains("://") {
         return Err(format!("{label} must be a relative path, not a URL"));
     }
+    // Reject backslashes on every platform: on Windows a backslash is a path
+    // separator (so `\\host\share` is a UNC path), but on Unix it is an ordinary
+    // filename character, so `Path::components` would not flag a UNC-style value
+    // as a Prefix. Requiring forward slashes keeps this check platform-agnostic.
+    if trimmed.contains('\\') {
+        return Err(format!(
+            "{label} must use forward slashes and must not be a UNC path"
+        ));
+    }
 
     let candidate = std::path::Path::new(trimmed);
     if candidate.is_absolute() {

--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -139,6 +139,15 @@ impl CommandExecutor {
         let command_json = command.to_json();
         let prev_op_id = state.last_op_id.clone();
 
+        // Refuse before touching `state`. The authoritative check lives in
+        // `OpsLog::append` (inside the write lock, so it cannot be raced), but
+        // by then the command has already mutated the in-memory state; failing
+        // there would leave this session's state ahead of its own log. On an
+        // unguarded log this is a no-op, so headless writers are unaffected.
+        if let Some(ops_log) = &self.ops_log {
+            ops_log.ensure_no_external_changes()?;
+        }
+
         tracing::debug!(
             command_type = %type_name,
             record_history,

--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -143,7 +143,8 @@ impl CommandExecutor {
         // `OpsLog::append` (inside the write lock, so it cannot be raced), but
         // by then the command has already mutated the in-memory state; failing
         // there would leave this session's state ahead of its own log. On an
-        // unguarded log this is a no-op, so headless writers are unaffected.
+        // unguarded log — a one-shot reader, a replay helper, a test — this is a
+        // no-op; every real session, GUI or headless, is guarded.
         if let Some(ops_log) = &self.ops_log {
             ops_log.ensure_no_external_changes()?;
         }

--- a/src-tauri/src/core/error.rs
+++ b/src-tauri/src/core/error.rs
@@ -46,6 +46,20 @@ pub enum CoreError {
         on_disk_op_count: usize,
     },
 
+    /// Another process rewrote the history manifest without appending to the log.
+    ///
+    /// Undo, redo and history jumps change which operations are applied without
+    /// recording a new operation, so the operation counts still agree and only
+    /// the manifest itself gives the change away. Continuing would re-apply this
+    /// session's view of history and silently revert the other process's undo.
+    #[error(
+        "{}: the project history changed on disk outside this session \
+         (another process undid, redid or jumped through history). \
+         Reload the project to continue.",
+        EXTERNAL_CHANGE_DETECTED_CODE
+    )]
+    ExternalHistoryChangeDetected,
+
     // =========================================================================
     // Asset Errors
     // =========================================================================

--- a/src-tauri/src/core/error.rs
+++ b/src-tauri/src/core/error.rs
@@ -6,6 +6,15 @@ use thiserror::Error;
 
 use super::{AssetId, ClipId, EffectId, OpId, SequenceId, TimeSec, TrackId};
 
+/// Stable machine-readable marker embedded in [`CoreError::ExternalChangeDetected`]
+/// messages.
+///
+/// IPC flattens `CoreError` to a string, so the frontend matches on this token to
+/// tell "another process edited this project" apart from ordinary command
+/// failures. Keep it in sync with `EXTERNAL_CHANGE_DETECTED_CODE` in
+/// `src/utils/externalChange.ts`.
+pub const EXTERNAL_CHANGE_DETECTED_CODE: &str = "ExternalChangeDetected";
+
 /// Core engine error types
 #[derive(Error, Debug)]
 pub enum CoreError {
@@ -23,6 +32,19 @@ pub enum CoreError {
 
     #[error("Failed to save project: {0}")]
     ProjectSaveFailed(String),
+
+    #[error(
+        "{}: the project operation log changed on disk outside this session \
+         (expected {expected_op_count} operations, found {on_disk_op_count}). \
+         Reload the project to continue.",
+        EXTERNAL_CHANGE_DETECTED_CODE
+    )]
+    ExternalChangeDetected {
+        /// Number of operations this session expects the log to contain.
+        expected_op_count: usize,
+        /// Number of operations currently present in the on-disk log.
+        on_disk_op_count: usize,
+    },
 
     // =========================================================================
     // Asset Errors

--- a/src-tauri/src/core/project/history.rs
+++ b/src-tauri/src/core/project/history.rs
@@ -69,9 +69,19 @@ impl ProjectHistory {
             return Ok(Self::default());
         }
 
-        let file = std::fs::File::open(path)?;
-        let history = serde_json::from_reader(file)?;
-        Ok(history)
+        let bytes = std::fs::read(path)?;
+        Self::from_json_slice(&bytes)
+    }
+
+    /// Parses a history manifest from raw JSON bytes.
+    ///
+    /// Opening a project reads the manifest inside the same critical section as
+    /// its external-change baseline (see
+    /// [`crate::core::project::OpsLog::begin_guarded_session_reading_all`]) and
+    /// parses the bytes it got, so the history the session runs on is exactly
+    /// the revision its guard is watching.
+    pub fn from_json_slice(bytes: &[u8]) -> CoreResult<Self> {
+        Ok(serde_json::from_slice(bytes)?)
     }
 
     /// Persists history to disk atomically.

--- a/src-tauri/src/core/project/ops_log.rs
+++ b/src-tauri/src/core/project/ops_log.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::core::{CoreResult, OpId};
+use crate::core::{CoreError, CoreResult, OpId};
 
 // =============================================================================
 // Operation Types
@@ -184,17 +184,35 @@ pub struct ReadResult {
     pub errors: Vec<(usize, String)>,
 }
 
+/// Revision of `ops.jsonl` a guarded session believes is on disk.
+///
+/// Shared by every handle derived from one another via [`OpsLog::shared_handle`],
+/// so an append made through the executor's handle advances the same watermark
+/// the project's own handle checks.
+///
+/// The byte length is the discriminator: it is an `O(1)` stat, and because the
+/// log is append-only any foreign write necessarily changes it. The operation
+/// count is carried alongside purely so a rejection can report meaningful
+/// numbers without rescanning the file on the happy path.
+#[derive(Debug)]
+struct SessionWatermark {
+    /// Byte length `ops.jsonl` had after this session's last write or resync.
+    expected_len: AtomicU64,
+    /// Operation count corresponding to `expected_len`.
+    expected_op_count: AtomicU64,
+}
+
 /// Append-only operation log backed by a JSONL file
 pub struct OpsLog {
     /// Path to the ops.jsonl file
     path: PathBuf,
-    /// Number of operations appended through this handle and every handle
-    /// derived from it via [`OpsLog::shared_handle`].
+    /// Session watermark installed by [`OpsLog::begin_guarded_session`].
     ///
-    /// This is the basis of external-change detection: the number of operations
-    /// the current session expects to find on disk is the count observed when
-    /// the log was opened plus the number of appends this session performed.
-    local_append_count: Arc<AtomicU64>,
+    /// `None` means this handle writes unguarded, which is the correct default
+    /// for one-shot readers, replay helpers and tests. Only a handle that
+    /// represents a live editing session (see [`crate::ActiveProject`]) opts in,
+    /// because only such a session can be *stale* relative to the file.
+    watermark: Option<Arc<SessionWatermark>>,
 }
 
 struct OpsLogLock(File);
@@ -211,28 +229,197 @@ impl OpsLog {
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         Self {
             path: path.as_ref().to_path_buf(),
-            local_append_count: Arc::new(AtomicU64::new(0)),
+            watermark: None,
         }
     }
 
-    /// Creates a second handle to the same log that shares this handle's local
-    /// append counter.
+    /// Creates a second handle to the same log that shares this handle's
+    /// session watermark.
     ///
     /// Use this whenever a component (for example [`crate::core::commands::CommandExecutor`])
     /// needs its own handle to a log that another component also writes to, so
-    /// that every append performed by this session is attributed to the same
-    /// counter and never mistaken for an external edit.
+    /// that every append performed by this session advances the same watermark
+    /// and is never mistaken for an external edit.
     pub fn shared_handle(&self) -> Self {
         Self {
             path: self.path.clone(),
-            local_append_count: Arc::clone(&self.local_append_count),
+            watermark: self.watermark.as_ref().map(Arc::clone),
         }
     }
 
-    /// Returns the number of operations appended through this handle family
-    /// since it was created.
-    pub fn local_append_count(&self) -> u64 {
-        self.local_append_count.load(Ordering::SeqCst)
+    // =========================================================================
+    // External-change guard
+    //
+    // Every write to ops.jsonl in the product funnels through `append` /
+    // `append_batch`, so enforcing the guard here covers all callers by
+    // construction instead of relying on each of them to remember a check.
+    // =========================================================================
+
+    /// Starts guarding this handle family against writes made by other
+    /// processes, using the log's current on-disk revision as the baseline.
+    ///
+    /// From this point on, [`OpsLog::append`] and [`OpsLog::append_batch`] fail
+    /// with [`CoreError::ExternalChangeDetected`] when the file no longer
+    /// matches what this session wrote, instead of interleaving this session's
+    /// operations with the foreign ones.
+    ///
+    /// Handles that do not opt in keep appending unconditionally, which is what
+    /// short-lived writers such as `openreelio-cli` invocations need.
+    pub fn begin_guarded_session(&mut self) -> CoreResult<()> {
+        let _lock = self.lock_shared()?;
+        let len = self.on_disk_len()?;
+        let count = self.count_unlocked()? as u64;
+        self.watermark = Some(Arc::new(SessionWatermark {
+            expected_len: AtomicU64::new(len),
+            expected_op_count: AtomicU64::new(count),
+        }));
+        Ok(())
+    }
+
+    /// Reads every operation, archived ones included, and installs the session
+    /// watermark from the same critical section.
+    ///
+    /// Opening a project needs both halves to describe the same revision of the
+    /// log. Reading first and sampling the baseline afterwards (or the reverse)
+    /// leaves a window in which another process can append: the freshly opened
+    /// session would then start out already disagreeing with the file and report
+    /// an external change that it had in fact just replayed.
+    pub fn begin_guarded_session_reading_all(&mut self) -> CoreResult<ReadResult> {
+        // Exclusive rather than shared: no other process may append between the
+        // replay and the baseline sample.
+        let _lock = self.lock_exclusive()?;
+
+        let mut all_ops = Vec::new();
+        let mut all_errors = Vec::new();
+
+        let archive_result = self.read_archive()?;
+        all_ops.extend(archive_result.operations);
+        all_errors.extend(
+            archive_result
+                .errors
+                .into_iter()
+                .map(|(line, err)| (line, format!("[archive] {}", err))),
+        );
+
+        let current_result = self.read_all_unlocked()?;
+        let archive_lines = all_ops.len();
+        all_ops.extend(current_result.operations);
+        all_errors.extend(
+            current_result
+                .errors
+                .into_iter()
+                .map(|(line, err)| (line + archive_lines, err)),
+        );
+
+        let len = self.on_disk_len()?;
+        let count = self.count_unlocked()? as u64;
+        self.watermark = Some(Arc::new(SessionWatermark {
+            expected_len: AtomicU64::new(len),
+            expected_op_count: AtomicU64::new(count),
+        }));
+
+        Ok(ReadResult {
+            operations: all_ops,
+            errors: all_errors,
+        })
+    }
+
+    /// Whether this handle rejects appends made on top of foreign writes.
+    pub fn is_guarded(&self) -> bool {
+        self.watermark.is_some()
+    }
+
+    /// Number of operations a guarded session expects the log to contain.
+    ///
+    /// Returns `None` for unguarded handles, which hold no expectation at all.
+    pub fn expected_op_count(&self) -> Option<u64> {
+        self.watermark
+            .as_ref()
+            .map(|watermark| watermark.expected_op_count.load(Ordering::SeqCst))
+    }
+
+    /// Fails with [`CoreError::ExternalChangeDetected`] when the on-disk log no
+    /// longer matches what this session wrote.
+    ///
+    /// Callers that mutate in-memory state before appending should call this
+    /// first so a rejection leaves nothing half-applied. It is a no-op on
+    /// unguarded handles.
+    pub fn ensure_no_external_changes(&self) -> CoreResult<()> {
+        if self.watermark.is_none() {
+            return Ok(());
+        }
+        let _lock = self.lock_shared()?;
+        self.verify_watermark_locked()
+    }
+
+    /// Byte length of the log, treating a missing file as empty.
+    fn on_disk_len(&self) -> CoreResult<u64> {
+        match std::fs::metadata(&self.path) {
+            Ok(metadata) => Ok(metadata.len()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(0),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Compares the on-disk log against the watermark. Requires a held lock.
+    fn verify_watermark_locked(&self) -> CoreResult<()> {
+        let Some(watermark) = self.watermark.as_ref() else {
+            return Ok(());
+        };
+
+        let expected_len = watermark.expected_len.load(Ordering::SeqCst);
+        let actual_len = self.on_disk_len()?;
+        if actual_len == expected_len {
+            return Ok(());
+        }
+
+        // Only the rejection path pays for an exact count; the numbers exist to
+        // explain the conflict to the user, not to detect it.
+        let expected_op_count = watermark.expected_op_count.load(Ordering::SeqCst) as usize;
+        let on_disk_op_count = self.count_unlocked()?;
+        tracing::warn!(
+            expected_op_count,
+            on_disk_op_count,
+            expected_len,
+            actual_len,
+            ops_log = %self.path.display(),
+            "External change detected in project ops log"
+        );
+        Err(CoreError::ExternalChangeDetected {
+            expected_op_count,
+            on_disk_op_count,
+        })
+    }
+
+    /// Records that this session just wrote `appended_ops` operations.
+    /// Requires a held lock so the sampled length reflects our own write.
+    fn advance_watermark_locked(&self, appended_ops: u64) -> CoreResult<()> {
+        let Some(watermark) = self.watermark.as_ref() else {
+            return Ok(());
+        };
+        watermark
+            .expected_len
+            .store(self.on_disk_len()?, Ordering::SeqCst);
+        watermark
+            .expected_op_count
+            .fetch_add(appended_ops, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Re-samples the watermark after this session deliberately rewrote the log
+    /// (compaction), so its own rewrite is not mistaken for a foreign edit.
+    /// Requires a held lock.
+    fn resync_watermark_locked(&self) -> CoreResult<()> {
+        let Some(watermark) = self.watermark.as_ref() else {
+            return Ok(());
+        };
+        watermark
+            .expected_len
+            .store(self.on_disk_len()?, Ordering::SeqCst);
+        watermark
+            .expected_op_count
+            .store(self.count_unlocked()? as u64, Ordering::SeqCst);
+        Ok(())
     }
 
     /// Returns the path to the ops.jsonl file
@@ -303,9 +490,15 @@ impl OpsLog {
     }
 
     /// Appends a single operation to the log
+    ///
+    /// On a guarded handle (see [`OpsLog::begin_guarded_session`]) this fails
+    /// with [`CoreError::ExternalChangeDetected`] when another process wrote to
+    /// the log first. The check runs inside the same exclusive lock as the
+    /// write, so no foreign append can slip in between the two.
     pub fn append(&self, op: &Operation) -> CoreResult<()> {
         tracing::debug!(op_id = %op.id, op_kind = ?op.kind, "Appending operation to ops log");
         let _lock = self.lock_exclusive()?;
+        self.verify_watermark_locked()?;
         let file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -321,20 +514,23 @@ impl OpsLog {
         // of the log on power loss can make snapshots diverge from history.
         writer.get_ref().sync_all()?;
 
-        // Only count appends that reached disk; an inflated counter would hide a
-        // genuine external edit.
-        self.local_append_count.fetch_add(1, Ordering::SeqCst);
+        // Only count appends that reached disk; an inflated watermark would hide
+        // a genuine external edit.
+        self.advance_watermark_locked(1)?;
 
         Ok(())
     }
 
     /// Appends multiple operations to the log atomically
+    ///
+    /// Guarded handles reject foreign writes exactly as [`OpsLog::append`] does.
     pub fn append_batch(&self, ops: &[Operation]) -> CoreResult<()> {
         tracing::debug!(
             op_count = ops.len(),
             "Appending batch operations to ops log"
         );
         let _lock = self.lock_exclusive()?;
+        self.verify_watermark_locked()?;
         let file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -350,8 +546,7 @@ impl OpsLog {
         // See `append` for durability rationale.
         writer.get_ref().sync_all()?;
 
-        self.local_append_count
-            .fetch_add(ops.len() as u64, Ordering::SeqCst);
+        self.advance_watermark_locked(ops.len() as u64)?;
 
         Ok(())
     }
@@ -441,6 +636,11 @@ impl OpsLog {
     /// Counts the total number of operations in the log
     pub fn count(&self) -> CoreResult<usize> {
         let _lock = self.lock_shared()?;
+        self.count_unlocked()
+    }
+
+    /// Counts operations without acquiring the lock. Requires a held lock.
+    fn count_unlocked(&self) -> CoreResult<usize> {
         if !self.exists() {
             return Ok(0);
         }
@@ -493,6 +693,9 @@ impl OpsLog {
 
         // Replace the original file
         std::fs::rename(&temp_path, &self.path)?;
+        // This session rewrote the log on purpose; re-baseline so its own
+        // rewrite is not reported as somebody else's edit.
+        self.resync_watermark_locked()?;
 
         Ok(error_count)
     }
@@ -562,6 +765,8 @@ impl OpsLog {
 
         // Atomic rename
         std::fs::rename(&temp_path, &self.path)?;
+        // See `compact`: compaction is a deliberate local rewrite.
+        self.resync_watermark_locked()?;
 
         Ok(archived_count)
     }
@@ -877,44 +1082,168 @@ this is not valid json
         assert_eq!(ops_log.count().unwrap(), 2);
     }
 
+    // =========================================================================
+    // External-change guard
+    //
+    // Feature: External edit safety
+    //   As an editor who drives OpenReelio from both the GUI and openreelio-cli
+    //   I want appends to stop at the log itself when another process wrote
+    //   So that no mutation path can bypass the check by forgetting to call it
+    // =========================================================================
+
+    /// Scenario: an unguarded handle is the default and never blocks.
     #[test]
-    fn test_ops_log_shared_handle_counts_appends_from_both_handles() {
+    fn should_append_unconditionally_on_an_unguarded_handle() {
+        // Given a plain handle, as short-lived headless writers and tests use
         let (ops_log, _temp_dir) = create_test_ops_log();
-        let executor_handle = ops_log.shared_handle();
+        assert!(!ops_log.is_guarded());
+        assert_eq!(ops_log.expected_op_count(), None);
 
-        assert_eq!(ops_log.local_append_count(), 0);
+        // When another writer appends underneath it
+        OpsLog::new(ops_log.path())
+            .append(&Operation::new(OpKind::AssetImport, serde_json::json!({})))
+            .unwrap();
 
+        // Then it still appends and reports no external change
+        ops_log.ensure_no_external_changes().unwrap();
+        ops_log
+            .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
+            .unwrap();
+        assert_eq!(ops_log.count().unwrap(), 2);
+    }
+
+    /// Scenario: a guarded handle refuses to write on top of a foreign append.
+    #[test]
+    fn should_reject_appends_on_a_guarded_handle_after_a_foreign_write() {
+        // Given a guarded session that has appended once
+        let (mut ops_log, _temp_dir) = create_test_ops_log();
+        ops_log.begin_guarded_session().unwrap();
         ops_log
             .append(&Operation::new(OpKind::AssetImport, serde_json::json!({})))
             .unwrap();
-        executor_handle
+        ops_log.ensure_no_external_changes().unwrap();
+        assert_eq!(ops_log.expected_op_count(), Some(1));
+
+        // When another process appends
+        OpsLog::new(ops_log.path())
             .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
             .unwrap();
-        executor_handle
-            .append_batch(&[
-                Operation::new(OpKind::ClipMove, serde_json::json!({})),
-                Operation::new(OpKind::ClipTrim, serde_json::json!({})),
-            ])
-            .unwrap();
 
-        // Both handles observe the same session-local total.
-        assert_eq!(ops_log.local_append_count(), 4);
-        assert_eq!(executor_handle.local_append_count(), 4);
-        assert_eq!(ops_log.count().unwrap(), 4);
+        // Then both the pre-flight check and the append itself refuse
+        assert!(matches!(
+            ops_log.ensure_no_external_changes(),
+            Err(CoreError::ExternalChangeDetected {
+                expected_op_count: 1,
+                on_disk_op_count: 2,
+            })
+        ));
+        assert!(matches!(
+            ops_log.append(&Operation::new(OpKind::ClipMove, serde_json::json!({}))),
+            Err(CoreError::ExternalChangeDetected { .. })
+        ));
+        assert!(matches!(
+            ops_log.append_batch(&[Operation::new(OpKind::ClipTrim, serde_json::json!({}))]),
+            Err(CoreError::ExternalChangeDetected { .. })
+        ));
+        // And the foreign operation is still the only thing that landed
+        assert_eq!(ops_log.count().unwrap(), 2);
     }
 
+    /// Scenario: the executor's derived handle shares one watermark.
     #[test]
-    fn test_ops_log_independent_handles_do_not_share_append_counts() {
-        let (ops_log, _temp_dir) = create_test_ops_log();
-        // A separate handle stands in for another process writing the same file.
-        let other_process = OpsLog::new(ops_log.path());
+    fn should_share_the_guard_with_handles_derived_from_the_same_session() {
+        // Given a guarded log and the handle the executor writes through
+        let (mut ops_log, _temp_dir) = create_test_ops_log();
+        ops_log.begin_guarded_session().unwrap();
+        let executor_handle = ops_log.shared_handle();
+        assert!(executor_handle.is_guarded());
 
-        other_process
+        // When each handle appends, neither sees the other as external
+        executor_handle
             .append(&Operation::new(OpKind::AssetImport, serde_json::json!({})))
             .unwrap();
+        ops_log
+            .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
+            .unwrap();
+        ops_log.ensure_no_external_changes().unwrap();
+        executor_handle.ensure_no_external_changes().unwrap();
 
-        assert_eq!(ops_log.local_append_count(), 0);
-        assert_eq!(ops_log.count().unwrap(), 1);
+        // Then a foreign append stops both of them
+        OpsLog::new(ops_log.path())
+            .append(&Operation::new(OpKind::ClipMove, serde_json::json!({})))
+            .unwrap();
+        assert!(matches!(
+            executor_handle.append(&Operation::new(OpKind::ClipTrim, serde_json::json!({}))),
+            Err(CoreError::ExternalChangeDetected { .. })
+        ));
+        assert!(matches!(
+            ops_log.ensure_no_external_changes(),
+            Err(CoreError::ExternalChangeDetected { .. })
+        ));
+    }
+
+    /// Scenario: opening a project baselines against the log it just replayed.
+    #[test]
+    fn should_baseline_the_guard_against_the_operations_it_replayed() {
+        // Given a log another process already populated, part of it archived so
+        // the replay has to read both files
+        let (ops_log, _temp_dir) = create_test_ops_log();
+        let ops: Vec<Operation> = (1..=5)
+            .map(|i| {
+                Operation::with_id(
+                    &format!("op_{:03}", i),
+                    OpKind::AssetImport,
+                    serde_json::json!({}),
+                )
+            })
+            .collect();
+        ops_log.append_batch(&ops).unwrap();
+        assert_eq!(ops_log.compact_after_snapshot("op_002").unwrap(), 2);
+
+        // When a session opens it
+        let mut session = OpsLog::new(ops_log.path());
+        let read = session.begin_guarded_session_reading_all().unwrap();
+
+        // Then the replay spans the archive, while the watermark tracks only the
+        // live log the session will append to
+        assert_eq!(read.operations.len(), 5);
+        assert!(read.errors.is_empty());
+        assert_eq!(session.expected_op_count(), Some(3));
+        session.ensure_no_external_changes().unwrap();
+        session
+            .append(&Operation::new(OpKind::ClipMove, serde_json::json!({})))
+            .unwrap();
+        assert_eq!(session.expected_op_count(), Some(4));
+    }
+
+    /// Scenario: this session's own compaction is not a foreign edit.
+    #[test]
+    fn should_rebaseline_the_guard_after_this_session_compacts() {
+        // Given a guarded session with several operations
+        let (mut ops_log, _temp_dir) = create_test_ops_log();
+        let ops: Vec<Operation> = (1..=6)
+            .map(|i| {
+                Operation::with_id(
+                    &format!("op_{:03}", i),
+                    OpKind::AssetImport,
+                    serde_json::json!({}),
+                )
+            })
+            .collect();
+        ops_log.append_batch(&ops).unwrap();
+        ops_log.begin_guarded_session().unwrap();
+
+        // When it compacts its own log, which rewrites the file
+        let archived = ops_log.compact_after_snapshot("op_003").unwrap();
+        assert_eq!(archived, 3);
+
+        // Then it keeps writing rather than accusing itself
+        ops_log.ensure_no_external_changes().unwrap();
+        assert_eq!(ops_log.expected_op_count(), Some(3));
+        ops_log
+            .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
+            .unwrap();
+        assert_eq!(ops_log.count().unwrap(), 4);
     }
 
     #[test]

--- a/src-tauri/src/core/project/ops_log.rs
+++ b/src-tauri/src/core/project/ops_log.rs
@@ -6,6 +6,8 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -186,6 +188,13 @@ pub struct ReadResult {
 pub struct OpsLog {
     /// Path to the ops.jsonl file
     path: PathBuf,
+    /// Number of operations appended through this handle and every handle
+    /// derived from it via [`OpsLog::shared_handle`].
+    ///
+    /// This is the basis of external-change detection: the number of operations
+    /// the current session expects to find on disk is the count observed when
+    /// the log was opened plus the number of appends this session performed.
+    local_append_count: Arc<AtomicU64>,
 }
 
 struct OpsLogLock(File);
@@ -202,7 +211,28 @@ impl OpsLog {
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         Self {
             path: path.as_ref().to_path_buf(),
+            local_append_count: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Creates a second handle to the same log that shares this handle's local
+    /// append counter.
+    ///
+    /// Use this whenever a component (for example [`crate::core::commands::CommandExecutor`])
+    /// needs its own handle to a log that another component also writes to, so
+    /// that every append performed by this session is attributed to the same
+    /// counter and never mistaken for an external edit.
+    pub fn shared_handle(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            local_append_count: Arc::clone(&self.local_append_count),
+        }
+    }
+
+    /// Returns the number of operations appended through this handle family
+    /// since it was created.
+    pub fn local_append_count(&self) -> u64 {
+        self.local_append_count.load(Ordering::SeqCst)
     }
 
     /// Returns the path to the ops.jsonl file
@@ -291,6 +321,10 @@ impl OpsLog {
         // of the log on power loss can make snapshots diverge from history.
         writer.get_ref().sync_all()?;
 
+        // Only count appends that reached disk; an inflated counter would hide a
+        // genuine external edit.
+        self.local_append_count.fetch_add(1, Ordering::SeqCst);
+
         Ok(())
     }
 
@@ -315,6 +349,9 @@ impl OpsLog {
 
         // See `append` for durability rationale.
         writer.get_ref().sync_all()?;
+
+        self.local_append_count
+            .fetch_add(ops.len() as u64, Ordering::SeqCst);
 
         Ok(())
     }
@@ -838,6 +875,46 @@ this is not valid json
         let op2 = Operation::new(OpKind::ClipAdd, serde_json::json!({}));
         ops_log.append(&op2).unwrap();
         assert_eq!(ops_log.count().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_ops_log_shared_handle_counts_appends_from_both_handles() {
+        let (ops_log, _temp_dir) = create_test_ops_log();
+        let executor_handle = ops_log.shared_handle();
+
+        assert_eq!(ops_log.local_append_count(), 0);
+
+        ops_log
+            .append(&Operation::new(OpKind::AssetImport, serde_json::json!({})))
+            .unwrap();
+        executor_handle
+            .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
+            .unwrap();
+        executor_handle
+            .append_batch(&[
+                Operation::new(OpKind::ClipMove, serde_json::json!({})),
+                Operation::new(OpKind::ClipTrim, serde_json::json!({})),
+            ])
+            .unwrap();
+
+        // Both handles observe the same session-local total.
+        assert_eq!(ops_log.local_append_count(), 4);
+        assert_eq!(executor_handle.local_append_count(), 4);
+        assert_eq!(ops_log.count().unwrap(), 4);
+    }
+
+    #[test]
+    fn test_ops_log_independent_handles_do_not_share_append_counts() {
+        let (ops_log, _temp_dir) = create_test_ops_log();
+        // A separate handle stands in for another process writing the same file.
+        let other_process = OpsLog::new(ops_log.path());
+
+        other_process
+            .append(&Operation::new(OpKind::AssetImport, serde_json::json!({})))
+            .unwrap();
+
+        assert_eq!(ops_log.local_append_count(), 0);
+        assert_eq!(ops_log.count().unwrap(), 1);
     }
 
     #[test]

--- a/src-tauri/src/core/project/ops_log.rs
+++ b/src-tauri/src/core/project/ops_log.rs
@@ -3,11 +3,13 @@
 //! Implements append-only event sourcing log for project operations.
 //! The ops.jsonl file is the single source of truth for all project state.
 
+use std::collections::hash_map::DefaultHasher;
 use std::fs::{File, OpenOptions};
+use std::hash::Hasher;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -184,22 +186,123 @@ pub struct ReadResult {
     pub errors: Vec<(usize, String)>,
 }
 
-/// Revision of `ops.jsonl` a guarded session believes is on disk.
+/// Revision of the project's persistent state a guarded session believes is on
+/// disk.
 ///
 /// Shared by every handle derived from one another via [`OpsLog::shared_handle`],
 /// so an append made through the executor's handle advances the same watermark
 /// the project's own handle checks.
 ///
-/// The byte length is the discriminator: it is an `O(1)` stat, and because the
-/// log is append-only any foreign write necessarily changes it. The operation
-/// count is carried alongside purely so a rejection can report meaningful
-/// numbers without rescanning the file on the happy path.
+/// Two files carry the revision, because two files can be rewritten
+/// independently:
+///
+/// - `ops.jsonl` — append-only, so its byte length is a sufficient
+///   discriminator: an `O(1)` stat that any foreign write necessarily changes.
+///   The operation count is carried alongside purely so a rejection can report
+///   meaningful numbers without rescanning the file on the happy path.
+/// - `history.json` — rewritten in place by undo, redo and history jumps, which
+///   append nothing. A process that only undoes leaves `ops.jsonl` byte-identical,
+///   so the log watermark alone cannot see it; the manifest is therefore tracked
+///   by content fingerprint (see [`FileFingerprint`]).
+///
+/// `snapshot.json` is deliberately *not* tracked: it is a regenerable cache
+/// derived from the log and the manifest, so a foreign rewrite of it cannot
+/// silently revert anybody's edits — the next open rebuilds it.
 #[derive(Debug)]
 struct SessionWatermark {
     /// Byte length `ops.jsonl` had after this session's last write or resync.
     expected_len: AtomicU64,
     /// Operation count corresponding to `expected_len`.
     expected_op_count: AtomicU64,
+    /// Baseline for the history manifest, once the session tracks one.
+    ///
+    /// Behind a mutex rather than an atomic because the baseline is a path plus
+    /// a fingerprint that must be replaced as one value, and because the
+    /// watermark is shared through an [`Arc`] by handles that only hold `&self`.
+    history: Mutex<Option<HistoryBaseline>>,
+}
+
+impl SessionWatermark {
+    fn new(expected_len: u64, expected_op_count: u64) -> Self {
+        Self {
+            expected_len: AtomicU64::new(expected_len),
+            expected_op_count: AtomicU64::new(expected_op_count),
+            history: Mutex::new(None),
+        }
+    }
+
+    /// Locks the history baseline, recovering from a poisoned mutex.
+    ///
+    /// Every writer replaces the whole value, so a panic elsewhere cannot leave
+    /// a half-updated baseline behind; refusing to edit because an unrelated
+    /// thread panicked would be worse than continuing.
+    fn history(&self) -> MutexGuard<'_, Option<HistoryBaseline>> {
+        self.history
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Revision of the history manifest (`history.json`) a session believes is on
+/// disk.
+#[derive(Debug)]
+struct HistoryBaseline {
+    /// Manifest this session writes and verifies.
+    path: PathBuf,
+    /// Fingerprint of the manifest, or `None` when it does not exist yet.
+    fingerprint: Option<FileFingerprint>,
+}
+
+/// Content identity of a small state file.
+///
+/// The manifest is a list of operation ids, so reading it whole costs far less
+/// than the `fsync` an append already pays. Length alone would not do: an undo
+/// followed by an unrelated redo can produce a same-length manifest that
+/// describes a different history, and mtime alone is at the mercy of filesystem
+/// timestamp granularity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FileFingerprint {
+    len: u64,
+    digest: u64,
+}
+
+impl FileFingerprint {
+    /// Fingerprints `path`, reporting `None` when the file does not exist.
+    ///
+    /// Callers write the manifest atomically (temp file plus rename), so a
+    /// concurrent reader observes either the whole old file or the whole new
+    /// one and never a torn fingerprint.
+    fn of_file(path: &Path) -> CoreResult<Option<Self>> {
+        match std::fs::read(path) {
+            Ok(bytes) => Ok(Some(Self::of_bytes(&bytes))),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn of_bytes(bytes: &[u8]) -> Self {
+        // Only ever compared against fingerprints taken by the same process, so
+        // a fast non-cryptographic hash is enough.
+        let mut hasher = DefaultHasher::new();
+        hasher.write(bytes);
+        Self {
+            len: bytes.len() as u64,
+            digest: hasher.finish(),
+        }
+    }
+}
+
+/// Everything [`OpsLog::begin_guarded_session_reading_all`] read while taking
+/// the session's baseline.
+#[derive(Debug)]
+pub struct GuardedSessionOpen {
+    /// Every operation in the log, archived ones included.
+    pub operations: ReadResult,
+    /// Raw bytes of the history manifest, or `None` when it does not exist.
+    ///
+    /// Returned rather than re-read by the caller so the manifest the session
+    /// parses is exactly the one its baseline describes.
+    pub history_manifest: Option<Vec<u8>>,
 }
 
 /// Append-only operation log backed by a JSONL file
@@ -210,8 +313,10 @@ pub struct OpsLog {
     ///
     /// `None` means this handle writes unguarded, which is the correct default
     /// for one-shot readers, replay helpers and tests. Only a handle that
-    /// represents a live editing session (see [`crate::ActiveProject`]) opts in,
-    /// because only such a session can be *stale* relative to the file.
+    /// represents a live editing session opts in, because only such a session
+    /// can be *stale* relative to the file. Every [`crate::ActiveProject`] is
+    /// one, whether it belongs to a GUI window or to an `openreelio-cli`
+    /// invocation.
     watermark: Option<Arc<SessionWatermark>>,
 }
 
@@ -251,40 +356,50 @@ impl OpsLog {
     // External-change guard
     //
     // Every write to ops.jsonl in the product funnels through `append` /
-    // `append_batch`, so enforcing the guard here covers all callers by
-    // construction instead of relying on each of them to remember a check.
+    // `append_batch`, and every write to history.json through
+    // `write_history_manifest`, so enforcing the guard at those three functions
+    // covers all callers by construction instead of relying on each of them to
+    // remember a check.
     // =========================================================================
 
     /// Starts guarding this handle family against writes made by other
     /// processes, using the log's current on-disk revision as the baseline.
     ///
-    /// From this point on, [`OpsLog::append`] and [`OpsLog::append_batch`] fail
-    /// with [`CoreError::ExternalChangeDetected`] when the file no longer
-    /// matches what this session wrote, instead of interleaving this session's
-    /// operations with the foreign ones.
+    /// From this point on, [`OpsLog::append`], [`OpsLog::append_batch`] and
+    /// [`OpsLog::write_history_manifest`] fail with
+    /// [`CoreError::ExternalChangeDetected`] when the files no longer match what
+    /// this session wrote, instead of interleaving this session's work with the
+    /// foreign one.
     ///
-    /// Handles that do not opt in keep appending unconditionally, which is what
-    /// short-lived writers such as `openreelio-cli` invocations need.
+    /// The history manifest joins the baseline on the session's first
+    /// [`OpsLog::write_history_manifest`]; use
+    /// [`OpsLog::begin_guarded_session_reading_all`] to baseline both files at
+    /// once when opening an existing project.
+    ///
+    /// Every live editing session opts in — the GUI and each `openreelio-cli`
+    /// invocation alike (see [`crate::ActiveProject`]). Handles that do not opt
+    /// in keep appending unconditionally, which is what one-shot readers, replay
+    /// helpers and tests need.
     pub fn begin_guarded_session(&mut self) -> CoreResult<()> {
         let _lock = self.lock_shared()?;
         let len = self.on_disk_len()?;
         let count = self.count_unlocked()? as u64;
-        self.watermark = Some(Arc::new(SessionWatermark {
-            expected_len: AtomicU64::new(len),
-            expected_op_count: AtomicU64::new(count),
-        }));
+        self.watermark = Some(Arc::new(SessionWatermark::new(len, count)));
         Ok(())
     }
 
-    /// Reads every operation, archived ones included, and installs the session
-    /// watermark from the same critical section.
+    /// Reads every operation, archived ones included, plus the history manifest,
+    /// and installs the session watermark from the same critical section.
     ///
-    /// Opening a project needs both halves to describe the same revision of the
-    /// log. Reading first and sampling the baseline afterwards (or the reverse)
-    /// leaves a window in which another process can append: the freshly opened
-    /// session would then start out already disagreeing with the file and report
-    /// an external change that it had in fact just replayed.
-    pub fn begin_guarded_session_reading_all(&mut self) -> CoreResult<ReadResult> {
+    /// Opening a project needs all of them to describe the same revision of the
+    /// project. Reading first and sampling the baseline afterwards (or the
+    /// reverse) leaves a window in which another process can write: the freshly
+    /// opened session would then start out already disagreeing with the files
+    /// and report an external change that it had in fact just replayed.
+    pub fn begin_guarded_session_reading_all(
+        &mut self,
+        history_path: &Path,
+    ) -> CoreResult<GuardedSessionOpen> {
         // Exclusive rather than shared: no other process may append between the
         // replay and the baseline sample.
         let _lock = self.lock_exclusive()?;
@@ -311,17 +426,55 @@ impl OpsLog {
                 .map(|(line, err)| (line + archive_lines, err)),
         );
 
+        let history_manifest = match std::fs::read(history_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+
         let len = self.on_disk_len()?;
         let count = self.count_unlocked()? as u64;
-        self.watermark = Some(Arc::new(SessionWatermark {
-            expected_len: AtomicU64::new(len),
-            expected_op_count: AtomicU64::new(count),
-        }));
+        let watermark = SessionWatermark::new(len, count);
+        // Fingerprint the bytes just read, not the file again: the caller
+        // rebuilds its history from exactly these bytes.
+        *watermark.history() = Some(HistoryBaseline {
+            path: history_path.to_path_buf(),
+            fingerprint: history_manifest.as_deref().map(FileFingerprint::of_bytes),
+        });
+        self.watermark = Some(Arc::new(watermark));
 
-        Ok(ReadResult {
-            operations: all_ops,
-            errors: all_errors,
+        Ok(GuardedSessionOpen {
+            operations: ReadResult {
+                operations: all_ops,
+                errors: all_errors,
+            },
+            history_manifest,
         })
+    }
+
+    /// Rewrites the project's history manifest through the session guard.
+    ///
+    /// Undo, redo and history jumps change which operations are applied without
+    /// appending anything, so they are invisible to the append-only log
+    /// watermark. Routing those rewrites through here gives them the same two
+    /// properties the append path has:
+    ///
+    /// 1. the write is refused with [`CoreError::ExternalChangeDetected`] or
+    ///    [`CoreError::ExternalHistoryChangeDetected`] when another process got
+    ///    there first, verified inside the same exclusive lock as the write; and
+    /// 2. the session's baseline advances to what it just wrote, so its own
+    ///    rewrite is never mistaken for somebody else's.
+    ///
+    /// `history_path` is expected to stay the same for the life of a session.
+    /// On an unguarded handle this is a plain write.
+    pub fn write_history_manifest<F>(&self, history_path: &Path, write: F) -> CoreResult<()>
+    where
+        F: FnOnce(&Path) -> CoreResult<()>,
+    {
+        let _lock = self.lock_exclusive()?;
+        self.verify_watermark_locked()?;
+        write(history_path)?;
+        self.rebaseline_history_locked(history_path)
     }
 
     /// Whether this handle rejects appends made on top of foreign writes.
@@ -338,8 +491,12 @@ impl OpsLog {
             .map(|watermark| watermark.expected_op_count.load(Ordering::SeqCst))
     }
 
-    /// Fails with [`CoreError::ExternalChangeDetected`] when the on-disk log no
-    /// longer matches what this session wrote.
+    /// Fails when the on-disk log or history manifest no longer matches what
+    /// this session wrote.
+    ///
+    /// Reports [`CoreError::ExternalChangeDetected`] for a foreign append and
+    /// [`CoreError::ExternalHistoryChangeDetected`] for a foreign undo, redo or
+    /// history jump.
     ///
     /// Callers that mutate in-memory state before appending should call this
     /// first so a rejection leaves nothing half-applied. It is a no-op on
@@ -361,7 +518,8 @@ impl OpsLog {
         }
     }
 
-    /// Compares the on-disk log against the watermark. Requires a held lock.
+    /// Compares the on-disk log and history manifest against the watermark.
+    /// Requires a held lock.
     fn verify_watermark_locked(&self) -> CoreResult<()> {
         let Some(watermark) = self.watermark.as_ref() else {
             return Ok(());
@@ -369,26 +527,62 @@ impl OpsLog {
 
         let expected_len = watermark.expected_len.load(Ordering::SeqCst);
         let actual_len = self.on_disk_len()?;
-        if actual_len == expected_len {
+        if actual_len != expected_len {
+            // Only the rejection path pays for an exact count; the numbers exist
+            // to explain the conflict to the user, not to detect it.
+            let expected_op_count = watermark.expected_op_count.load(Ordering::SeqCst) as usize;
+            let on_disk_op_count = self.count_unlocked()?;
+            tracing::warn!(
+                expected_op_count,
+                on_disk_op_count,
+                expected_len,
+                actual_len,
+                ops_log = %self.path.display(),
+                "External change detected in project ops log"
+            );
+            return Err(CoreError::ExternalChangeDetected {
+                expected_op_count,
+                on_disk_op_count,
+            });
+        }
+
+        self.verify_history_baseline_locked(watermark)
+    }
+
+    /// Compares the on-disk history manifest against the baseline. Requires a
+    /// held lock.
+    fn verify_history_baseline_locked(&self, watermark: &SessionWatermark) -> CoreResult<()> {
+        let history = watermark.history();
+        let Some(baseline) = history.as_ref() else {
+            return Ok(());
+        };
+
+        let actual = FileFingerprint::of_file(&baseline.path)?;
+        if actual == baseline.fingerprint {
             return Ok(());
         }
 
-        // Only the rejection path pays for an exact count; the numbers exist to
-        // explain the conflict to the user, not to detect it.
-        let expected_op_count = watermark.expected_op_count.load(Ordering::SeqCst) as usize;
-        let on_disk_op_count = self.count_unlocked()?;
         tracing::warn!(
-            expected_op_count,
-            on_disk_op_count,
-            expected_len,
-            actual_len,
-            ops_log = %self.path.display(),
-            "External change detected in project ops log"
+            history_manifest = %baseline.path.display(),
+            expected = ?baseline.fingerprint,
+            actual = ?actual,
+            "External change detected in project history manifest"
         );
-        Err(CoreError::ExternalChangeDetected {
-            expected_op_count,
-            on_disk_op_count,
-        })
+        Err(CoreError::ExternalHistoryChangeDetected)
+    }
+
+    /// Records the history manifest this session just wrote. Requires a held
+    /// lock so the sampled fingerprint reflects our own write.
+    fn rebaseline_history_locked(&self, history_path: &Path) -> CoreResult<()> {
+        let Some(watermark) = self.watermark.as_ref() else {
+            return Ok(());
+        };
+        let fingerprint = FileFingerprint::of_file(history_path)?;
+        *watermark.history() = Some(HistoryBaseline {
+            path: history_path.to_path_buf(),
+            fingerprint,
+        });
+        Ok(())
     }
 
     /// Records that this session just wrote `appended_ops` operations.
@@ -493,8 +687,9 @@ impl OpsLog {
     ///
     /// On a guarded handle (see [`OpsLog::begin_guarded_session`]) this fails
     /// with [`CoreError::ExternalChangeDetected`] when another process wrote to
-    /// the log first. The check runs inside the same exclusive lock as the
-    /// write, so no foreign append can slip in between the two.
+    /// the log first, or [`CoreError::ExternalHistoryChangeDetected`] when one
+    /// rewrote the history manifest. The check runs inside the same exclusive
+    /// lock as the write, so no foreign write can slip in between the two.
     pub fn append(&self, op: &Operation) -> CoreResult<()> {
         tracing::debug!(op_id = %op.id, op_kind = ?op.kind, "Appending operation to ops log");
         let _lock = self.lock_exclusive()?;
@@ -1091,6 +1286,21 @@ this is not valid json
     //   So that no mutation path can bypass the check by forgetting to call it
     // =========================================================================
 
+    /// Path of the history manifest that lives beside a test log.
+    fn history_path(ops_log: &OpsLog) -> PathBuf {
+        ops_log.path().with_file_name("history.json")
+    }
+
+    /// Writes a manifest the way `ProjectHistory::save` does, as far as the
+    /// guard is concerned: whole-file replacement of small JSON.
+    fn write_manifest(path: &Path, applied: &[&str]) -> CoreResult<()> {
+        std::fs::write(
+            path,
+            serde_json::json!({ "appliedOpIds": applied }).to_string(),
+        )?;
+        Ok(())
+    }
+
     /// Scenario: an unguarded handle is the default and never blocks.
     #[test]
     fn should_append_unconditionally_on_an_unguarded_handle() {
@@ -1202,7 +1412,10 @@ this is not valid json
 
         // When a session opens it
         let mut session = OpsLog::new(ops_log.path());
-        let read = session.begin_guarded_session_reading_all().unwrap();
+        let read = session
+            .begin_guarded_session_reading_all(&history_path(&ops_log))
+            .unwrap()
+            .operations;
 
         // Then the replay spans the archive, while the watermark tracks only the
         // live log the session will append to
@@ -1244,6 +1457,131 @@ this is not valid json
             .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
             .unwrap();
         assert_eq!(ops_log.count().unwrap(), 4);
+    }
+
+    /// Scenario: another process moves through history without appending.
+    ///
+    /// This is the case the append-only log watermark structurally cannot see:
+    /// an undo rewrites the manifest and leaves `ops.jsonl` byte-identical.
+    #[test]
+    fn should_reject_writes_after_a_foreign_history_rewrite() {
+        // Given a guarded session baselined against a log and a manifest
+        let (mut ops_log, _temp_dir) = create_test_ops_log();
+        let manifest = history_path(&ops_log);
+        write_manifest(&manifest, &["op_001"]).unwrap();
+        let read = ops_log
+            .begin_guarded_session_reading_all(&manifest)
+            .unwrap();
+        assert_eq!(
+            read.history_manifest.as_deref(),
+            Some(std::fs::read(&manifest).unwrap().as_slice()),
+            "the session parses exactly the manifest its baseline describes"
+        );
+        ops_log
+            .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
+            .unwrap();
+        let log_len_before = std::fs::metadata(ops_log.path()).unwrap().len();
+
+        // When another process undoes, rewriting only the manifest
+        write_manifest(&manifest, &[]).unwrap();
+        assert_eq!(
+            std::fs::metadata(ops_log.path()).unwrap().len(),
+            log_len_before,
+            "an undo appends nothing, so the log watermark cannot see it"
+        );
+
+        // Then every guarded write refuses, naming the manifest as the reason
+        assert!(matches!(
+            ops_log.ensure_no_external_changes(),
+            Err(CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            ops_log.append(&Operation::new(OpKind::ClipMove, serde_json::json!({}))),
+            Err(CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            ops_log.append_batch(&[Operation::new(OpKind::ClipTrim, serde_json::json!({}))]),
+            Err(CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            ops_log.write_history_manifest(&manifest, |path| write_manifest(path, &["op_001"])),
+            Err(CoreError::ExternalHistoryChangeDetected)
+        ));
+        // And nothing this session wanted to write landed
+        assert_eq!(
+            std::fs::metadata(ops_log.path()).unwrap().len(),
+            log_len_before
+        );
+        assert_eq!(
+            std::fs::read_to_string(&manifest).unwrap(),
+            serde_json::json!({ "appliedOpIds": [] }).to_string()
+        );
+    }
+
+    /// Scenario: this session's own history writes are not foreign edits.
+    #[test]
+    fn should_rebaseline_the_history_manifest_this_session_wrote() {
+        // Given a guarded session whose manifest does not exist yet
+        let (mut ops_log, _temp_dir) = create_test_ops_log();
+        let manifest = history_path(&ops_log);
+        let read = ops_log
+            .begin_guarded_session_reading_all(&manifest)
+            .unwrap();
+        assert!(read.history_manifest.is_none());
+
+        // When it writes the manifest through the guard, repeatedly
+        for applied in [&["op_001"][..], &["op_001", "op_002"][..], &[][..]] {
+            ops_log
+                .write_history_manifest(&manifest, |path| write_manifest(path, applied))
+                .unwrap();
+            ops_log.ensure_no_external_changes().unwrap();
+        }
+
+        // Then it keeps editing rather than accusing itself
+        ops_log
+            .append(&Operation::new(OpKind::ClipAdd, serde_json::json!({})))
+            .unwrap();
+        assert_eq!(ops_log.count().unwrap(), 1);
+    }
+
+    /// Scenario: the guard covers the manifest write in both directions.
+    #[test]
+    fn should_refuse_a_history_write_after_a_foreign_append() {
+        // Given a guarded session with a manifest baseline
+        let (mut ops_log, _temp_dir) = create_test_ops_log();
+        let manifest = history_path(&ops_log);
+        ops_log
+            .begin_guarded_session_reading_all(&manifest)
+            .unwrap();
+
+        // When another process appends to the log
+        OpsLog::new(ops_log.path())
+            .append(&Operation::new(OpKind::AssetImport, serde_json::json!({})))
+            .unwrap();
+
+        // Then this session may not persist a history move on top of it
+        assert!(matches!(
+            ops_log.write_history_manifest(&manifest, |path| write_manifest(path, &["op_001"])),
+            Err(CoreError::ExternalChangeDetected { .. })
+        ));
+        assert!(!manifest.exists(), "the refused write must not have run");
+    }
+
+    /// Scenario: an unguarded handle writes the manifest unconditionally.
+    #[test]
+    fn should_write_the_history_manifest_unconditionally_on_an_unguarded_handle() {
+        let (ops_log, _temp_dir) = create_test_ops_log();
+        let manifest = history_path(&ops_log);
+        write_manifest(&manifest, &["op_001"]).unwrap();
+
+        ops_log
+            .write_history_manifest(&manifest, |path| write_manifest(path, &["op_002"]))
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&manifest).unwrap(),
+            serde_json::json!({ "appliedOpIds": ["op_002"] }).to_string()
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/workspace/service.rs
+++ b/src-tauri/src/core/workspace/service.rs
@@ -345,6 +345,10 @@ impl WorkspaceService {
                     }
                 }
             }
+            WorkspaceEvent::ProjectStateChanged(_) => {
+                // Project state files are not workspace media; external-change
+                // handling lives in the workspace event loop.
+            }
         }
         Ok(())
     }
@@ -375,6 +379,9 @@ impl WorkspaceService {
             }
             WorkspaceEvent::FileRemoved(rel_path) => {
                 self.index.remove(rel_path)?;
+            }
+            WorkspaceEvent::ProjectStateChanged(_) => {
+                // Project state files are never indexed as workspace media.
             }
         }
         Ok(())

--- a/src-tauri/src/core/workspace/watcher.rs
+++ b/src-tauri/src/core/workspace/watcher.rs
@@ -22,6 +22,37 @@ pub enum WorkspaceEvent {
     FileRemoved(String),
     /// A file was modified in the workspace
     FileModified(String),
+    /// A persistent project state file (`ops.jsonl` / `snapshot.json`) changed.
+    ///
+    /// These files are excluded from workspace indexing, but a change to them
+    /// may mean another process edited the project, so they are reported
+    /// separately instead of being filtered out.
+    ProjectStateChanged(String),
+}
+
+/// Project state files, relative to the project root, that must be reported even
+/// though the workspace ignore rules exclude their directory.
+///
+/// Both the current hidden layout and the legacy root layout are covered, so a
+/// project written by an older build is still watched.
+const PROJECT_STATE_RELATIVE_PATHS: &[&str] = &[
+    ".openreelio/state/ops.jsonl",
+    ".openreelio/state/snapshot.json",
+    "ops.jsonl",
+    "snapshot.json",
+];
+
+/// Returns `true` when the given project-root-relative path is a persistent
+/// project state file.
+///
+/// The comparison is case-insensitive and separator-agnostic so it behaves the
+/// same on Windows and POSIX hosts.
+pub fn is_project_state_path(relative_path: &std::path::Path) -> bool {
+    let normalized = relative_path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    PROJECT_STATE_RELATIVE_PATHS.contains(&normalized.as_str())
 }
 
 /// Maximum number of filesystem events buffered between the watcher thread and
@@ -84,6 +115,33 @@ impl WorkspaceWatcher {
                                 Err(_) => continue,
                             };
 
+                            let rel_str = rel_path.to_string_lossy().replace('\\', "/");
+
+                            // Project state files must bypass both the ignore
+                            // rules (they live under `.openreelio/`) and the
+                            // media-extension gate, otherwise external edits by
+                            // openreelio-cli would never reach the app.
+                            if is_project_state_path(rel_path) {
+                                match event_tx
+                                    .try_send(WorkspaceEvent::ProjectStateChanged(rel_str))
+                                {
+                                    Ok(()) => {}
+                                    Err(mpsc::error::TrySendError::Full(_)) => {
+                                        tracing::warn!(
+                                            capacity = WORKSPACE_EVENT_CHANNEL_CAPACITY,
+                                            "Workspace event channel full; dropping project state event"
+                                        );
+                                    }
+                                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                                        tracing::debug!(
+                                            "Workspace event channel closed, stopping watcher"
+                                        );
+                                        return;
+                                    }
+                                }
+                                continue;
+                            }
+
                             // Check ignore rules
                             if ignore_rules.is_ignored(rel_path) {
                                 continue;
@@ -95,8 +153,6 @@ impl WorkspaceWatcher {
                             if !is_media_extension(ext) {
                                 continue;
                             }
-
-                            let rel_str = rel_path.to_string_lossy().replace('\\', "/");
 
                             let ws_event = match event.kind {
                                 DebouncedEventKind::Any => {
@@ -194,6 +250,52 @@ mod tests {
         assert!(!is_media_extension("txt"));
         assert!(!is_media_extension("rs"));
         assert!(!is_media_extension("json"));
+    }
+
+    #[test]
+    fn test_is_project_state_path_matches_hidden_and_legacy_layouts() {
+        use std::path::Path;
+
+        assert!(is_project_state_path(Path::new(
+            ".openreelio/state/ops.jsonl"
+        )));
+        assert!(is_project_state_path(Path::new(
+            ".openreelio\\state\\snapshot.json"
+        )));
+        assert!(is_project_state_path(Path::new("ops.jsonl")));
+        assert!(is_project_state_path(Path::new("snapshot.json")));
+
+        assert!(!is_project_state_path(Path::new(
+            ".openreelio/state/history.json"
+        )));
+        assert!(!is_project_state_path(Path::new("footage/clip.mp4")));
+        assert!(!is_project_state_path(Path::new("nested/ops.jsonl")));
+    }
+
+    #[tokio::test]
+    async fn test_watcher_reports_project_state_changes_despite_ignore_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join(".openreelio").join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        let rules = Arc::new(IgnoreRules::defaults());
+        let (tx, mut rx) = mpsc::channel(WORKSPACE_EVENT_CHANNEL_CAPACITY);
+        let _watcher = WorkspaceWatcher::start(dir.path().to_path_buf(), rules, tx).unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Simulate an external process appending to the ops log.
+        std::fs::write(state_dir.join("ops.jsonl"), b"{}\n").unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+
+        let event = rx.try_recv().expect("expected a project state event");
+        match event {
+            WorkspaceEvent::ProjectStateChanged(path) => {
+                assert_eq!(path, ".openreelio/state/ops.jsonl");
+            }
+            other => panic!("Unexpected event: {:?}", other),
+        }
     }
 
     #[test]

--- a/src-tauri/src/core/workspace/watcher.rs
+++ b/src-tauri/src/core/workspace/watcher.rs
@@ -22,7 +22,8 @@ pub enum WorkspaceEvent {
     FileRemoved(String),
     /// A file was modified in the workspace
     FileModified(String),
-    /// A persistent project state file (`ops.jsonl` / `snapshot.json`) changed.
+    /// A persistent project state file (`ops.jsonl` / `snapshot.json` /
+    /// `history.json`) changed.
     ///
     /// These files are excluded from workspace indexing, but a change to them
     /// may mean another process edited the project, so they are reported
@@ -33,11 +34,17 @@ pub enum WorkspaceEvent {
 /// Project state files, relative to the project root, that must be reported even
 /// though the workspace ignore rules exclude their directory.
 ///
+/// `history.json` is watched alongside the log because undo, redo and history
+/// jumps rewrite only the manifest: another process can change which operations
+/// are applied while `ops.jsonl` stays byte-identical.
+///
 /// Both the current hidden layout and the legacy root layout are covered, so a
-/// project written by an older build is still watched.
+/// project written by an older build is still watched. The legacy layout predates
+/// the history manifest, so it has no `history.json` entry.
 const PROJECT_STATE_RELATIVE_PATHS: &[&str] = &[
     ".openreelio/state/ops.jsonl",
     ".openreelio/state/snapshot.json",
+    ".openreelio/state/history.json",
     "ops.jsonl",
     "snapshot.json",
 ];
@@ -264,10 +271,11 @@ mod tests {
         )));
         assert!(is_project_state_path(Path::new("ops.jsonl")));
         assert!(is_project_state_path(Path::new("snapshot.json")));
-
-        assert!(!is_project_state_path(Path::new(
+        // An external undo rewrites only the manifest, so it has to be watched.
+        assert!(is_project_state_path(Path::new(
             ".openreelio/state/history.json"
         )));
+
         assert!(!is_project_state_path(Path::new("footage/clip.mp4")));
         assert!(!is_project_state_path(Path::new("nested/ops.jsonl")));
     }

--- a/src-tauri/src/ipc/commands/project.rs
+++ b/src-tauri/src/ipc/commands/project.rs
@@ -11,6 +11,15 @@ use tauri::State;
 use crate::core::{assets::Asset, fs::validate_existing_project_dir, CoreError};
 use crate::{ActiveProject, AppState};
 
+/// How many times [`reload_project_from_disk`] re-reads the project when another
+/// process appends while the reload is in flight.
+///
+/// Reloading has to release the project lock to replay the log off the async
+/// runtime, so a busy external writer can land an operation in that window. A
+/// couple of retries absorb that; beyond it the honest answer is that something
+/// else owns the project right now.
+const RELOAD_MAX_ATTEMPTS: u32 = 3;
+
 // =============================================================================
 // Helper Functions
 // =============================================================================
@@ -740,48 +749,80 @@ pub async fn reload_project_from_disk(state: State<'_, AppState>) -> Result<Proj
             .clone()
     };
 
-    // Reopening replays the ops log; keep it off the async runtime threads.
-    let reloaded = tokio::task::spawn_blocking(move || ActiveProject::open(project_path))
-        .await
-        .map_err(|e| format!("Project reload task failed: {e}"))?
-        .map_err(|e| e.to_ipc_error())?;
+    for attempt in 1..=RELOAD_MAX_ATTEMPTS {
+        let path_for_open = project_path.clone();
+        // Reopening replays the ops log; keep it off the async runtime threads.
+        // `ActiveProject::open` takes its external-change baseline in the same
+        // critical section as the replay, so the reloaded session's watermark
+        // always describes exactly the revision it replayed.
+        let reloaded = tokio::task::spawn_blocking(move || ActiveProject::open(path_for_open))
+            .await
+            .map_err(|e| format!("Project reload task failed: {e}"))?
+            .map_err(|e| e.to_ipc_error())?;
 
-    let assets_for_scope: Vec<Asset> = reloaded.state.assets.values().cloned().collect();
-    let project_path_canon =
-        std::fs::canonicalize(&reloaded.path).unwrap_or_else(|_| reloaded.path.clone());
+        let assets_for_scope: Vec<Asset> = reloaded.state.assets.values().cloned().collect();
+        let project_path_canon =
+            std::fs::canonicalize(&reloaded.path).unwrap_or_else(|_| reloaded.path.clone());
 
-    let info = ProjectInfo {
-        id: reloaded.state.meta.id.clone(),
-        name: reloaded.state.meta.name.clone(),
-        path: project_path_canon.to_string_lossy().to_string(),
-        created_at: reloaded.state.meta.created_at.clone(),
-    };
+        let info = ProjectInfo {
+            id: reloaded.state.meta.id.clone(),
+            name: reloaded.state.meta.name.clone(),
+            path: project_path_canon.to_string_lossy().to_string(),
+            created_at: reloaded.state.meta.created_at.clone(),
+        };
 
-    {
-        let mut guard = state.project.lock().await;
-        // Guard against the project being closed or replaced while reopening.
-        let is_same_project = guard
-            .as_ref()
-            .is_some_and(|current| current.path == reloaded.path);
-        if !is_same_project {
-            return Err(
-                "The active project changed while reloading. Reopen the project instead."
-                    .to_string(),
-            );
+        {
+            let mut guard = state.project.lock().await;
+            // Guard against the project being closed or replaced while reopening.
+            let is_same_project = guard
+                .as_ref()
+                .is_some_and(|current| current.path == reloaded.path);
+            if !is_same_project {
+                return Err(
+                    "The active project changed while reloading. Reopen the project instead."
+                        .to_string(),
+                );
+            }
+
+            // The project lock was released while reopening, so another process
+            // may have appended in the meantime. Publishing such a session would
+            // hand the user a project that is stale the moment it appears and
+            // re-raises the banner on their next edit. Re-read instead, while
+            // still holding the lock that keeps this decision and the swap
+            // atomic against the rest of the app.
+            if reloaded.ensure_no_external_changes().is_err() {
+                if attempt == RELOAD_MAX_ATTEMPTS {
+                    return Err(format!(
+                        "The project kept changing on disk during reload \
+                         ({RELOAD_MAX_ATTEMPTS} attempts). Another process is still \
+                         writing to it; wait for it to finish and reload again."
+                    ));
+                }
+                tracing::warn!(
+                    attempt,
+                    project = %project_path_canon.display(),
+                    "Project changed on disk during reload; retrying"
+                );
+                continue;
+            }
+
+            *guard = Some(reloaded);
         }
-        *guard = Some(reloaded);
+
+        // Asset ids may have changed while this session was stale; re-derive the scope.
+        allow_project_asset_protocol(&state, &project_path_canon, &assets_for_scope);
+        reset_runtime_state_for_project_change(&state).await;
+
+        tracing::info!(
+            project = %project_path_canon.display(),
+            "Project reloaded from disk after external change"
+        );
+
+        return Ok(info);
     }
 
-    // Asset ids may have changed while this session was stale; re-derive the scope.
-    allow_project_asset_protocol(&state, &project_path_canon, &assets_for_scope);
-    reset_runtime_state_for_project_change(&state).await;
-
-    tracing::info!(
-        project = %project_path_canon.display(),
-        "Project reloaded from disk after external change"
-    );
-
-    Ok(info)
+    // The loop either returns or continues, so this is unreachable in practice.
+    Err("Project reload did not complete.".to_string())
 }
 
 /// Gets current project info

--- a/src-tauri/src/ipc/commands/project.rs
+++ b/src-tauri/src/ipc/commands/project.rs
@@ -714,6 +714,76 @@ pub async fn save_project(state: State<'_, AppState>) -> Result<(), String> {
     Ok(())
 }
 
+/// Rebuilds the active project from its on-disk state, discarding the in-memory
+/// session.
+///
+/// This is the recovery path for an external edit: `openreelio-cli`, a second
+/// window or an agent appended to `ops.jsonl`, so this session's state is stale
+/// and every mutation is refused by
+/// [`ActiveProject::ensure_no_external_changes`]. Reopening rebuilds state from
+/// the log rather than merging, which keeps the event-sourced log authoritative
+/// and resets the external-change watermark.
+///
+/// Unsaved in-memory changes are lost by design; the caller is expected to warn
+/// first. The workspace watcher, asset-protocol scope and project path are
+/// preserved because the project root does not change.
+#[tauri::command]
+#[specta::specta]
+#[tracing::instrument(skip(state))]
+pub async fn reload_project_from_disk(state: State<'_, AppState>) -> Result<ProjectInfo, String> {
+    let project_path = {
+        let guard = state.project.lock().await;
+        guard
+            .as_ref()
+            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?
+            .path
+            .clone()
+    };
+
+    // Reopening replays the ops log; keep it off the async runtime threads.
+    let reloaded = tokio::task::spawn_blocking(move || ActiveProject::open(project_path))
+        .await
+        .map_err(|e| format!("Project reload task failed: {e}"))?
+        .map_err(|e| e.to_ipc_error())?;
+
+    let assets_for_scope: Vec<Asset> = reloaded.state.assets.values().cloned().collect();
+    let project_path_canon =
+        std::fs::canonicalize(&reloaded.path).unwrap_or_else(|_| reloaded.path.clone());
+
+    let info = ProjectInfo {
+        id: reloaded.state.meta.id.clone(),
+        name: reloaded.state.meta.name.clone(),
+        path: project_path_canon.to_string_lossy().to_string(),
+        created_at: reloaded.state.meta.created_at.clone(),
+    };
+
+    {
+        let mut guard = state.project.lock().await;
+        // Guard against the project being closed or replaced while reopening.
+        let is_same_project = guard
+            .as_ref()
+            .is_some_and(|current| current.path == reloaded.path);
+        if !is_same_project {
+            return Err(
+                "The active project changed while reloading. Reopen the project instead."
+                    .to_string(),
+            );
+        }
+        *guard = Some(reloaded);
+    }
+
+    // Asset ids may have changed while this session was stale; re-derive the scope.
+    allow_project_asset_protocol(&state, &project_path_canon, &assets_for_scope);
+    reset_runtime_state_for_project_change(&state).await;
+
+    tracing::info!(
+        project = %project_path_canon.display(),
+        "Project reloaded from disk after external change"
+    );
+
+    Ok(info)
+}
+
 /// Gets current project info
 #[tauri::command]
 #[specta::specta]

--- a/src-tauri/src/ipc/commands/timeline.rs
+++ b/src-tauri/src/ipc/commands/timeline.rs
@@ -155,6 +155,13 @@ pub async fn execute_command(
         .as_mut()
         .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
 
+    // Refuse to append on top of edits made by another process (openreelio-cli,
+    // a second window, an agent). The frontend maps this error to a reload
+    // prompt; merging is never attempted automatically.
+    project
+        .ensure_no_external_changes()
+        .map_err(|e| e.to_ipc_error())?;
+
     // Strict validation via CommandPayload::parse
     let typed_command = CommandPayload::parse(command_type, payload)?;
 

--- a/src-tauri/src/ipc/commands/workspace.rs
+++ b/src-tauri/src/ipc/commands/workspace.rs
@@ -145,9 +145,12 @@ const MAX_DOCUMENT_LIST_LIMIT: usize = 2_000;
 /// Builds the `project:external-change` payload for a project state file change,
 /// or `None` when the change was written by this process.
 ///
-/// Suppression compares the on-disk operation count with the count this session
-/// expects, so the app's own appends (edit commands, workspace auto-registration)
-/// never surface as external changes.
+/// Suppression asks the session guard whether the project on disk still matches
+/// what this session wrote, which is the same question every mutation asks. The
+/// app's own writes (edit commands, workspace auto-registration, undo/redo,
+/// save) advance the guard's baseline, so they never surface as external
+/// changes, while a foreign undo — which appends nothing and leaves the
+/// operation counts equal — still does.
 async fn external_change_payload(
     app_handle: &tauri::AppHandle,
     relative_path: &str,
@@ -155,6 +158,10 @@ async fn external_change_payload(
     let app_state = app_handle.state::<crate::AppState>();
     let guard = app_state.project.lock().await;
     let project = guard.as_ref()?;
+
+    if project.ensure_no_external_changes().is_ok() {
+        return None;
+    }
 
     let expected = project.expected_op_count();
     let on_disk = match project.on_disk_op_count() {
@@ -167,10 +174,6 @@ async fn external_change_payload(
             return None;
         }
     };
-
-    if on_disk == expected {
-        return None;
-    }
 
     tracing::info!(
         expected_op_count = expected,

--- a/src-tauri/src/ipc/commands/workspace.rs
+++ b/src-tauri/src/ipc/commands/workspace.rs
@@ -32,6 +32,12 @@ use crate::core::CoreError;
 use crate::{ActiveProject, AppState};
 use tauri::{Emitter, Manager};
 
+/// Tauri event emitted when the active project's state files were changed by
+/// another process.
+///
+/// Payload: `{ "opCount": number, "expectedOpCount": number, "relativePath": string }`.
+pub const PROJECT_EXTERNAL_CHANGE_EVENT: &str = "project:external-change";
+
 // =============================================================================
 // Response Types
 // =============================================================================
@@ -135,6 +141,50 @@ pub struct WorkspaceDocumentWriteResultDto {
 const MAX_DOCUMENT_BYTES: usize = 512 * 1024;
 const DEFAULT_DOCUMENT_LIST_LIMIT: usize = 500;
 const MAX_DOCUMENT_LIST_LIMIT: usize = 2_000;
+
+/// Builds the `project:external-change` payload for a project state file change,
+/// or `None` when the change was written by this process.
+///
+/// Suppression compares the on-disk operation count with the count this session
+/// expects, so the app's own appends (edit commands, workspace auto-registration)
+/// never surface as external changes.
+async fn external_change_payload(
+    app_handle: &tauri::AppHandle,
+    relative_path: &str,
+) -> Option<serde_json::Value> {
+    let app_state = app_handle.state::<crate::AppState>();
+    let guard = app_state.project.lock().await;
+    let project = guard.as_ref()?;
+
+    let expected = project.expected_op_count();
+    let on_disk = match project.on_disk_op_count() {
+        Ok(count) => count,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "Workspace watcher: failed to read on-disk op count"
+            );
+            return None;
+        }
+    };
+
+    if on_disk == expected {
+        return None;
+    }
+
+    tracing::info!(
+        expected_op_count = expected,
+        on_disk_op_count = on_disk,
+        path = %relative_path,
+        "Detected external project state change"
+    );
+
+    Some(serde_json::json!({
+        "opCount": on_disk,
+        "expectedOpCount": expected,
+        "relativePath": relative_path,
+    }))
+}
 
 fn record_workspace_operation(
     project: &mut ActiveProject,
@@ -331,6 +381,22 @@ async fn start_workspace_watcher(project_root: PathBuf, state: &AppState) -> Res
 
         let mut rx = event_rx;
         while let Some(event) = rx.recv().await {
+            // 0. Project state files bypass indexing entirely: they only tell us
+            //    whether another process edited the project.
+            if let WorkspaceEvent::ProjectStateChanged(rel_path) = &event {
+                if let Some(payload) = external_change_payload(&app_handle, rel_path.as_str()).await
+                {
+                    if let Err(e) = app_handle.emit(PROJECT_EXTERNAL_CHANGE_EVENT, payload) {
+                        tracing::warn!(
+                            event = PROJECT_EXTERNAL_CHANGE_EVENT,
+                            error = %e,
+                            "Workspace watcher: failed to emit external change event"
+                        );
+                    }
+                }
+                continue;
+            }
+
             // 1. Update the on-disk workspace index
             if let Err(e) = service.handle_event(&event) {
                 tracing::warn!(error = %e, "Workspace watcher: failed to update index");
@@ -429,6 +495,8 @@ async fn start_workspace_watcher(project_root: PathBuf, state: &AppState) -> Res
                                 }
                             }
                         }
+                        // Handled before indexing; the loop never reaches here.
+                        WorkspaceEvent::ProjectStateChanged(_) => {}
                     }
                 }
             } // project lock released here
@@ -438,6 +506,8 @@ async fn start_workspace_watcher(project_root: PathBuf, state: &AppState) -> Res
                 WorkspaceEvent::FileAdded(p) => ("workspace:file-added", p.clone()),
                 WorkspaceEvent::FileRemoved(p) => ("workspace:file-removed", p.clone()),
                 WorkspaceEvent::FileModified(p) => ("workspace:file-modified", p.clone()),
+                // Handled above; the loop never reaches this point for them.
+                WorkspaceEvent::ProjectStateChanged(_) => continue,
             };
 
             let kind = kind_string_for_path(&rel_path);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,16 +65,15 @@ pub struct ActiveProject {
     pub state: ProjectState,
     /// Command executor with undo/redo
     pub executor: CommandExecutor,
-    /// Operations log path
+    /// Operations log path.
+    ///
+    /// The handle is guarded (see [`OpsLog::begin_guarded_session`]), so it —
+    /// and the executor handle derived from it — reject appends made on top of
+    /// another process's edits. That is where external-edit safety is enforced;
+    /// no caller has to remember a check.
     pub ops_log: OpsLog,
     /// Persistent history metadata used by headless clients.
     pub history: ProjectHistory,
-    /// Number of operations the on-disk ops log contained when this session last
-    /// synchronized with it, excluding operations appended afterwards by this
-    /// session.
-    ops_baseline_count: u64,
-    /// Value of `ops_log.local_append_count()` at the last synchronization.
-    ops_baseline_appends: u64,
 }
 
 pub struct PreparedProjectSave {
@@ -412,10 +411,11 @@ impl ActiveProject {
         // Both point to the same file but operate independently; this is safe
         // because OpsLog performs atomic appends. The executor handle is derived
         // with `shared_handle` so appends made through it count towards the same
-        // session-local append counter used for external-change detection.
-        let ops_log = OpsLog::new(&ops_path);
-        let ops_baseline_count = ops_log.count()?;
-        let ops_baseline_appends = ops_log.local_append_count();
+        // session-local append counter and share the external-change watermark.
+        let mut ops_log = OpsLog::new(&ops_path);
+        // Guard first, so even the bootstrap sequence command below writes
+        // through the guarded path.
+        ops_log.begin_guarded_session()?;
         let mut executor = CommandExecutor::with_ops_log(ops_log.shared_handle());
 
         // Create default sequence via Command to ensure ops log recording
@@ -454,8 +454,6 @@ impl ActiveProject {
             executor,
             ops_log,
             history,
-            ops_baseline_count: ops_baseline_count as u64,
-            ops_baseline_appends,
         })
     }
 
@@ -518,10 +516,12 @@ impl ActiveProject {
             ProjectMeta::new("Untitled")
         };
 
-        let ops_log = OpsLog::new(&ops_path);
-        let ops_baseline_count = ops_log.count()?;
-        let ops_baseline_appends = ops_log.local_append_count();
-        let read_result = ops_log.read_all_with_archive()?;
+        let mut ops_log = OpsLog::new(&ops_path);
+        // Replay the log and take the external-change baseline in one critical
+        // section. Sampling the baseline separately would leave a window in
+        // which another process appends, so the session would start life already
+        // disagreeing with the file it had just replayed.
+        let read_result = ops_log.begin_guarded_session_reading_all()?;
         let mut history = if history_path.exists() {
             match ProjectHistory::load(&history_path) {
                 Ok(history) => history,
@@ -586,21 +586,16 @@ impl ActiveProject {
             executor,
             ops_log,
             history,
-            ops_baseline_count: ops_baseline_count as u64,
-            ops_baseline_appends,
         })
     }
 
     /// Number of operations this session expects the on-disk ops log to contain.
     ///
-    /// This is the count observed at the last synchronization plus every append
-    /// this session has performed since then.
+    /// This is the count observed when the session was opened plus every append
+    /// it has performed since. Used by the workspace watcher to tell the app's
+    /// own writes apart from foreign ones.
     pub fn expected_op_count(&self) -> u64 {
-        self.ops_baseline_count
-            + self
-                .ops_log
-                .local_append_count()
-                .saturating_sub(self.ops_baseline_appends)
+        self.ops_log.expected_op_count().unwrap_or_default()
     }
 
     /// Reads the number of operations currently present in the on-disk ops log.
@@ -615,24 +610,12 @@ impl ActiveProject {
     /// an agent) appended to or rewrote `ops.jsonl`. Continuing would interleave
     /// this session's stale state with the external edits, so callers must
     /// surface the error and let the user reload instead of merging.
+    ///
+    /// This is a pre-flight convenience for callers that do bookkeeping before
+    /// writing; enforcement itself lives in [`OpsLog::append`], so paths that
+    /// forget to call this are still refused at the append.
     pub fn ensure_no_external_changes(&self) -> crate::core::CoreResult<()> {
-        let on_disk = self.on_disk_op_count()?;
-        let expected = self.expected_op_count();
-
-        if on_disk != expected {
-            tracing::warn!(
-                expected_op_count = expected,
-                on_disk_op_count = on_disk,
-                ops_log = %self.ops_log.path().display(),
-                "External change detected in project ops log"
-            );
-            return Err(crate::core::CoreError::ExternalChangeDetected {
-                expected_op_count: expected as usize,
-                on_disk_op_count: on_disk as usize,
-            });
-        }
-
-        Ok(())
+        self.ops_log.ensure_no_external_changes()
     }
 
     /// Saves the project state
@@ -3318,5 +3301,296 @@ mod tests {
         project
             .prepare_save()
             .expect("save should still be allowed");
+    }
+
+    // -------------------------------------------------------------------------
+    // Structural coverage
+    //
+    // The guard lives in `OpsLog::append`, the one place the product writes
+    // ops.jsonl, rather than at the ~25 IPC commands that reach it. These tests
+    // exercise a spread of those surfaces *without* calling
+    // `ensure_no_external_changes` first, which is exactly what the real
+    // commands do, so they fail if the guard ever regresses to a per-call-site
+    // opt-in.
+    // -------------------------------------------------------------------------
+
+    /// Runs a command through the executor the way the IPC layer does, keeping
+    /// the error instead of panicking.
+    fn try_execute_command(
+        project: &mut ActiveProject,
+        command_type: &str,
+        payload: serde_json::Value,
+    ) -> crate::core::CoreResult<crate::core::commands::CommandResult> {
+        let parsed = crate::ipc::CommandPayload::parse(command_type.to_string(), payload)
+            .unwrap_or_else(|error| panic!("failed to parse {command_type} payload: {error}"));
+        let command = parsed.build_command(&project.path);
+        project.executor.execute(command, &mut project.state)
+    }
+
+    /// One mutation surface, reproduced the way its IPC command performs it.
+    struct MutationPath {
+        /// The IPC command this stands in for.
+        surface: &'static str,
+        /// Performs the mutation and reports only whether it was allowed.
+        run: fn(&mut ActiveProject, &SharedProjectFixture) -> crate::core::CoreResult<()>,
+    }
+
+    /// Ids and paths the mutation surfaces need to build valid payloads.
+    struct SharedProjectFixture {
+        project_path: PathBuf,
+        sequence_id: String,
+        media_path: PathBuf,
+    }
+
+    /// A representative slice of the product's project-mutating surfaces.
+    ///
+    /// Between them they cover all four channels that reach the ops log:
+    /// `executor.execute`, repeated `executor.execute` inside a plan,
+    /// `executor.execute_without_history`, and a direct `ops_log.append`.
+    fn mutation_paths() -> Vec<MutationPath> {
+        vec![
+            MutationPath {
+                // ipc::commands::asset::import_asset
+                surface: "import asset",
+                run: |project, fixture| {
+                    try_execute_command(
+                        project,
+                        "importAsset",
+                        serde_json::json!({
+                            "name": "late.mp4",
+                            "uri": fixture.media_path.to_string_lossy(),
+                        }),
+                    )
+                    .map(|_| ())
+                },
+            },
+            MutationPath {
+                // ipc::commands::agent::execute_agent_plan
+                surface: "agent plan",
+                run: |project, fixture| {
+                    for name in ["Plan Track A", "Plan Track B"] {
+                        try_execute_command(
+                            project,
+                            "createTrack",
+                            serde_json::json!({
+                                "sequenceId": fixture.sequence_id,
+                                "kind": "video",
+                                "name": name,
+                            }),
+                        )?;
+                    }
+                    Ok(())
+                },
+            },
+            MutationPath {
+                // ipc::commands::timeline::create_sequence
+                surface: "create sequence",
+                run: |project, _fixture| {
+                    try_execute_command(
+                        project,
+                        "createSequence",
+                        serde_json::json!({ "name": "Sequence 2", "format": "1080p" }),
+                    )
+                    .map(|_| ())
+                },
+            },
+            MutationPath {
+                // ipc::commands::asset::update_asset_proxy (background metadata)
+                surface: "system update without history",
+                run: |project, _fixture| {
+                    project
+                        .executor
+                        .execute_without_history(
+                            Box::new(
+                                crate::core::commands::UpdateProjectSettingsCommand::new()
+                                    .with_name("Renamed By System"),
+                            ),
+                            &mut project.state,
+                        )
+                        .map(|_| ())
+                },
+            },
+            MutationPath {
+                // ipc::commands::workspace::record_workspace_operation
+                surface: "workspace auto-registration",
+                run: |project, _fixture| {
+                    project
+                        .ops_log
+                        .append(&crate::core::project::Operation::new(
+                            crate::core::project::OpKind::AssetImport,
+                            serde_json::json!({ "assetId": "workspace_asset" }),
+                        ))
+                },
+            },
+        ]
+    }
+
+    /// Creates a project plus a media file the import surface can reference.
+    fn create_shared_project(project_path: PathBuf) -> (ActiveProject, SharedProjectFixture) {
+        std::fs::create_dir_all(&project_path).unwrap();
+        let media_path = project_path.join("late.mp4");
+        std::fs::write(&media_path, b"fake media bytes").unwrap();
+
+        let project = ActiveProject::create("Shared Project", project_path.clone()).unwrap();
+        let sequence_id = project.state.active_sequence_id.clone().unwrap();
+
+        (
+            project,
+            SharedProjectFixture {
+                project_path,
+                sequence_id,
+                media_path,
+            },
+        )
+    }
+
+    /// Appends an operation from a second process holding the same directory.
+    fn append_external_edit(fixture: &SharedProjectFixture) -> String {
+        let mut other_process = ActiveProject::open(fixture.project_path.clone()).unwrap();
+        let result = execute_cli_command(
+            &mut other_process,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": fixture.sequence_id,
+                "kind": "audio",
+                "name": "External Track",
+            }),
+        );
+        other_process.save().unwrap();
+        result.created_ids[0].clone()
+    }
+
+    /// Scenario: every mutation surface is refused, not just `execute_command`.
+    #[test]
+    fn should_refuse_every_mutation_surface_after_an_external_edit() {
+        for path in mutation_paths() {
+            // Given a session that has gone stale behind another process
+            let temp_dir = TempDir::new().unwrap();
+            let (mut project, fixture) =
+                create_shared_project(temp_dir.path().join("shared_project"));
+            append_external_edit(&fixture);
+
+            let ops_before = project.on_disk_op_count().unwrap();
+            let assets_before = project.state.assets.len();
+            let sequences_before = project.state.sequences.len();
+            let name_before = project.state.meta.name.clone();
+
+            // When the surface mutates without checking for external edits first
+            let outcome = (path.run)(&mut project, &fixture);
+
+            // Then it is refused
+            assert!(
+                matches!(
+                    outcome,
+                    Err(crate::core::CoreError::ExternalChangeDetected { .. })
+                ),
+                "{} must be refused after an external edit, got {outcome:?}",
+                path.surface
+            );
+            // And nothing was appended on top of the external operations
+            assert_eq!(
+                project.on_disk_op_count().unwrap(),
+                ops_before,
+                "{} must not append after an external edit",
+                path.surface
+            );
+            // And the in-memory state was not left half-applied
+            assert_eq!(
+                project.state.assets.len(),
+                assets_before,
+                "{}",
+                path.surface
+            );
+            assert_eq!(
+                project.state.sequences.len(),
+                sequences_before,
+                "{}",
+                path.surface
+            );
+            assert_eq!(project.state.meta.name, name_before, "{}", path.surface);
+        }
+    }
+
+    /// Scenario: reloading re-baselines the session so editing resumes.
+    #[test]
+    fn should_resume_every_mutation_surface_after_reloading_from_disk() {
+        for path in mutation_paths() {
+            // Given a stale session that has already been refused once
+            let temp_dir = TempDir::new().unwrap();
+            let (mut project, fixture) =
+                create_shared_project(temp_dir.path().join("shared_project"));
+            let external_track_id = append_external_edit(&fixture);
+            assert!((path.run)(&mut project, &fixture).is_err());
+
+            // When the user reloads, the way `reload_project_from_disk` does
+            drop(project);
+            let mut reloaded = ActiveProject::open(fixture.project_path.clone()).unwrap();
+
+            // Then the external edit is present
+            assert!(
+                reloaded.state.sequences[&fixture.sequence_id]
+                    .tracks
+                    .iter()
+                    .any(|track| track.id == external_track_id),
+                "{}: reload should surface the external edit",
+                path.surface
+            );
+            // And the same surface now succeeds against the fresh watermark
+            (path.run)(&mut reloaded, &fixture)
+                .unwrap_or_else(|error| panic!("{} after reload: {error}", path.surface));
+            reloaded
+                .prepare_save()
+                .unwrap_or_else(|error| panic!("{} save after reload: {error}", path.surface));
+        }
+    }
+
+    /// Scenario: a headless writer is the *external* party and must never be
+    /// blocked by the guard, because every invocation opens the project afresh.
+    #[test]
+    fn should_let_a_fresh_headless_session_append_after_another_process_wrote() {
+        // Given a project a long-lived GUI session already edited
+        let temp_dir = TempDir::new().unwrap();
+        let (mut gui, fixture) = create_shared_project(temp_dir.path().join("headless_project"));
+        execute_cli_command(
+            &mut gui,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": fixture.sequence_id,
+                "kind": "video",
+                "name": "GUI Track",
+            }),
+        );
+        gui.save().unwrap();
+
+        // When openreelio-cli runs three times, each a fresh open/edit/save
+        for index in 0..3 {
+            let mut cli = ActiveProject::open(fixture.project_path.clone()).unwrap();
+            try_execute_command(
+                &mut cli,
+                "createTrack",
+                serde_json::json!({
+                    "sequenceId": fixture.sequence_id,
+                    "kind": "audio",
+                    "name": format!("CLI Track {index}"),
+                }),
+            )
+            .unwrap_or_else(|error| panic!("headless invocation {index} was blocked: {error}"));
+            cli.save()
+                .unwrap_or_else(|error| panic!("headless save {index} was blocked: {error}"));
+        }
+
+        // Then every headless edit landed
+        let reloaded = ActiveProject::open(fixture.project_path).unwrap();
+        let track_names: Vec<&str> = reloaded.state.sequences[&fixture.sequence_id]
+            .tracks
+            .iter()
+            .map(|track| track.name.as_str())
+            .collect();
+        for index in 0..3 {
+            assert!(
+                track_names.contains(&format!("CLI Track {index}").as_str()),
+                "missing headless edit {index} in {track_names:?}"
+            );
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,8 +69,14 @@ pub struct ActiveProject {
     ///
     /// The handle is guarded (see [`OpsLog::begin_guarded_session`]), so it —
     /// and the executor handle derived from it — reject appends made on top of
-    /// another process's edits. That is where external-edit safety is enforced;
-    /// no caller has to remember a check.
+    /// another process's edits, and reject history rewrites the same way. That
+    /// is where external-edit safety is enforced; no caller has to remember a
+    /// check.
+    ///
+    /// Every session is guarded, GUI and `openreelio-cli` alike. A CLI
+    /// invocation opens, edits and exits, so it only ever collides with a
+    /// process editing the same project *at the same time* — which is exactly
+    /// the case that must not silently interleave.
     pub ops_log: OpsLog,
     /// Persistent history metadata used by headless clients.
     pub history: ProjectHistory,
@@ -83,6 +89,13 @@ pub struct PreparedProjectSave {
     pub state_snapshot: ProjectState,
     pub history_snapshot: ProjectHistory,
     pub saved_last_op_id: Option<String>,
+    /// Guarded log handle of the session that prepared this save.
+    ///
+    /// [`ActiveProject::write_prepared_save`] runs without the project lock, so
+    /// the save carries the guard with it: the history manifest is written
+    /// inside the guard's lock, and the write advances this session's history
+    /// baseline instead of leaving it describing the pre-save file.
+    pub session_log: OpsLog,
 }
 
 impl ActiveProject {
@@ -442,7 +455,9 @@ impl ActiveProject {
             discarded_op_ids: Vec::new(),
             protected_prefix_len: 1,
         };
-        history.save(&history_path)?;
+        // Through the guard, so the session's history baseline starts out
+        // describing the manifest it just wrote.
+        ops_log.write_history_manifest(&history_path, |path| history.save(path))?;
 
         Ok(Self {
             path,
@@ -517,13 +532,16 @@ impl ActiveProject {
         };
 
         let mut ops_log = OpsLog::new(&ops_path);
-        // Replay the log and take the external-change baseline in one critical
-        // section. Sampling the baseline separately would leave a window in
-        // which another process appends, so the session would start life already
-        // disagreeing with the file it had just replayed.
-        let read_result = ops_log.begin_guarded_session_reading_all()?;
-        let mut history = if history_path.exists() {
-            match ProjectHistory::load(&history_path) {
+        // Replay the log, read the history manifest and take the external-change
+        // baseline in one critical section. Sampling the baseline separately
+        // would leave a window in which another process writes, so the session
+        // would start life already disagreeing with the files it had just
+        // replayed.
+        let opened = ops_log.begin_guarded_session_reading_all(&history_path)?;
+        let read_result = opened.operations;
+        let has_history_manifest = opened.history_manifest.is_some();
+        let mut history = match opened.history_manifest.as_deref() {
+            Some(bytes) => match ProjectHistory::from_json_slice(bytes) {
                 Ok(history) => history,
                 Err(error) => {
                     tracing::warn!(
@@ -533,9 +551,8 @@ impl ActiveProject {
                     );
                     ProjectHistory::from_operations(&read_result.operations, meta.clone())
                 }
-            }
-        } else {
-            ProjectHistory::from_operations(&read_result.operations, meta.clone())
+            },
+            None => ProjectHistory::from_operations(&read_result.operations, meta.clone()),
         };
         if history.base_meta.is_none() {
             history.base_meta = Some(meta.clone());
@@ -544,7 +561,7 @@ impl ActiveProject {
         let history_meta = history.base_meta.clone().unwrap_or_else(|| meta.clone());
 
         // Load state from history when available. Fall back to snapshot + replay or full ops replay.
-        let state = if !history.applied_op_ids.is_empty() || history_path.exists() {
+        let state = if !history.applied_op_ids.is_empty() || has_history_manifest {
             let by_id: std::collections::HashMap<&str, crate::core::project::Operation> =
                 read_result
                     .operations
@@ -603,13 +620,17 @@ impl ActiveProject {
         Ok(self.ops_log.count()? as u64)
     }
 
-    /// Fails with [`crate::core::CoreError::ExternalChangeDetected`] when the
-    /// on-disk operation log no longer matches what this session wrote.
+    /// Fails when the on-disk operation log or history manifest no longer
+    /// matches what this session wrote.
     ///
     /// A mismatch means another process (`openreelio-cli`, a second app window,
-    /// an agent) appended to or rewrote `ops.jsonl`. Continuing would interleave
-    /// this session's stale state with the external edits, so callers must
-    /// surface the error and let the user reload instead of merging.
+    /// an agent) appended to `ops.jsonl`
+    /// ([`crate::core::CoreError::ExternalChangeDetected`]) or undid, redid or
+    /// jumped through history, rewriting `history.json` without appending
+    /// anything ([`crate::core::CoreError::ExternalHistoryChangeDetected`]).
+    /// Continuing would interleave this session's stale state with the external
+    /// edits — or silently revert them — so callers must surface the error and
+    /// let the user reload instead of merging.
     ///
     /// This is a pre-flight convenience for callers that do bookkeeping before
     /// writing; enforcement itself lives in [`OpsLog::append`], so paths that
@@ -650,6 +671,7 @@ impl ActiveProject {
             state_snapshot,
             history_snapshot: self.history.clone(),
             saved_last_op_id: self.state.last_op_id.clone(),
+            session_log: self.ops_log.shared_handle(),
         })
     }
 
@@ -666,7 +688,15 @@ impl ActiveProject {
             &prepared.meta_path,
             &prepared.state_snapshot.meta,
         )?;
-        prepared.history_snapshot.save(&prepared.history_path)?;
+        // The manifest is guarded state, unlike the snapshot and metadata which
+        // are regenerable caches: write it through the session's guard so a
+        // concurrent process's undo cannot be overwritten, and so this session's
+        // own write re-baselines it.
+        prepared
+            .session_log
+            .write_history_manifest(&prepared.history_path, |path| {
+                prepared.history_snapshot.save(path)
+            })?;
         Ok(())
     }
 
@@ -746,7 +776,10 @@ impl ActiveProject {
         Self::sync_history_with_operations(&mut candidate_history, &read_result.operations);
         let candidate_state =
             self.build_state_from_operations(&mut candidate_history, &read_result.operations)?;
-        candidate_history.save(&self.history_path)?;
+        // Undo/redo/jump rewrite the manifest without appending, so the guarded
+        // write is the only thing standing between two processes' histories.
+        self.ops_log
+            .write_history_manifest(&self.history_path, |path| candidate_history.save(path))?;
 
         self.history = candidate_history;
         self.state = candidate_state;
@@ -772,7 +805,8 @@ impl ActiveProject {
 
         let candidate_state =
             self.build_state_from_operations(&mut candidate_history, &read_result.operations)?;
-        candidate_history.save(&self.history_path)?;
+        self.ops_log
+            .write_history_manifest(&self.history_path, |path| candidate_history.save(path))?;
 
         self.history = candidate_history;
         self.state = candidate_state;
@@ -869,7 +903,8 @@ impl ActiveProject {
         target_index: i32,
     ) -> crate::core::CoreResult<i32> {
         // Same hazard as undo/redo: history indices computed here would address
-        // operations written by another process.
+        // operations written by another process, or a history position another
+        // process has already moved away from.
         self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
 
@@ -907,7 +942,10 @@ impl ActiveProject {
     ///
     /// Fails with [`crate::core::CoreError::ExternalChangeDetected`] when another
     /// process appended operations, because the newest applied operation would
-    /// then belong to that process rather than to this session.
+    /// then belong to that process rather than to this session, and with
+    /// [`crate::core::CoreError::ExternalHistoryChangeDetected`] when another
+    /// process moved through history itself, because undoing from this session's
+    /// stale position would silently revert that move.
     pub fn undo_persisted(&mut self) -> crate::core::CoreResult<OpId> {
         self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
@@ -919,8 +957,8 @@ impl ActiveProject {
 
     /// Performs a persisted redo that survives process restarts.
     ///
-    /// Fails with [`crate::core::CoreError::ExternalChangeDetected`] when another
-    /// process appended operations. See [`ActiveProject::undo_persisted`].
+    /// Rejects external appends and external history moves exactly as
+    /// [`ActiveProject::undo_persisted`] does.
     pub fn redo_persisted(&mut self) -> crate::core::CoreResult<OpId> {
         self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
@@ -3280,6 +3318,93 @@ mod tests {
             .expect("a freshly reloaded session is in sync with disk");
     }
 
+    /// Scenario: a second process undoes, which appends nothing.
+    ///
+    /// `ops.jsonl` is append-only, so undo/redo/jump record their move in
+    /// `history.json` instead. A session that watched only the log's byte length
+    /// would see nothing here and keep editing on top of a history position the
+    /// other process had already left, silently reverting it.
+    #[test]
+    fn should_detect_an_external_history_move_that_appends_nothing() {
+        // Given a session that edited and saved
+        let temp_dir = TempDir::new().unwrap();
+        let (mut gui, fixture) = create_shared_project(temp_dir.path().join("shared_project"));
+        let gui_track = execute_cli_command(
+            &mut gui,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": fixture.sequence_id,
+                "kind": "video",
+                "name": "GUI Track",
+            }),
+        );
+        let gui_track_id = gui_track.created_ids[0].clone();
+        gui.save().unwrap();
+        let ops_log_len_before = std::fs::metadata(gui.ops_log.path()).unwrap().len();
+
+        // When another process undoes it
+        let mut other_process = ActiveProject::open(fixture.project_path.clone()).unwrap();
+        let undone_op_id = other_process.undo_persisted().unwrap();
+        drop(other_process);
+
+        // Then the log is byte-identical and the operation counts still agree,
+        // so only a history baseline can tell the difference
+        assert_eq!(
+            std::fs::metadata(gui.ops_log.path()).unwrap().len(),
+            ops_log_len_before
+        );
+        assert_eq!(gui.on_disk_op_count().unwrap(), gui.expected_op_count());
+
+        // And every mutating entry point refuses
+        assert!(matches!(
+            gui.ensure_no_external_changes(),
+            Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            try_execute_command(
+                &mut gui,
+                "createSequence",
+                serde_json::json!({ "name": "Sequence 2", "format": "1080p" }),
+            ),
+            Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            gui.prepare_save(),
+            Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            gui.undo_persisted(),
+            Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            gui.redo_persisted(),
+            Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+        ));
+        assert!(matches!(
+            gui.jump_to_history_index_persisted(-1),
+            Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+        ));
+
+        // And the error carries the marker the frontend matches on
+        let message = gui.ensure_no_external_changes().unwrap_err().to_ipc_error();
+        assert!(
+            message.contains(crate::core::EXTERNAL_CHANGE_DETECTED_CODE),
+            "unexpected message: {message}"
+        );
+
+        // And reloading adopts the other process's undo instead of reverting it
+        drop(gui);
+        let reloaded = ActiveProject::open(fixture.project_path).unwrap();
+        assert!(!reloaded.history.applied_op_ids.contains(&undone_op_id));
+        assert!(!reloaded.state.sequences[&fixture.sequence_id]
+            .tracks
+            .iter()
+            .any(|track| track.id == gui_track_id));
+        reloaded
+            .ensure_no_external_changes()
+            .expect("a freshly reloaded session is in sync with disk");
+    }
+
     /// Scenario: the app's own workspace-watcher appends must not look external.
     #[test]
     fn should_not_report_direct_ops_log_appends_by_this_session_as_external() {
@@ -3511,6 +3636,77 @@ mod tests {
         }
     }
 
+    /// Undoes from a second process holding the same directory, which rewrites
+    /// `history.json` without appending to the log. Returns the undone op id.
+    fn undo_externally(fixture: &SharedProjectFixture) -> String {
+        let mut other_process = ActiveProject::open(fixture.project_path.clone()).unwrap();
+        other_process.undo_persisted().unwrap()
+    }
+
+    /// Scenario: every mutation surface is refused after an external *history*
+    /// move too, not just after an external append.
+    #[test]
+    fn should_refuse_every_mutation_surface_after_an_external_history_move() {
+        for path in mutation_paths() {
+            // Given a session that has edited and saved, so there is something
+            // for another process to undo
+            let temp_dir = TempDir::new().unwrap();
+            let (mut project, fixture) =
+                create_shared_project(temp_dir.path().join("shared_project"));
+            try_execute_command(
+                &mut project,
+                "createTrack",
+                serde_json::json!({
+                    "sequenceId": fixture.sequence_id,
+                    "kind": "video",
+                    "name": "Undo Me",
+                }),
+            )
+            .unwrap();
+            project.save().unwrap();
+
+            // And another process has undone it behind this session's back
+            undo_externally(&fixture);
+
+            let ops_before = project.on_disk_op_count().unwrap();
+            let assets_before = project.state.assets.len();
+            let sequences_before = project.state.sequences.len();
+            let name_before = project.state.meta.name.clone();
+
+            // When the surface mutates without checking for external edits first
+            let outcome = (path.run)(&mut project, &fixture);
+
+            // Then it is refused, even though the operation counts still agree
+            assert!(
+                matches!(
+                    outcome,
+                    Err(crate::core::CoreError::ExternalHistoryChangeDetected)
+                ),
+                "{} must be refused after an external history move, got {outcome:?}",
+                path.surface
+            );
+            assert_eq!(
+                project.on_disk_op_count().unwrap(),
+                ops_before,
+                "{} must not append on top of an external history move",
+                path.surface
+            );
+            assert_eq!(
+                project.state.assets.len(),
+                assets_before,
+                "{}",
+                path.surface
+            );
+            assert_eq!(
+                project.state.sequences.len(),
+                sequences_before,
+                "{}",
+                path.surface
+            );
+            assert_eq!(project.state.meta.name, name_before, "{}", path.surface);
+        }
+    }
+
     /// Scenario: reloading re-baselines the session so editing resumes.
     #[test]
     fn should_resume_every_mutation_surface_after_reloading_from_disk() {
@@ -3544,10 +3740,21 @@ mod tests {
         }
     }
 
-    /// Scenario: a headless writer is the *external* party and must never be
-    /// blocked by the guard, because every invocation opens the project afresh.
+    // -------------------------------------------------------------------------
+    // Headless writers
+    //
+    // `openreelio-cli` is not exempt from the guard: every invocation goes
+    // through `ActiveProject::open`, which installs it. What makes headless
+    // editing keep working is the shape of an invocation — open, mutate, save,
+    // exit — so a *sequential* writer always baselines against the current tail
+    // and appends onto it. Only a writer that overlaps in time with another one
+    // is refused, which is the case that would otherwise write a snapshot built
+    // from a state that never saw the other process's operations.
+    // -------------------------------------------------------------------------
+
+    /// Scenario: headless invocations run one after another, as they normally do.
     #[test]
-    fn should_let_a_fresh_headless_session_append_after_another_process_wrote() {
+    fn should_let_each_sequential_headless_session_append_after_the_previous_one() {
         // Given a project a long-lived GUI session already edited
         let temp_dir = TempDir::new().unwrap();
         let (mut gui, fixture) = create_shared_project(temp_dir.path().join("headless_project"));
@@ -3592,5 +3799,80 @@ mod tests {
                 "missing headless edit {index} in {track_names:?}"
             );
         }
+
+        // And the guard applied to them as much as to anyone: the session that
+        // stayed open through all three is the one that now has to reload
+        assert!(matches!(
+            gui.ensure_no_external_changes(),
+            Err(crate::core::CoreError::ExternalChangeDetected { .. })
+        ));
+    }
+
+    /// Scenario: two writers hold the same project at the same time.
+    #[test]
+    fn should_reject_a_concurrent_headless_writer_until_it_reopens() {
+        // Given two sessions that opened the project before either of them wrote
+        let temp_dir = TempDir::new().unwrap();
+        let (mut first, fixture) =
+            create_shared_project(temp_dir.path().join("concurrent_project"));
+        let mut second = ActiveProject::open(fixture.project_path.clone()).unwrap();
+
+        // When the first one edits and saves
+        try_execute_command(
+            &mut first,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": fixture.sequence_id,
+                "kind": "video",
+                "name": "First Writer",
+            }),
+        )
+        .unwrap();
+        first.save().unwrap();
+
+        // Then the second one is refused rather than interleaved. Letting it
+        // through would append onto a log it has not replayed and then save a
+        // snapshot built from a state that never saw the first writer's
+        // operation.
+        let ops_before = second.on_disk_op_count().unwrap();
+        assert!(matches!(
+            try_execute_command(
+                &mut second,
+                "createTrack",
+                serde_json::json!({
+                    "sequenceId": fixture.sequence_id,
+                    "kind": "audio",
+                    "name": "Second Writer",
+                }),
+            ),
+            Err(crate::core::CoreError::ExternalChangeDetected { .. })
+        ));
+        assert_eq!(second.on_disk_op_count().unwrap(), ops_before);
+
+        // And reopening — which is what a headless invocation does anyway — puts
+        // it back in sync, so the retry lands on top of the first writer's edit
+        drop(second);
+        let mut reopened = ActiveProject::open(fixture.project_path.clone()).unwrap();
+        try_execute_command(
+            &mut reopened,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": fixture.sequence_id,
+                "kind": "audio",
+                "name": "Second Writer",
+            }),
+        )
+        .unwrap();
+        reopened.save().unwrap();
+        drop(reopened);
+
+        let reloaded = ActiveProject::open(fixture.project_path).unwrap();
+        let track_names: Vec<&str> = reloaded.state.sequences[&fixture.sequence_id]
+            .tracks
+            .iter()
+            .map(|track| track.name.as_str())
+            .collect();
+        assert!(track_names.contains(&"First Writer"));
+        assert!(track_names.contains(&"Second Writer"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,12 @@ pub struct ActiveProject {
     pub ops_log: OpsLog,
     /// Persistent history metadata used by headless clients.
     pub history: ProjectHistory,
+    /// Number of operations the on-disk ops log contained when this session last
+    /// synchronized with it, excluding operations appended afterwards by this
+    /// session.
+    ops_baseline_count: u64,
+    /// Value of `ops_log.local_append_count()` at the last synchronization.
+    ops_baseline_appends: u64,
 }
 
 pub struct PreparedProjectSave {
@@ -402,11 +408,15 @@ impl ActiveProject {
         // Start with empty state - default sequence will be added via Command
         let mut state = ProjectState::new_empty(name);
 
-        // Create OpsLog instances - one for ActiveProject, one for executor
-        // Both point to the same file but operate independently
-        // This is safe because OpsLog performs atomic appends
+        // Create OpsLog instances - one for ActiveProject, one for executor.
+        // Both point to the same file but operate independently; this is safe
+        // because OpsLog performs atomic appends. The executor handle is derived
+        // with `shared_handle` so appends made through it count towards the same
+        // session-local append counter used for external-change detection.
         let ops_log = OpsLog::new(&ops_path);
-        let mut executor = CommandExecutor::with_ops_log(OpsLog::new(&ops_path));
+        let ops_baseline_count = ops_log.count()?;
+        let ops_baseline_appends = ops_log.local_append_count();
+        let mut executor = CommandExecutor::with_ops_log(ops_log.shared_handle());
 
         // Create default sequence via Command to ensure ops log recording
         // This maintains Event Sourcing principle: all changes go through commands
@@ -444,6 +454,8 @@ impl ActiveProject {
             executor,
             ops_log,
             history,
+            ops_baseline_count: ops_baseline_count as u64,
+            ops_baseline_appends,
         })
     }
 
@@ -507,6 +519,8 @@ impl ActiveProject {
         };
 
         let ops_log = OpsLog::new(&ops_path);
+        let ops_baseline_count = ops_log.count()?;
+        let ops_baseline_appends = ops_log.local_append_count();
         let read_result = ops_log.read_all_with_archive()?;
         let mut history = if history_path.exists() {
             match ProjectHistory::load(&history_path) {
@@ -558,8 +572,9 @@ impl ActiveProject {
             ProjectState::from_ops_log(&ops_log, meta)?
         };
 
-        // Create executor with its own OpsLog instance (both point to same file)
-        let executor = CommandExecutor::with_ops_log(OpsLog::new(&ops_path));
+        // Create executor with its own OpsLog handle (both point to same file and
+        // share the session-local append counter).
+        let executor = CommandExecutor::with_ops_log(ops_log.shared_handle());
 
         Ok(Self {
             path,
@@ -571,7 +586,53 @@ impl ActiveProject {
             executor,
             ops_log,
             history,
+            ops_baseline_count: ops_baseline_count as u64,
+            ops_baseline_appends,
         })
+    }
+
+    /// Number of operations this session expects the on-disk ops log to contain.
+    ///
+    /// This is the count observed at the last synchronization plus every append
+    /// this session has performed since then.
+    pub fn expected_op_count(&self) -> u64 {
+        self.ops_baseline_count
+            + self
+                .ops_log
+                .local_append_count()
+                .saturating_sub(self.ops_baseline_appends)
+    }
+
+    /// Reads the number of operations currently present in the on-disk ops log.
+    pub fn on_disk_op_count(&self) -> crate::core::CoreResult<u64> {
+        Ok(self.ops_log.count()? as u64)
+    }
+
+    /// Fails with [`crate::core::CoreError::ExternalChangeDetected`] when the
+    /// on-disk operation log no longer matches what this session wrote.
+    ///
+    /// A mismatch means another process (`openreelio-cli`, a second app window,
+    /// an agent) appended to or rewrote `ops.jsonl`. Continuing would interleave
+    /// this session's stale state with the external edits, so callers must
+    /// surface the error and let the user reload instead of merging.
+    pub fn ensure_no_external_changes(&self) -> crate::core::CoreResult<()> {
+        let on_disk = self.on_disk_op_count()?;
+        let expected = self.expected_op_count();
+
+        if on_disk != expected {
+            tracing::warn!(
+                expected_op_count = expected,
+                on_disk_op_count = on_disk,
+                ops_log = %self.ops_log.path().display(),
+                "External change detected in project ops log"
+            );
+            return Err(crate::core::CoreError::ExternalChangeDetected {
+                expected_op_count: expected as usize,
+                on_disk_op_count: on_disk as usize,
+            });
+        }
+
+        Ok(())
     }
 
     /// Saves the project state
@@ -590,6 +651,9 @@ impl ActiveProject {
     }
 
     pub fn prepare_save(&mut self) -> crate::core::CoreResult<PreparedProjectSave> {
+        // Saving on top of external edits would snapshot this session's stale
+        // state under the external head op id, silently discarding them.
+        self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
         self.state.last_op_id = self.history.current_head().map(str::to_string);
         self.state.op_count = self.history.applied_op_ids.len();
@@ -821,6 +885,9 @@ impl ActiveProject {
         &mut self,
         target_index: i32,
     ) -> crate::core::CoreResult<i32> {
+        // Same hazard as undo/redo: history indices computed here would address
+        // operations written by another process.
+        self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
 
         let visible_undo_len = self
@@ -854,7 +921,12 @@ impl ActiveProject {
     }
 
     /// Performs a persisted undo that survives process restarts.
+    ///
+    /// Fails with [`crate::core::CoreError::ExternalChangeDetected`] when another
+    /// process appended operations, because the newest applied operation would
+    /// then belong to that process rather than to this session.
     pub fn undo_persisted(&mut self) -> crate::core::CoreResult<OpId> {
+        self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
         let mut candidate_history = self.history.clone();
         let op_id = candidate_history.undo()?;
@@ -863,7 +935,11 @@ impl ActiveProject {
     }
 
     /// Performs a persisted redo that survives process restarts.
+    ///
+    /// Fails with [`crate::core::CoreError::ExternalChangeDetected`] when another
+    /// process appended operations. See [`ActiveProject::undo_persisted`].
     pub fn redo_persisted(&mut self) -> crate::core::CoreResult<OpId> {
+        self.ensure_no_external_changes()?;
         self.sync_history_with_ops_log()?;
         let mut candidate_history = self.history.clone();
         let op_id = candidate_history.redo()?;
@@ -1326,6 +1402,7 @@ mod tauri_app {
                 $crate::ipc::open_or_init_project,
                 $crate::ipc::close_project,
                 $crate::ipc::save_project,
+                $crate::ipc::reload_project_from_disk,
                 $crate::ipc::get_project_info,
                 $crate::ipc::get_project_state,
                 $crate::ipc::get_sequence_text_clip_data,
@@ -1855,6 +1932,7 @@ mod tauri_app {
             ipc::open_or_init_project,
             ipc::close_project,
             ipc::save_project,
+            ipc::reload_project_from_disk,
             ipc::get_project_info,
             ipc::get_project_state,
             ipc::get_sequence_text_clip_data,
@@ -2901,5 +2979,344 @@ mod tests {
         assert_eq!(state.in_point, Some(1.0));
         assert_eq!(state.out_point, Some(6.0));
         assert_eq!(state.playhead_sec, 4.25);
+    }
+
+    // =========================================================================
+    // External Edit Safety
+    //
+    // Feature: External edit safety
+    //   As an editor who drives OpenReelio from both the GUI and openreelio-cli
+    //   I want the app to notice when another process edited the same project
+    //   So that my CLI edits are never silently overwritten
+    // =========================================================================
+
+    /// Executes a command the way the CLI does: parse the JSON payload, build
+    /// the command, then run it through the project's executor.
+    fn execute_cli_command(
+        project: &mut ActiveProject,
+        command_type: &str,
+        payload: serde_json::Value,
+    ) -> crate::core::commands::CommandResult {
+        let parsed = crate::ipc::CommandPayload::parse(command_type.to_string(), payload)
+            .unwrap_or_else(|error| panic!("failed to parse {command_type} payload: {error}"));
+        let command = parsed.build_command(&project.path);
+        project
+            .executor
+            .execute(command, &mut project.state)
+            .unwrap_or_else(|error| panic!("failed to execute {command_type}: {error}"))
+    }
+
+    fn base_track_id(project: &ActiveProject, kind: crate::core::timeline::TrackKind) -> String {
+        let sequence_id = project
+            .state
+            .active_sequence_id
+            .clone()
+            .expect("project should have an active sequence");
+        project.state.sequences[&sequence_id]
+            .tracks
+            .iter()
+            .find(|track| track.kind == kind)
+            .unwrap_or_else(|| panic!("sequence should have a {kind:?} track"))
+            .id
+            .clone()
+    }
+
+    fn count_clips(project: &ActiveProject, track_id: &str) -> usize {
+        project
+            .state
+            .sequences
+            .values()
+            .flat_map(|sequence| sequence.tracks.iter())
+            .find(|track| track.id == track_id)
+            .map(|track| track.clips.len())
+            .unwrap_or(0)
+    }
+
+    /// A project built exactly the way `openreelio-cli` builds one.
+    struct CliBuiltProject {
+        project: ActiveProject,
+        sequence_id: String,
+        video_track_id: String,
+        caption_track_id: String,
+    }
+
+    fn build_project_like_cli(project_path: PathBuf) -> CliBuiltProject {
+        std::fs::create_dir_all(&project_path).unwrap();
+        let media_path = project_path.join("footage.mp4");
+        std::fs::write(&media_path, b"fake media bytes").unwrap();
+
+        let mut project = ActiveProject::create("CLI Project", project_path).unwrap();
+        let sequence_id = project.state.active_sequence_id.clone().unwrap();
+        let video_track_id = base_track_id(&project, crate::core::timeline::TrackKind::Video);
+
+        let import = execute_cli_command(
+            &mut project,
+            "importAsset",
+            serde_json::json!({
+                "name": "footage.mp4",
+                "uri": media_path.to_string_lossy(),
+            }),
+        );
+        let asset_id = import.created_ids[0].clone();
+
+        execute_cli_command(
+            &mut project,
+            "insertClip",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "trackId": video_track_id,
+                "assetId": asset_id,
+                "timelineStart": 0.0,
+                "sourceIn": 0.0,
+                "sourceOut": 12.0,
+            }),
+        );
+
+        let clip_id = project.state.sequences[&sequence_id]
+            .tracks
+            .iter()
+            .find(|track| track.id == video_track_id)
+            .unwrap()
+            .clips[0]
+            .id
+            .clone();
+
+        execute_cli_command(
+            &mut project,
+            "splitClip",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "trackId": video_track_id,
+                "clipId": clip_id,
+                "splitTime": 5.0,
+            }),
+        );
+
+        execute_cli_command(
+            &mut project,
+            "trimClip",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "trackId": video_track_id,
+                "clipId": clip_id,
+                "newSourceOut": 4.0,
+            }),
+        );
+
+        execute_cli_command(
+            &mut project,
+            "addEffect",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "trackId": video_track_id,
+                "clipId": clip_id,
+                "effectType": "brightness",
+            }),
+        );
+
+        let caption_track = execute_cli_command(
+            &mut project,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "kind": "caption",
+                "name": "Captions 1",
+            }),
+        );
+        let caption_track_id = caption_track.created_ids[0].clone();
+
+        execute_cli_command(
+            &mut project,
+            "createCaption",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "trackId": caption_track_id,
+                "text": "Hello from the CLI",
+                "startSec": 1.0,
+                "endSec": 3.0,
+            }),
+        );
+
+        CliBuiltProject {
+            project,
+            sequence_id,
+            video_track_id,
+            caption_track_id,
+        }
+    }
+
+    /// Scenario: a project built purely through CLI-style commands opens in the GUI.
+    #[test]
+    fn should_open_a_cli_built_project_with_identical_state() {
+        // Given a project created and edited only through CommandPayload/executor
+        let temp_dir = TempDir::new().unwrap();
+        let project_path = temp_dir.path().join("cli_built");
+        let CliBuiltProject {
+            mut project,
+            sequence_id,
+            video_track_id,
+            caption_track_id,
+        } = build_project_like_cli(project_path.clone());
+
+        let expected_video_clips = count_clips(&project, &video_track_id);
+        let expected_caption_clips = count_clips(&project, &caption_track_id);
+        let expected_assets = project.state.assets.len();
+        let expected_effects = project.state.effects.len();
+        assert_eq!(expected_video_clips, 2, "split should produce two clips");
+        assert_eq!(expected_caption_clips, 1);
+        assert_eq!(expected_assets, 1);
+        assert_eq!(expected_effects, 1);
+
+        // And the CLI saved it the way `openreelio-cli` does
+        project.save().unwrap();
+        drop(project);
+
+        // When the GUI opens the same directory
+        let reopened = ActiveProject::open(project_path).unwrap();
+
+        // Then the replayed state matches, with no operations lost
+        assert_eq!(reopened.state.meta.name, "CLI Project");
+        assert!(reopened.state.sequences.contains_key(&sequence_id));
+        assert_eq!(
+            count_clips(&reopened, &video_track_id),
+            expected_video_clips
+        );
+        assert_eq!(
+            count_clips(&reopened, &caption_track_id),
+            expected_caption_clips
+        );
+        assert_eq!(reopened.state.assets.len(), expected_assets);
+        assert_eq!(reopened.state.effects.len(), expected_effects);
+        assert!(!reopened.state.is_dirty);
+    }
+
+    /// Scenario: the CLI never got to save; only the append-only log survives.
+    #[test]
+    fn should_open_a_cli_built_project_from_the_ops_log_without_a_save() {
+        // Given a CLI session that appended operations but never saved
+        let temp_dir = TempDir::new().unwrap();
+        let project_path = temp_dir.path().join("cli_unsaved");
+        let built = build_project_like_cli(project_path.clone());
+        let expected_video_clips = count_clips(&built.project, &built.video_track_id);
+        let expected_caption_clips = count_clips(&built.project, &built.caption_track_id);
+        let video_track_id = built.video_track_id.clone();
+        let caption_track_id = built.caption_track_id.clone();
+        drop(built);
+
+        // When the GUI opens the same directory
+        let reopened = ActiveProject::open(project_path).unwrap();
+
+        // Then the state is rebuilt from the ops log alone
+        assert_eq!(
+            count_clips(&reopened, &video_track_id),
+            expected_video_clips
+        );
+        assert_eq!(
+            count_clips(&reopened, &caption_track_id),
+            expected_caption_clips
+        );
+        assert_eq!(reopened.state.effects.len(), 1);
+    }
+
+    /// Scenario: a second process appends while this session holds the project.
+    #[test]
+    fn should_detect_external_ops_and_refuse_mutations_until_reload() {
+        // Given a GUI session with one edit of its own
+        let temp_dir = TempDir::new().unwrap();
+        let project_path = temp_dir.path().join("shared_project");
+        std::fs::create_dir_all(&project_path).unwrap();
+        let mut gui = ActiveProject::create("Shared Project", project_path.clone()).unwrap();
+        let sequence_id = gui.state.active_sequence_id.clone().unwrap();
+        let gui_track = execute_cli_command(
+            &mut gui,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "kind": "video",
+                "name": "GUI Track",
+            }),
+        );
+        let gui_track_id = gui_track.created_ids[0].clone();
+        gui.ensure_no_external_changes()
+            .expect("this session's own appends are not external changes");
+
+        // When another process (openreelio-cli) opens the same project and edits it
+        let mut cli = ActiveProject::open(project_path.clone()).unwrap();
+        let cli_track = execute_cli_command(
+            &mut cli,
+            "createTrack",
+            serde_json::json!({
+                "sequenceId": sequence_id,
+                "kind": "audio",
+                "name": "CLI Track",
+            }),
+        );
+        let cli_track_id = cli_track.created_ids[0].clone();
+        cli.save().unwrap();
+        drop(cli);
+
+        // Then every mutating entry point in the stale session refuses to run
+        assert!(
+            matches!(
+                gui.ensure_no_external_changes(),
+                Err(crate::core::CoreError::ExternalChangeDetected { .. })
+            ),
+            "the guard used by execute_command must report the external change"
+        );
+        assert!(matches!(
+            gui.prepare_save(),
+            Err(crate::core::CoreError::ExternalChangeDetected { .. })
+        ));
+        assert!(matches!(
+            gui.undo_persisted(),
+            Err(crate::core::CoreError::ExternalChangeDetected { .. })
+        ));
+        assert!(matches!(
+            gui.redo_persisted(),
+            Err(crate::core::CoreError::ExternalChangeDetected { .. })
+        ));
+
+        // And the error message carries the marker the frontend matches on
+        let message = gui.ensure_no_external_changes().unwrap_err().to_ipc_error();
+        assert!(
+            message.contains(crate::core::EXTERNAL_CHANGE_DETECTED_CODE),
+            "unexpected message: {message}"
+        );
+
+        // And reloading from disk recovers with both sessions' edits visible
+        let reloaded = ActiveProject::open(project_path).unwrap();
+        let track_ids: Vec<&str> = reloaded.state.sequences[&sequence_id]
+            .tracks
+            .iter()
+            .map(|track| track.id.as_str())
+            .collect();
+        assert!(track_ids.contains(&gui_track_id.as_str()));
+        assert!(track_ids.contains(&cli_track_id.as_str()));
+        reloaded
+            .ensure_no_external_changes()
+            .expect("a freshly reloaded session is in sync with disk");
+    }
+
+    /// Scenario: the app's own workspace-watcher appends must not look external.
+    #[test]
+    fn should_not_report_direct_ops_log_appends_by_this_session_as_external() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_path = temp_dir.path().join("watcher_project");
+        let mut project = ActiveProject::create("Watcher Project", project_path).unwrap();
+
+        // The workspace watcher writes through `project.ops_log` rather than the
+        // executor; that path must also be attributed to this session.
+        let operation = crate::core::project::Operation::new(
+            crate::core::project::OpKind::AssetUpdate,
+            serde_json::json!({ "assetId": "asset_001" }),
+        );
+        project.ops_log.append(&operation).unwrap();
+
+        project
+            .ensure_no_external_changes()
+            .expect("direct ops log appends by this session are not external");
+        project
+            .prepare_save()
+            .expect("save should still be allowed");
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   useAppLifecycle,
 } from './hooks';
 import { UpdateBanner } from './components/features/update';
+import { ExternalChangeBanner } from './components/features/project';
 import { AppFrame } from './components/layout';
 import { createLogger, initializeLogger } from './services/logger';
 import {
@@ -244,7 +245,13 @@ function App(): JSX.Element {
   return (
     <>
       <AppFrame
-        banner={<UpdateBanner checkOnMount={settingsLoaded && general.checkUpdatesOnStartup} />}
+        banner={
+          <>
+            <UpdateBanner checkOnMount={settingsLoaded && general.checkUpdatesOnStartup} />
+            {/* Only meaningful with a project open, so this branch alone mounts it. */}
+            <ExternalChangeBanner />
+          </>
+        }
       >
         <ErrorBoundary
           onError={handleEditorError}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -121,6 +121,28 @@ async saveProject() : Promise<Result<null, string>> {
 }
 },
 /**
+ * Rebuilds the active project from its on-disk state, discarding the in-memory
+ * session.
+ * 
+ * This is the recovery path for an external edit: `openreelio-cli`, a second
+ * window or an agent appended to `ops.jsonl`, so this session's state is stale
+ * and every mutation is refused by
+ * [`ActiveProject::ensure_no_external_changes`]. Reopening rebuilds state from
+ * the log rather than merging, which keeps the event-sourced log authoritative
+ * and resets the external-change watermark.
+ * 
+ * Unsaved in-memory changes are lost by design; the caller is expected to warn
+ * first. The workspace watcher, asset-protocol scope and project path are
+ * preserved because the project root does not change.
+ */
+async reloadProjectFromDisk() : Promise<Result<ProjectInfo, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reload_project_from_disk") };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
+/**
  * Gets current project info
  */
 async getProjectInfo() : Promise<Result<ProjectInfo | null, string>> {

--- a/src/components/features/project/ExternalChangeBanner.test.tsx
+++ b/src/components/features/project/ExternalChangeBanner.test.tsx
@@ -1,0 +1,136 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useProjectStore, _resetCommandQueueForTesting } from '@/stores/projectStore';
+import {
+  createMockProjectMeta,
+  createMockProjectState,
+  getMockedInvoke,
+  mockTauriCommands,
+  resetTauriMocks,
+} from '@/test/mocks/tauri';
+import { ExternalChangeBanner, ExternalChangeBannerContent } from './ExternalChangeBanner';
+
+describe('ExternalChangeBannerContent', () => {
+  it('should render nothing when no external change is pending', () => {
+    const { container } = render(
+      <ExternalChangeBannerContent
+        notice={null}
+        isReloading={false}
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should explain that the refused edit was not applied when a command triggered it', () => {
+    render(
+      <ExternalChangeBannerContent
+        notice={{ source: 'command' }}
+        isReloading={false}
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('That edit was not applied');
+    expect(screen.getByRole('alert')).toHaveTextContent('Unsaved changes in this window');
+  });
+
+  it('should report the on-disk operation count when the watcher reported one', () => {
+    render(
+      <ExternalChangeBannerContent
+        notice={{ source: 'watcher', opCount: 14 }}
+        isReloading={false}
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('14 operations');
+  });
+
+  it('should disable the actions while a reload is in flight', () => {
+    render(
+      <ExternalChangeBannerContent
+        notice={{ source: 'watcher', opCount: 2 }}
+        isReloading
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('external-change-banner-reload')).toBeDisabled();
+    expect(screen.getByTestId('external-change-banner-dismiss')).toBeDisabled();
+  });
+});
+
+describe('ExternalChangeBanner', () => {
+  beforeEach(() => {
+    resetTauriMocks();
+    _resetCommandQueueForTesting();
+    useProjectStore.setState({
+      isLoaded: false,
+      isLoading: false,
+      isDirty: false,
+      meta: null,
+      assets: new Map(),
+      sequences: new Map(),
+      effects: new Map(),
+      activeSequenceId: null,
+      sequenceNavigationStack: [],
+      selectedAssetId: null,
+      proxyJobIdsByAssetId: {},
+      error: null,
+      stateVersion: 0,
+      externalChange: null,
+      isReloadingFromDisk: false,
+    });
+  });
+
+  it('should stay hidden until the store reports an external change', () => {
+    render(<ExternalChangeBanner />);
+    expect(screen.queryByTestId('external-change-banner')).not.toBeInTheDocument();
+
+    act(() => {
+      useProjectStore.setState({ isLoaded: true });
+      useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 5 });
+    });
+
+    expect(screen.getByTestId('external-change-banner')).toBeInTheDocument();
+  });
+
+  it('should reload the project from disk when the user chooses to reload', async () => {
+    mockTauriCommands({
+      reload_project_from_disk: createMockProjectMeta({ name: 'Reloaded Project' }),
+      get_project_state: createMockProjectState(),
+    });
+    useProjectStore.setState({ isLoaded: true });
+    useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 5 });
+
+    render(<ExternalChangeBanner />);
+    await userEvent.click(screen.getByTestId('external-change-banner-reload'));
+
+    await waitFor(() => {
+      expect(getMockedInvoke()).toHaveBeenCalledWith('reload_project_from_disk');
+    });
+    await waitFor(() => {
+      expect(useProjectStore.getState().externalChange).toBeNull();
+    });
+    expect(screen.queryByTestId('external-change-banner')).not.toBeInTheDocument();
+  });
+
+  it('should clear the notice without reloading when dismissed', async () => {
+    useProjectStore.setState({ isLoaded: true });
+    useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 5 });
+
+    render(<ExternalChangeBanner />);
+    await userEvent.click(screen.getByTestId('external-change-banner-dismiss'));
+
+    expect(useProjectStore.getState().externalChange).toBeNull();
+    expect(getMockedInvoke()).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/features/project/ExternalChangeBanner.tsx
+++ b/src/components/features/project/ExternalChangeBanner.tsx
@@ -2,9 +2,10 @@
  * External Change Banner
  *
  * Shown when another process — `openreelio-cli`, an agent, or a second app
- * window — edited the open project's operation log. The backend refuses further
- * edits until this session reloads, so the banner is the recovery affordance
- * rather than a passive notice.
+ * window — changed the open project on disk, either by appending to its
+ * operation log or by moving through its history (undo/redo/jump). The backend
+ * refuses further edits until this session reloads, so the banner is the
+ * recovery affordance rather than a passive notice.
  */
 
 import { useCallback } from 'react';

--- a/src/components/features/project/ExternalChangeBanner.tsx
+++ b/src/components/features/project/ExternalChangeBanner.tsx
@@ -1,0 +1,139 @@
+/**
+ * External Change Banner
+ *
+ * Shown when another process — `openreelio-cli`, an agent, or a second app
+ * window — edited the open project's operation log. The backend refuses further
+ * edits until this session reloads, so the banner is the recovery affordance
+ * rather than a passive notice.
+ */
+
+import { useCallback } from 'react';
+import { useProjectStore } from '@/stores/projectStore';
+import { useToastStore } from '@/hooks/useToast';
+import { createLogger } from '@/services/logger';
+import { getUserFriendlyError } from '@/utils/errorMessages';
+import type { ExternalChangeNotice } from '@/utils/externalChange';
+
+const logger = createLogger('ExternalChangeBanner');
+
+function buildBody(notice: ExternalChangeNotice): string {
+  const base =
+    notice.source === 'command'
+      ? 'That edit was not applied because this project changed on disk outside this window.'
+      : 'This project changed on disk outside this window.';
+
+  const detail =
+    typeof notice.opCount === 'number' && notice.opCount > 0
+      ? ` The operation log now has ${notice.opCount} operations.`
+      : '';
+
+  return `${base}${detail} Reload to pick up those edits. Unsaved changes in this window will be discarded.`;
+}
+
+export interface ExternalChangeBannerContentProps {
+  /** The detected change, or `null` to render nothing. */
+  notice: ExternalChangeNotice | null;
+  /** Whether a reload is currently in flight. */
+  isReloading: boolean;
+  /** Invoked when the user chooses to reload the project. */
+  onReload: () => void;
+  /** Invoked when the user dismisses the banner without reloading. */
+  onDismiss: () => void;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Presentational half of the banner. Kept free of store access so it can be
+ * rendered directly in tests and previews.
+ */
+export function ExternalChangeBannerContent({
+  notice,
+  isReloading,
+  onReload,
+  onDismiss,
+  className = '',
+}: ExternalChangeBannerContentProps): JSX.Element | null {
+  if (!notice) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="external-change-banner"
+      role="alert"
+      className={`flex flex-wrap items-center gap-3 border-b border-status-warning/30 bg-status-warning/10 px-4 py-2 ${className}`}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-status-warning">
+          Project changed outside this window
+        </p>
+        <p className="mt-1 text-xs text-text-secondary">{buildBody(notice)}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onReload}
+        disabled={isReloading}
+        data-testid="external-change-banner-reload"
+        className="rounded bg-primary-600 px-3 py-1 text-sm text-white transition-colors hover:bg-primary-500 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isReloading ? 'Reloading…' : 'Reload project'}
+      </button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        disabled={isReloading}
+        aria-label="Dismiss"
+        data-testid="external-change-banner-dismiss"
+        className="rounded px-2 py-1 text-sm text-text-secondary transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export interface ExternalChangeBannerProps {
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Container half: reads the external-change flag from the project store and
+ * wires the reload action.
+ */
+export function ExternalChangeBanner({
+  className = '',
+}: ExternalChangeBannerProps): JSX.Element | null {
+  const notice = useProjectStore((state) => state.externalChange);
+  const isReloading = useProjectStore((state) => state.isReloadingFromDisk);
+
+  const handleReload = useCallback(() => {
+    void useProjectStore
+      .getState()
+      .reloadProjectFromDisk()
+      .catch((error: unknown) => {
+        logger.error('Reload after external change failed', { error });
+        useToastStore.getState().addToast({
+          message: getUserFriendlyError(error, { includeTechnicalDetails: false }),
+          variant: 'error',
+        });
+      });
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    useProjectStore.getState().dismissExternalChange();
+  }, []);
+
+  return (
+    <ExternalChangeBannerContent
+      notice={notice}
+      isReloading={isReloading}
+      onReload={handleReload}
+      onDismiss={handleDismiss}
+      className={className}
+    />
+  );
+}
+
+export default ExternalChangeBanner;

--- a/src/components/features/project/index.ts
+++ b/src/components/features/project/index.ts
@@ -2,6 +2,11 @@
  * Project Feature Components
  */
 
+export { ExternalChangeBanner, ExternalChangeBannerContent } from './ExternalChangeBanner';
+export type {
+  ExternalChangeBannerProps,
+  ExternalChangeBannerContentProps,
+} from './ExternalChangeBanner';
 export { ProjectCreationDialog } from './ProjectCreationDialog';
 export type {
   ProjectCreationDialogProps,

--- a/src/stores/projectStore.externalChange.test.ts
+++ b/src/stores/projectStore.externalChange.test.ts
@@ -146,6 +146,37 @@ describe('projectStore external change handling', () => {
     });
   });
 
+  describe('executeBackendMutation', () => {
+    it('should raise the external-change flag when the backend refuses the mutation', async () => {
+      // Agent tools and several hooks mutate through this path rather than
+      // executeCommand, so it needs the same reload affordance.
+      useProjectStore.setState({ isLoaded: true });
+
+      await expect(
+        useProjectStore.getState().executeBackendMutation('importAsset', () => {
+          throw new Error(
+            `${EXTERNAL_CHANGE_DETECTED_CODE}: the project operation log changed on disk ` +
+              'outside this session (expected 3 operations, found 5). Reload the project to continue.',
+          );
+        }),
+      ).rejects.toThrow(EXTERNAL_CHANGE_DETECTED_CODE);
+
+      expect(useProjectStore.getState().externalChange).toEqual({ source: 'command' });
+    });
+
+    it('should not raise the flag for ordinary mutation failures', async () => {
+      useProjectStore.setState({ isLoaded: true });
+
+      await expect(
+        useProjectStore.getState().executeBackendMutation('importAsset', () => {
+          throw new Error('Asset not found: asset_001');
+        }),
+      ).rejects.toThrow('Asset not found');
+
+      expect(useProjectStore.getState().externalChange).toBeNull();
+    });
+  });
+
   describe('reloadProjectFromDisk', () => {
     it('should rebuild from disk and clear the flag', async () => {
       const sequence = createMockSequence({ id: 'seq_reloaded' });

--- a/src/stores/projectStore.externalChange.test.ts
+++ b/src/stores/projectStore.externalChange.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Feature: External edit safety (frontend contract)
+ *
+ * Covers the store half of the contract: the app must notice when another
+ * process edited the open project and must offer a rebuild-from-disk rather
+ * than silently continuing on stale state.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listen } from '@tauri-apps/api/event';
+import {
+  useProjectStore,
+  setupProxyEventListeners,
+  cleanupProxyEventListeners,
+  _resetCommandQueueForTesting,
+} from './projectStore';
+import {
+  createMockProjectMeta,
+  createMockProjectState,
+  createMockSequence,
+  getMockedInvoke,
+  mockTauriCommands,
+  resetTauriMocks,
+} from '@/test/mocks/tauri';
+import {
+  EXTERNAL_CHANGE_DETECTED_CODE,
+  PROJECT_EXTERNAL_CHANGE_EVENT,
+} from '@/utils/externalChange';
+
+type EventHandler = (event: { payload: unknown }) => void;
+
+function resetProjectStore(): void {
+  useProjectStore.setState({
+    isLoaded: false,
+    isLoading: false,
+    isDirty: false,
+    meta: null,
+    assets: new Map(),
+    sequences: new Map(),
+    effects: new Map(),
+    activeSequenceId: null,
+    sequenceNavigationStack: [],
+    selectedAssetId: null,
+    proxyJobIdsByAssetId: {},
+    error: null,
+    stateVersion: 0,
+    externalChange: null,
+    isReloadingFromDisk: false,
+  });
+}
+
+describe('projectStore external change handling', () => {
+  beforeEach(() => {
+    resetTauriMocks();
+    _resetCommandQueueForTesting();
+    resetProjectStore();
+  });
+
+  describe('markExternalChange', () => {
+    it('should set the banner flag when a project is open', () => {
+      useProjectStore.setState({ isLoaded: true });
+
+      useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 7 });
+
+      expect(useProjectStore.getState().externalChange).toEqual({ source: 'watcher', opCount: 7 });
+    });
+
+    it('should ignore the signal when no project is open', () => {
+      useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 7 });
+
+      expect(useProjectStore.getState().externalChange).toBeNull();
+    });
+
+    it('should clear the flag when dismissed', () => {
+      useProjectStore.setState({ isLoaded: true });
+      useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 2 });
+
+      useProjectStore.getState().dismissExternalChange();
+
+      expect(useProjectStore.getState().externalChange).toBeNull();
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('should raise the external-change flag when the backend refuses the command', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      mockTauriCommands({
+        execute_command: () => {
+          throw new Error(
+            `${EXTERNAL_CHANGE_DETECTED_CODE}: the project operation log changed on disk ` +
+              'outside this session (expected 3 operations, found 5). Reload the project to continue.',
+          );
+        },
+      });
+
+      await expect(
+        useProjectStore.getState().executeCommand({ type: 'SplitClip', payload: {} }),
+      ).rejects.toThrow(EXTERNAL_CHANGE_DETECTED_CODE);
+
+      expect(useProjectStore.getState().externalChange).toEqual({ source: 'command' });
+    });
+
+    it('should raise the flag when undo is refused by the guard', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      mockTauriCommands({
+        undo: () => {
+          throw new Error(`${EXTERNAL_CHANGE_DETECTED_CODE}: the project changed on disk`);
+        },
+      });
+
+      await expect(useProjectStore.getState().undo()).rejects.toThrow(
+        EXTERNAL_CHANGE_DETECTED_CODE,
+      );
+
+      expect(useProjectStore.getState().externalChange).toEqual({ source: 'command' });
+    });
+
+    it('should raise the flag when saving is refused by the guard', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      mockTauriCommands({
+        save_project: () => {
+          throw new Error(`${EXTERNAL_CHANGE_DETECTED_CODE}: the project changed on disk`);
+        },
+      });
+
+      await expect(useProjectStore.getState().saveProject()).rejects.toThrow(
+        EXTERNAL_CHANGE_DETECTED_CODE,
+      );
+
+      expect(useProjectStore.getState().externalChange).toEqual({ source: 'command' });
+    });
+
+    it('should not raise the flag for ordinary command failures', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      mockTauriCommands({
+        execute_command: () => {
+          throw new Error('Clip not found: clip_001');
+        },
+      });
+
+      await expect(
+        useProjectStore.getState().executeCommand({ type: 'SplitClip', payload: {} }),
+      ).rejects.toThrow('Clip not found');
+
+      expect(useProjectStore.getState().externalChange).toBeNull();
+    });
+  });
+
+  describe('reloadProjectFromDisk', () => {
+    it('should rebuild from disk and clear the flag', async () => {
+      const sequence = createMockSequence({ id: 'seq_reloaded' });
+      useProjectStore.setState({ isLoaded: true, isDirty: true });
+      useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 9 });
+
+      mockTauriCommands({
+        reload_project_from_disk: createMockProjectMeta({ name: 'Reloaded Project' }),
+        get_project_state: createMockProjectState({
+          sequences: [sequence],
+          activeSequenceId: 'seq_reloaded',
+        }),
+      });
+
+      await useProjectStore.getState().reloadProjectFromDisk();
+
+      const invokeMock = getMockedInvoke();
+      expect(invokeMock).toHaveBeenCalledWith('reload_project_from_disk');
+
+      const state = useProjectStore.getState();
+      expect(state.externalChange).toBeNull();
+      expect(state.isReloadingFromDisk).toBe(false);
+      expect(state.isDirty).toBe(false);
+      expect(state.meta?.name).toBe('Reloaded Project');
+      expect(state.sequences.has('seq_reloaded')).toBe(true);
+      expect(state.activeSequenceId).toBe('seq_reloaded');
+    });
+
+    it('should keep the flag raised when the reload fails', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      useProjectStore.getState().markExternalChange({ source: 'watcher', opCount: 9 });
+
+      mockTauriCommands({
+        reload_project_from_disk: () => {
+          throw new Error('No project open');
+        },
+      });
+
+      await expect(useProjectStore.getState().reloadProjectFromDisk()).rejects.toThrow(
+        'No project open',
+      );
+
+      const state = useProjectStore.getState();
+      expect(state.externalChange).toEqual({ source: 'watcher', opCount: 9 });
+      expect(state.isReloadingFromDisk).toBe(false);
+      expect(state.error).toBe('No project open');
+    });
+  });
+
+  describe('project:external-change listener', () => {
+    const handlers = new Map<string, EventHandler>();
+
+    beforeEach(() => {
+      handlers.clear();
+      (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+      vi.mocked(listen).mockImplementation(async (event, handler) => {
+        handlers.set(String(event), handler as EventHandler);
+        return () => {
+          handlers.delete(String(event));
+        };
+      });
+    });
+
+    afterEach(async () => {
+      await cleanupProxyEventListeners();
+      delete (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    });
+
+    it('should raise the flag when the backend reports an external change', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      await setupProxyEventListeners();
+
+      handlers.get(PROJECT_EXTERNAL_CHANGE_EVENT)?.({
+        payload: { opCount: 11, expectedOpCount: 8, relativePath: '.openreelio/state/ops.jsonl' },
+      });
+
+      expect(useProjectStore.getState().externalChange).toEqual({
+        source: 'watcher',
+        opCount: 11,
+      });
+    });
+
+    it('should ignore malformed payloads', async () => {
+      useProjectStore.setState({ isLoaded: true });
+      await setupProxyEventListeners();
+
+      handlers.get(PROJECT_EXTERNAL_CHANGE_EVENT)?.({ payload: { opCount: 'lots' } });
+
+      expect(useProjectStore.getState().externalChange).toBeNull();
+    });
+  });
+});

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1069,6 +1069,10 @@ export const useProjectStore = create<ProjectState>()(
 
             set((state) => {
               state.error = errorMessage;
+              // Agent tools and several hooks mutate through this path, so it
+              // needs the same reload affordance as executeCommand - otherwise a
+              // refused mutation surfaces as a bare error with no way forward.
+              noteExternalChangeIfDetected(state, error);
             });
             throw error;
           }

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -147,9 +147,10 @@ interface ProjectState {
   /** State version for conflict detection (increments on each state update) */
   stateVersion: number;
   /**
-   * Set when another process (openreelio-cli, an agent, a second window) edited
-   * this project's operation log. While set, backend mutations are refused and
-   * the user is offered a reload.
+   * Set when another process (openreelio-cli, an agent, a second window) changed
+   * this project on disk — an appended operation, or an undo/redo/jump that
+   * rewrote its history. While set, backend mutations are refused and the user
+   * is offered a reload.
    */
   externalChange: ExternalChangeNotice | null;
   /** True while {@link ProjectState.reloadProjectFromDisk} is in flight. */

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -36,6 +36,12 @@ import {
   _resetDeduplicatorForTesting as resetDeduplicator,
 } from '@/utils/requestDeduplicator';
 import { refreshProjectState, applyProjectState } from '@/utils/stateRefreshHelper';
+import {
+  PROJECT_EXTERNAL_CHANGE_EVENT,
+  isExternalChangeError,
+  parseExternalChangeEvent,
+  type ExternalChangeNotice,
+} from '@/utils/externalChange';
 import { useWorkspaceStore, setupWorkspaceEventListeners } from '@/stores/workspaceStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useCommandPaletteStore } from '@/stores/commandPaletteStore';
@@ -50,6 +56,27 @@ const logger = createLogger('ProjectStore');
 function shouldAutoScanWorkspaceOnOpen(): boolean {
   const workspaceSettings = useSettingsStore.getState().settings.workspace;
   return workspaceSettings?.autoScanOnOpen ?? true;
+}
+
+/**
+ * Raises the external-change flag when a backend rejection came from the
+ * external-edit guard.
+ *
+ * An external edit is not a command failure: the user needs a reload prompt, not
+ * a generic error. Callers still rethrow so they stop treating the mutation as
+ * applied. Structurally typed so it accepts an Immer draft.
+ *
+ * @param draft - The store draft being mutated inside `set()`.
+ * @param error - The rejection value from the backend.
+ */
+function noteExternalChangeIfDetected(
+  draft: { isLoaded: boolean; externalChange: ExternalChangeNotice | null },
+  error: unknown,
+): void {
+  if (!draft.isLoaded || draft.externalChange !== null || !isExternalChangeError(error)) {
+    return;
+  }
+  draft.externalChange = { source: 'command' };
 }
 
 // =============================================================================
@@ -119,6 +146,14 @@ interface ProjectState {
   error: string | null;
   /** State version for conflict detection (increments on each state update) */
   stateVersion: number;
+  /**
+   * Set when another process (openreelio-cli, an agent, a second window) edited
+   * this project's operation log. While set, backend mutations are refused and
+   * the user is offered a reload.
+   */
+  externalChange: ExternalChangeNotice | null;
+  /** True while {@link ProjectState.reloadProjectFromDisk} is in flight. */
+  isReloadingFromDisk: boolean;
 
   // Actions
   loadProject: (path: string) => Promise<void>;
@@ -126,6 +161,14 @@ interface ProjectState {
   openOrInitProject: (path: string) => Promise<void>;
   saveProject: () => Promise<void>;
   closeProject: () => Promise<void>;
+
+  // External change handling
+  /** Flags that another process changed the project on disk. */
+  markExternalChange: (notice: ExternalChangeNotice) => void;
+  /** Clears the external-change flag without reloading. */
+  dismissExternalChange: () => void;
+  /** Rebuilds the project from disk, adopting the external edits. */
+  reloadProjectFromDisk: () => Promise<void>;
 
   // Asset actions
   importAsset: (uri?: string) => Promise<string>;
@@ -189,6 +232,8 @@ export const useProjectStore = create<ProjectState>()(
     proxyJobIdsByAssetId: {},
     error: null,
     stateVersion: 0,
+    externalChange: null,
+    isReloadingFromDisk: false,
 
     // Load existing project
     loadProject: async (path: string) => {
@@ -211,6 +256,7 @@ export const useProjectStore = create<ProjectState>()(
           state.selectedAssetId = null;
           state.proxyJobIdsByAssetId = {};
           state.sequenceNavigationStack = [];
+          state.externalChange = null;
 
           // Populate assets
           state.assets = projectState.assets;
@@ -291,6 +337,7 @@ export const useProjectStore = create<ProjectState>()(
           state.proxyJobIdsByAssetId = {};
           state.isDirty = false;
           state.sequenceNavigationStack = [];
+          state.externalChange = null;
 
           // Populate assets (empty for new project)
           state.assets = projectState.assets;
@@ -347,6 +394,7 @@ export const useProjectStore = create<ProjectState>()(
           state.selectedAssetId = null;
           state.proxyJobIdsByAssetId = {};
           state.sequenceNavigationStack = [];
+          state.externalChange = null;
 
           // Populate assets
           state.assets = projectState.assets;
@@ -416,6 +464,7 @@ export const useProjectStore = create<ProjectState>()(
       } catch (error) {
         set((state) => {
           state.error = error instanceof Error ? error.message : String(error);
+          noteExternalChangeIfDetected(state, error);
         });
         throw error;
       }
@@ -449,6 +498,8 @@ export const useProjectStore = create<ProjectState>()(
         state.proxyJobIdsByAssetId = {};
         state.isDirty = false;
         state.error = null;
+        state.externalChange = null;
+        state.isReloadingFromDisk = false;
         // Increment (not reset) so in-flight ops from the old project
         // see a version mismatch and abort instead of applying stale state.
         state.stateVersion += 1;
@@ -465,6 +516,69 @@ export const useProjectStore = create<ProjectState>()(
       }
 
       logger.info('Project closed and state reset');
+    },
+
+    // Flag an external edit to the project's operation log.
+    markExternalChange: (notice: ExternalChangeNotice) => {
+      set((state) => {
+        if (!state.isLoaded) {
+          return;
+        }
+        state.externalChange = notice;
+      });
+    },
+
+    // Dismiss the external-change notice without reloading.
+    dismissExternalChange: () => {
+      set((state) => {
+        state.externalChange = null;
+      });
+    },
+
+    /**
+     * Rebuilds the project from its on-disk operation log.
+     *
+     * This is a rebuild, not a merge: the backend replays the log and this store
+     * adopts the result. In-memory edits that were never written to the log are
+     * discarded by design.
+     */
+    reloadProjectFromDisk: async () => {
+      // Drop queued commands: they were built against the stale state and the
+      // backend would refuse them anyway.
+      commandQueue.clear();
+
+      set((state) => {
+        state.isReloadingFromDisk = true;
+        state.error = null;
+      });
+
+      try {
+        const projectInfo = await invoke<ProjectMeta>('reload_project_from_disk');
+        const projectState = await refreshProjectState();
+
+        set((state) => {
+          state.meta = projectInfo;
+          state.isLoaded = true;
+          state.isReloadingFromDisk = false;
+          state.externalChange = null;
+          state.isDirty = false;
+          state.error = null;
+          state.selectedAssetId = null;
+          state.proxyJobIdsByAssetId = {};
+          state.stateVersion += 1;
+          applyProjectState(state, projectState);
+        });
+
+        logger.info('Project reloaded from disk after external change');
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error('Failed to reload project from disk', { error: errorMessage });
+        set((state) => {
+          state.isReloadingFromDisk = false;
+          state.error = errorMessage;
+        });
+        throw error;
+      }
     },
 
     // Import asset
@@ -883,6 +997,7 @@ export const useProjectStore = create<ProjectState>()(
 
             set((state) => {
               state.error = errorMessage;
+              noteExternalChangeIfDetected(state, error);
             });
             throw error;
           }
@@ -1057,6 +1172,7 @@ export const useProjectStore = create<ProjectState>()(
 
           set((state) => {
             state.error = errorMessage;
+            noteExternalChangeIfDetected(state, error);
           });
           throw error;
         }
@@ -1110,6 +1226,7 @@ export const useProjectStore = create<ProjectState>()(
 
           set((state) => {
             state.error = errorMessage;
+            noteExternalChangeIfDetected(state, error);
           });
           throw error;
         }
@@ -1166,6 +1283,7 @@ export const useProjectStore = create<ProjectState>()(
 
           set((state) => {
             state.error = errorMessage;
+            noteExternalChangeIfDetected(state, error);
           });
           throw error;
         }
@@ -1313,6 +1431,32 @@ export async function setupProxyEventListeners(): Promise<void> {
       newUnlisteners.push(unlistenFailed);
     } catch (error) {
       logger.error('Failed to setup proxy-failed listener', { error });
+    }
+
+    // Listen for external edits to the project's operation log.
+    // Registered here rather than per-project because the watcher outlives any
+    // single project load and the payload is project-agnostic.
+    try {
+      const unlistenExternalChange = await listen<unknown>(
+        PROJECT_EXTERNAL_CHANGE_EVENT,
+        (event) => {
+          const payload = parseExternalChangeEvent(event.payload);
+          if (!payload) {
+            logger.warn('Ignoring invalid project:external-change payload');
+            return;
+          }
+          logger.warn('External project change detected', {
+            opCount: payload.opCount,
+            relativePath: payload.relativePath,
+          });
+          useProjectStore
+            .getState()
+            .markExternalChange({ source: 'watcher', opCount: payload.opCount });
+        },
+      );
+      newUnlisteners.push(unlistenExternalChange);
+    } catch (error) {
+      logger.error('Failed to setup project external-change listener', { error });
     }
 
     // Only assign after all setup attempts complete

--- a/src/utils/externalChange.test.ts
+++ b/src/utils/externalChange.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXTERNAL_CHANGE_DETECTED_CODE,
+  isExternalChangeError,
+  parseExternalChangeEvent,
+} from './externalChange';
+
+describe('isExternalChangeError', () => {
+  it('should recognize the backend external-change error when it is an Error', () => {
+    const error = new Error(
+      `${EXTERNAL_CHANGE_DETECTED_CODE}: the project operation log changed on disk outside this session ` +
+        '(expected 4 operations, found 6). Reload the project to continue.',
+    );
+
+    expect(isExternalChangeError(error)).toBe(true);
+  });
+
+  it('should recognize the error when it arrives as a bare string', () => {
+    expect(isExternalChangeError(`${EXTERNAL_CHANGE_DETECTED_CODE}: something changed`)).toBe(true);
+  });
+
+  it('should not match unrelated command failures', () => {
+    expect(isExternalChangeError(new Error('Clip not found: clip_001'))).toBe(false);
+    expect(isExternalChangeError(undefined)).toBe(false);
+  });
+});
+
+describe('parseExternalChangeEvent', () => {
+  it('should parse a full payload', () => {
+    const parsed = parseExternalChangeEvent({
+      opCount: 12,
+      expectedOpCount: 9,
+      relativePath: '.openreelio/state/ops.jsonl',
+    });
+
+    expect(parsed).toEqual({
+      opCount: 12,
+      expectedOpCount: 9,
+      relativePath: '.openreelio/state/ops.jsonl',
+    });
+  });
+
+  it('should tolerate a payload with only the operation count', () => {
+    expect(parseExternalChangeEvent({ opCount: 3 })).toEqual({
+      opCount: 3,
+      expectedOpCount: undefined,
+      relativePath: undefined,
+    });
+  });
+
+  it('should return null when the payload is not usable', () => {
+    expect(parseExternalChangeEvent(null)).toBeNull();
+    expect(parseExternalChangeEvent('ops.jsonl')).toBeNull();
+    expect(parseExternalChangeEvent({})).toBeNull();
+    expect(parseExternalChangeEvent({ opCount: 'many' })).toBeNull();
+    expect(parseExternalChangeEvent({ opCount: Number.NaN })).toBeNull();
+  });
+});

--- a/src/utils/externalChange.ts
+++ b/src/utils/externalChange.ts
@@ -1,0 +1,89 @@
+/**
+ * External project change detection helpers.
+ *
+ * A project directory is shared: `openreelio-cli`, an agent or a second app
+ * window can append to the same `ops.jsonl`. When that happens the backend
+ * refuses further mutations instead of silently interleaving them, and the app
+ * must offer a reload rather than a generic error.
+ */
+
+/**
+ * Stable marker embedded in the backend's external-change error message.
+ *
+ * Keep in sync with `EXTERNAL_CHANGE_DETECTED_CODE` in
+ * `src-tauri/src/core/error.rs`. IPC flattens the Rust error to a string, so
+ * this token is the contract between the two sides.
+ */
+export const EXTERNAL_CHANGE_DETECTED_CODE = 'ExternalChangeDetected';
+
+/**
+ * Tauri event emitted by the workspace watcher when another process changed the
+ * active project's state files.
+ */
+export const PROJECT_EXTERNAL_CHANGE_EVENT = 'project:external-change';
+
+/**
+ * How an external change was noticed.
+ *
+ * - `watcher`: the filesystem watcher reported a project state file change.
+ * - `command`: a mutation was refused by the backend guard.
+ */
+export type ExternalChangeSource = 'watcher' | 'command';
+
+/** Store-level record of a detected external change. */
+export interface ExternalChangeNotice {
+  /** Where the detection came from. */
+  source: ExternalChangeSource;
+  /** Operation count on disk, when the detection reported one. */
+  opCount?: number;
+}
+
+/** Payload of {@link PROJECT_EXTERNAL_CHANGE_EVENT}. */
+export interface ExternalChangeEventPayload {
+  /** Number of operations currently present in the on-disk ops log. */
+  opCount: number;
+  /** Number of operations this app session expected to find. */
+  expectedOpCount?: number;
+  /** Project-root-relative path of the state file that changed. */
+  relativePath?: string;
+}
+
+/**
+ * Returns `true` when the given value is a backend external-change error.
+ *
+ * @param error - Rejection value from an `invoke` call.
+ */
+export function isExternalChangeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(EXTERNAL_CHANGE_DETECTED_CODE);
+}
+
+/**
+ * Parses an unvalidated {@link PROJECT_EXTERNAL_CHANGE_EVENT} payload.
+ *
+ * Returns `null` for anything that is not a usable payload so a malformed event
+ * cannot put the UI into a state the user cannot leave.
+ *
+ * @param payload - Raw event payload from Tauri.
+ */
+export function parseExternalChangeEvent(payload: unknown): ExternalChangeEventPayload | null {
+  if (typeof payload !== 'object' || payload === null) {
+    return null;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const { opCount, expectedOpCount, relativePath } = candidate;
+
+  if (typeof opCount !== 'number' || !Number.isFinite(opCount)) {
+    return null;
+  }
+
+  return {
+    opCount,
+    expectedOpCount:
+      typeof expectedOpCount === 'number' && Number.isFinite(expectedOpCount)
+        ? expectedOpCount
+        : undefined,
+    relativePath: typeof relativePath === 'string' ? relativePath : undefined,
+  };
+}


### PR DESCRIPTION
## Description

Makes concurrent CLI+GUI use of the same project safe. A GUI holding a project open detects appends AND history rewrites made by another process (openreelio-cli, an agent, a second instance), refuses to mutate or save over them with a typed error, and offers a one-click reload. The guard lives at the single ops-log write chokepoint so all ~25 mutation paths are covered by construction; a follow-up round closed the two residuals an adversarial re-audit found.

## Related Issue

Closes # (external edit safety; audit finding C2 + re-audit RC-C residuals)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Test update

## Changes Made

- **Guard at the single append chokepoint (`OpsLog::append`/`append_batch`)** — covers the 21 executor command sites, `execute_without_history`, the workspace auto-registration that bypasses the executor, and the in-app AI plan executor. Verified under the same exclusive lock as the write.
- **History-rewrite detection** — a `history.json` fingerprint is a second watermark component verified at every write chokepoint, so an external undo/redo/jump (which rewrites history without appending an op) is detected instead of silently reverted; reload rebaselines both components atomically.
- **Every session is guarded, GUI and `openreelio-cli` alike** — a second *concurrent* writer would otherwise corrupt the snapshot (it would claim a higher opCount than the state it holds). Sequential CLI invocations (open → mutate → save → exit) are unaffected; the docs and tests state this precisely.
- Typed `ExternalChangeDetected` / `ExternalHistoryChangeDetected` errors; guards on execute, undo/redo, history jump, and save; the reload banner is driven from every mutation path including the agent-tool path.
- `reload_project_from_disk` IPC rebuilds from disk and rebaselines atomically (no immediate re-banner race).

## Screenshots / Videos

Banner appears when an external process appends to — or undoes on — the open project; reload restores the current on-disk state.

## Testing

### Test Environment

- OS: Windows 11 Pro (10.0.26200); CI covers ubuntu/windows/macos
- Node.js / Rust: repo-pinned (CI)

### Tests Performed

- [x] Unit tests pass (`pnpm test`) — external-change vitest + full suite
- [x] Rust tests pass (`cargo test`) — lib 3,623; CLI 141 unit + 96 integration (real FFmpeg)
- [x] Manual testing performed — five mutation surfaces reject after an external append AND after an external history move; reload recovers
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Rebased on main after #789 and #790 (audit remediation rounds 1 and 2). A structural-coverage test drives five mutation surfaces that never call the guard helper directly, so a regression back to per-call-site fails. One residual chipped as follow-up: the workspace watcher mutates state before appending, so on a rejected append memory diverges until reload.