### PR TITLE
fix(api): harden the batch-plan surface and close the executor coverage gap

### DIFF
--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -524,7 +524,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli text list --path ./project"
             },
             "plan.execute": {
-                "description": "Execute a plan file atomically. The whole plan is validated before anything is mutated, so an invalid payload never takes the project through a rollback. Exits 0 when applied and saved, 1 when the plan was rejected or a step failed and the rollback completed cleanly, and 2 when the tool could not run or the rollback was incomplete ('rollbackIncomplete': true, with 'rollbackFailures'). A failure report names 'failedStep' and 'error'. Plans are capped at 1000 steps",
+                "description": "Execute a plan file atomically. The whole plan is validated before anything is mutated, so an invalid payload never takes the project through a rollback. Exits 0 when applied and saved, 1 when the plan was rejected or a step failed and the rollback completed cleanly, and 2 when the tool could not run, the rollback was incomplete ('rollbackIncomplete': true, with 'rollbackFailures'), or the plan applied but could not be saved ('appliedNotSaved': true). An 'appliedNotSaved' report means the steps are already durable: re-running the plan would apply it twice. A failure report names 'failedStep' and 'error'. Plans are capped at 1000 steps",
                 "params": {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "file": { "type": "string", "required": true, "desc": "Path to plan JSON file" }

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -532,7 +532,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli plan execute --path ./project --file edit_plan.json"
             },
             "plan.validate": {
-                "description": "Validate a plan file without executing. Checks duplicate and missing step ids, dependency cycles, the 1000-step cap, and parses every step payload. Always exits 0; read 'status' and 'errors'",
+                "description": "Validate a plan file without executing. Checks duplicate and missing step ids, dependency cycles, the 1000-step cap, and parses every step payload. Exits 0 with the findings in 'status' and 'errors' whenever the plan file parses; exits nonzero with empty stdout when the tool itself cannot run, such as an unreadable plan file, malformed plan JSON, or a project that will not open",
                 "params": {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "file": { "type": "string", "required": true, "desc": "Path to plan JSON file" }

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -524,7 +524,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli text list --path ./project"
             },
             "plan.execute": {
-                "description": "Execute a plan file atomically (rollback on failure)",
+                "description": "Execute a plan file atomically. The whole plan is validated before anything is mutated, so an invalid payload never takes the project through a rollback. Exits 0 when applied and saved, 1 when the plan was rejected or a step failed and the rollback completed cleanly, and 2 when the tool could not run or the rollback was incomplete ('rollbackIncomplete': true, with 'rollbackFailures'). A failure report names 'failedStep' and 'error'. Plans are capped at 1000 steps",
                 "params": {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "file": { "type": "string", "required": true, "desc": "Path to plan JSON file" }
@@ -532,7 +532,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli plan execute --path ./project --file edit_plan.json"
             },
             "plan.validate": {
-                "description": "Validate a plan file without executing",
+                "description": "Validate a plan file without executing. Checks duplicate and missing step ids, dependency cycles, the 1000-step cap, and parses every step payload. Always exits 0; read 'status' and 'errors'",
                 "params": {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "file": { "type": "string", "required": true, "desc": "Path to plan JSON file" }

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -2035,8 +2035,17 @@ fn apply_plan(state: &McpServerState, arguments: Value) -> Result<Value, ToolErr
         .map_err(|error| ToolError::Execution(error.to_string()))?;
 
     if result["status"] == "ok" {
-        super::save_project(&mut project)
-            .map_err(|error| ToolError::Execution(error.to_string()))?;
+        // Every step is already fsynced into the append-only ops log, so a save
+        // failure leaves the plan durably applied: the next open folds those ops
+        // back in. The message has to say so, or a client reading a plain
+        // execution error will re-apply the whole plan.
+        super::save_project(&mut project).map_err(|error| {
+            ToolError::Execution(format!(
+                "Plan applied but the project could not be saved: {error}. \
+                 Every step is already in the operations log and will be present \
+                 on the next open — do NOT re-apply this plan."
+            ))
+        })?;
     }
 
     Ok(result)

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -609,12 +609,12 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
         tool(
             "openreelio.plan.validate",
             "OpenReelio plan validation",
-            "Validate a multi-step command plan without executing it.",
+            "Validate a multi-step command plan without executing it. Reports duplicate and missing step ids, dependency cycles, the step cap, and any payload that does not parse.",
             serde_json::json!({
                 "type": "object",
                 "required": ["plan"],
                 "properties": {
-                    "plan": { "type": "object" }
+                    "plan": plan_schema()
                 },
                 "additionalProperties": false
             }),
@@ -696,13 +696,13 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
         tools.push(tool(
             "openreelio.plan.apply",
             "OpenReelio approved plan apply",
-            "Apply a validated edit plan, including text/caption commands, through the OpenReelio command log path using an approval token.",
+            "Apply a validated edit plan, including text/caption commands, through the OpenReelio command log path using an approval token. The whole plan is validated before anything is mutated, and a step failure rolls every applied step back.",
             serde_json::json!({
                 "type": "object",
                 "required": required_fields(state, &["plan"]),
                 "properties": {
                     "approvalToken": { "type": "string" },
-                    "plan": { "type": "object" }
+                    "plan": plan_schema()
                 },
                 "additionalProperties": false
             }),
@@ -710,6 +710,55 @@ fn build_tools(state: &McpServerState) -> Vec<Value> {
     }
 
     tools
+}
+
+/// JSON Schema for an [`plan::EditPlan`], shared by both plan tools.
+///
+/// Spelled out rather than left as an opaque object: a client that cannot see
+/// the step shape has to guess it, and a guessed plan fails validation for
+/// reasons the schema could have prevented. Nested objects stay open because
+/// the deserializer tolerates unknown fields — a stricter schema than the
+/// parser would reject plans that actually work.
+fn plan_schema() -> Value {
+    serde_json::json!({
+        "type": "object",
+        "description": "An atomic edit plan. Every step is validated before any is applied, and a step failure rolls the whole plan back.",
+        "required": ["id", "steps"],
+        "properties": {
+            "id": {
+                "type": "string",
+                "description": "Plan identifier. An approval token is scoped to this value."
+            },
+            "steps": {
+                "type": "array",
+                "maxItems": plan::MAX_PLAN_STEPS,
+                "description": "Plan steps. Execution order comes from dependsOn, not array order; a dependency cycle rejects the plan.",
+                "items": {
+                    "type": "object",
+                    "required": ["id", "commandType", "payload"],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "Step identifier, unique within the plan."
+                        },
+                        "commandType": {
+                            "type": "string",
+                            "description": "Backend command type, e.g. SplitClip. Call openreelio.command.schema for the supported list."
+                        },
+                        "payload": {
+                            "type": "object",
+                            "description": "Command payload for commandType, in the same shape openreelio.command.validate accepts."
+                        },
+                        "dependsOn": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Step ids that must complete first. Each must name a step in this plan."
+                        }
+                    }
+                }
+            }
+        }
+    })
 }
 
 /// Builds a mutating tool's `required` list.
@@ -1887,87 +1936,46 @@ fn validate_command(arguments: Value) -> Result<Value, ToolError> {
 }
 
 fn validate_plan(arguments: Value) -> Result<Value, ToolError> {
-    let plan = arguments
+    let plan_value = arguments
         .get("plan")
+        .cloned()
         .ok_or_else(|| ToolError::InvalidArguments("plan is required".to_string()))?;
-    let plan_id = plan.get("id").and_then(Value::as_str).unwrap_or("unknown");
-    let steps = plan
-        .get("steps")
-        .and_then(Value::as_array)
-        .ok_or_else(|| ToolError::InvalidArguments("plan.steps must be an array".to_string()))?;
-
-    let mut errors = Vec::new();
-    let mut step_ids = std::collections::HashSet::new();
-    if plan
+    let plan_id = plan_value
         .get("id")
         .and_then(Value::as_str)
-        .unwrap_or_default()
-        .is_empty()
-    {
-        errors.push("plan.id is required".to_string());
-    }
+        .unwrap_or("unknown")
+        .to_string();
 
-    for step in steps {
-        let step_id = step.get("id").and_then(Value::as_str).unwrap_or_default();
-        if step_id.is_empty() {
-            errors.push("Every step must include id".to_string());
-        } else if !step_ids.insert(step_id.to_string()) {
-            errors.push(format!("Duplicate step id '{step_id}'"));
+    // A plan that will not even deserialize is a validation finding, not a
+    // protocol error: the caller asked what is wrong with the plan, and an
+    // error list answers that better than a JSON-RPC failure does.
+    let edit_plan: plan::EditPlan = match serde_json::from_value(plan_value) {
+        Ok(edit_plan) => edit_plan,
+        Err(error) => {
+            return Ok(serde_json::json!({
+                "status": "error",
+                "planId": plan_id,
+                "message": "Plan validation failed",
+                "errors": [format!("Plan does not match the expected shape: {error}")]
+            }))
         }
+    };
 
-        let command_type = step.get("commandType").and_then(Value::as_str);
-        let payload = step.get("payload").cloned();
-        match (command_type, payload) {
-            (Some(_), Some(payload)) if payload.is_object() => {}
-            _ => errors.push(format!(
-                "Step '{}' must include commandType and object payload",
-                if step_id.is_empty() {
-                    "<missing>"
-                } else {
-                    step_id
-                }
-            )),
-        }
-    }
-
-    for step in steps {
-        let step_id = step
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or("<missing>");
-        let Some(depends_on) = step.get("dependsOn").and_then(Value::as_array) else {
-            continue;
-        };
-        for dependency in depends_on {
-            let Some(dependency_id) = dependency.as_str() else {
-                errors.push(format!("Step '{step_id}' has a non-string dependency"));
-                continue;
-            };
-            if !step_ids.contains(dependency_id) {
-                errors.push(format!(
-                    "Step '{step_id}' depends on missing step '{dependency_id}'"
-                ));
-            }
-        }
-    }
-
-    if errors.is_empty() {
-        let edit_plan: plan::EditPlan = serde_json::from_value(plan.clone())
-            .map_err(|error| ToolError::InvalidArguments(format!("Invalid plan JSON: {error}")))?;
-        errors.extend(plan::validate_edit_plan(&edit_plan));
-    }
+    // Everything structural lives in the shared validator, so this surface
+    // cannot drift from what `plan execute` will actually accept.
+    let errors = plan::validate_edit_plan(&edit_plan);
 
     Ok(if errors.is_empty() {
         serde_json::json!({
             "status": "ok",
-            "planId": plan_id,
-            "stepCount": steps.len(),
+            "planId": edit_plan.id,
+            "stepCount": edit_plan.steps.len(),
             "message": "Plan is valid"
         })
     } else {
         serde_json::json!({
             "status": "error",
-            "planId": plan_id,
+            "planId": edit_plan.id,
             "message": "Plan validation failed",
             "errors": errors
         })
@@ -2674,6 +2682,104 @@ mod tests {
         assert!(errors
             .iter()
             .any(|error| error.as_str().expect("error").contains("Cycle detected")));
+    }
+
+    /// The step cap lives in the shared validator, so MCP must inherit it
+    /// without mcp.rs knowing the number.
+    #[test]
+    fn should_reject_an_over_cap_plan_through_the_mcp_validator() {
+        let steps: Vec<Value> = (0..=plan::MAX_PLAN_STEPS)
+            .map(|index| {
+                serde_json::json!({
+                    "id": format!("step-{index}"),
+                    "commandType": "AddTrack",
+                    "payload": { "sequenceId": "sequence-1", "name": "T", "kind": "video" }
+                })
+            })
+            .collect();
+
+        let result = call_plan_validate(serde_json::json!({
+            "id": "over-cap",
+            "steps": steps
+        }));
+
+        assert_eq!(result["status"], "error");
+        assert!(
+            result["errors"]
+                .as_array()
+                .expect("errors")
+                .iter()
+                .any(|error| error
+                    .as_str()
+                    .expect("error")
+                    .contains("exceeds the maximum")),
+            "the shared step cap must reach MCP: {result}"
+        );
+    }
+
+    /// Asking what is wrong with a plan must answer with findings, not with a
+    /// protocol failure the caller cannot act on.
+    #[test]
+    fn should_report_a_malformed_plan_as_validation_findings() {
+        let result = call_plan_validate(serde_json::json!({
+            "id": "malformed",
+            "steps": [{ "id": "step-a", "payload": {} }]
+        }));
+
+        assert_eq!(result["status"], "error");
+        assert_eq!(result["planId"], "malformed");
+        assert!(!result["errors"].as_array().expect("errors").is_empty());
+    }
+
+    #[test]
+    fn should_describe_real_plan_steps_in_both_plan_tool_schemas() {
+        let state = McpServerState {
+            allow_write: true,
+            ..Default::default()
+        };
+        let tools = build_tools(&state);
+
+        for name in ["openreelio.plan.validate", "openreelio.plan.apply"] {
+            let schema = &tools
+                .iter()
+                .find(|tool| tool["name"] == name)
+                .unwrap_or_else(|| panic!("{name} must be advertised"))["inputSchema"]
+                ["properties"]["plan"];
+
+            let step = &schema["properties"]["steps"]["items"];
+            assert_eq!(
+                schema["required"],
+                serde_json::json!(["id", "steps"]),
+                "{name} must name the plan's required fields"
+            );
+            assert_eq!(
+                step["required"],
+                serde_json::json!(["id", "commandType", "payload"]),
+                "{name} must describe a step instead of an opaque object"
+            );
+            assert!(step["properties"]["dependsOn"].is_object());
+            assert_eq!(
+                schema["properties"]["steps"]["maxItems"],
+                plan::MAX_PLAN_STEPS
+            );
+        }
+    }
+
+    fn call_plan_validate(plan: Value) -> Value {
+        let response = handle_jsonrpc_request(
+            &McpServerState::default(),
+            request(
+                "tools/call",
+                serde_json::json!({
+                    "name": "openreelio.plan.validate",
+                    "arguments": { "plan": plan }
+                }),
+            ),
+        );
+        let text = response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("text content");
+        serde_json::from_str(text).expect("validate result JSON")
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -1935,6 +1935,39 @@ fn validate_command(arguments: Value) -> Result<Value, ToolError> {
     }
 }
 
+/// Names the steps that are missing a field the plan shape requires.
+///
+/// Deserialization reports the first missing field as one serde message with no
+/// step attribution, which is useless to an agent holding a fifty-step plan.
+/// This is deliberately presence-only: it says which step lacks which key and
+/// stops there, so every judgement about what those keys *contain* still comes
+/// from the shared validator and cannot drift from what `plan execute` accepts.
+fn missing_step_field_errors(plan_value: &Value) -> Vec<String> {
+    let Some(steps) = plan_value.get("steps").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut errors = Vec::new();
+    for (index, step) in steps.iter().enumerate() {
+        let Some(fields) = step.as_object() else {
+            errors.push(format!("Step at index {index} must be a JSON object"));
+            continue;
+        };
+
+        let label = match fields.get("id").and_then(Value::as_str) {
+            Some(id) => format!("Step '{id}' (index {index})"),
+            None => format!("Step at index {index}"),
+        };
+        for required in ["id", "commandType", "payload"] {
+            if !fields.contains_key(required) {
+                errors.push(format!("{label} is missing '{required}'"));
+            }
+        }
+    }
+
+    errors
+}
+
 fn validate_plan(arguments: Value) -> Result<Value, ToolError> {
     let plan_value = arguments
         .get("plan")
@@ -1949,15 +1982,17 @@ fn validate_plan(arguments: Value) -> Result<Value, ToolError> {
     // A plan that will not even deserialize is a validation finding, not a
     // protocol error: the caller asked what is wrong with the plan, and an
     // error list answers that better than a JSON-RPC failure does.
-    let edit_plan: plan::EditPlan = match serde_json::from_value(plan_value) {
+    let edit_plan: plan::EditPlan = match serde_json::from_value(plan_value.clone()) {
         Ok(edit_plan) => edit_plan,
         Err(error) => {
+            let mut errors = missing_step_field_errors(&plan_value);
+            errors.push(format!("Plan does not match the expected shape: {error}"));
             return Ok(serde_json::json!({
                 "status": "error",
                 "planId": plan_id,
                 "message": "Plan validation failed",
-                "errors": [format!("Plan does not match the expected shape: {error}")]
-            }))
+                "errors": errors
+            }));
         }
     };
 
@@ -2789,6 +2824,68 @@ mod tests {
             .as_str()
             .expect("text content");
         serde_json::from_str(text).expect("validate result JSON")
+    }
+
+    /// A plan that will not deserialize must still name the step at fault.
+    ///
+    /// Serde reports the first missing field once, with no step attribution; an
+    /// agent holding a long plan cannot act on that.
+    #[test]
+    fn should_name_the_step_that_is_missing_a_required_field() {
+        let result = call_plan_validate(serde_json::json!({
+            "id": "shape-plan",
+            "steps": [
+                {
+                    "id": "step-a",
+                    "commandType": "AddTrack",
+                    "payload": { "sequenceId": "sequence-1", "name": "A", "kind": "video" }
+                },
+                {
+                    "id": "step-b",
+                    "payload": { "sequenceId": "sequence-1", "name": "B", "kind": "video" }
+                }
+            ]
+        }));
+
+        assert_eq!(result["status"], "error");
+        let errors = result["errors"].as_array().expect("errors");
+        assert!(
+            errors.iter().any(|error| {
+                let error = error.as_str().expect("error");
+                error.contains("step-b")
+                    && error.contains("index 1")
+                    && error.contains("commandType")
+            }),
+            "the report must say which step lacks which field: {result}"
+        );
+        assert!(
+            !errors
+                .iter()
+                .any(|error| error.as_str().expect("error").contains("step-a")),
+            "the sound step must not be blamed: {result}"
+        );
+    }
+
+    /// A step that is not an object at all is attributed by index.
+    #[test]
+    fn should_report_a_non_object_step_by_index() {
+        let result = call_plan_validate(serde_json::json!({
+            "id": "shape-plan",
+            "steps": ["not-a-step"]
+        }));
+
+        assert_eq!(result["status"], "error");
+        assert!(
+            result["errors"]
+                .as_array()
+                .expect("errors")
+                .iter()
+                .any(|error| error
+                    .as_str()
+                    .expect("error")
+                    .contains("Step at index 0 must be a JSON object")),
+            "{result}"
+        );
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -11,7 +11,8 @@
 //!
 //! Exit codes for `plan execute`: `0` applied and saved, `1` the plan was
 //! rejected or a step failed and the rollback completed cleanly, `2` the tool
-//! could not run or the rollback was incomplete (`rollbackIncomplete: true`).
+//! could not run, the rollback was incomplete (`rollbackIncomplete: true`), or
+//! the plan applied but could not be saved (`appliedNotSaved: true`).
 //! `plan validate` and `plan template` keep reporting through JSON alone.
 
 use crate::output;
@@ -31,7 +32,8 @@ pub const MAX_PLAN_STEPS: usize = 1000;
 /// Exit code for a plan that was rejected, or failed and rolled back cleanly.
 const EXIT_PLAN_FAILED: i32 = 1;
 
-/// Exit code for a failure of the tool itself, or an incomplete rollback.
+/// Exit code for a failure of the tool itself, an incomplete rollback, or a
+/// plan that applied but could not be saved.
 const EXIT_TOOL_FAILURE: i32 = 2;
 
 #[derive(Subcommand)]
@@ -202,9 +204,13 @@ fn read_plan(file: &Path) -> anyhow::Result<EditPlan> {
 
 /// Validates and applies the plan, prints the report, returns the exit code.
 ///
-/// Returning `Err` means the tool failed before it could produce a report; a
-/// plan that was merely rejected or rolled back returns `Ok` with a non-zero
-/// code, so stdout still carries exactly one JSON object.
+/// Returning `Err` is reserved for failures that happen *before* anything is
+/// applied — an unreadable plan file, a project that will not open. Every
+/// outcome that touched the project reports through `Ok` with a non-zero code,
+/// including a plan that applied but could not be saved: a bare `Err` there
+/// would leave stdout empty and invite the caller to retry work that is already
+/// durable. stdout therefore carries exactly one JSON object whenever the
+/// project was mutated.
 fn run_execute(path: &PathBuf, file: &Path) -> anyhow::Result<i32> {
     let plan = read_plan(file)?;
     let mut project = super::load_project(path)?;
@@ -223,9 +229,11 @@ fn run_execute(path: &PathBuf, file: &Path) -> anyhow::Result<i32> {
         return Ok(EXIT_PLAN_FAILED);
     }
 
-    let result = apply_edit_plan(&mut project, &plan)?;
+    let mut result = apply_edit_plan(&mut project, &plan)?;
     if result["status"] == "ok" {
-        super::save_project(&mut project)?;
+        if let Err(save_error) = super::save_project(&mut project) {
+            result = applied_not_saved_report(&plan, &result, &save_error);
+        }
     }
 
     let exit_code = plan_exit_code(&result);
@@ -233,13 +241,45 @@ fn run_execute(path: &PathBuf, file: &Path) -> anyhow::Result<i32> {
     Ok(exit_code)
 }
 
+/// Report for a plan whose steps all applied but whose save failed.
+///
+/// Every step is already fsynced into the append-only ops log by the time the
+/// save runs, so the plan is durably applied whether or not the snapshot caught
+/// up — the next open folds those ops back in. Discarding them is not on the
+/// table either: they are legitimately applied truth, and the discard writes
+/// through the same handle that just failed. What the caller needs instead is
+/// to be told, in the report rather than in an empty stdout, that re-running
+/// the plan would apply it twice.
+fn applied_not_saved_report(
+    plan: &EditPlan,
+    applied: &serde_json::Value,
+    save_error: &anyhow::Error,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "error",
+        "message": format!(
+            "Plan applied but the project could not be saved: {save_error}. \
+             Every step is already in the operations log and will be present on \
+             the next open — do NOT re-run this plan."
+        ),
+        "planId": plan.id,
+        "appliedNotSaved": true,
+        "stepsApplied": applied["stepsExecuted"].clone(),
+        "error": save_error.to_string(),
+        "stepResults": applied["stepResults"].clone(),
+    })
+}
+
 /// Maps an [`apply_edit_plan`] report onto the process exit code.
 fn plan_exit_code(result: &serde_json::Value) -> i32 {
     if result["status"] == "ok" {
         0
-    } else if result["rollbackIncomplete"] == serde_json::Value::Bool(true) {
-        // The project is not back where it started and no further command can
-        // assume it is, so this is a tool failure rather than a rejected plan.
+    } else if result["rollbackIncomplete"] == serde_json::Value::Bool(true)
+        || result["appliedNotSaved"] == serde_json::Value::Bool(true)
+    {
+        // The project is not where any further command would assume it is —
+        // either not back at the start, or applied without a current snapshot —
+        // so this is a tool failure rather than a rejected plan.
         EXIT_TOOL_FAILURE
     } else {
         EXIT_PLAN_FAILED
@@ -590,6 +630,45 @@ mod tests {
                 "rollbackFailures": ["undo failed"],
             })),
             EXIT_TOOL_FAILURE
+        );
+    }
+
+    #[test]
+    fn should_map_an_applied_but_unsaved_plan_to_the_tool_failure_exit_code() {
+        assert_eq!(
+            plan_exit_code(&serde_json::json!({
+                "status": "error",
+                "appliedNotSaved": true,
+            })),
+            EXIT_TOOL_FAILURE
+        );
+    }
+
+    #[test]
+    fn should_report_an_applied_but_unsaved_plan_without_inviting_a_retry() {
+        let applied = serde_json::json!({
+            "status": "ok",
+            "planId": "plan-1",
+            "stepsExecuted": 2,
+            "stepResults": [{ "stepId": "a" }, { "stepId": "b" }],
+        });
+
+        let report = applied_not_saved_report(
+            &plan(vec![step("a", &[]), step("b", &["a"])]),
+            &applied,
+            &anyhow::anyhow!("disk is full"),
+        );
+
+        assert_eq!(report["status"], "error");
+        assert_eq!(report["appliedNotSaved"], true);
+        assert_eq!(report["stepsApplied"], 2);
+        assert_eq!(report["planId"], "plan-1");
+        assert_eq!(report["stepResults"], applied["stepResults"]);
+        let message = report["message"].as_str().unwrap();
+        assert!(message.contains("disk is full"), "{message}");
+        assert!(
+            message.contains("do NOT re-run this plan"),
+            "the report has to say the work is already durable: {message}"
         );
     }
 }

--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -353,12 +353,24 @@ pub(crate) fn apply_edit_plan(
                 // in as new user edits and the rollback reverts itself. Marking
                 // them discarded is what makes the rollback stick.
                 if !applied_op_ids.is_empty() {
-                    if let Err(discard_error) =
-                        project.discard_persisted_operations(&applied_op_ids)
-                    {
-                        rollback_failures.push(format!(
-                            "Failed to discard rolled-back operations from persisted history: {discard_error}"
-                        ));
+                    match project.discard_persisted_operations(&applied_op_ids) {
+                        // A protected operation stays applied and comes back on
+                        // the next open, so the project is not where it started.
+                        // Reporting that as a clean rollback would be a lie the
+                        // caller cannot check.
+                        Ok(still_applied) if !still_applied.is_empty() => {
+                            rollback_failures.push(format!(
+                                "Rollback could not discard protected operation(s) [{}]: they stay \
+                                 in the project's applied history and will be present on the next open",
+                                still_applied.join(", ")
+                            ));
+                        }
+                        Ok(_) => {}
+                        Err(discard_error) => {
+                            rollback_failures.push(format!(
+                                "Failed to discard rolled-back operations from persisted history: {discard_error}"
+                            ));
+                        }
                     }
                 }
 

--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -37,7 +37,10 @@ pub enum PlanAction {
     /// Generate a plan template
     Template {
         /// Template type (e.g., split-and-move, multi-trim)
-        #[arg(long, name = "type")]
+        ///
+        /// `--template-type` stays accepted as a hidden alias: it was the flag
+        /// this command actually shipped while the docs advertised `--type`.
+        #[arg(long = "type", alias = "template-type")]
         template_type: String,
     },
 }

--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -3,12 +3,36 @@
 //! Plans are JSON files containing a sequence of editing operations
 //! that are executed atomically. If any step fails, the entire plan
 //! is rolled back.
+//!
+//! `plan execute` validates the whole plan before it mutates anything, because
+//! rolling a plan back is strictly more expensive than refusing it: every
+//! applied step is already fsynced into the append-only ops log by the time the
+//! next one fails.
+//!
+//! Exit codes for `plan execute`: `0` applied and saved, `1` the plan was
+//! rejected or a step failed and the rollback completed cleanly, `2` the tool
+//! could not run or the rollback was incomplete (`rollbackIncomplete: true`).
+//! `plan validate` and `plan template` keep reporting through JSON alone.
 
 use crate::output;
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Upper bound on the steps a single plan may carry.
+///
+/// A backstop against runaway generation, not a capacity limit: an agent that
+/// emits thousands of steps in one plan has lost the thread, and the damage of
+/// letting that run is far larger than the cost of refusing it.
+pub const MAX_PLAN_STEPS: usize = 1000;
+
+/// Exit code for a plan that was rejected, or failed and rolled back cleanly.
+const EXIT_PLAN_FAILED: i32 = 1;
+
+/// Exit code for a failure of the tool itself, or an incomplete rollback.
+const EXIT_TOOL_FAILURE: i32 = 2;
 
 #[derive(Subcommand)]
 pub enum PlanAction {
@@ -72,28 +96,23 @@ pub struct EditPlan {
 
 pub fn execute(action: PlanAction) -> anyhow::Result<()> {
     match action {
-        PlanAction::Execute { path, file } => {
-            let plan_content = std::fs::read_to_string(&file).map_err(|e| {
-                anyhow::anyhow!("Failed to read plan file '{}': {}", file.display(), e)
-            })?;
-            let plan: EditPlan = serde_json::from_str(&plan_content)
-                .map_err(|e| anyhow::anyhow!("Invalid plan JSON: {}", e))?;
-
-            let mut project = super::load_project(&path)?;
-            let result = apply_edit_plan(&mut project, &plan)?;
-            if result["status"] == "ok" {
-                super::save_project(&mut project)?;
+        // Only `execute` mutates, so only `execute` carries the exit-code
+        // contract; the read-only verbs keep reporting through JSON alone.
+        PlanAction::Execute { path, file } => match run_execute(&path, &file) {
+            Ok(0) => Ok(()),
+            Ok(exit_code) => {
+                flush_stdout();
+                std::process::exit(exit_code)
             }
-
-            output::print_json(&result)
-        }
+            Err(error) => {
+                flush_stdout();
+                eprintln!("error: {error}");
+                std::process::exit(EXIT_TOOL_FAILURE)
+            }
+        },
 
         PlanAction::Validate { path, file } => {
-            let plan_content = std::fs::read_to_string(&file).map_err(|e| {
-                anyhow::anyhow!("Failed to read plan file '{}': {}", file.display(), e)
-            })?;
-            let plan: EditPlan = serde_json::from_str(&plan_content)
-                .map_err(|e| anyhow::anyhow!("Invalid plan JSON: {}", e))?;
+            let plan = read_plan(&file)?;
 
             let _project = super::load_project(&path)?;
 
@@ -174,9 +193,84 @@ pub fn execute(action: PlanAction) -> anyhow::Result<()> {
     }
 }
 
+/// Reads and deserializes a plan file.
+fn read_plan(file: &Path) -> anyhow::Result<EditPlan> {
+    let plan_content = std::fs::read_to_string(file)
+        .map_err(|e| anyhow::anyhow!("Failed to read plan file '{}': {}", file.display(), e))?;
+    serde_json::from_str(&plan_content).map_err(|e| anyhow::anyhow!("Invalid plan JSON: {}", e))
+}
+
+/// Validates and applies the plan, prints the report, returns the exit code.
+///
+/// Returning `Err` means the tool failed before it could produce a report; a
+/// plan that was merely rejected or rolled back returns `Ok` with a non-zero
+/// code, so stdout still carries exactly one JSON object.
+fn run_execute(path: &PathBuf, file: &Path) -> anyhow::Result<i32> {
+    let plan = read_plan(file)?;
+    let mut project = super::load_project(path)?;
+
+    // Nothing is mutated until the whole plan is known to be sound. A payload
+    // that only fails when its step is reached takes the project through a
+    // rollback it never needed to risk.
+    let validation_errors = validate_edit_plan(&plan);
+    if !validation_errors.is_empty() {
+        output::print_json(&serde_json::json!({
+            "status": "error",
+            "message": "Plan validation failed",
+            "planId": plan.id,
+            "errors": validation_errors,
+        }))?;
+        return Ok(EXIT_PLAN_FAILED);
+    }
+
+    let result = apply_edit_plan(&mut project, &plan)?;
+    if result["status"] == "ok" {
+        super::save_project(&mut project)?;
+    }
+
+    let exit_code = plan_exit_code(&result);
+    output::print_json(&result)?;
+    Ok(exit_code)
+}
+
+/// Maps an [`apply_edit_plan`] report onto the process exit code.
+fn plan_exit_code(result: &serde_json::Value) -> i32 {
+    if result["status"] == "ok" {
+        0
+    } else if result["rollbackIncomplete"] == serde_json::Value::Bool(true) {
+        // The project is not back where it started and no further command can
+        // assume it is, so this is a tool failure rather than a rejected plan.
+        EXIT_TOOL_FAILURE
+    } else {
+        EXIT_PLAN_FAILED
+    }
+}
+
+fn flush_stdout() {
+    let _ = std::io::stdout().flush();
+}
+
 pub(crate) fn validate_edit_plan(plan: &EditPlan) -> Vec<String> {
     let mut step_ids = HashSet::new();
     let mut errors = Vec::new();
+
+    if plan.id.trim().is_empty() {
+        errors.push("plan.id is required".to_string());
+    }
+
+    if plan.steps.len() > MAX_PLAN_STEPS {
+        errors.push(format!(
+            "Plan has {} steps, which exceeds the maximum of {}",
+            plan.steps.len(),
+            MAX_PLAN_STEPS
+        ));
+    }
+
+    for step in &plan.steps {
+        if step.id.trim().is_empty() {
+            errors.push("Every step must include id".to_string());
+        }
+    }
 
     for step in &plan.steps {
         if !step_ids.insert(step.id.as_str()) {
@@ -218,6 +312,7 @@ pub(crate) fn apply_edit_plan(
 ) -> anyhow::Result<serde_json::Value> {
     let mut results = Vec::new();
     let mut succeeded = 0;
+    let mut applied_op_ids: Vec<String> = Vec::new();
 
     let sorted_steps = topological_sort(&plan.steps)?;
     for step in sorted_steps {
@@ -230,6 +325,7 @@ pub(crate) fn apply_edit_plan(
                     "createdIds": result.created_ids,
                     "deletedIds": result.deleted_ids,
                 }));
+                applied_op_ids.push(result.op_id);
                 succeeded += 1;
             }
             Err(e) => {
@@ -244,10 +340,30 @@ pub(crate) fn apply_edit_plan(
                         rollback_failures.push(undo_err.to_string());
                     }
                 }
+
+                // Undo only unwinds memory. `execute` already fsynced an op for
+                // every step that succeeded, and skipping the save does not
+                // remove them: the next open folds those durable entries back
+                // in as new user edits and the rollback reverts itself. Marking
+                // them discarded is what makes the rollback stick.
+                if !applied_op_ids.is_empty() {
+                    if let Err(discard_error) =
+                        project.discard_persisted_operations(&applied_op_ids)
+                    {
+                        rollback_failures.push(format!(
+                            "Failed to discard rolled-back operations from persisted history: {discard_error}"
+                        ));
+                    }
+                }
+
                 return Ok(serde_json::json!({
                     "status": "error",
                     "message": format!("Plan failed at step '{}': {}", step.id, e),
+                    "planId": plan.id,
+                    "failedStep": step.id,
+                    "error": e.to_string(),
                     "rolledBack": succeeded,
+                    "rollbackIncomplete": !rollback_failures.is_empty(),
                     "rollbackFailures": rollback_failures,
                     "stepResults": results,
                 }));
@@ -327,4 +443,135 @@ fn topological_sort(steps: &[PlanStep]) -> anyhow::Result<Vec<&PlanStep>> {
         return Err(anyhow::anyhow!("Cycle detected in plan step dependencies"));
     }
     Ok(sorted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step(id: &str, depends_on: &[&str]) -> PlanStep {
+        PlanStep {
+            id: id.to_string(),
+            command_type: "AddTrack".to_string(),
+            payload: serde_json::json!({
+                "sequenceId": "sequence-1",
+                "name": id,
+                "kind": "video"
+            }),
+            depends_on: depends_on.iter().map(|d| d.to_string()).collect(),
+        }
+    }
+
+    fn plan(steps: Vec<PlanStep>) -> EditPlan {
+        EditPlan {
+            id: "plan-1".to_string(),
+            steps,
+        }
+    }
+
+    #[test]
+    fn should_accept_a_sound_plan() {
+        assert!(validate_edit_plan(&plan(vec![step("a", &[]), step("b", &["a"])])).is_empty());
+    }
+
+    #[test]
+    fn should_reject_a_plan_over_the_step_cap() {
+        let steps = (0..=MAX_PLAN_STEPS)
+            .map(|index| step(&format!("step-{index}"), &[]))
+            .collect();
+
+        let errors = validate_edit_plan(&plan(steps));
+
+        assert!(
+            errors.iter().any(
+                |error| error.contains(&format!("{} steps", MAX_PLAN_STEPS + 1))
+                    && error.contains(&MAX_PLAN_STEPS.to_string())
+            ),
+            "the error must state the cap and the offending count: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn should_accept_a_plan_exactly_at_the_step_cap() {
+        let steps = (0..MAX_PLAN_STEPS)
+            .map(|index| step(&format!("step-{index}"), &[]))
+            .collect();
+
+        assert!(validate_edit_plan(&plan(steps)).is_empty());
+    }
+
+    #[test]
+    fn should_require_plan_and_step_ids() {
+        let mut candidate = plan(vec![step("", &[])]);
+        candidate.id = "  ".to_string();
+
+        let errors = validate_edit_plan(&candidate);
+
+        assert!(errors.iter().any(|error| error == "plan.id is required"));
+        assert!(errors
+            .iter()
+            .any(|error| error == "Every step must include id"));
+    }
+
+    #[test]
+    fn should_report_cycles_duplicates_and_missing_dependencies() {
+        let errors = validate_edit_plan(&plan(vec![
+            step("a", &["b"]),
+            step("b", &["a"]),
+            step("b", &[]),
+            step("c", &["ghost"]),
+        ]));
+
+        assert!(errors.iter().any(|error| error.contains("Cycle detected")));
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("Duplicate step id 'b'")));
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("'ghost'") && error.contains("does not exist")));
+    }
+
+    #[test]
+    fn should_reject_a_step_whose_payload_cannot_parse() {
+        let mut broken = step("a", &[]);
+        broken.payload = serde_json::json!({ "sequenceId": "sequence-1", "kind": "not-a-kind" });
+
+        let errors = validate_edit_plan(&plan(vec![broken]));
+
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("Step 'a' has invalid command payload")));
+    }
+
+    #[test]
+    fn should_map_an_applied_plan_to_the_success_exit_code() {
+        assert_eq!(
+            plan_exit_code(&serde_json::json!({ "status": "ok", "stepsExecuted": 2 })),
+            0
+        );
+    }
+
+    #[test]
+    fn should_map_a_clean_rollback_to_the_plan_failure_exit_code() {
+        assert_eq!(
+            plan_exit_code(&serde_json::json!({
+                "status": "error",
+                "rollbackIncomplete": false,
+                "rollbackFailures": [],
+            })),
+            EXIT_PLAN_FAILED
+        );
+    }
+
+    #[test]
+    fn should_map_an_incomplete_rollback_to_the_tool_failure_exit_code() {
+        assert_eq!(
+            plan_exit_code(&serde_json::json!({
+                "status": "error",
+                "rollbackIncomplete": true,
+                "rollbackFailures": ["undo failed"],
+            })),
+            EXIT_TOOL_FAILURE
+        );
+    }
 }

--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -314,6 +314,12 @@ pub(crate) fn apply_edit_plan(
     let mut succeeded = 0;
     let mut applied_op_ids: Vec<String> = Vec::new();
 
+    // Rollback unwinds the executor's in-memory undo stack, and that stack is
+    // capped for interactive use — far below the plan step cap. Without this,
+    // a plan that fails deep enough has already had its earliest steps evicted
+    // and could not undo them.
+    project.executor.ensure_history_capacity(plan.steps.len());
+
     let sorted_steps = topological_sort(&plan.steps)?;
     for step in sorted_steps {
         match execute_step(project, step) {

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -1959,30 +1959,40 @@ fn test_frame_extract_builds_contact_sheet_for_grid() {
 // Plan Commands
 // =============================================================================
 
+/// Both spellings of the template flag must work.
+///
+/// `--type` is what the docs and `help-json` have always advertised;
+/// `--template-type` is what the binary actually accepted, so it stays a hidden
+/// alias rather than breaking callers that learned the real flag.
 #[test]
 fn test_plan_template_split_and_move() {
-    let result = run_cli_ok(&["plan", "template", "--template-type", "split-and-move"]);
-    assert_eq!(result["id"], "plan_001");
-    let steps = result["steps"].as_array().unwrap();
-    assert_eq!(steps.len(), 2);
-    assert_eq!(steps[0]["commandType"], "SplitClip");
-    assert_eq!(steps[1]["commandType"], "MoveClip");
+    for flag in ["--type", "--template-type"] {
+        let result = run_cli_ok(&["plan", "template", flag, "split-and-move"]);
+        assert_eq!(result["id"], "plan_001", "flag {flag}");
+        let steps = result["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[0]["commandType"], "SplitClip");
+        assert_eq!(steps[1]["commandType"], "MoveClip");
+    }
 }
 
 #[test]
 fn test_plan_template_multi_trim() {
-    let result = run_cli_ok(&["plan", "template", "--template-type", "multi-trim"]);
-    assert_eq!(result["id"], "plan_002");
+    for flag in ["--type", "--template-type"] {
+        let result = run_cli_ok(&["plan", "template", flag, "multi-trim"]);
+        assert_eq!(result["id"], "plan_002", "flag {flag}");
+    }
 }
 
 #[test]
 fn test_plan_template_invalid() {
-    let (_stdout, stderr) = run_cli_err(&["plan", "template", "--template-type", "nonexistent"]);
-    assert!(
-        stderr.contains("Unknown template type"),
-        "Expected template type error, got: {}",
-        stderr
-    );
+    for flag in ["--type", "--template-type"] {
+        let (_stdout, stderr) = run_cli_err(&["plan", "template", flag, "nonexistent"]);
+        assert!(
+            stderr.contains("Unknown template type"),
+            "Expected template type error for {flag}, got: {stderr}"
+        );
+    }
 }
 
 #[test]

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2102,7 +2102,21 @@ fn active_sequence(path: &str) -> String {
         .to_string()
 }
 
-/// A plan that applies cleanly exits 0 and survives a reopen.
+/// Reads the persisted snapshot, the cache only a completed save advances.
+///
+/// A reopen alone cannot tell a saved plan from an unsaved one — replaying the
+/// append-only ops log rebuilds the same state either way, which is exactly the
+/// trap `appliedNotSaved` exists to report. The snapshot is where the two
+/// outcomes differ.
+fn persisted_snapshot(path: &str) -> serde_json::Value {
+    let snapshot_path = std::path::Path::new(path)
+        .join(".openreelio")
+        .join("state")
+        .join("snapshot.json");
+    serde_json::from_str(&std::fs::read_to_string(&snapshot_path).unwrap()).unwrap()
+}
+
+/// A plan that applies cleanly exits 0, reaches the snapshot, and survives a reopen.
 #[test]
 fn test_plan_execute_applies_and_persists() {
     let dir = create_temp_project("plan_execute_ok");
@@ -2124,6 +2138,16 @@ fn test_plan_execute_applies_and_persists() {
     let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(result["status"], "ok");
     assert_eq!(result["stepsExecuted"], 1);
+
+    // Exit 0 promises applied *and saved*. Without this, an
+    // applied-but-not-saved run would satisfy the reopen assertion below just
+    // as well, and the exit code would be asserting nothing.
+    let applied_op_id = result["stepResults"][0]["opId"].as_str().unwrap();
+    assert_eq!(
+        persisted_snapshot(&path)["lastOpId"],
+        applied_op_id,
+        "exit 0 must mean the plan reached the snapshot, not only the ops log"
+    );
 
     // A separate process, so this reads the project back off disk.
     assert!(track_names(&path).contains(&"KEPT".to_string()));

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2069,6 +2069,273 @@ fn test_plan_validate_cycle() {
         .any(|e| e.as_str().unwrap().contains("Cycle")));
 }
 
+/// Writes a plan file and returns its path.
+fn write_plan(dir: &tempfile::TempDir, name: &str, plan: serde_json::Value) -> String {
+    let plan_file = dir.path().join(name);
+    std::fs::write(&plan_file, plan.to_string()).unwrap();
+    plan_file.to_string_lossy().to_string()
+}
+
+/// One `AddTrack` step, the cheapest step that actually mutates the project.
+fn add_track_step(id: &str, sequence_id: &str, name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "commandType": "AddTrack",
+        "payload": { "sequenceId": sequence_id, "name": name, "kind": "video" },
+        "dependsOn": []
+    })
+}
+
+fn track_names(path: &str) -> Vec<String> {
+    run_cli_ok(&["timeline", "tracks", "--path", path])["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|track| track["name"].as_str().unwrap().to_string())
+        .collect()
+}
+
+fn active_sequence(path: &str) -> String {
+    run_cli_ok(&["project", "info", "--path", path])["activeSequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// A plan that applies cleanly exits 0 and survives a reopen.
+#[test]
+fn test_plan_execute_applies_and_persists() {
+    let dir = create_temp_project("plan_execute_ok");
+    let path = project_path(&dir, "plan_execute_ok");
+    let sequence_id = active_sequence(&path);
+
+    let plan_file = write_plan(
+        &dir,
+        "ok.json",
+        serde_json::json!({
+            "id": "ok_plan",
+            "steps": [add_track_step("step_1", &sequence_id, "KEPT")]
+        }),
+    );
+
+    let (stdout, stderr, code) =
+        run_cli_exit(&["plan", "execute", "--path", &path, "--file", &plan_file]);
+    assert_eq!(code, 0, "a clean plan must exit 0.\nstderr: {stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["stepsExecuted"], 1);
+
+    // A separate process, so this reads the project back off disk.
+    assert!(track_names(&path).contains(&"KEPT".to_string()));
+}
+
+/// A step that only fails once it runs must leave nothing behind.
+///
+/// This is the regression that mattered: `CommandExecutor::execute` fsyncs an
+/// op before it returns and `undo` only unwinds memory, so skipping the save
+/// was not enough — the next open folded the applied ops back in as new user
+/// edits and the rollback reverted itself.
+///
+/// The contract asserted here is the reopened state, not the bytes on disk:
+/// the ops log is append-only by design, so a rolled-back plan necessarily
+/// leaves its ops in the file and records them as discarded in the manifest.
+#[test]
+fn test_plan_execute_rolls_back_a_failed_step_durably() {
+    let dir = create_temp_project("plan_execute_rollback");
+    let path = project_path(&dir, "plan_execute_rollback");
+    let sequence_id = active_sequence(&path);
+    let before = track_names(&path);
+
+    // Step 2 parses fine and only fails against real project state, so the
+    // failure lands mid-execution — after step 1 is already durable.
+    let plan_file = write_plan(
+        &dir,
+        "rollback.json",
+        serde_json::json!({
+            "id": "rollback_plan",
+            "steps": [
+                add_track_step("step_1", &sequence_id, "SHOULD NOT SURVIVE"),
+                {
+                    "id": "step_2",
+                    "commandType": "SplitClip",
+                    "payload": {
+                        "sequenceId": sequence_id,
+                        "trackId": "no-such-track",
+                        "clipId": "no-such-clip",
+                        "splitTime": 1.0
+                    },
+                    "dependsOn": ["step_1"]
+                }
+            ]
+        }),
+    );
+
+    let (stdout, stderr, code) =
+        run_cli_exit(&["plan", "execute", "--path", &path, "--file", &plan_file]);
+    assert_eq!(
+        code, 1,
+        "a failed step that rolled back cleanly is exit 1.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(result["status"], "error");
+    assert_eq!(result["failedStep"], "step_2");
+    assert_eq!(result["rolledBack"], 1);
+    assert_eq!(result["rollbackIncomplete"], false);
+    assert!(result["error"].as_str().unwrap().contains("SplitClip"));
+
+    assert_eq!(
+        track_names(&path),
+        before,
+        "the rolled-back track must not come back when the project is reopened"
+    );
+}
+
+/// A cycle is caught before anything is applied, not by the sort mid-flight.
+#[test]
+fn test_plan_execute_rejects_a_cycle_without_mutating() {
+    let dir = create_temp_project("plan_execute_cycle");
+    let path = project_path(&dir, "plan_execute_cycle");
+    let sequence_id = active_sequence(&path);
+    let before = track_names(&path);
+
+    let plan_file = write_plan(
+        &dir,
+        "cycle.json",
+        serde_json::json!({
+            "id": "cycle_plan",
+            "steps": [
+                {
+                    "id": "step_a",
+                    "commandType": "AddTrack",
+                    "payload": { "sequenceId": sequence_id, "name": "A", "kind": "video" },
+                    "dependsOn": ["step_b"]
+                },
+                {
+                    "id": "step_b",
+                    "commandType": "AddTrack",
+                    "payload": { "sequenceId": sequence_id, "name": "B", "kind": "video" },
+                    "dependsOn": ["step_a"]
+                }
+            ]
+        }),
+    );
+
+    let (stdout, _stderr, code) =
+        run_cli_exit(&["plan", "execute", "--path", &path, "--file", &plan_file]);
+    assert_eq!(code, 1, "an invalid plan is exit 1: {stdout}");
+
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(result["status"], "error");
+    assert!(result["errors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|error| error.as_str().unwrap().contains("Cycle detected")));
+
+    assert_eq!(track_names(&path), before);
+}
+
+/// An unparseable payload is caught up front, so the earlier steps never run.
+#[test]
+fn test_plan_execute_validates_every_payload_before_mutating() {
+    let dir = create_temp_project("plan_execute_prevalidate");
+    let path = project_path(&dir, "plan_execute_prevalidate");
+    let sequence_id = active_sequence(&path);
+    let before = track_names(&path);
+
+    let plan_file = write_plan(
+        &dir,
+        "bad-payload.json",
+        serde_json::json!({
+            "id": "bad_payload_plan",
+            "steps": [
+                add_track_step("step_1", &sequence_id, "MUST NEVER BE CREATED"),
+                {
+                    "id": "step_2",
+                    "commandType": "AddTrack",
+                    "payload": { "sequenceId": sequence_id, "name": "X", "kind": "not-a-kind" },
+                    "dependsOn": ["step_1"]
+                }
+            ]
+        }),
+    );
+
+    let (stdout, _stderr, code) =
+        run_cli_exit(&["plan", "execute", "--path", &path, "--file", &plan_file]);
+    assert_eq!(code, 1, "{stdout}");
+
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(result["message"], "Plan validation failed");
+    assert!(result["errors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|error| error.as_str().unwrap().contains("step_2")));
+
+    assert_eq!(
+        track_names(&path),
+        before,
+        "step_1 must never run when a later step cannot parse"
+    );
+}
+
+/// The step cap is a backstop against runaway generation.
+#[test]
+fn test_plan_execute_and_validate_reject_an_over_cap_plan() {
+    let dir = create_temp_project("plan_step_cap");
+    let path = project_path(&dir, "plan_step_cap");
+    let sequence_id = active_sequence(&path);
+    let before = track_names(&path);
+
+    let steps: Vec<serde_json::Value> = (0..1001)
+        .map(|index| add_track_step(&format!("step_{index}"), &sequence_id, "T"))
+        .collect();
+    let plan_file = write_plan(
+        &dir,
+        "over-cap.json",
+        serde_json::json!({ "id": "over_cap_plan", "steps": steps }),
+    );
+
+    let cap_error = |result: &serde_json::Value| {
+        result["errors"].as_array().unwrap().iter().any(|error| {
+            let error = error.as_str().unwrap();
+            error.contains("1001 steps") && error.contains("1000")
+        })
+    };
+
+    let validated = run_cli_ok(&["plan", "validate", "--path", &path, "--file", &plan_file]);
+    assert_eq!(validated["status"], "error");
+    assert!(cap_error(&validated), "{validated}");
+
+    let (stdout, _stderr, code) =
+        run_cli_exit(&["plan", "execute", "--path", &path, "--file", &plan_file]);
+    assert_eq!(code, 1, "{stdout}");
+    assert!(cap_error(&serde_json::from_str(&stdout).unwrap()));
+
+    assert_eq!(track_names(&path), before);
+}
+
+/// A plan file the tool cannot even read is a tool failure, not a bad plan.
+#[test]
+fn test_plan_execute_reports_an_unreadable_plan_as_a_tool_failure() {
+    let dir = create_temp_project("plan_missing_file");
+    let path = project_path(&dir, "plan_missing_file");
+    let missing = dir.path().join("does-not-exist.json");
+
+    let (_stdout, stderr, code) = run_cli_exit(&[
+        "plan",
+        "execute",
+        "--path",
+        &path,
+        "--file",
+        missing.to_str().unwrap(),
+    ]);
+
+    assert_eq!(code, 2, "the tool could not run: {stderr}");
+    assert!(stderr.contains("Failed to read plan file"), "{stderr}");
+}
+
 // =============================================================================
 // State Commands
 // =============================================================================

--- a/docs/QUALITY_ROADMAP_PLAN.md
+++ b/docs/QUALITY_ROADMAP_PLAN.md
@@ -1,0 +1,125 @@
+# Edit Quality Roadmap — Design & Implementation Plan
+
+**Status**: DESIGN APPROVED — implementation in progress.
+**Goal**: Close the quality gap in agent-driven editing. Research (2026-08) established that the
+gap is a missing *taste and verification layer*, not missing perception: quality comes from
+(a) constrained, human-curated components the agent selects instead of invents, (b) atomic
+batch plans as the unit of edit, and (c) a self-judging loop where the agent inspects its own
+rendered output and picks the best of N candidates. This plan lands all three inside the
+existing editable, event-sourced engine — CLI/MCP (the flagship agent surface) first.
+
+## Thesis (from research, condensed)
+
+- **The loop is the win, not the LLM.** Coding-agent-style editing works because of
+  render → inspect → re-edit iteration, not model taste. Both our in-app engine and the
+  external CLI path currently share one bottleneck: the agent cannot systematically judge its
+  own rendered output.
+- **Quality comes from constraint.** Tool-constrained agents produce ~80% valid specs vs ~0%
+  free-form. Agents are measurably worst at numeric parameter choice and aesthetic judgment —
+  so bad looks must be *unrepresentable*: enum-valued pack IDs resolved deterministically in
+  core, not 21 free-form numbers per caption.
+- **Contact-sheet judging is cheap and real.** One grid of keyframes + durations ≈ 1–2k tokens,
+  ~80% human agreement (human inter-rater is ~79%). Use it for best-of-N selection over
+  candidate plans, with deterministic priors (`verify`, `shot.length_stats`) listed first.
+
+## Root causes addressed
+
+| ID | Root cause | Evidence |
+|----|-----------|----------|
+| RQ-1 | **Batch plan surface is fragmented and soft.** Three incompatible plan schemas (in-app `execute_plan` steps, CLI/MCP `EditPlan`, backend `AgentPlan`); CLI `plan execute` runs without pre-validation, reports failure with a success exit code, and no surface bounds step count. The in-app `execute_plan` is hidden and its reachable fallback handler has no rollback. | plan.rs:72-261; metaTools.ts:842-950; BackendToolExecutor.ts:57-70; help_json `--type` vs actual `--template-type` |
+| RQ-2 | **The agent cannot judge its own output.** Contact-sheet cells are pinned to 320×180 with no labels; sampling is uniform (never cut-aware); `frame extract` cannot read a rendered file; there is no history-jump verb for candidate iteration; no judging rubric or best-of-N guidance exists anywhere in docs or skills. | frame.rs:824-832; visual.rs:43-46; lib.rs:901 (unexposed); skills teach single-candidate convergence only |
+| RQ-3 | **Style vocabulary is unconstrained and divergent.** The same design content lives in five hand-maintained catalogs that already disagree (TS 22 text presets / Rust CLI 14 / prose hints 17 — hints advertise presets the CLI rejects). Captions expose 21 free-form numeric params; transitions hide direction/duration so every wipe is `wipeleft@1.0s`; core has zero pack/preset registry reachable by any agent surface. | textPresets.ts:58 vs text.rs:462-728 vs mcp.rs:1370; captionTools.ts:1120-1228; transitionTools.ts:73 + metaTools.ts:596 |
+
+## Design decisions (locked)
+
+- **D1 — Canonical headless plan schema is `EditPlan`** (`{id, steps:[{id, commandType, payload, dependsOn}]}`). It maps 1:1 onto `CommandPayload` (the real 79-command registry) with no tool-name indirection. The in-app engine keeps `AgentPlan` internally; the existing legacy bridge converts. Full in-app schema convergence is deferred, not forced.
+- **D2 — Packs resolve in core, at the command chokepoint.** Every surface (UI, CLI, agent tools, MCP) converges on `CommandPayload` → `Command::execute`; a resolver there serves all four at once. Registries are const tables in core following the proven `ExportPreset::from_legacy_id` + `render presets` pattern (normalize → match → hard-error with the valid list). Types are serde-friendly so bundled/user JSON pack files can be added later without schema change.
+- **D3 — The judge is the agent, not the CLI.** The CLI never embeds an LLM. It produces judge-ready artifacts (labeled contact sheets, structural stats, verify reports); the skill teaches the rubric and the best-of-N procedure; judgement persistence is a documented JSON convention the agent writes, not a CLI feature.
+- **D4 — Candidate iteration = linear rewind + replayable plans.** No branching machinery. The loop is: apply plan A (atomic) → render range → sheet → score → `state jump` back → apply plan B → … → re-apply the winner's plan JSON. Parallel candidates use N project-directory copies (the external-edit guard forbids concurrent writers by design). A branch/checkout model is explicitly out of scope.
+- **D5 — Judge the artifact, not a re-render.** `frame extract --file <render>` sheets the actual proxy the agent just rendered (fast seek, no per-cell timeline renders), so the judge sees exactly what `verify --file` measured. Composite-mode grids remain for pre-render inspection.
+
+## Task breakdown (sequential PRs)
+
+### PR 1 — `fix/plan-batch-hardening` (RQ-1, CLI+MCP)
+
+| Task | Deliverable |
+|------|-------------|
+| Q1.1 | `plan execute` runs full `validate_edit_plan` (payload parse, dupes, deps, cycles) **before** any mutation. |
+| Q1.2 | Shared `MAX_PLAN_STEPS` cap (1000, anti-runaway backstop) enforced in validation, CLI and MCP. |
+| Q1.3 | Exit-code contract: `0` applied / `1` plan failed + rolled back cleanly / `2` could not run **or rollback incomplete** (`rollbackIncomplete: true` in JSON). No more success-shaped failures. |
+| Q1.4 | Audit CLI failure path for persisted-op leakage; add `discard`/no-save parity with `execute_agent_plan` where needed. |
+| Q1.5 | Fix `--type` vs `--template-type` drift: `--type` becomes real (keep the old spelling as a hidden alias), help_json matches reality. |
+| Q1.6 | Executor coverage parity guard: every `SUPPORTED_COMMAND_TYPES` entry must execute through `CommandExecutor` (closes the SetClipEnabled/SetClipOpacity/ReverseClip registration chips if confirmed). |
+| Q1.7 | MCP `plan.validate` delegates to `plan::validate_edit_plan` (delete the duplicated pre-pass); `plan.apply`/`plan.validate` tool schemas describe real steps instead of an opaque object. |
+| Q1.8 | Tests: rollback-on-failure, cycle-on-execute, step-cap, exit codes (integration). |
+
+### PR 2 — `feature/judge-loop` (RQ-2, CLI + skills)
+
+| Task | Deliverable |
+|------|-------------|
+| Q2.1 | `--cell-width/--cell-height` on `--grid` (clamped ~64..1024; default stays 320×180); parametrize the pinned consts in `generate_contact_sheet_with_layout`. |
+| Q2.2 | `--label-cells`: burn cell index + timecode into each cell (drawtext at extraction, before tiling) so the mapping is self-evident in the image beyond 3×3. |
+| Q2.3 | `--grid` + `--times`: contact sheet from an explicit time list (cut-boundary sheets become possible; the agent computes boundary times from `timeline clips`). |
+| Q2.4 | `--file <RENDER>` source mode: extract stills/sheets from a rendered file (file timebase, fast seek) — the cheap, truthful judge path (D5). |
+| Q2.5 | `state history` (indexed op list + current position) and `state jump --index N` wrapping the existing core `jump_to_history_index_persisted`; respects the external-edit guard. |
+| Q2.6 | help_json entries for every new flag (parity test enforces) + integration tests. |
+| Q2.7 | Skills: new `judging/REFERENCE.md` — fixed pointwise rubric (deterministic priors first: verify report + `shot.length_stats`; then hook, pacing, continuity, caption legibility, framing), the best-of-N jump-loop procedure (D4), judgement JSON convention, cost ladder. Router entry in SKILL.md + AGENT_GUIDE.md section. |
+
+### PR 3 — `feature/curated-packs` (RQ-3: caption packs + transition recipes)
+
+| Task | Deliverable |
+|------|-------------|
+| Q3.1 | `core/style/` pack registries: ~8 caption style packs (typed `CaptionStyle` + position; e.g. `clean-minimal`, `boxed-contrast`, `yellow-classic`, `shorts-bold-outline`, `broadcast-lower`) and ~10 transition recipes (`{effectType, direction, duration, offset}`; e.g. `dissolve-soft`, `wipe-left-fast`, `fade-in`). Resolvers follow `ExportPreset::from_legacy_id`. |
+| Q3.2 | `stylePack` field on Create/Update/ImportGeneratedCaptions payloads, resolved inside command execute (explicit style fields override pack values). Transition recipe resolution feeding `AddEffect`. |
+| Q3.3 | Surfaces: CLI `packs list [--kind caption\|transition]` + `caption create --style-pack`; agent `style_caption`/`add_transition` gain enum pack params (+ `direction` finally exposed; enum restored at the meta-tool boundary); MCP payload hints; help_json. |
+| Q3.4 | Contract tests: every pack round-trips `CommandPayload::parse`, passes `CaptionSafeAreaRule` by construction, and every recipe builds a valid xfade/fade filter. |
+
+### PR 4 — `refactor/text-preset-unification` (RQ-3: one text catalog)
+
+| Task | Deliverable |
+|------|-------------|
+| Q4.1 | Port all 22 text presets into the core registry (single source, carries `category`, `defaultDurationSec`, placement); CLI `parse_text_preset` (~270 lines) deletes and delegates; `packs list --kind text`. |
+| Q4.2 | Divergence closed: prose hints (`mcp.rs`, `help_json.rs`, `toolReference.ts`, Codex adapter) and the meta-tool 4-value enum all reference the full registry; `quote`/`watermark`/`countdown` actually work. TS `textPresets.ts` gains a parity test against the core list. |
+
+### PR 5 — `feature/execute-plan-revival` (RQ-1, in-app TS)
+
+| Task | Deliverable |
+|------|-------------|
+| Q5.1 | `execute_plan` visible again (out of `LEGACY_META_TOOL_NAMES`); visibility tests + openspec drift updated. |
+| Q5.2 | Expand `BACKEND_DIRECT_TOOLS` from 12 toward the full backend-safe catalog; rejection errors name the offending step/tool instead of the opaque blanket message. |
+| Q5.3 | Delete the unreachable-when-backend naive handler (no rollback, empty context); `execute_plan` always routes through the atomic backend path. |
+| Q5.4 | Shared step cap on `steps[]`; `permissionSubject` META_TOOL_NAMES dedup; prompt guidance ("prefer execute_plan for ≥3-step edits"). |
+
+### PR 6 — `feature/pacing-profiles` (RQ-3, taste layer for auto-cut)
+
+| Task | Deliverable |
+|------|-------------|
+| Q6.1 | `PacingProfile` pack `{tempo, targetShotSec, variance, transitionRecipe, transitionEveryN}` + registry. |
+| Q6.2 | `StylePlanner::plan_from_profile` reusing `compute_scaled_cut_times`/`generate_steps` (profile as alternative input to an ESD). |
+| Q6.3 | `generate_steps` emits transition `AddEffect` steps honoring recipes — makes good the "transitions not yet supported" warning at style_planner.rs:188. |
+| Q6.4 | CLI exposure (exact verb decided at implementation: extend `analysis build-selects` vs new `plan from-profile`). |
+
+### PR 7 — `feature/mcp-frame-tool` (RQ-2, MCP image path)
+
+| Task | Deliverable |
+|------|-------------|
+| Q7.1 | MCP server emits `{"type":"image", data, mimeType}` content blocks (protocol already supports it; today everything is hard-coded text). |
+| Q7.2 | `openreelio.frame.extract` MCP read tool returning the sheet inline — MCP-connected vision agents get the judge loop without Bash. |
+
+## Explicitly deferred (tracked, not forgotten)
+
+- In-app engine image port (`ILLMClient` is `content: string` throughout) — large; revisit after PR 7 proves the MCP path.
+- Beat-times array + cut-on-beat (needs new analysis; BPM is a single scalar today).
+- FilmGPT-style learned cut ranker (candidate re-ranker slot exists once best-of-N lands).
+- Effect look packs (`BUILT_IN_VISUAL_EFFECT_PRESETS` → core) — mechanical but multi-command recipes belong in a plan-builder.
+- Branch/checkout project model (D4 rejects it for now).
+- Template engine `template/engine.rs`: do **not** wire up as-is; harvest `SectionConfig` (pack-reference shape) and `TemplateParamType::Choice` (constrained param shape), then decide deletion separately.
+- Judgement persistence as a CLI feature (starts as a documented convention per D3).
+
+## Verification protocol (every PR)
+
+1. `cargo fmt` + `cargo clippy -D warnings` + full `cargo test` (lib + CLI) + affected JS/TS suites.
+2. Contract tests listed per PR are non-negotiable: they prove the class is closed, not that the new code agrees with itself.
+3. help_json parity test must pass for any new clap leaf/flag.
+4. CI verified by **per-check conclusion** (`gh pr checks` / `gh run view --json conclusion`), never the watch exit code.
+5. Skills/docs updated in the same PR that changes behavior they describe.

--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -104,6 +104,20 @@ impl CommandExecutor {
         self
     }
 
+    /// Raises the undo history cap to at least `size` entries.
+    ///
+    /// A transactional caller can only unwind what the undo stack still holds.
+    /// The default cap ([`DEFAULT_MAX_HISTORY_SIZE`]) is sized for a human
+    /// pressing Ctrl+Z, not for a batch: a plan that fails after more than that
+    /// many applied steps has already had its earliest entries evicted, and the
+    /// rollback silently stops short. Callers that execute a known number of
+    /// commands as one unit must size the history to that unit first.
+    ///
+    /// The cap is only ever raised, so this cannot shrink a caller's history.
+    pub fn ensure_history_capacity(&mut self, size: usize) {
+        self.max_history_size = self.max_history_size.max(size);
+    }
+
     /// Executes a command and adds it to history
     pub fn execute(
         &mut self,
@@ -3749,6 +3763,58 @@ mod tests {
         }
 
         assert_eq!(executor.undo_count(), 3);
+    }
+
+    /// A batch caller can size the undo stack to the batch it is about to run.
+    ///
+    /// The default cap is sized for interactive undo, so a transaction longer
+    /// than that would have its earliest entries evicted mid-flight and could
+    /// only unwind part of itself.
+    #[test]
+    fn test_executor_history_capacity_can_be_raised_to_cover_a_batch() {
+        let mut executor = CommandExecutor::new().with_max_history(3);
+        let mut state = ProjectState::new("Test");
+        let batch_size = 10;
+
+        executor.ensure_history_capacity(batch_size);
+        for index in 0..batch_size {
+            let asset = Asset::new_video(
+                &format!("video_{index}.mp4"),
+                &format!("/video_{index}.mp4"),
+                VideoInfo::default(),
+            );
+            executor
+                .execute(Box::new(TestAddAssetCommand { asset }), &mut state)
+                .unwrap();
+        }
+
+        assert_eq!(executor.undo_count(), batch_size);
+        for _ in 0..batch_size {
+            executor.undo(&mut state).unwrap();
+        }
+        assert_eq!(executor.undo_count(), 0);
+        assert!(state.assets.is_empty(), "the whole batch must unwind");
+    }
+
+    /// Raising the cap must never shrink a history that is already larger.
+    #[test]
+    fn test_executor_history_capacity_is_never_lowered() {
+        let mut executor = CommandExecutor::new().with_max_history(8);
+        let mut state = ProjectState::new("Test");
+
+        executor.ensure_history_capacity(2);
+        for index in 0..8 {
+            let asset = Asset::new_video(
+                &format!("video_{index}.mp4"),
+                &format!("/video_{index}.mp4"),
+                VideoInfo::default(),
+            );
+            executor
+                .execute(Box::new(TestAddAssetCommand { asset }), &mut state)
+                .unwrap();
+        }
+
+        assert_eq!(executor.undo_count(), 8);
     }
 
     #[test]

--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -1427,6 +1427,23 @@ impl CommandExecutor {
                     payload.insert("blendMode".to_string(), to_value(&clip.blend_mode)?);
                 }
 
+                // Realized-value snapshots. The command payload alone cannot
+                // reproduce these on replay: `SetClipOpacity` clamps its input,
+                // and `ReverseClip` is a toggle whose payload says nothing at
+                // all about the resulting value. Logging what the clip actually
+                // holds keeps replay idempotent.
+                if type_name == "SetClipOpacity" {
+                    payload.insert("opacity".to_string(), to_value(&clip.opacity)?);
+                }
+
+                if type_name == "SetClipEnabled" {
+                    payload.insert("enabled".to_string(), to_value(&clip.enabled)?);
+                }
+
+                if type_name == "ReverseClip" {
+                    payload.insert("reverse".to_string(), to_value(&clip.reverse)?);
+                }
+
                 Ok(serde_json::Value::Object(payload))
             }
 
@@ -2075,7 +2092,10 @@ impl CommandExecutor {
             | "MoveAudioKeyframe"
             | "SetAudioKeyframeValue"
             | "SetAudioFadeIn"
-            | "SetAudioFadeOut" => OpKind::ClipUpdate,
+            | "SetAudioFadeOut"
+            | "SetClipOpacity"
+            | "SetClipEnabled"
+            | "ReverseClip" => OpKind::ClipUpdate,
             "SplitClip" => OpKind::ClipSplit,
             "CreateCompoundClip" => OpKind::CompoundClipCreate,
             "UnnestCompoundClip" => OpKind::CompoundClipUnnest,
@@ -2270,10 +2290,11 @@ mod tests {
         CreateCompoundClipCommand, CreateSequenceCommand, ExtractEditCommand,
         GeneratedCaptionSegment, GroupClipsCommand, ImportAssetCommand,
         ImportGeneratedCaptionsCommand, InsertClipCommand, InsertEditCommand, LiftCommand,
-        LinkClipsCommand, MoveClipCommand, OverwriteEditCommand, RippleDeleteCommand,
-        SetAudioFadeInCommand, SetAudioFadeOutCommand, SetClipBlendModeCommand,
-        SetClipMotionKeyframesCommand, SetMasterVolumeCommand, SetTrackBlendModeCommand,
-        SplitClipCommand, StateChange, TrimClipCommand, UngroupClipsCommand, UnlinkClipsCommand,
+        LinkClipsCommand, MoveClipCommand, OverwriteEditCommand, ReverseClipCommand,
+        RippleDeleteCommand, SetAudioFadeInCommand, SetAudioFadeOutCommand,
+        SetClipBlendModeCommand, SetClipEnabledCommand, SetClipMotionKeyframesCommand,
+        SetClipOpacityCommand, SetMasterVolumeCommand, SetTrackBlendModeCommand, SplitClipCommand,
+        StateChange, TrimClipCommand, UngroupClipsCommand, UnlinkClipsCommand,
         UnnestCompoundClipCommand,
     };
     use crate::core::effects::{EffectType, ParamValue};
@@ -3818,6 +3839,206 @@ mod tests {
         assert!(state.assets.is_empty());
         assert_eq!(executor.undo_count(), 0);
         assert!(!state.is_dirty);
+    }
+
+    /// The three newly registered clip flags must execute *and* replay.
+    ///
+    /// Registration alone would be a downgrade: the command would start
+    /// appending an op that replay ignores, so the edit would vanish on the
+    /// next reopen instead of failing loudly. Opacity is clamped on execute and
+    /// reverse is a toggle, so both are asserted against the realized value.
+    #[test]
+    fn test_executor_persists_clip_flag_updates_as_replayable() {
+        let temp_dir = TempDir::new().unwrap();
+        let ops_path = temp_dir.path().join("ops.jsonl");
+
+        let mut executor = CommandExecutor::with_ops_log(OpsLog::new(&ops_path));
+        let mut state = ProjectState::new_empty("Test Project");
+
+        let seq_result = executor
+            .execute(
+                Box::new(CreateSequenceCommand::new("Sequence", "1080p")),
+                &mut state,
+            )
+            .unwrap();
+        let seq_id = seq_result.created_ids[0].clone();
+        let track_id = state.sequences[&seq_id].tracks[0].id.clone();
+
+        let asset_path = temp_dir.path().join("test.mp4");
+        std::fs::write(&asset_path, b"test").unwrap();
+        let asset_uri = asset_path.to_string_lossy().to_string();
+        let import_cmd = ImportAssetCommand::new("test.mp4", &asset_uri).with_duration(30.0);
+        executor
+            .execute(Box::new(import_cmd.clone()), &mut state)
+            .unwrap();
+
+        let insert_result = executor
+            .execute(
+                Box::new(
+                    InsertClipCommand::new(&seq_id, &track_id, import_cmd.asset_id(), 0.0)
+                        .with_source_range(0.0, 5.0),
+                ),
+                &mut state,
+            )
+            .unwrap();
+        let clip_id = insert_result.created_ids[0].clone();
+
+        // Out of range on purpose: the log must carry the clamped value, not
+        // the requested one.
+        executor
+            .execute(
+                Box::new(SetClipOpacityCommand::new(
+                    &seq_id, &track_id, &clip_id, 1.5,
+                )),
+                &mut state,
+            )
+            .unwrap();
+        executor
+            .execute(
+                Box::new(SetClipEnabledCommand::new(
+                    &seq_id, &track_id, &clip_id, false,
+                )),
+                &mut state,
+            )
+            .unwrap();
+        executor
+            .execute(
+                Box::new(ReverseClipCommand::new(&seq_id, &track_id, &clip_id)),
+                &mut state,
+            )
+            .unwrap();
+
+        let live_clip = state.sequences[&seq_id]
+            .get_track(&track_id)
+            .unwrap()
+            .get_clip(&clip_id)
+            .unwrap()
+            .clone();
+        assert_eq!(live_clip.opacity, 1.0);
+        assert!(!live_clip.enabled);
+        assert!(live_clip.reverse);
+
+        let replayed =
+            ProjectState::from_ops_log(&OpsLog::new(&ops_path), ProjectMeta::new("Replay"))
+                .unwrap();
+        let replayed_clip = replayed.sequences[&seq_id]
+            .get_track(&track_id)
+            .unwrap()
+            .get_clip(&clip_id)
+            .unwrap();
+
+        assert_eq!(replayed_clip.opacity, live_clip.opacity);
+        assert_eq!(replayed_clip.enabled, live_clip.enabled);
+        assert_eq!(replayed_clip.reverse, live_clip.reverse);
+    }
+
+    /// Command types whose `Command::type_name()` differs from the payload tag.
+    ///
+    /// Each entry is proved against the real command in
+    /// [`payload_type_aliases_still_build_the_command_they_claim`], so this
+    /// table cannot quietly go stale.
+    const PAYLOAD_TYPE_ALIASES: &[(&str, &str)] = &[("CreateTrack", "AddTrack")];
+
+    /// Supported command types that `CommandExecutor::execute` still refuses.
+    ///
+    /// Registering a command is only half of making it work: the op it appends
+    /// must also replay, and each of these needs more than an op-kind arm.
+    /// `SetTimeRemap`/`ClearTimeRemap` change a derived clip duration that the
+    /// payload does not carry; `RemoveAttributes`, `PasteEffects` and
+    /// `PasteAttributes` touch the effect registry and several clips at once;
+    /// `DetachAudio` and `CreateFreezeFrame` create clips (and possibly a
+    /// track) with runtime-generated ids their `to_json` drops;
+    /// `ApplyAudioDucking` drops its keyframes the same way. Registering them
+    /// without fixing the logged payload would trade a clean rejection for
+    /// silent data loss on the next reopen.
+    ///
+    /// This list may only shrink. Adding to it means shipping a command the
+    /// executor cannot run.
+    const KNOWN_UNREGISTERED_COMMAND_TYPES: &[&str] = &[
+        "ApplyAudioDucking",
+        "ClearTimeRemap",
+        "CreateFreezeFrame",
+        "DetachAudio",
+        "PasteAttributes",
+        "PasteEffects",
+        "RemoveAttributes",
+        "SetTimeRemap",
+    ];
+
+    /// Resolves a payload command type to the `type_name()` it executes under.
+    fn executed_type_name(payload_type: &str) -> &str {
+        PAYLOAD_TYPE_ALIASES
+            .iter()
+            .find(|(payload, _)| *payload == payload_type)
+            .map(|(_, command)| *command)
+            .unwrap_or(payload_type)
+    }
+
+    /// Every advertised command type must be executable.
+    ///
+    /// `CommandPayload::SUPPORTED_COMMAND_TYPES` is what the CLI, MCP and the
+    /// frontend advertise, while `type_name_to_op_kind` is what
+    /// `CommandExecutor::execute` will actually accept — nothing in the type
+    /// system connects the two, so a new variant can ship as callable and fail
+    /// at runtime. This test is that connection.
+    #[test]
+    fn every_supported_command_type_is_registered_with_the_executor() {
+        let unregistered: Vec<&str> = crate::ipc::CommandPayload::SUPPORTED_COMMAND_TYPES
+            .iter()
+            .copied()
+            .filter(|payload_type| {
+                CommandExecutor::type_name_to_op_kind(executed_type_name(payload_type)).is_err()
+            })
+            .filter(|payload_type| !KNOWN_UNREGISTERED_COMMAND_TYPES.contains(payload_type))
+            .collect();
+
+        assert!(
+            unregistered.is_empty(),
+            "these command types parse and build but CommandExecutor::execute will reject them: \
+             {unregistered:?}. Add an arm to type_name_to_op_kind and make sure the op replays."
+        );
+    }
+
+    /// Keeps the known-gap list honest in the other direction.
+    #[test]
+    fn known_unregistered_command_types_are_still_unregistered_and_supported() {
+        for payload_type in KNOWN_UNREGISTERED_COMMAND_TYPES {
+            assert!(
+                crate::ipc::CommandPayload::SUPPORTED_COMMAND_TYPES.contains(payload_type),
+                "'{payload_type}' is no longer a supported command type; drop it from the list"
+            );
+            assert!(
+                CommandExecutor::type_name_to_op_kind(executed_type_name(payload_type)).is_err(),
+                "'{payload_type}' is registered now — remove it from \
+                 KNOWN_UNREGISTERED_COMMAND_TYPES so the list keeps shrinking"
+            );
+        }
+    }
+
+    #[test]
+    fn payload_type_aliases_still_build_the_command_they_claim() {
+        let project_path = std::path::Path::new("/tmp/openreelio-alias-guard");
+
+        for (payload_type, expected_type_name) in PAYLOAD_TYPE_ALIASES {
+            let payload = match *payload_type {
+                "CreateTrack" => serde_json::json!({
+                    "sequenceId": "sequence-1",
+                    "name": "Track",
+                    "kind": "video"
+                }),
+                other => panic!("add a payload fixture for the '{other}' alias"),
+            };
+
+            let command = crate::ipc::CommandPayload::parse(payload_type.to_string(), payload)
+                .unwrap_or_else(|error| panic!("'{payload_type}' must parse: {error}"))
+                .build_command(project_path);
+
+            assert_eq!(
+                &command.type_name(),
+                expected_type_name,
+                "the alias table claims '{payload_type}' executes as '{expected_type_name}'"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -1432,16 +1432,23 @@ impl CommandExecutor {
                 // and `ReverseClip` is a toggle whose payload says nothing at
                 // all about the resulting value. Logging what the clip actually
                 // holds keeps replay idempotent.
-                if type_name == "SetClipOpacity" {
-                    payload.insert("opacity".to_string(), to_value(&clip.opacity)?);
-                }
-
-                if type_name == "SetClipEnabled" {
-                    payload.insert("enabled".to_string(), to_value(&clip.enabled)?);
-                }
-
-                if type_name == "ReverseClip" {
-                    payload.insert("reverse".to_string(), to_value(&clip.reverse)?);
+                //
+                // They go under `CLIP_FLAGS_PAYLOAD_KEY` rather than at the
+                // payload root because the root is shared: `SetClipSpeed` also
+                // writes `reverse` there, and replay — which sees only the
+                // `ClipUpdate` op kind — would otherwise apply that command's
+                // reverse without its speed.
+                let clip_flags = match type_name {
+                    "SetClipOpacity" => Some(serde_json::json!({ "opacity": clip.opacity })),
+                    "SetClipEnabled" => Some(serde_json::json!({ "enabled": clip.enabled })),
+                    "ReverseClip" => Some(serde_json::json!({ "reverse": clip.reverse })),
+                    _ => None,
+                };
+                if let Some(clip_flags) = clip_flags {
+                    payload.insert(
+                        crate::core::project::CLIP_FLAGS_PAYLOAD_KEY.to_string(),
+                        clip_flags,
+                    );
                 }
 
                 Ok(serde_json::Value::Object(payload))
@@ -2293,9 +2300,9 @@ mod tests {
         LinkClipsCommand, MoveClipCommand, OverwriteEditCommand, ReverseClipCommand,
         RippleDeleteCommand, SetAudioFadeInCommand, SetAudioFadeOutCommand,
         SetClipBlendModeCommand, SetClipEnabledCommand, SetClipMotionKeyframesCommand,
-        SetClipOpacityCommand, SetMasterVolumeCommand, SetTrackBlendModeCommand, SplitClipCommand,
-        StateChange, TrimClipCommand, UngroupClipsCommand, UnlinkClipsCommand,
-        UnnestCompoundClipCommand,
+        SetClipOpacityCommand, SetClipSpeedCommand, SetMasterVolumeCommand,
+        SetTrackBlendModeCommand, SplitClipCommand, StateChange, TrimClipCommand,
+        UngroupClipsCommand, UnlinkClipsCommand, UnnestCompoundClipCommand,
     };
     use crate::core::effects::{EffectType, ParamValue};
     use crate::core::masks::{MaskShape, RectMask};
@@ -3847,6 +3854,9 @@ mod tests {
     /// appending an op that replay ignores, so the edit would vanish on the
     /// next reopen instead of failing loudly. Opacity is clamped on execute and
     /// reverse is a toggle, so both are asserted against the realized value.
+    ///
+    /// Every asserted value differs from the field's default, or a replay that
+    /// did nothing at all would satisfy the assertion.
     #[test]
     fn test_executor_persists_clip_flag_updates_as_replayable() {
         let temp_dir = TempDir::new().unwrap();
@@ -3893,6 +3903,27 @@ mod tests {
                 &mut state,
             )
             .unwrap();
+        assert_eq!(
+            state.sequences[&seq_id]
+                .get_track(&track_id)
+                .unwrap()
+                .get_clip(&clip_id)
+                .unwrap()
+                .opacity,
+            1.0,
+            "opacity must clamp on execute"
+        );
+
+        // Settle on a value the default (1.0) cannot be mistaken for, so the
+        // replay assertion below can actually fail when replay drops the flag.
+        executor
+            .execute(
+                Box::new(SetClipOpacityCommand::new(
+                    &seq_id, &track_id, &clip_id, 0.5,
+                )),
+                &mut state,
+            )
+            .unwrap();
         executor
             .execute(
                 Box::new(SetClipEnabledCommand::new(
@@ -3914,7 +3945,7 @@ mod tests {
             .get_clip(&clip_id)
             .unwrap()
             .clone();
-        assert_eq!(live_clip.opacity, 1.0);
+        assert_eq!(live_clip.opacity, 0.5);
         assert!(!live_clip.enabled);
         assert!(live_clip.reverse);
 
@@ -3930,6 +3961,74 @@ mod tests {
         assert_eq!(replayed_clip.opacity, live_clip.opacity);
         assert_eq!(replayed_clip.enabled, live_clip.enabled);
         assert_eq!(replayed_clip.reverse, live_clip.reverse);
+    }
+
+    /// Replay must never apply part of a command it does not replay in full.
+    ///
+    /// `SetClipSpeed` shares the `ClipUpdate` op kind with `ReverseClip` and
+    /// logs its own root-level `reverse`. Replaying that field on its own would
+    /// leave the clip reversed at the wrong speed — a half-applied command,
+    /// strictly worse than the skipped one. Full `SetClipSpeed` replay is a
+    /// separate gap; the invariant here is all-or-nothing.
+    #[test]
+    fn test_replay_does_not_half_apply_a_speed_change_as_a_reverse() {
+        let temp_dir = TempDir::new().unwrap();
+        let ops_path = temp_dir.path().join("ops.jsonl");
+
+        let mut executor = CommandExecutor::with_ops_log(OpsLog::new(&ops_path));
+        let mut state = ProjectState::new_empty("Test Project");
+
+        let seq_result = executor
+            .execute(
+                Box::new(CreateSequenceCommand::new("Sequence", "1080p")),
+                &mut state,
+            )
+            .unwrap();
+        let seq_id = seq_result.created_ids[0].clone();
+        let track_id = state.sequences[&seq_id].tracks[0].id.clone();
+
+        let asset_path = temp_dir.path().join("test.mp4");
+        std::fs::write(&asset_path, b"test").unwrap();
+        let asset_uri = asset_path.to_string_lossy().to_string();
+        let import_cmd = ImportAssetCommand::new("test.mp4", &asset_uri).with_duration(30.0);
+        executor
+            .execute(Box::new(import_cmd.clone()), &mut state)
+            .unwrap();
+
+        let insert_result = executor
+            .execute(
+                Box::new(
+                    InsertClipCommand::new(&seq_id, &track_id, import_cmd.asset_id(), 0.0)
+                        .with_source_range(0.0, 5.0),
+                ),
+                &mut state,
+            )
+            .unwrap();
+        let clip_id = insert_result.created_ids[0].clone();
+
+        executor
+            .execute(
+                Box::new(SetClipSpeedCommand::new(
+                    &seq_id, &track_id, &clip_id, 2.0, true,
+                )),
+                &mut state,
+            )
+            .unwrap();
+
+        let replayed =
+            ProjectState::from_ops_log(&OpsLog::new(&ops_path), ProjectMeta::new("Replay"))
+                .unwrap();
+        let replayed_clip = replayed.sequences[&seq_id]
+            .get_track(&track_id)
+            .unwrap()
+            .get_clip(&clip_id)
+            .unwrap();
+
+        assert_eq!(
+            (replayed_clip.speed, replayed_clip.reverse),
+            (1.0, false),
+            "SetClipSpeed replays neither field or both, never just reverse"
+        );
     }
 
     /// Command types whose `Command::type_name()` differs from the payload tag.

--- a/src-tauri/src/core/project/history.rs
+++ b/src-tauri/src/core/project/history.rs
@@ -156,7 +156,13 @@ impl ProjectHistory {
     /// The ops log remains append-only, so failed transactional work cannot be
     /// deleted from disk. Recording discarded IDs prevents later history syncs
     /// from treating those durable log entries as newly applied user edits.
-    pub fn discard_operations<I>(&mut self, op_ids: I)
+    ///
+    /// Operations inside the protected prefix are refused, and their ids are
+    /// returned in the order they were requested. A caller rolling a
+    /// transaction back has to know about that shortfall: those ops stay
+    /// applied, so the rollback did not put the project back where it started.
+    #[must_use = "a non-empty result means part of the rollback did not stick"]
+    pub fn discard_operations<I>(&mut self, op_ids: I) -> Vec<OpId>
     where
         I: IntoIterator<Item = OpId>,
     {
@@ -166,9 +172,13 @@ impl ProjectHistory {
             .take(self.protected_prefix_len)
             .cloned()
             .collect();
+        let mut skipped_protected = Vec::new();
         let mut discard_set = HashSet::new();
         for op_id in op_ids {
             if protected_ids.contains(&op_id) {
+                if !skipped_protected.contains(&op_id) {
+                    skipped_protected.push(op_id);
+                }
                 continue;
             }
 
@@ -183,7 +193,7 @@ impl ProjectHistory {
         }
 
         if discard_set.is_empty() {
-            return;
+            return skipped_protected;
         }
 
         self.applied_op_ids
@@ -191,6 +201,8 @@ impl ProjectHistory {
         self.redo_op_ids
             .retain(|op_id| !discard_set.contains(op_id));
         self.protected_prefix_len = self.protected_prefix_len.min(self.applied_op_ids.len());
+
+        skipped_protected
     }
 
     /// Removes references to missing/duplicate operation IDs.
@@ -327,7 +339,8 @@ mod tests {
         let mut history =
             ProjectHistory::from_operations(&operations, ProjectMeta::new("History Test"));
 
-        history.discard_operations(["op2".to_string(), "op3".to_string()]);
+        let skipped = history.discard_operations(["op2".to_string(), "op3".to_string()]);
+        assert!(skipped.is_empty(), "nothing here is protected: {skipped:?}");
         history.sanitize(&operations);
         history.append_new_operations(["op2".to_string(), "op3".to_string()]);
         history.sanitize(&operations);
@@ -351,11 +364,16 @@ mod tests {
         let mut history =
             ProjectHistory::from_operations(&operations, ProjectMeta::new("History Test"));
 
-        history.discard_operations(["op1".to_string(), "op2".to_string()]);
+        let skipped = history.discard_operations(["op1".to_string(), "op2".to_string()]);
         history.sanitize(&operations);
 
         assert_eq!(history.applied_op_ids, vec!["op1".to_string()]);
         assert_eq!(history.discarded_op_ids, vec!["op2".to_string()]);
         assert_eq!(history.protected_prefix_len, 1);
+        assert_eq!(
+            skipped,
+            vec!["op1".to_string()],
+            "the protected op it refused to discard has to be reported, not swallowed"
+        );
     }
 }

--- a/src-tauri/src/core/project/state.rs
+++ b/src-tauri/src/core/project/state.rs
@@ -1091,6 +1091,51 @@ impl ProjectState {
         Ok(())
     }
 
+    /// Replays the scalar clip flags carried by a `ClipUpdate` payload.
+    ///
+    /// The executor logs the realized post-execute value for each of these, so
+    /// replay assigns rather than recomputes — `ReverseClip` in particular is a
+    /// toggle, and re-toggling on replay would diverge the moment an op is
+    /// skipped. A missing or null field means "no change", matching the rest of
+    /// `apply_clip_update`.
+    fn apply_replayed_clip_flags(clip: &mut Clip, payload: &serde_json::Value) -> CoreResult<()> {
+        if let Some(value) = payload.get("opacity") {
+            if !value.is_null() {
+                let opacity = value.as_f64().ok_or_else(|| {
+                    CoreError::InvalidCommand("Invalid opacity value (expected number)".to_string())
+                })?;
+                if !opacity.is_finite() {
+                    return Err(CoreError::InvalidCommand(
+                        "Invalid opacity value (expected finite number)".to_string(),
+                    ));
+                }
+                clip.opacity = (opacity as f32).clamp(0.0, 1.0);
+            }
+        }
+
+        if let Some(value) = payload.get("enabled") {
+            if !value.is_null() {
+                clip.enabled = value.as_bool().ok_or_else(|| {
+                    CoreError::InvalidCommand(
+                        "Invalid enabled value (expected boolean)".to_string(),
+                    )
+                })?;
+            }
+        }
+
+        if let Some(value) = payload.get("reverse") {
+            if !value.is_null() {
+                clip.reverse = value.as_bool().ok_or_else(|| {
+                    CoreError::InvalidCommand(
+                        "Invalid reverse value (expected boolean)".to_string(),
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
     fn apply_clip_update(&mut self, op: &Operation) -> CoreResult<()> {
         fn sanitize_replayed_audio_settings(
             mut audio: AudioSettings,
@@ -1319,6 +1364,10 @@ impl ProjectState {
                 if let Some(blend_mode) = parsed_blend_mode {
                     clip.blend_mode = blend_mode;
                 }
+
+                // Applied before the full-audio early return below so these
+                // fields replay regardless of which branch the payload takes.
+                Self::apply_replayed_clip_flags(clip, &op.payload)?;
 
                 if has_full_audio_payload {
                     // Full audio payloads are already normalized above.

--- a/src-tauri/src/core/project/state.rs
+++ b/src-tauri/src/core/project/state.rs
@@ -22,6 +22,20 @@ use crate::core::{
     AssetId, CoreError, CoreResult, EffectId, SequenceId,
 };
 
+/// `ClipUpdate` payload key holding the realized clip flags replay must assign.
+///
+/// An [`Operation`] carries an [`OpKind`] and no record of the command behind
+/// it, and `ClipUpdate` is shared by sixteen commands whose payload roots
+/// overlap — `SetClipSpeed` writes a root-level `reverse`, exactly like
+/// `ReverseClip`. Nesting the replayable flags under a key that only
+/// `SetClipOpacity`, `SetClipEnabled` and `ReverseClip` write is what lets
+/// replay tell "this command owns this field" from "this field happens to be
+/// here", so no command is ever half-applied.
+///
+/// The three commands became executable in this same change, so no operation
+/// written by a released build carries these flags at the payload root.
+pub(crate) const CLIP_FLAGS_PAYLOAD_KEY: &str = "clipFlags";
+
 // =============================================================================
 // Project Metadata
 // =============================================================================
@@ -1098,8 +1112,27 @@ impl ProjectState {
     /// toggle, and re-toggling on replay would diverge the moment an op is
     /// skipped. A missing or null field means "no change", matching the rest of
     /// `apply_clip_update`.
+    ///
+    /// The flags are read only from [`CLIP_FLAGS_PAYLOAD_KEY`], never from the
+    /// payload root. An [`Operation`] records an [`OpKind`] and nothing about
+    /// the command that produced it, and `ClipUpdate` covers sixteen commands:
+    /// `SetClipSpeed` logs a root-level `reverse` of its own, so reading the
+    /// root would replay half of that command — its reverse without its speed —
+    /// which is worse than replaying none of it.
     fn apply_replayed_clip_flags(clip: &mut Clip, payload: &serde_json::Value) -> CoreResult<()> {
-        if let Some(value) = payload.get("opacity") {
+        let Some(flags) = payload.get(CLIP_FLAGS_PAYLOAD_KEY) else {
+            return Ok(());
+        };
+        if flags.is_null() {
+            return Ok(());
+        }
+        if !flags.is_object() {
+            return Err(CoreError::InvalidCommand(format!(
+                "Invalid {CLIP_FLAGS_PAYLOAD_KEY} value (expected object)"
+            )));
+        }
+
+        if let Some(value) = flags.get("opacity") {
             if !value.is_null() {
                 let opacity = value.as_f64().ok_or_else(|| {
                     CoreError::InvalidCommand("Invalid opacity value (expected number)".to_string())
@@ -1113,7 +1146,7 @@ impl ProjectState {
             }
         }
 
-        if let Some(value) = payload.get("enabled") {
+        if let Some(value) = flags.get("enabled") {
             if !value.is_null() {
                 clip.enabled = value.as_bool().ok_or_else(|| {
                     CoreError::InvalidCommand(
@@ -1123,7 +1156,7 @@ impl ProjectState {
             }
         }
 
-        if let Some(value) = payload.get("reverse") {
+        if let Some(value) = flags.get("reverse") {
             if !value.is_null() {
                 clip.reverse = value.as_bool().ok_or_else(|| {
                     CoreError::InvalidCommand(

--- a/src-tauri/src/ipc/commands/agent.rs
+++ b/src-tauri/src/ipc/commands/agent.rs
@@ -808,11 +808,24 @@ fn rollback_steps(
 
     if !completed_operation_ids.is_empty() {
         match project.discard_persisted_operations(&completed_operation_ids) {
-            Ok(()) => {
-                tracing::debug!(
-                    discarded_ops = completed_operation_ids.len(),
-                    "Discarded rolled-back agent plan operations from persisted history"
-                );
+            Ok(still_applied) => {
+                if still_applied.is_empty() {
+                    tracing::debug!(
+                        discarded_ops = completed_operation_ids.len(),
+                        "Discarded rolled-back agent plan operations from persisted history"
+                    );
+                } else {
+                    // Protected operations stay applied and return on the next
+                    // open, so this rollback did not put the project back.
+                    let error_msg = format!(
+                        "Rollback could not discard protected operation(s) [{}]: they stay in the \
+                         project's applied history and will be present on the next open",
+                        still_applied.join(", ")
+                    );
+                    tracing::error!("{}", error_msg);
+                    rollback_errors.push(error_msg);
+                    failed = failed.max(1);
+                }
             }
             Err(e) => {
                 let error_msg =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -799,16 +799,26 @@ impl ActiveProject {
     /// Every transactional caller that rolls back — the agent plan executor and
     /// the CLI/MCP plan path — must call this, or the rollback silently reverts
     /// itself on the next open.
-    pub fn discard_persisted_operations(&mut self, op_ids: &[OpId]) -> crate::core::CoreResult<()> {
+    ///
+    /// Returns the requested ids that stay applied because they sit inside the
+    /// history's protected prefix (the project's first `SequenceCreate` is
+    /// never discardable). A non-empty result is a rollback shortfall, not a
+    /// detail: those operations survive the next open, so the caller must not
+    /// report a clean rollback.
+    #[must_use = "a non-empty result means part of the rollback did not stick"]
+    pub fn discard_persisted_operations(
+        &mut self,
+        op_ids: &[OpId],
+    ) -> crate::core::CoreResult<Vec<OpId>> {
         if op_ids.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let read_result = self.ops_log.read_all_with_archive()?;
         Self::sync_history_with_operations(&mut self.history, &read_result.operations);
 
         let mut candidate_history = self.history.clone();
-        candidate_history.discard_operations(op_ids.iter().cloned());
+        let skipped_protected = candidate_history.discard_operations(op_ids.iter().cloned());
         candidate_history.sanitize(&read_result.operations);
 
         let candidate_state =
@@ -820,7 +830,7 @@ impl ActiveProject {
         self.state = candidate_state;
         self.executor.clear_history();
 
-        Ok(())
+        Ok(skipped_protected)
     }
 
     fn visible_history_current_index_for(history: &ProjectHistory) -> i32 {
@@ -2570,9 +2580,13 @@ mod tests {
 
         assert_eq!(project.state.meta.name, "Discarded Name");
 
-        project
+        let still_applied = project
             .discard_persisted_operations(std::slice::from_ref(&result.op_id))
             .unwrap();
+        assert!(
+            still_applied.is_empty(),
+            "nothing here is protected: {still_applied:?}"
+        );
         project.save().unwrap();
 
         assert_eq!(project.state.meta.name, "History Discard");
@@ -2625,9 +2639,13 @@ mod tests {
             )
             .unwrap();
 
-        project
+        let still_applied = project
             .discard_persisted_operations(std::slice::from_ref(&track_result.op_id))
             .unwrap();
+        assert!(
+            still_applied.is_empty(),
+            "nothing here is protected: {still_applied:?}"
+        );
 
         assert_eq!(
             project.state.active_sequence_id.as_deref(),
@@ -2639,6 +2657,45 @@ mod tests {
             .tracks
             .iter()
             .any(|track| track.name == "Temporary Captions"));
+    }
+
+    /// A discard that hits the protected prefix must say so.
+    ///
+    /// The project's first `SequenceCreate` is never discardable, so a
+    /// transaction whose first step created it cannot be rolled back to
+    /// nothing. Returning `Ok(())` there told every caller the rollback was
+    /// clean while the operation stayed applied and came back on the next open.
+    #[test]
+    fn test_active_project_discard_reports_operations_the_protected_prefix_kept() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_path = temp_dir.path().join("history_discard_protected_project");
+        std::fs::create_dir_all(&project_path).unwrap();
+
+        // Opened rather than created, so the ops log starts empty and the first
+        // command's operation becomes the protected head.
+        let mut project = ActiveProject::open(project_path.clone()).unwrap();
+        let created = project
+            .executor
+            .execute(
+                Box::new(crate::core::commands::CreateSequenceCommand::new(
+                    "Plan Sequence",
+                    "1080p",
+                )),
+                &mut project.state,
+            )
+            .unwrap();
+
+        let still_applied = project
+            .discard_persisted_operations(std::slice::from_ref(&created.op_id))
+            .unwrap();
+
+        assert_eq!(
+            still_applied,
+            vec![created.op_id.clone()],
+            "the protected operation stayed applied, so the caller has to hear about it"
+        );
+        assert!(project.history.applied_op_ids.contains(&created.op_id));
+        assert!(!project.history.discarded_op_ids.contains(&created.op_id));
     }
 
     #[test]
@@ -2658,9 +2715,13 @@ mod tests {
             )
             .unwrap();
 
-        project
+        let still_applied = project
             .discard_persisted_operations(std::slice::from_ref(&discarded.op_id))
             .unwrap();
+        assert!(
+            still_applied.is_empty(),
+            "nothing here is protected: {still_applied:?}"
+        );
 
         let kept = project
             .executor

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -788,10 +788,18 @@ impl ActiveProject {
         Ok(())
     }
 
-    pub(crate) fn discard_persisted_operations(
-        &mut self,
-        op_ids: &[OpId],
-    ) -> crate::core::CoreResult<()> {
+    /// Excludes already-persisted operations from history replay.
+    ///
+    /// The ops log is append-only, so work that has to be rolled back cannot be
+    /// deleted from disk: `CommandExecutor::execute` fsyncs each op before it
+    /// returns, and `CommandExecutor::undo` only unwinds memory. Recording the
+    /// ids as discarded is what stops the next `sync_history_with_ops_log` from
+    /// mistaking those durable entries for new user edits and replaying them.
+    ///
+    /// Every transactional caller that rolls back — the agent plan executor and
+    /// the CLI/MCP plan path — must call this, or the rollback silently reverts
+    /// itself on the next open.
+    pub fn discard_persisted_operations(&mut self, op_ids: &[OpId]) -> crate::core::CoreResult<()> {
         if op_ids.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
### **User description**
## Description

PR 1 of the edit-quality roadmap (`docs/QUALITY_ROADMAP_PLAN.md`, included in this PR): hardens the batch-plan surface (CLI `plan execute` + MCP `plan.apply`/`plan.validate`) that agents rely on for atomic multi-step edits, and closes an executor coverage gap that made three schema-valid commands unexecutable.

Two real defects found and fixed along the way:

1. **CLI plan rollback silently reverted itself.** `CommandExecutor::execute` fsyncs each op into the append-only `ops.jsonl` before returning, while `undo` only unwinds memory — so every succeeded step of a "rolled back" plan stayed durable, and the next project open folded those ops back in as new edits. Reproduced on the pre-fix binary (a rolled-back plan's track survived reopen, exit code 0). Fixed by mirroring `execute_agent_plan`'s discard mechanism: rolled-back op ids are now recorded in the history manifest's discarded set (`ActiveProject::discard_persisted_operations`, promoted to `pub` for the CLI crate).
2. **`SetClipEnabled`, `SetClipOpacity`, `ReverseClip` were unexecutable** — parsed and built real commands but were missing from `type_name_to_op_kind`, so `execute` rejected them on every surface (UI, CLI, MCP). Registered with realized-value snapshots in the logged payload (opacity is clamped on execute; `ReverseClip` is a toggle whose payload carries no result), plus replay support in `apply_clip_update`, so execute and replay agree.

## Related Issue

Part of the edit-quality roadmap (no standalone issue).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test update

## Changes Made

- `plan execute` now runs the full `validate_edit_plan` (payload parse, duplicate/dangling deps, cycles) **before** any mutation; invalid plans are rejected without touching the project.
- Shared `MAX_PLAN_STEPS = 1000` cap enforced in validation — inherited by CLI validate, CLI execute, and MCP.
- Exit-code contract for `plan execute` (matches `verify`'s mechanism): `0` applied+saved / `1` rejected or failed-and-rolled-back-cleanly / `2` tool failure or incomplete rollback (`rollbackIncomplete: true` in the report).
- Failed plans no longer resurrect on reopen: rolled-back op ids are marked discarded in persisted history (parity with the backend agent-plan executor).
- `plan template --type` is now the real flag (docs said `--type`, the binary only accepted `--template-type`); the old spelling stays as a hidden alias.
- MCP `plan.validate` delegates to the shared validator (hand-rolled duplicate pre-pass deleted); both plan tool schemas now describe the real step shape (`{id, steps:[{id, commandType, payload, dependsOn?}]}`) instead of an opaque object. `apply_plan`'s grant → validate → token-consume ordering is untouched.
- Executor parity guard test: every `CommandPayload::SUPPORTED_COMMAND_TYPES` entry must be executable; the known-gap list (8 remaining types, each needing payload/replay design work) is a ratchet that fails on any new gap and on any silently fixed entry.
- Registered the three clip-flag commands with execute-then-replay round-trip coverage.
- Added `docs/QUALITY_ROADMAP_PLAN.md` (root causes, locked design decisions, PR 1–7 breakdown).

## Screenshots / Videos

N/A (CLI/backend only).

## Testing

### Test Environment

- OS: Windows 11 Pro
- Node.js version: n/a (no JS changes)
- Rust version: workspace toolchain

### Tests Performed

- [x] Unit tests pass (`pnpm test`) — no TS changes; suite unaffected
- [x] Rust tests pass (`cargo test`)
- [x] Manual testing performed
- [x] New tests added for changes

22 new tests: rollback-on-failure with on-disk state asserted from a separate process reopen, cycle rejection at execute, step-cap rejection, exit-code mapping, `--type`/`--template-type` both accepted, executor parity guard, clip-flag execute-vs-replay round-trips. Full runs: `openreelio --lib` 3627 passed, `openreelio-cli` 153 + 102 passed, clippy `--workspace --all-targets -D warnings` clean, `cargo fmt --check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- The rollback test asserts the *reopened* state rather than `ops.jsonl` byte-length: the log is append-only by design, so rolled-back ops legitimately remain in the file and are excluded via the history manifest's discarded set — that is the actual contract.
- Follow-ups deliberately out of scope (tracked): the 8 remaining unexecutable command types (each needs payload/replay design, not a registration line; `ApplyAudioDucking` is the cheapest), and a pre-existing `SetClipSpeed`/`SetClipSlowMotionInterpolation` replay no-op (registered but ignored by `apply_clip_update` — a different defect class the parity guard cannot catch).


___

### **PR Type**
Bug fix, Enhancement, Documentation, Tests


___

### **Description**
- Validates full edit plans before mutation.

- Fixes CLI rollback persistence via operation discarding.

- Registers missing clip commands for execution/replay.

- Standardizes MCP and CLI plan validation logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Validation
    V1["validate_edit_plan"] -- "Check Steps & Cycles" --> V2["MAX_PLAN_STEPS"]
  end
  subgraph Execution
    E1["apply_edit_plan"] -- "Failure" --> E2["Undo Memory"]
    E2 -- "Fix: Persist Rollback" --> E3["discard_persisted_operations"]
  end
  Validation -- "Success" --> Execution
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>QUALITY_ROADMAP_PLAN.md</strong><dd><code>Add edit quality roadmap design document</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-cb56ea39c5aefdd5e5cff91b843ec14466d21d28c3db6f969c7e8a5cb33c8fc4">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>help_json.rs</strong><dd><code>Update CLI schema with detailed plan metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>plan.rs</strong><dd><code>Implement pre-validation and durable rollback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-f785809d35119699191fc261c8b8eee110c5be15fcf0bb5cadb1da8c4bcd1792">+271/-21</a></td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Expose operation discarding for CLI/MCP rollbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>executor.rs</strong><dd><code>Register clip commands and add coverage guards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-ef781f77e71d37b770c063002c84fcc01b122dc1b694a44036f644fa4106d946">+226/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>state.rs</strong><dd><code>Support replaying scalar clip flags in history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-0fc2d8061589576bbb640630c10ba515b1532fafe1de0524754a126d0f551b0e">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactor</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mcp.rs</strong><dd><code>Delegate MCP validation to shared plan validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+176/-70</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>integration.rs</strong><dd><code>Add integration tests for plan execution/rollback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/791/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+291/-14</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive plan validation before execution, including required identifiers, dependency checks, payload validation, and a 1,000-step limit.
  * Added clearer execution results, exit codes, failure reports, and rollback status.
  * Added `--type` as an option for plan templates, while retaining `--template-type`.
  * Clip opacity, enabled, and reverse settings now persist and replay reliably.

* **Documentation**
  * Added a quality roadmap covering upcoming editing improvements and verification practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->