### PR TITLE
feat(core): add curated caption style packs and transition recipes

### DIFF
--- a/crates/openreelio-cli/src/commands/caption.rs
+++ b/crates/openreelio-cli/src/commands/caption.rs
@@ -3,9 +3,11 @@
 use crate::output;
 use crate::validate;
 use clap::Subcommand;
-use openreelio_core::captions::{map_source_segments_to_timeline, parse_srt, parse_vtt, Caption};
+use openreelio_core::captions::{
+    map_source_segments_to_timeline, parse_srt, parse_vtt, Caption, CaptionPosition,
+};
 use openreelio_core::commands::*;
-use openreelio_core::style::resolve_caption_layers;
+use openreelio_core::style::{resolve_caption_layers, resolve_caption_pack, resolve_caption_style};
 use openreelio_core::timeline::{Clip, Sequence, TrackKind};
 use openreelio_core::ActiveProject;
 use serde_json::{Map, Value};
@@ -44,7 +46,8 @@ pub enum CaptionAction {
         #[arg(long = "style-json")]
         style_json: Option<String>,
 
-        /// Optional position preset: top, center, bottom
+        /// Optional position preset: top, center, bottom. Names a vertical
+        /// anchor only; the margin comes from --style-pack when one is named.
         #[arg(long)]
         position: Option<String>,
 
@@ -84,7 +87,8 @@ pub enum CaptionAction {
         end: Option<f64>,
 
         /// Optional curated caption pack id (see `packs list --kind caption`).
-        /// The pack is the base layer; --style-json and --position override it.
+        /// Restyles only: the caption keeps its position unless --position or
+        /// --position-json is also given. --style-json overrides the pack.
         #[arg(long = "style-pack")]
         style_pack: Option<String>,
 
@@ -92,7 +96,8 @@ pub enum CaptionAction {
         #[arg(long = "style-json")]
         style_json: Option<String>,
 
-        /// Optional position preset: top, center, bottom
+        /// Optional position preset: top, center, bottom. Names a vertical
+        /// anchor only; the margin comes from --style-pack when one is named.
         #[arg(long)]
         position: Option<String>,
 
@@ -166,7 +171,8 @@ pub enum CaptionAction {
         #[arg(long = "style-json")]
         style_json: Option<String>,
 
-        /// Optional position preset: top, center, bottom
+        /// Optional position preset: top, center, bottom. Names a vertical
+        /// anchor only; the margin comes from --style-pack when one is named.
         #[arg(long)]
         position: Option<String>,
 
@@ -517,7 +523,33 @@ fn validate_caption_style_json(style: &Value) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_position_preset(position: Option<String>) -> anyhow::Result<Option<serde_json::Value>> {
+/// Margin the CLI falls back to when nothing else supplies one.
+const DEFAULT_PRESET_MARGIN_PERCENT: f64 = 5.0;
+
+/// Returns the margin `--position top|center|bottom` should carry.
+///
+/// The flag names a vertical anchor, not a margin, so the number underneath it
+/// is the CLI's choice rather than the caller's. When a pack is named, the
+/// pack's own checked margin is that choice: a synthesized default would
+/// otherwise displace the margin the pack exists to guarantee, dropping a
+/// caption lifted clear of platform UI back under it.
+fn preset_margin_percent(style_pack: Option<&str>) -> anyhow::Result<f64> {
+    let Some(pack_id) = style_pack else {
+        return Ok(DEFAULT_PRESET_MARGIN_PERCENT);
+    };
+
+    let pack = resolve_caption_pack(pack_id).map_err(|error| anyhow::anyhow!("{}", error))?;
+    Ok(match pack.position() {
+        CaptionPosition::Preset { margin_percent, .. } => margin_percent,
+        // A pack anchored by coordinates has no margin to lend.
+        CaptionPosition::Custom(_) => DEFAULT_PRESET_MARGIN_PERCENT,
+    })
+}
+
+fn parse_position_preset(
+    position: Option<String>,
+    margin_percent: f64,
+) -> anyhow::Result<Option<serde_json::Value>> {
     let Some(position) = position else {
         return Ok(None);
     };
@@ -537,7 +569,7 @@ fn parse_position_preset(position: Option<String>) -> anyhow::Result<Option<serd
     Ok(Some(serde_json::json!({
         "type": "preset",
         "vertical": vertical,
-        "marginPercent": 5,
+        "marginPercent": margin_percent,
     })))
 }
 
@@ -621,6 +653,7 @@ fn validate_custom_position_coordinate(
 fn parse_caption_position(
     position: Option<String>,
     position_json: Option<String>,
+    style_pack: Option<&str>,
 ) -> anyhow::Result<Option<serde_json::Value>> {
     if position.is_some() && position_json.is_some() {
         return Err(anyhow::anyhow!(
@@ -633,7 +666,7 @@ fn parse_caption_position(
         return Ok(parsed_json);
     }
 
-    parse_position_preset(position)
+    parse_position_preset(position, preset_margin_percent(style_pack)?)
 }
 
 /// Applies a curated caption pack underneath the caller's explicit style and
@@ -651,6 +684,18 @@ fn apply_caption_pack(
     let resolved = resolve_caption_layers(style_pack, style, position)
         .map_err(|error| anyhow::anyhow!("{}", error))?;
     Ok((resolved.style, resolved.position))
+}
+
+/// Applies a curated caption pack as style only.
+///
+/// `caption update` writes whatever position it is given, so a pack anchor
+/// riding along with a restyle would move a caption the caller only asked to
+/// restyle. `--position`/`--position-json` remain the way to move one.
+fn apply_caption_pack_style(
+    style_pack: Option<&str>,
+    style: Option<serde_json::Value>,
+) -> anyhow::Result<Option<serde_json::Value>> {
+    resolve_caption_style(style_pack, style).map_err(|error| anyhow::anyhow!("{}", error))
 }
 
 fn get_sequence<'a>(project: &'a ActiveProject, sequence_id: &str) -> anyhow::Result<&'a Sequence> {
@@ -1071,7 +1116,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             validate::time_range_ordered(start, end, "start", "end")?;
 
             let style = parse_style_json(style_json)?;
-            let position = parse_caption_position(position, position_json)?;
+            let position = parse_caption_position(position, position_json, style_pack.as_deref())?;
             let (style, position) = apply_caption_pack(style_pack.as_deref(), style, position)?;
 
             let mut project = super::load_project(&path)?;
@@ -1120,8 +1165,10 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             }
 
             let style = parse_style_json(style_json)?;
-            let position = parse_caption_position(position, position_json)?;
-            let (style, position) = apply_caption_pack(style_pack.as_deref(), style, position)?;
+            // A pack on an update restyles; only an explicit position moves the
+            // caption.
+            let position = parse_caption_position(position, position_json, style_pack.as_deref())?;
+            let style = apply_caption_pack_style(style_pack.as_deref(), style)?;
 
             if text.is_none()
                 && start.is_none()
@@ -1241,7 +1288,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             let language = normalize_caption_language_arg(language)?;
             let captions = load_caption_file(&subtitle_path, format)?;
             let style = parse_style_json(style_json)?;
-            let position = parse_caption_position(position, position_json)?;
+            let position = parse_caption_position(position, position_json, style_pack.as_deref())?;
             let (style, position) = apply_caption_pack(style_pack.as_deref(), style, position)?;
 
             if captions.is_empty() {

--- a/crates/openreelio-cli/src/commands/caption.rs
+++ b/crates/openreelio-cli/src/commands/caption.rs
@@ -5,6 +5,7 @@ use crate::validate;
 use clap::Subcommand;
 use openreelio_core::captions::{map_source_segments_to_timeline, parse_srt, parse_vtt, Caption};
 use openreelio_core::commands::*;
+use openreelio_core::style::resolve_caption_layers;
 use openreelio_core::timeline::{Clip, Sequence, TrackKind};
 use openreelio_core::ActiveProject;
 use serde_json::{Map, Value};
@@ -33,6 +34,11 @@ pub enum CaptionAction {
         /// End time in seconds
         #[arg(long)]
         end: f64,
+
+        /// Optional curated caption pack id (see `packs list --kind caption`).
+        /// The pack is the base layer; --style-json and --position override it.
+        #[arg(long = "style-pack")]
+        style_pack: Option<String>,
 
         /// Optional caption style JSON object
         #[arg(long = "style-json")]
@@ -76,6 +82,11 @@ pub enum CaptionAction {
         /// Optional new end time in seconds
         #[arg(long)]
         end: Option<f64>,
+
+        /// Optional curated caption pack id (see `packs list --kind caption`).
+        /// The pack is the base layer; --style-json and --position override it.
+        #[arg(long = "style-pack")]
+        style_pack: Option<String>,
 
         /// Optional caption style JSON object
         #[arg(long = "style-json")]
@@ -145,6 +156,11 @@ pub enum CaptionAction {
         /// Optional language code stored on the caption track and generated caption segments
         #[arg(long)]
         language: Option<String>,
+
+        /// Optional curated caption pack id (see `packs list --kind caption`).
+        /// The pack is the base layer; --style-json and --position override it.
+        #[arg(long = "style-pack")]
+        style_pack: Option<String>,
 
         /// Optional caption style JSON object applied to every imported caption
         #[arg(long = "style-json")]
@@ -620,6 +636,23 @@ fn parse_caption_position(
     parse_position_preset(position)
 }
 
+/// Applies a curated caption pack underneath the caller's explicit style and
+/// position.
+///
+/// This is the same core resolver `CommandPayload::parse` uses, so
+/// `--style-pack clean-minimal` and a `stylePack` in a `command execute`
+/// payload land on identical clip state. The pack is the base layer: whatever
+/// `--style-json` or `--position`/`--position-json` supplied wins key by key.
+fn apply_caption_pack(
+    style_pack: Option<&str>,
+    style: Option<serde_json::Value>,
+    position: Option<serde_json::Value>,
+) -> anyhow::Result<(Option<serde_json::Value>, Option<serde_json::Value>)> {
+    let resolved = resolve_caption_layers(style_pack, style, position)
+        .map_err(|error| anyhow::anyhow!("{}", error))?;
+    Ok((resolved.style, resolved.position))
+}
+
 fn get_sequence<'a>(project: &'a ActiveProject, sequence_id: &str) -> anyhow::Result<&'a Sequence> {
     project
         .state
@@ -1028,6 +1061,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             text,
             start,
             end,
+            style_pack,
             style_json,
             position,
             position_json,
@@ -1038,6 +1072,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
 
             let style = parse_style_json(style_json)?;
             let position = parse_caption_position(position, position_json)?;
+            let (style, position) = apply_caption_pack(style_pack.as_deref(), style, position)?;
 
             let mut project = super::load_project(&path)?;
             let seq_id = super::resolve_sequence_id(&project, sequence)?;
@@ -1069,6 +1104,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             text,
             start,
             end,
+            style_pack,
             style_json,
             position,
             position_json,
@@ -1085,6 +1121,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
 
             let style = parse_style_json(style_json)?;
             let position = parse_caption_position(position, position_json)?;
+            let (style, position) = apply_caption_pack(style_pack.as_deref(), style, position)?;
 
             if text.is_none()
                 && start.is_none()
@@ -1093,7 +1130,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
                 && position.is_none()
             {
                 return Err(anyhow::anyhow!(
-                    "No update requested. Provide one of --text, --start, --end, --style-json, --position, or --position-json."
+                    "No update requested. Provide one of --text, --start, --end, --style-pack, --style-json, --position, or --position-json."
                 ));
             }
 
@@ -1190,6 +1227,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             track,
             format,
             language,
+            style_pack,
             style_json,
             position,
             position_json,
@@ -1204,6 +1242,7 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             let captions = load_caption_file(&subtitle_path, format)?;
             let style = parse_style_json(style_json)?;
             let position = parse_caption_position(position, position_json)?;
+            let (style, position) = apply_caption_pack(style_pack.as_deref(), style, position)?;
 
             if captions.is_empty() {
                 return Err(anyhow::anyhow!(

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -309,7 +309,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "end": { "type": "number", "required": true, "desc": "End time in seconds" },
                     "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list; the pack is the base layer and --style-json/--position override it key by key" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object" },
-                    "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
+                    "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom. A vertical anchor only; the margin comes from --style-pack when one is named, else 5%" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },
@@ -350,7 +350,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "language": { "type": "string", "required": false, "desc": "Language code stored on the caption track and generated caption segments" },
                     "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list applied to every imported cue" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object applied to all cues" },
-                    "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
+                    "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom. A vertical anchor only; the margin comes from --style-pack when one is named, else 5%" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object applied to all cues" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },
@@ -409,9 +409,9 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "text": { "type": "string", "required": false, "desc": "New caption text" },
                     "start": { "type": "number", "required": false, "desc": "New caption start time in seconds" },
                     "end": { "type": "number", "required": false, "desc": "New caption end time in seconds" },
-                    "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list; restyles an existing caption in one flag" },
+                    "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list; restyles an existing caption in one flag and leaves its position alone (pass --position to move it)" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object" },
-                    "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
+                    "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom. A vertical anchor only; the margin comes from --style-pack when one is named, else 5%" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -307,12 +307,20 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "text": { "type": "string", "required": true, "desc": "Caption text" },
                     "start": { "type": "number", "required": true, "desc": "Start time in seconds" },
                     "end": { "type": "number", "required": true, "desc": "End time in seconds" },
+                    "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list; the pack is the base layer and --style-json/--position override it key by key" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object" },
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" }
                 },
                 "example": "openreelio-cli caption add --path ./project --text \"Hello\" --start 0.0 --end 3.0"
+            },
+            "packs.list": {
+                "description": "List curated caption style packs and transition recipes. Packs are the quality floor: name one instead of assembling typography or a transition duration by hand. Every listed id is accepted by caption --style-pack, by stylePack on CreateCaption/UpdateCaption/ImportGeneratedCaptions, and by recipe on AddEffect",
+                "params": {
+                    "kind": { "type": "string", "required": false, "desc": "Registry to list: caption, transition, or all (default: all)" }
+                },
+                "example": "openreelio-cli packs list --kind caption"
             },
             "caption.list": {
                 "description": "List all captions in the sequence",
@@ -340,6 +348,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "track": { "type": "string", "required": false, "desc": "Caption track ID (auto-created when omitted)" },
                     "format": { "type": "string", "required": false, "desc": "Subtitle format: srt, vtt, or transcript-json (auto-detected when omitted)" },
                     "language": { "type": "string", "required": false, "desc": "Language code stored on the caption track and generated caption segments" },
+                    "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list applied to every imported cue" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object applied to all cues" },
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object applied to all cues" },
@@ -400,6 +409,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "text": { "type": "string", "required": false, "desc": "New caption text" },
                     "start": { "type": "number", "required": false, "desc": "New caption start time in seconds" },
                     "end": { "type": "number", "required": false, "desc": "New caption end time in seconds" },
+                    "style-pack": { "type": "string", "required": false, "desc": "Curated caption pack id from packs.list; restyles an existing caption in one flag" },
                     "style-json": { "type": "string", "required": false, "desc": "Caption style override JSON object" },
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object" },
@@ -547,7 +557,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli plan template --type split-and-move"
             },
             "command.execute": {
-                "description": "Execute any supported backend edit command using the shared CommandPayload parser",
+                "description": "Execute any supported backend edit command using the shared CommandPayload parser. Curated packs are resolved by that parser, so CreateCaption/UpdateCaption/ImportGeneratedCaptions accept stylePack and AddEffect accepts recipe; see packs.list for the ids",
                 "params": {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "type": { "type": "string", "required": true, "desc": "Backend command type, e.g. SplitClip or AddMask" },
@@ -563,7 +573,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "payload": { "type": "string", "required": false, "desc": "Inline JSON object payload" },
                     "payload-file": { "type": "string", "required": false, "desc": "Path to a JSON object payload file" }
                 },
-                "example": "openreelio-cli command validate --type RenameTrack --payload '{\"sequenceId\":\"seq_1\",\"trackId\":\"track_v1\",\"name\":\"Main Video\"}'"
+                "example": "openreelio-cli command validate --type AddEffect --payload '{\"sequenceId\":\"seq_1\",\"trackId\":\"track_v1\",\"clipId\":\"clip_1\",\"recipe\":\"dissolve-soft\"}'"
             },
             "command.schema": {
                 "description": "Print the backend command surface available to headless agents",
@@ -772,6 +782,38 @@ mod tests {
         assert!(commands.contains_key("analysis.search-library"));
         assert!(commands.contains_key("analysis.build-selects"));
         assert!(commands.contains_key("render.graph"));
+    }
+
+    #[test]
+    fn build_schema_documents_the_curated_pack_surface() {
+        let schema = build_schema();
+        let commands = schema["commands"]
+            .as_object()
+            .expect("schema commands must be an object");
+
+        assert!(commands.contains_key("packs.list"));
+        assert!(commands["packs.list"]["params"]["kind"].is_object());
+
+        for verb in ["caption.add", "caption.update", "caption.import"] {
+            assert!(
+                commands[verb]["params"]["style-pack"].is_object(),
+                "{verb} --style-pack must be documented"
+            );
+        }
+
+        // `command execute` inherits the payload fields, so its description has
+        // to say so or an agent will only ever find them through the CLI flags.
+        let execute_description = commands["command.execute"]["description"]
+            .as_str()
+            .expect("description");
+        assert!(
+            execute_description.contains("stylePack"),
+            "{execute_description}"
+        );
+        assert!(
+            execute_description.contains("recipe"),
+            "{execute_description}"
+        );
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -41,6 +41,7 @@ use crate::{
 use clap::Args;
 use openreelio_core::commands::{get_text_data, is_text_clip, InsertMediaCommand};
 use openreelio_core::ipc::CommandPayload;
+use openreelio_core::style::{caption_pack_ids, transition_recipe_ids};
 use openreelio_core::timeline::TrackKind;
 use serde_json::Value;
 use std::io::{BufRead, Write};
@@ -1374,6 +1375,12 @@ fn load_annotation_for_asset(
 }
 
 fn build_command_schema() -> Value {
+    // Read the curated ids from the core registries rather than restating them:
+    // a pack added to core shows up in the hints, and a hint can never name an
+    // id the validator would reject.
+    let caption_style_pack_ids = caption_pack_ids();
+    let transition_recipe_ids = transition_recipe_ids();
+
     serde_json::json!({
         "commands": CommandPayload::SUPPORTED_COMMAND_TYPES,
         "count": CommandPayload::SUPPORTED_COMMAND_TYPES.len(),
@@ -1395,11 +1402,27 @@ fn build_command_schema() -> Value {
             },
             "ImportGeneratedCaptions": {
                 "required": ["sequenceId", "trackId", "segments"],
-                "optional": ["style", "position", "replaceExisting"],
+                "optional": ["stylePack", "style", "position", "replaceExisting"],
                 "segmentShape": { "startSec": "number", "endSec": "number", "text": "string" },
                 "styleShape": "Caption style may include fontFamily, fontSize, fontWeight, bold, italic, underline, color, opacity, backgroundColor, backgroundPadding, outlineColor, outlineWidth, shadowColor, shadowOffsetX, shadowOffsetY, shadowBlur, alignment, lineHeight, and letterSpacing.",
                 "positionShape": "Caption position supports preset top/center/bottom or custom xPercent/yPercent.",
-                "note": "Use this for AI/STT transcript segments so generated captions are imported atomically and remain undoable as one command."
+                "stylePackHints": caption_style_pack_ids,
+                "stylePackShape": "stylePack names a curated caption pack that is applied as the base layer; style and position override it key by key. Every pack is checked to stay inside the title-safe area on both 1920x1080 and 1080x1920.",
+                "note": "Use this for AI/STT transcript segments so generated captions are imported atomically and remain undoable as one command. Prefer stylePack over hand-assembled style values unless the brief needs something no pack expresses."
+            },
+            "CreateCaption": {
+                "required": ["sequenceId", "trackId", "text", "startSec", "endSec"],
+                "optional": ["stylePack", "style", "position"],
+                "stylePackHints": caption_style_pack_ids,
+                "stylePackShape": "stylePack names a curated caption pack that is applied as the base layer; style and position override it key by key.",
+                "note": "Use this for individual caption lines. UpdateCaption accepts the same stylePack field, so restyling an existing caption is one call."
+            },
+            "AddEffect": {
+                "required": ["sequenceId", "trackId", "clipId"],
+                "optional": ["effectType", "recipe", "params", "keyframes", "position"],
+                "recipeHints": transition_recipe_ids,
+                "recipeShape": "recipe names a curated transition recipe and supplies both effectType and its baseline params (duration, offset, direction, fade_in, zoom_factor); anything in params overrides the recipe key by key. Naming a recipe and a contradictory effectType is rejected.",
+                "note": "Transitions are effects: there is no AddTransition command. Either effectType or recipe must be present. fade-out does not set start_time because only the caller knows the clip duration; pass params.start_time = (clip duration - fade duration) for a tail fade."
             },
             "transcriptionGenerate": {
                 "tool": "openreelio.transcription.generate",
@@ -1451,6 +1474,7 @@ fn build_command_schema() -> Value {
                 "Prefer openreelio.transcription.generate(sequenceAudio=true, sequenceId, language=\"auto\", model=\"auto\") as the default captioning path: its segment times are TIMELINE-relative and reflect cuts, trims, overlaps, and volume, so they pass straight to ImportGeneratedCaptions.",
                 "Use openreelio.transcription.generate(assetId, language=\"auto\", model=\"auto\") for source-asset analysis only: its times are SOURCE-relative (0-based to the asset) and must be mapped to the placed clip before ImportGeneratedCaptions, not used as direct timeline caption times.",
                 "Use ImportGeneratedCaptions for AI transcript segments or CreateCaption/UpdateCaption for individual caption lines.",
+                "Pass stylePack (a curated caption pack id) rather than assembling caption typography field by field; the packs are the checked quality floor and stay inside the title-safe area on landscape and vertical canvases alike.",
                 "Use caption style/position metadata for subtitle readability instead of editable overlay text when the user wants semantic subtitles."
             ],
             "placementDefaults": {
@@ -2302,6 +2326,56 @@ mod tests {
             schema["textWorkflows"]["placementDefaults"]["subtitle"],
             "Bottom center around y=0.85 with outline/shadow unless it covers important visual content."
         );
+    }
+
+    #[test]
+    fn should_advertise_curated_pack_ids_from_the_core_registries() {
+        let schema = build_command_schema();
+
+        // The hint lists must be the registries themselves, not a restatement:
+        // an id an agent reads here has to be an id the parser accepts.
+        for hint_path in ["CreateCaption", "ImportGeneratedCaptions"] {
+            let hints = schema["payloadHints"][hint_path]["stylePackHints"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{hint_path} must advertise stylePackHints"));
+            let advertised: Vec<&str> = hints.iter().filter_map(Value::as_str).collect();
+            assert_eq!(advertised, caption_pack_ids());
+        }
+
+        let recipes = schema["payloadHints"]["AddEffect"]["recipeHints"]
+            .as_array()
+            .expect("AddEffect must advertise recipeHints");
+        let advertised: Vec<&str> = recipes.iter().filter_map(Value::as_str).collect();
+        assert_eq!(advertised, transition_recipe_ids());
+
+        // Every advertised id must round-trip through the strict parser.
+        for pack_id in caption_pack_ids() {
+            CommandPayload::parse(
+                "CreateCaption".to_string(),
+                serde_json::json!({
+                    "sequenceId": "seq",
+                    "trackId": "track",
+                    "text": "hint check",
+                    "startSec": 0.0,
+                    "endSec": 1.0,
+                    "stylePack": pack_id,
+                }),
+            )
+            .unwrap_or_else(|error| panic!("advertised pack '{pack_id}' must parse: {error}"));
+        }
+
+        for recipe_id in transition_recipe_ids() {
+            CommandPayload::parse(
+                "AddEffect".to_string(),
+                serde_json::json!({
+                    "sequenceId": "seq",
+                    "trackId": "track",
+                    "clipId": "clip",
+                    "recipe": recipe_id,
+                }),
+            )
+            .unwrap_or_else(|error| panic!("advertised recipe '{recipe_id}' must parse: {error}"));
+        }
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -1415,14 +1415,14 @@ fn build_command_schema() -> Value {
                 "optional": ["stylePack", "style", "position"],
                 "stylePackHints": caption_style_pack_ids,
                 "stylePackShape": "stylePack names a curated caption pack that is applied as the base layer; style and position override it key by key.",
-                "note": "Use this for individual caption lines. UpdateCaption accepts the same stylePack field, so restyling an existing caption is one call."
+                "note": "Use this for individual caption lines. UpdateCaption accepts the same stylePack field, where it restyles WITHOUT moving the caption: an update keeps the existing anchor unless it also carries an explicit position."
             },
             "AddEffect": {
                 "required": ["sequenceId", "trackId", "clipId"],
                 "optional": ["effectType", "recipe", "params", "keyframes", "position"],
                 "recipeHints": transition_recipe_ids,
-                "recipeShape": "recipe names a curated transition recipe and supplies both effectType and its baseline params (duration, offset, direction, fade_in, zoom_factor); anything in params overrides the recipe key by key. Naming a recipe and a contradictory effectType is rejected.",
-                "note": "Transitions are effects: there is no AddTransition command. Either effectType or recipe must be present. fade-out does not set start_time because only the caller knows the clip duration; pass params.start_time = (clip duration - fade duration) for a tail fade."
+                "recipeShape": "recipe names a curated transition recipe and supplies both effectType and its baseline params (duration, offset, direction, fade_in); anything in params overrides the recipe key by key. Naming a recipe and a contradictory effectType is rejected.",
+                "note": "Transitions are effects: there is no AddTransition command. Either effectType or recipe must be present. fade-out is anchored on the clip's tail when the command is executed, so pass params.start_time only to place the fade somewhere else."
             },
             "transcriptionGenerate": {
                 "tool": "openreelio.transcription.generate",

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod ffmpeg;
 mod frame;
 mod help_json;
 mod mcp;
+mod packs;
 mod perception;
 mod plan;
 mod project;
@@ -74,6 +75,12 @@ pub enum Commands {
     Caption {
         #[command(subcommand)]
         action: caption::CaptionAction,
+    },
+
+    /// Curated caption style packs and transition recipes
+    Packs {
+        #[command(subcommand)]
+        action: packs::PacksAction,
     },
 
     /// Speech-to-text transcription and auto-caption generation
@@ -142,6 +149,7 @@ pub fn execute(cli: Cli) -> anyhow::Result<()> {
         Commands::Analysis { action } => analysis::execute(action),
         Commands::Timeline { action } => timeline::execute(action),
         Commands::Caption { action } => caption::execute(action),
+        Commands::Packs { action } => packs::execute(action),
         Commands::Transcription { action } => transcription::execute(action),
         Commands::Text { action } => text::execute(action),
         Commands::Render { action } => render::execute(action),

--- a/crates/openreelio-cli/src/commands/packs.rs
+++ b/crates/openreelio-cli/src/commands/packs.rs
@@ -1,0 +1,76 @@
+//! Curated style pack listing.
+//!
+//! Packs are the quality floor for captions and transitions: a named,
+//! hand-checked style beats a guessed one, and the id is the whole payload. This
+//! verb is the discovery half of that — the same `const` tables that validate a
+//! `--style-pack` or a `recipe` are what it prints, so a listed id is by
+//! construction an accepted id.
+
+use clap::{Subcommand, ValueEnum};
+use openreelio_core::style::{list_caption_packs, list_transition_recipes};
+use serde_json::Value;
+
+use crate::output;
+
+/// Which registry `packs list` should print.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum PackKind {
+    /// Caption style packs only.
+    Caption,
+    /// Transition recipes only.
+    Transition,
+    /// Both registries.
+    #[default]
+    All,
+}
+
+impl PackKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Caption => "caption",
+            Self::Transition => "transition",
+            Self::All => "all",
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum PacksAction {
+    /// List curated caption style packs and transition recipes
+    List {
+        /// Which registry to list: caption, transition, or all
+        #[arg(long, value_enum, default_value_t = PackKind::All)]
+        kind: PackKind,
+    },
+}
+
+pub fn execute(action: PacksAction) -> anyhow::Result<()> {
+    match action {
+        PacksAction::List { kind } => {
+            let mut packs: Vec<Value> = Vec::new();
+
+            if matches!(kind, PackKind::Caption | PackKind::All) {
+                for descriptor in list_caption_packs() {
+                    packs.push(serde_json::to_value(descriptor).map_err(|error| {
+                        anyhow::anyhow!("Failed to serialize caption pack: {}", error)
+                    })?);
+                }
+            }
+
+            if matches!(kind, PackKind::Transition | PackKind::All) {
+                for descriptor in list_transition_recipes() {
+                    packs.push(serde_json::to_value(descriptor).map_err(|error| {
+                        anyhow::anyhow!("Failed to serialize transition recipe: {}", error)
+                    })?);
+                }
+            }
+
+            output::print_json_pretty(&serde_json::json!({
+                "status": "ok",
+                "kind": kind.as_str(),
+                "count": packs.len(),
+                "packs": packs,
+            }))
+        }
+    }
+}

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -5956,3 +5956,97 @@ fn test_command_execute_accepts_style_pack_and_recipe() {
     let combined = format!("{stdout}{stderr}");
     assert!(combined.contains("dissolve-standard"), "{combined}");
 }
+
+#[test]
+fn test_caption_style_pack_never_overrides_an_explicit_placement() {
+    let dir = create_temp_project("caption_pack_placement_test");
+    let path = project_path(&dir, "caption_pack_placement_test");
+
+    // A --position-json without a `type` is a custom anchor (the validator
+    // itself reads it that way), so the pack styles the caption while the
+    // caller places it.
+    let placed = run_cli_ok(&[
+        "caption",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "Custom placed",
+        "--start",
+        "0",
+        "--end",
+        "2",
+        "--style-pack",
+        "clean-minimal",
+        "--position-json",
+        r##"{"xPercent":25,"yPercent":80}"##,
+    ]);
+    let placed_id = placed["createdIds"][0].as_str().unwrap().to_string();
+
+    // --position names a vertical anchor only, so a pack lifted clear of
+    // platform UI keeps its own margin instead of dropping to a synthesized
+    // default.
+    let anchored = run_cli_ok(&[
+        "caption",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "Anchored",
+        "--start",
+        "3",
+        "--end",
+        "5",
+        "--style-pack",
+        "shorts-bold-outline",
+        "--position",
+        "bottom",
+    ]);
+    let anchored_id = anchored["createdIds"][0].as_str().unwrap().to_string();
+
+    let find = |list: &serde_json::Value, id: &str| -> serde_json::Value {
+        list["captions"]
+            .as_array()
+            .expect("captions")
+            .iter()
+            .find(|caption| caption["id"] == id)
+            .expect("caption present")
+            .clone()
+    };
+
+    let list = run_cli_ok(&["caption", "list", "--path", &path]);
+
+    let placed_caption = find(&list, &placed_id);
+    assert_eq!(placed_caption["position"]["xPercent"], 25.0);
+    assert_eq!(placed_caption["position"]["yPercent"], 80.0);
+    assert!(
+        placed_caption["position"].get("marginPercent").is_none(),
+        "a custom anchor must not carry the pack's preset keys: {}",
+        placed_caption["position"]
+    );
+    assert_eq!(placed_caption["style"]["fontSize"], 48);
+
+    let anchored_caption = find(&list, &anchored_id);
+    assert_eq!(anchored_caption["position"]["vertical"], "bottom");
+    assert_eq!(anchored_caption["position"]["marginPercent"], 18.0);
+
+    // Restyling is not a move.
+    run_cli_ok(&[
+        "caption",
+        "update",
+        "--path",
+        &path,
+        "--id",
+        &placed_id,
+        "--style-pack",
+        "boxed-contrast",
+    ]);
+
+    let restyled = find(
+        &run_cli_ok(&["caption", "list", "--path", &path]),
+        &placed_id,
+    );
+    assert_eq!(restyled["position"]["xPercent"], 25.0);
+    assert_eq!(restyled["position"]["yPercent"], 80.0);
+    assert_eq!(restyled["style"]["backgroundColor"]["a"], 180);
+}

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -5718,3 +5718,241 @@ fn test_agent_perception_loop_end_to_end() {
     assert_eq!(gap["status"], "passed");
     assert_eq!(gap["violationCount"], 0);
 }
+
+// ============================================================================
+// Curated style packs
+// ============================================================================
+
+#[test]
+fn test_packs_list_returns_both_registries() {
+    let all = run_cli_ok(&["packs", "list"]);
+    assert_eq!(all["status"], "ok");
+    assert_eq!(all["kind"], "all");
+
+    let packs = all["packs"].as_array().expect("packs array");
+    assert_eq!(all["count"].as_u64().unwrap() as usize, packs.len());
+
+    let caption_ids: Vec<&str> = packs
+        .iter()
+        .filter(|pack| pack["kind"] == "caption")
+        .filter_map(|pack| pack["id"].as_str())
+        .collect();
+    let transition_ids: Vec<&str> = packs
+        .iter()
+        .filter(|pack| pack["kind"] == "transition")
+        .filter_map(|pack| pack["id"].as_str())
+        .collect();
+
+    assert!(caption_ids.contains(&"clean-minimal"), "{caption_ids:?}");
+    assert!(caption_ids.contains(&"boxed-contrast"), "{caption_ids:?}");
+    assert!(
+        transition_ids.contains(&"dissolve-standard"),
+        "{transition_ids:?}"
+    );
+    assert!(transition_ids.contains(&"wipe-left"), "{transition_ids:?}");
+
+    // Every entry carries the fields an agent needs to choose without guessing.
+    for pack in packs {
+        assert!(pack["id"].as_str().is_some_and(|id| !id.is_empty()));
+        assert!(pack["description"]
+            .as_str()
+            .is_some_and(|desc| !desc.is_empty()));
+        match pack["kind"].as_str() {
+            Some("caption") => {
+                assert!(pack["style"].is_object(), "{pack}");
+                assert!(pack["position"].is_object(), "{pack}");
+            }
+            Some("transition") => {
+                assert!(pack["effectType"].is_string(), "{pack}");
+                assert!(pack["params"].is_object(), "{pack}");
+            }
+            other => panic!("unexpected pack kind {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_packs_list_filters_by_kind() {
+    let captions = run_cli_ok(&["packs", "list", "--kind", "caption"]);
+    assert_eq!(captions["kind"], "caption");
+    assert!(captions["packs"]
+        .as_array()
+        .expect("packs")
+        .iter()
+        .all(|pack| pack["kind"] == "caption"));
+
+    let transitions = run_cli_ok(&["packs", "list", "--kind", "transition"]);
+    assert_eq!(transitions["kind"], "transition");
+    assert!(transitions["packs"]
+        .as_array()
+        .expect("packs")
+        .iter()
+        .all(|pack| pack["kind"] == "transition"));
+
+    let (_stdout, stderr) = run_cli_err(&["packs", "list", "--kind", "nonsense"]);
+    assert!(
+        stderr.contains("caption") && stderr.contains("transition"),
+        "clap must list the valid kinds, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_caption_style_pack_applies_and_is_overridable() {
+    let dir = create_temp_project("caption_style_pack_test");
+    let path = project_path(&dir, "caption_style_pack_test");
+
+    run_cli_ok(&[
+        "caption",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "Packed caption",
+        "--start",
+        "0",
+        "--end",
+        "2",
+        "--style-pack",
+        "boxed-contrast",
+    ]);
+
+    let list = run_cli_ok(&["caption", "list", "--path", &path]);
+    let caption = &list["captions"][0];
+    let caption_id = caption["id"].as_str().unwrap().to_string();
+    assert_eq!(caption["style"]["fontFamily"], "Arial");
+    assert_eq!(caption["style"]["fontSize"], 48);
+    assert_eq!(caption["style"]["backgroundColor"]["a"], 180);
+    assert_eq!(caption["position"]["type"], "preset");
+    assert_eq!(caption["position"]["vertical"], "bottom");
+    assert_eq!(caption["position"]["marginPercent"], 10.0);
+
+    // A pack is a base layer, not a lock: the explicit size wins and everything
+    // else stays packed.
+    run_cli_ok(&[
+        "caption",
+        "update",
+        "--path",
+        &path,
+        "--id",
+        &caption_id,
+        "--style-pack",
+        "boxed-contrast",
+        "--style-json",
+        r##"{"fontSize":96}"##,
+    ]);
+
+    let restyled = run_cli_ok(&["caption", "list", "--path", &path]);
+    assert_eq!(restyled["captions"][0]["style"]["fontSize"], 96);
+    assert_eq!(
+        restyled["captions"][0]["style"]["backgroundColor"]["a"],
+        180
+    );
+}
+
+#[test]
+fn test_caption_style_pack_rejects_unknown_id_with_the_valid_list() {
+    let dir = create_temp_project("caption_style_pack_error_test");
+    let path = project_path(&dir, "caption_style_pack_error_test");
+
+    let (_stdout, stderr) = run_cli_err(&[
+        "caption",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "Bad pack",
+        "--start",
+        "0",
+        "--end",
+        "2",
+        "--style-pack",
+        "not-a-pack",
+    ]);
+
+    assert!(stderr.contains("not-a-pack"), "{stderr}");
+    assert!(stderr.contains("clean-minimal"), "{stderr}");
+    assert!(stderr.contains("boxed-contrast"), "{stderr}");
+}
+
+#[test]
+fn test_command_execute_accepts_style_pack_and_recipe() {
+    let dir = create_temp_project("pack_command_execute_test");
+    let path = project_path(&dir, "pack_command_execute_test");
+
+    let info = run_cli_ok(&["timeline", "info", "--path", &path]);
+    let sequence_id = info["sequenceId"].as_str().unwrap().to_string();
+
+    let track = run_cli_ok(&[
+        "timeline",
+        "add-track",
+        "--path",
+        &path,
+        "--kind",
+        "caption",
+        "--name",
+        "Captions",
+    ]);
+    let caption_track_id = track["createdIds"][0].as_str().unwrap().to_string();
+
+    let payload = serde_json::json!({
+        "sequenceId": sequence_id,
+        "trackId": caption_track_id,
+        "text": "From command execute",
+        "startSec": 0.0,
+        "endSec": 2.0,
+        "stylePack": "yellow-classic",
+    })
+    .to_string();
+
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "CreateCaption",
+        "--payload",
+        &payload,
+    ]);
+
+    let list = run_cli_ok(&["caption", "list", "--path", &path]);
+    assert_eq!(list["captions"][0]["style"]["color"]["r"], 255);
+    assert_eq!(list["captions"][0]["style"]["color"]["b"], 0);
+
+    // The recipe half of the same chokepoint: validate without a project write.
+    let effect_payload = serde_json::json!({
+        "sequenceId": sequence_id,
+        "trackId": caption_track_id,
+        "clipId": "clip_placeholder",
+        "recipe": "dissolve-soft",
+    })
+    .to_string();
+    let validated = run_cli_ok(&[
+        "command",
+        "validate",
+        "--type",
+        "AddEffect",
+        "--payload",
+        &effect_payload,
+    ]);
+    assert_eq!(validated["status"], "ok");
+    assert_eq!(validated["commandType"], "AddEffect");
+
+    let bad_payload = serde_json::json!({
+        "sequenceId": sequence_id,
+        "trackId": caption_track_id,
+        "clipId": "clip_placeholder",
+        "recipe": "not-a-recipe",
+    })
+    .to_string();
+    let (stdout, stderr, _success) = run_cli(&[
+        "command",
+        "validate",
+        "--type",
+        "AddEffect",
+        "--payload",
+        &bad_payload,
+    ]);
+    let combined = format!("{stdout}{stderr}");
+    assert!(combined.contains("dissolve-standard"), "{combined}");
+}

--- a/distribution/skills/skills/openreelio/SKILL.md
+++ b/distribution/skills/skills/openreelio/SKILL.md
@@ -32,8 +32,9 @@ in them.
 Treat the binary as the source of truth, not this skill.
 `openreelio-cli help-json` prints the entire command schema as JSON, and
 `openreelio-cli <verb> --help` is authoritative for any single verb. `help-json`
-is roughly 58 KB — fetch per-verb help instead of loading all of it. Use
-`openreelio-cli command schema` for the 79 backend command types.
+is roughly 68 KB — fetch per-verb help instead of loading all of it. Use
+`openreelio-cli command schema` for the 79 backend command types, and
+`openreelio-cli packs list` for the curated caption styles and transitions.
 
 Its *examples* are not copy-paste ready: IDs are readable placeholders
 (`asset_001`) rather than the ULIDs the CLI actually returns, and some spell a
@@ -61,13 +62,15 @@ you can look at. Load [Perception](./perception/REFERENCE.md).
 
 ## Editing
 
-Place, trim, split, move, and speed-change clips; reach every backend command;
-run atomic batches. Load [Editing](./editing/REFERENCE.md).
+Place, trim, split, move, and speed-change clips; add transitions from curated
+recipes; reach every backend command; run atomic batches. Load
+[Editing](./editing/REFERENCE.md).
 
 ## Captions and text
 
-Add subtitles and styled text overlays, import/export SRT and VTT, and generate
-transcripts locally. Load [Captions](./captions/REFERENCE.md).
+Add subtitles and styled text overlays with curated style packs, import/export
+SRT and VTT, and generate transcripts locally. Load
+[Captions](./captions/REFERENCE.md).
 
 ## Render
 

--- a/distribution/skills/skills/openreelio/captions/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/captions/REFERENCE.md
@@ -8,9 +8,11 @@ op log, so both are undoable.
 
 ```bash
 openreelio-cli caption add    --path ./demo --text "Hello" --start 0.5 --end 3.0 \
-                              [--track <TRACK_ID>] [--position <POS>] [--style-json '{…}']
+                              [--track <TRACK_ID>] [--style-pack <PACK_ID>] \
+                              [--position <POS>] [--style-json '{…}']
 openreelio-cli caption update --path ./demo --id <CAPTION_ID> [--text "Updated"] \
-                              [--start 1.0] [--end 4.0] [--style-json '{…}']
+                              [--start 1.0] [--end 4.0] [--style-pack <PACK_ID>] \
+                              [--style-json '{…}']
 openreelio-cli caption list   --path ./demo
 openreelio-cli caption remove --path ./demo --id <CAPTION_ID>
 ```
@@ -29,6 +31,47 @@ openreelio-cli caption export --path ./demo --format srt --output subs.srt
 
 `--format` is auto-detected from the file extension on import when omitted.
 Export supports `srt` and `vtt`.
+
+## Caption style packs
+
+Packs are the quality floor — reach for free-form styling only when a pack
+cannot express the brief. A pack is a named, checked pairing of typography and
+anchor: every one is verified to stay inside the title-safe area on both a
+1920x1080 and a 1080x1920 canvas, which is exactly the check `verify` runs as
+`caption.safe_area`. Hand-assembled styling gets no such guarantee.
+
+```bash
+openreelio-cli packs list --kind caption
+```
+
+| Pack | Use it for |
+|------|-----------|
+| `standard-outline` | The default. White text, thin black outline, soft shadow. |
+| `clean-minimal` | No outline or shadow — controlled, consistently dark footage only. |
+| `boxed-contrast` | Translucent black box; survives busy or bright backgrounds. |
+| `yellow-classic` | Legacy broadcast yellow; reads as dialogue subtitling. |
+| `shorts-bold-outline` | Large bold with thick outline, lifted clear of vertical-platform UI. |
+| `broadcast-lower` | Left-aligned boxed name plate at lower-third height. |
+| `high-contrast-accessible` | Oversized bold on a near-opaque box; highest legibility floor. |
+| `caption-top` | Top-anchored, for shots whose lower half is already busy. |
+
+Ids tolerate `_` and spaces and case (`clean_minimal`, `Clean Minimal`), and each
+pack carries short aliases (`minimal`, `boxed`, `shorts`, `accessible`) that
+`packs list` prints.
+
+A pack is a **base layer, not a lock**. Anything you also pass overrides it key
+by key, so this is the boxed pack at 96pt with everything else intact:
+
+```bash
+openreelio-cli caption add --path ./demo --text "Hello" --start 0 --end 3 \
+  --style-pack boxed-contrast --style-json '{"fontSize":96}'
+```
+
+`--style-pack` on `caption update` restyles an existing caption in one flag.
+`caption import` applies a pack to every cue it writes. The same field is
+available on the backend commands as `stylePack`, so
+`command execute --type CreateCaption|UpdateCaption|ImportGeneratedCaptions`
+takes it too. An unknown id is rejected with the full list of valid ids.
 
 ## Text overlays
 

--- a/distribution/skills/skills/openreelio/captions/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/captions/REFERENCE.md
@@ -36,9 +36,10 @@ Export supports `srt` and `vtt`.
 
 Packs are the quality floor — reach for free-form styling only when a pack
 cannot express the brief. A pack is a named, checked pairing of typography and
-anchor: every one is verified to stay inside the title-safe area on both a
-1920x1080 and a 1080x1920 canvas, which is exactly the check `verify` runs as
-`caption.safe_area`. Hand-assembled styling gets no such guarantee.
+anchor: every one is verified to draw zero `caption.safe_area` violations on both
+a 1920x1080 and a 1080x1920 canvas — exactly the check `verify` runs, and it
+measures the text block against each canvas rather than only comparing margins.
+Hand-assembled styling gets no such guarantee.
 
 ```bash
 openreelio-cli packs list --kind caption
@@ -51,7 +52,7 @@ openreelio-cli packs list --kind caption
 | `boxed-contrast` | Translucent black box; survives busy or bright backgrounds. |
 | `yellow-classic` | Legacy broadcast yellow; reads as dialogue subtitling. |
 | `shorts-bold-outline` | Large bold with thick outline, lifted clear of vertical-platform UI. |
-| `broadcast-lower` | Left-aligned boxed name plate at lower-third height. |
+| `broadcast-lower` | Left-aligned boxed name plate anchored in the lower-left third. |
 | `high-contrast-accessible` | Oversized bold on a near-opaque box; highest legibility floor. |
 | `caption-top` | Top-anchored, for shots whose lower half is already busy. |
 
@@ -67,9 +68,14 @@ openreelio-cli caption add --path ./demo --text "Hello" --start 0 --end 3 \
   --style-pack boxed-contrast --style-json '{"fontSize":96}'
 ```
 
-`--style-pack` on `caption update` restyles an existing caption in one flag.
-`caption import` applies a pack to every cue it writes. The same field is
-available on the backend commands as `stylePack`, so
+`--position top|center|bottom` names a vertical anchor only, so combining it
+with a pack keeps the pack's checked margin instead of replacing it.
+
+`--style-pack` on `caption update` restyles an existing caption in one flag and
+leaves it where it is — an update replaces whatever position it carries, so the
+pack's own anchor deliberately stays out of it. Pass `--position` when the
+caption should move as well. `caption import` applies a pack to every cue it
+writes. The same field is available on the backend commands as `stylePack`, so
 `command execute --type CreateCaption|UpdateCaption|ImportGeneratedCaptions`
 takes it too. An unknown id is rejected with the full list of valid ids.
 

--- a/distribution/skills/skills/openreelio/editing/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/editing/REFERENCE.md
@@ -64,15 +64,16 @@ openreelio-cli command execute --path ./demo --type AddEffect \
 
 The recipes are `dissolve-soft` / `dissolve-standard` / `dissolve-long`,
 `fade-in` / `fade-out`, `wipe-left` / `wipe-right` / `wipe-up` / `wipe-down`,
-`slide-left` / `slide-right`, and `zoom-punch`. Each supplies the effect type
-plus the duration and direction that go with it, so the choice is one token
-rather than four guesses.
+and `slide-left` / `slide-right`. Each supplies the effect type plus the
+duration and direction that go with it, so the choice is one token rather than
+four guesses.
 
 Like caption packs, a recipe is a base layer: `params` overrides it key by key
 (`{"recipe":"dissolve-soft","params":{"duration":1.5}}`). Naming a recipe *and*
-a contradictory `effectType` is rejected rather than silently resolved. One
-recipe deliberately leaves a gap: `fade-out` cannot know the clip length, so
-pass `params.start_time = clipDuration - 1.0` for a fade that lands on the tail.
+a contradictory `effectType` is rejected rather than silently resolved.
+`fade-out` is anchored on the clip's tail when the command executes — it reads
+the target clip's duration — so pass `params.start_time` only to put the fade
+somewhere else in the clip.
 
 ## Atomic batches: `plan execute`
 

--- a/distribution/skills/skills/openreelio/editing/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/editing/REFERENCE.md
@@ -50,6 +50,30 @@ Payloads are camelCase JSON objects matching the IPC payload format. Use
 `command validate` runs the same strict parser without touching the project —
 check before you execute.
 
+## Transitions
+
+Transitions are effects — there is no `AddTransition` command. `AddEffect`
+accepts a curated `recipe` instead of an `effectType` plus hand-picked params:
+
+```bash
+openreelio-cli packs list --kind transition
+
+openreelio-cli command execute --path ./demo --type AddEffect \
+  --payload '{"sequenceId":"…","trackId":"…","clipId":"…","recipe":"dissolve-soft"}'
+```
+
+The recipes are `dissolve-soft` / `dissolve-standard` / `dissolve-long`,
+`fade-in` / `fade-out`, `wipe-left` / `wipe-right` / `wipe-up` / `wipe-down`,
+`slide-left` / `slide-right`, and `zoom-punch`. Each supplies the effect type
+plus the duration and direction that go with it, so the choice is one token
+rather than four guesses.
+
+Like caption packs, a recipe is a base layer: `params` overrides it key by key
+(`{"recipe":"dissolve-soft","params":{"duration":1.5}}`). Naming a recipe *and*
+a contradictory `effectType` is rejected rather than silently resolved. One
+recipe deliberately leaves a gap: `fade-out` cannot know the clip length, so
+pass `params.start_time = clipDuration - 1.0` for a fade that lands on the tail.
+
 ## Atomic batches: `plan execute`
 
 An edit plan is:

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -82,10 +82,11 @@ everywhere rather than tracking the exceptions.
 
 ### Discovering the surface
 
-`help-json` prints the whole command schema, but it is ~58 KB — do not preload
+`help-json` prints the whole command schema, but it is ~68 KB — do not preload
 it into a context window. Fetch help per verb instead
-(`openreelio-cli verify --help`, `openreelio-cli frame extract --help`), and use
-`openreelio-cli command schema` for the 79 backend command types.
+(`openreelio-cli verify --help`, `openreelio-cli frame extract --help`), use
+`openreelio-cli command schema` for the 79 backend command types, and
+`openreelio-cli packs list` for the curated caption styles and transitions.
 
 ### Self-diagnosis
 
@@ -166,6 +167,24 @@ openreelio-cli command execute  --path ./demo --type SplitClip \
 Payloads are camelCase JSON objects. Use `--payload-file <FILE>` instead of
 `--payload` when the JSON is large or shell quoting is awkward. `command
 validate` runs the same strict parser without touching the project.
+
+### Transitions
+
+Transitions are effects — there is no `AddTransition` command. `AddEffect`
+accepts a curated `recipe` in place of an `effectType` plus hand-picked
+parameters:
+
+```bash
+openreelio-cli packs list --kind transition
+openreelio-cli command execute --path ./demo --type AddEffect   --payload '{"sequenceId":"…","trackId":"…","clipId":"…","recipe":"dissolve-soft"}'
+```
+
+Recipes: `dissolve-soft`, `dissolve-standard`, `dissolve-long`, `fade-in`,
+`fade-out`, `wipe-left`, `wipe-right`, `wipe-up`, `wipe-down`, `slide-left`,
+`slide-right`, `zoom-punch`. A recipe is a base layer — `params` overrides it
+key by key — and a recipe paired with a contradictory `effectType` is rejected.
+`fade-out` cannot know the clip length, so pass
+`params.start_time = clipDuration - 1.0` for a tail fade.
 
 ### Atomic batches: `plan execute`
 
@@ -449,8 +468,8 @@ Captions are timed subtitle entries; text clips are styled overlays with
 position, transform and effects. Both are ordinary commands in the op log.
 
 ```bash
-openreelio-cli caption add    --path ./demo --text "Hello" --start 0.5 --end 3.0
-openreelio-cli caption update --path ./demo --id <CAPTION_ID> --text "Updated"
+openreelio-cli caption add    --path ./demo --text "Hello" --start 0.5 --end 3.0 [--style-pack <PACK_ID>]
+openreelio-cli caption update --path ./demo --id <CAPTION_ID> --text "Updated" [--style-pack <PACK_ID>]
 openreelio-cli caption list   --path ./demo
 openreelio-cli caption remove --path ./demo --id <CAPTION_ID>
 openreelio-cli caption import --path ./demo --file subs.srt [--format srt|vtt|transcript-json]
@@ -462,6 +481,27 @@ openreelio-cli text transform --path ./demo --id <CLIP_ID> --x 0.38 --y 0.42 --s
 openreelio-cli text list      --path ./demo
 openreelio-cli text remove    --path ./demo --id <CLIP_ID>
 ```
+
+### Caption style packs
+
+Packs are the quality floor — reach for free-form styling only when a pack
+cannot express the brief. Each pairs typography with an anchor and is verified to
+stay inside the title-safe area on both 1920x1080 and 1080x1920, the same check
+`verify` runs as `caption.safe_area`.
+
+```bash
+openreelio-cli packs list --kind caption
+```
+
+`standard-outline` (the default), `clean-minimal`, `boxed-contrast`,
+`yellow-classic`, `shorts-bold-outline`, `broadcast-lower`,
+`high-contrast-accessible`, `caption-top`.
+
+A pack is a base layer, not a lock: `--style-json` / `--position` override it key
+by key, so `--style-pack boxed-contrast --style-json '{"fontSize":96}'` is the
+boxed pack at 96pt. The same field is `stylePack` on `CreateCaption`,
+`UpdateCaption`, and `ImportGeneratedCaptions`, so `command execute` and MCP
+clients get it for free. An unknown id is rejected with the full valid list.
 
 Speech-to-text is local (Whisper); `--import` writes the result straight into a
 caption track.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -181,10 +181,10 @@ openreelio-cli command execute --path ./demo --type AddEffect   --payload '{"seq
 
 Recipes: `dissolve-soft`, `dissolve-standard`, `dissolve-long`, `fade-in`,
 `fade-out`, `wipe-left`, `wipe-right`, `wipe-up`, `wipe-down`, `slide-left`,
-`slide-right`, `zoom-punch`. A recipe is a base layer — `params` overrides it
-key by key — and a recipe paired with a contradictory `effectType` is rejected.
-`fade-out` cannot know the clip length, so pass
-`params.start_time = clipDuration - 1.0` for a tail fade.
+`slide-right`. A recipe is a base layer — `params` overrides it key by key —
+and a recipe paired with a contradictory `effectType` is rejected. `fade-out`
+is anchored on the clip's tail when the command executes; pass
+`params.start_time` only to put the fade somewhere else in the clip.
 
 ### Atomic batches: `plan execute`
 
@@ -486,8 +486,9 @@ openreelio-cli text remove    --path ./demo --id <CLIP_ID>
 
 Packs are the quality floor — reach for free-form styling only when a pack
 cannot express the brief. Each pairs typography with an anchor and is verified to
-stay inside the title-safe area on both 1920x1080 and 1080x1920, the same check
-`verify` runs as `caption.safe_area`.
+draw zero `caption.safe_area` violations on both 1920x1080 and 1080x1920 — the
+same check `verify` runs, measuring the text block against each canvas rather
+than only comparing margins.
 
 ```bash
 openreelio-cli packs list --kind caption
@@ -499,9 +500,16 @@ openreelio-cli packs list --kind caption
 
 A pack is a base layer, not a lock: `--style-json` / `--position` override it key
 by key, so `--style-pack boxed-contrast --style-json '{"fontSize":96}'` is the
-boxed pack at 96pt. The same field is `stylePack` on `CreateCaption`,
-`UpdateCaption`, and `ImportGeneratedCaptions`, so `command execute` and MCP
-clients get it for free. An unknown id is rejected with the full valid list.
+boxed pack at 96pt. `--position top|center|bottom` names a vertical anchor only,
+so it keeps the pack's checked margin rather than replacing it. The same field is
+`stylePack` on `CreateCaption`, `UpdateCaption`, and `ImportGeneratedCaptions`,
+so `command execute` and MCP clients get it for free. An unknown id is rejected
+with the full valid list.
+
+On an **update** a pack restyles without moving the caption: `caption update
+--style-pack …` keeps the anchor the caption already has, because an update
+replaces whatever position it carries. Pass `--position` when you do want it
+moved.
 
 Speech-to-text is local (Whisper); `--import` writes the result straight into a
 caption track.

--- a/src-tauri/src/core/commands/effect.rs
+++ b/src-tauri/src/core/commands/effect.rs
@@ -39,6 +39,50 @@ fn validate_target_clips(
     Ok(())
 }
 
+/// Anchors a fade-out on the end of the clip it is being added to.
+///
+/// `fade=t=out` measures `st` from the clip's own zero, so a fade-out without a
+/// `start_time` fades during the clip's first second and holds black for the
+/// rest of it. The value cannot live in the recipe table — only the target clip
+/// knows its duration — so it is computed here, where the clip is in hand and
+/// the op has not been written yet. That keeps the logged effect concrete:
+/// replay reads the resolved `start_time` out of the op and never consults the
+/// recipe table.
+///
+/// An explicit `start_time` always wins, and a clip shorter than the fade gets
+/// the whole clip as the fade. Trimming the clip afterwards leaves the anchor
+/// where it was; re-adding the effect (or passing `start_time`) re-anchors it.
+fn anchor_fade_out_on_clip_tail(
+    effect_type: &EffectType,
+    params: &mut std::collections::HashMap<String, ParamValue>,
+    clip_duration_sec: f64,
+) {
+    if !matches!(effect_type, EffectType::Fade) || params.contains_key("start_time") {
+        return;
+    }
+
+    let fades_out = params
+        .get("fade_in")
+        .and_then(ParamValue::as_bool)
+        .is_some_and(|fade_in| !fade_in);
+    if !fades_out || !clip_duration_sec.is_finite() || clip_duration_sec <= 0.0 {
+        return;
+    }
+
+    let requested = params
+        .get("duration")
+        .and_then(ParamValue::as_float)
+        .filter(|duration| duration.is_finite() && *duration > 0.0)
+        .unwrap_or(1.0);
+
+    let duration = requested.min(clip_duration_sec);
+    params.insert("duration".to_string(), ParamValue::Float(duration));
+    params.insert(
+        "start_time".to_string(),
+        ParamValue::Float(clip_duration_sec - duration),
+    );
+}
+
 fn deserialize_source_effects(source_effects: &[serde_json::Value]) -> CoreResult<Vec<Effect>> {
     source_effects
         .iter()
@@ -177,6 +221,10 @@ impl Command for AddEffectCommand {
         let clip = track
             .get_clip_mut(&self.clip_id)
             .ok_or_else(|| CoreError::ClipNotFound(self.clip_id.clone()))?;
+
+        // Resolve clip-relative parameters while the clip is in hand, so the
+        // effect the op records is fully concrete.
+        anchor_fade_out_on_clip_tail(&effect_type, &mut self.params, clip.place.duration_sec);
 
         // Create the effect
         let mut effect = Effect::new(effect_type);

--- a/src-tauri/src/core/commands/effect.rs
+++ b/src-tauri/src/core/commands/effect.rs
@@ -62,6 +62,10 @@ fn deserialize_source_effects(source_effects: &[serde_json::Value]) -> CoreResul
 /// - `effect_type`: The type of effect to add
 /// - `params`: Optional initial parameters for the effect
 ///
+/// The effect type is optional on the wire because a transition recipe can
+/// supply it instead; `CommandPayload::parse` resolves the recipe before the
+/// command is built, and executing without either is a validation error.
+///
 /// # Example
 /// ```ignore
 /// let cmd = AddEffectCommand::new("seq-1", "track-1", "clip-1", EffectType::GaussianBlur)
@@ -74,7 +78,8 @@ pub struct AddEffectCommand {
     pub sequence_id: SequenceId,
     pub track_id: TrackId,
     pub clip_id: ClipId,
-    pub effect_type: EffectType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effect_type: Option<EffectType>,
     #[serde(default)]
     pub params: std::collections::HashMap<String, ParamValue>,
     #[serde(default)]
@@ -92,6 +97,28 @@ impl AddEffectCommand {
         track_id: impl Into<String>,
         clip_id: impl Into<String>,
         effect_type: EffectType,
+    ) -> Self {
+        Self {
+            sequence_id: sequence_id.into(),
+            track_id: track_id.into(),
+            clip_id: clip_id.into(),
+            effect_type: Some(effect_type),
+            params: std::collections::HashMap::new(),
+            keyframes: std::collections::HashMap::new(),
+            position: None,
+            created_effect_id: None,
+        }
+    }
+
+    /// Creates the command from an effect type that may still be unresolved.
+    ///
+    /// Used by payload construction, where a transition recipe may have supplied
+    /// the type; executing without a type is rejected with a validation error.
+    pub fn with_optional_type(
+        sequence_id: impl Into<String>,
+        track_id: impl Into<String>,
+        clip_id: impl Into<String>,
+        effect_type: Option<EffectType>,
     ) -> Self {
         Self {
             sequence_id: sequence_id.into(),
@@ -126,6 +153,15 @@ impl AddEffectCommand {
 
 impl Command for AddEffectCommand {
     fn execute(&mut self, state: &mut ProjectState) -> CoreResult<CommandResult> {
+        // A transition recipe is resolved into an explicit effect type before the
+        // command is built, so reaching execute without one means neither was
+        // supplied.
+        let effect_type = self.effect_type.clone().ok_or_else(|| {
+            CoreError::ValidationError(
+                "AddEffect requires effectType, or a recipe that supplies one".to_string(),
+            )
+        })?;
+
         // Validate sequence exists
         let sequence = state
             .sequences
@@ -143,7 +179,7 @@ impl Command for AddEffectCommand {
             .ok_or_else(|| CoreError::ClipNotFound(self.clip_id.clone()))?;
 
         // Create the effect
-        let mut effect = Effect::new(self.effect_type.clone());
+        let mut effect = Effect::new(effect_type);
         for (key, value) in &self.params {
             effect.set_param(key, value.clone());
         }

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -1600,7 +1600,10 @@ impl Effect {
     /// - `x`: Normalized X position 0.0-1.0 (default: 0.5 = center)
     /// - `y`: Normalized Y position 0.0-1.0 (default: 0.5 = center)
     /// - `background_color`: Background box color as hex (optional)
+    /// - `background_opacity`: Box alpha 0.0-1.0, composed with `opacity` (default: 1.0)
     /// - `shadow_color`: Shadow color as hex (optional)
+    /// - `shadow_opacity`: Shadow alpha 0.0-1.0, composed with `opacity` (default: 0.8)
+    /// - `outline_opacity`: Outline alpha 0.0-1.0, composed with `opacity` (default: 1.0)
     /// - `shadow_x`: Shadow X offset in pixels (default: 2)
     /// - `shadow_y`: Shadow Y offset in pixels (default: 2)
     /// - `outline_color`: Outline/border color as hex (optional)
@@ -1702,9 +1705,17 @@ impl Effect {
         }
 
         // Background box
+        //
+        // `background_opacity` carries the alpha channel of the style's box
+        // color. It composes with the text opacity rather than replacing it, so
+        // a translucent box inside a faded overlay fades with the overlay.
         if let Some(bg_color) = self.get_param("background_color").and_then(|v| v.as_str()) {
             if !bg_color.is_empty() {
-                let bg_ffmpeg = hex_to_ffmpeg_color(bg_color, opacity);
+                let bg_alpha = self
+                    .get_float("background_opacity")
+                    .unwrap_or(1.0)
+                    .clamp(0.0, 1.0);
+                let bg_ffmpeg = hex_to_ffmpeg_color(bg_color, bg_alpha * opacity);
                 let padding = self
                     .get_param("background_padding")
                     .and_then(|v| v.as_int())
@@ -1726,7 +1737,13 @@ impl Effect {
                 .get_param("shadow_y")
                 .and_then(|v| v.as_int())
                 .unwrap_or(2);
-            let shadow_ffmpeg = hex_to_ffmpeg_color(shadow_color, opacity * 0.8);
+            // A shadow with no alpha of its own keeps the historical 80% of the
+            // text opacity; one that names an alpha uses it.
+            let shadow_alpha = self
+                .get_float("shadow_opacity")
+                .map(|alpha| alpha.clamp(0.0, 1.0))
+                .unwrap_or(0.8);
+            let shadow_ffmpeg = hex_to_ffmpeg_color(shadow_color, opacity * shadow_alpha);
             params.push(format!("shadowcolor={}", shadow_ffmpeg));
             params.push(format!("shadowx={}", shadow_x));
             params.push(format!("shadowy={}", shadow_y));
@@ -1738,7 +1755,11 @@ impl Effect {
                 .get_param("outline_width")
                 .and_then(|v| v.as_int())
                 .unwrap_or(2);
-            let outline_ffmpeg = hex_to_ffmpeg_color(outline_color, opacity);
+            let outline_alpha = self
+                .get_float("outline_opacity")
+                .unwrap_or(1.0)
+                .clamp(0.0, 1.0);
+            let outline_ffmpeg = hex_to_ffmpeg_color(outline_color, outline_alpha * opacity);
             params.push(format!("borderw={}", outline_width));
             params.push(format!("bordercolor={}", outline_ffmpeg));
         }

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -41,6 +41,7 @@ pub mod render;
 pub mod search;
 pub mod settings;
 pub mod shapes;
+pub mod style;
 pub mod template;
 pub mod terminal_command_line;
 pub mod text;

--- a/src-tauri/src/core/qc/rules.rs
+++ b/src-tauri/src/core/qc/rules.rs
@@ -9,7 +9,9 @@ use std::collections::HashMap;
 
 use super::context::QCContext;
 use super::violation::{merged_span_duration_sec, QCViolation, Severity, ViolationFix};
-use crate::core::captions::{CaptionPosition, CaptionStyle, CustomPosition, VerticalPosition};
+use crate::core::captions::{
+    CaptionPosition, CaptionStyle, CustomPosition, TextAlignment, VerticalPosition,
+};
 use crate::core::project::ProjectState;
 use crate::core::timeline::{Clip, Sequence, Track};
 use crate::core::CoreResult;
@@ -1460,6 +1462,14 @@ impl QCRule for AudioClippingRule {
 /// style as untyped JSON, which is deserialized defensively so a legacy or
 /// partially written blob degrades to the caption defaults instead of failing
 /// the whole check.
+///
+/// Both anchoring modes are measured against the canvas, not just compared to a
+/// margin: a preset anchor places the *center* of the text block on its margin
+/// line, so a large enough font pushes the block past the edge the margin was
+/// supposed to protect. Horizontal extent is modelled for custom anchors, where
+/// the caller chose x and the renderer honors alignment; a preset anchor is
+/// always horizontally centered, and an over-long line there is a
+/// text-authoring problem this rule cannot fix by moving the caption.
 #[derive(Debug, Default)]
 pub struct CaptionSafeAreaRule;
 
@@ -1479,15 +1489,19 @@ impl CaptionSafeAreaRule {
     /// while breaching only the title-safe margin stays informational.
     const ACTION_SAFE_MARGIN_PERCENT: f64 = 5.0;
 
-    /// Characters that fit across the full canvas width at the default font size
+    /// Average glyph advance as a fraction of the font size
     ///
     /// Core has no text shaping, so rendered text width can only be
-    /// approximated; this average glyph advance keeps the estimate conservative
-    /// for Latin text and is intentionally coarse.
-    const CHARS_PER_CANVAS_WIDTH: f64 = 42.0;
+    /// approximated; half an em is the usual figure for mixed-case Latin and is
+    /// intentionally coarse.
+    const GLYPH_ADVANCE_FACTOR: f64 = 0.5;
 
     /// Maximum estimated text-box width as a percentage of canvas width
-    const MAX_TEXT_BOX_WIDTH_PERCENT: f64 = 90.0;
+    ///
+    /// A cap only so a pathological font size cannot produce a nonsense span in
+    /// the violation message; it is far above the safe band, so it never hides
+    /// an overflow.
+    const MAX_TEXT_BOX_WIDTH_PERCENT: f64 = 500.0;
 
     /// Line height as a multiple of the font size (typographic default)
     const LINE_HEIGHT_FACTOR: f64 = 1.2;
@@ -1515,23 +1529,84 @@ impl CaptionSafeAreaRule {
     }
 
     /// Returns the estimated text box size as (width, height) percentages.
-    fn estimate_text_box_percent(clip: &Clip, canvas_height: u32) -> (f64, f64) {
+    ///
+    /// Both axes scale with the font size and the canvas, because that is what
+    /// the renderer does: `drawtext` emits an absolute `fontsize` and does not
+    /// wrap, so the same caption occupies twice the width on a 1080-wide
+    /// vertical canvas that it does on a 1920-wide landscape one.
+    fn estimate_text_box_percent(clip: &Clip, canvas_width: u32, canvas_height: u32) -> (f64, f64) {
         let char_count = clip
             .label
             .as_ref()
             .map(|label| label.chars().count())
             .unwrap_or(0) as f64;
 
-        let width_percent = (char_count / Self::CHARS_PER_CANVAS_WIDTH * 100.0)
-            .min(Self::MAX_TEXT_BOX_WIDTH_PERCENT);
+        let font_size = Self::font_size_px(clip.caption_style.as_ref());
+
+        let canvas_width = if canvas_width > 0 { canvas_width } else { 1 };
+        let width_percent =
+            (char_count * font_size * Self::GLYPH_ADVANCE_FACTOR / f64::from(canvas_width) * 100.0)
+                .min(Self::MAX_TEXT_BOX_WIDTH_PERCENT);
 
         let canvas_height = if canvas_height > 0 { canvas_height } else { 1 };
-        let height_percent = Self::font_size_px(clip.caption_style.as_ref())
-            * Self::LINE_HEIGHT_FACTOR
-            / f64::from(canvas_height)
-            * 100.0;
+        let height_percent =
+            font_size * Self::LINE_HEIGHT_FACTOR / f64::from(canvas_height) * 100.0;
 
         (width_percent, height_percent)
+    }
+
+    /// Reads the caption's horizontal alignment from its style JSON.
+    ///
+    /// Mirrors the render path's alias list; anything unrecognized is centered,
+    /// which is the renderer's own default.
+    fn alignment(style: Option<&serde_json::Value>) -> TextAlignment {
+        let Some(value) = style.and_then(serde_json::Value::as_object) else {
+            return TextAlignment::Center;
+        };
+
+        let raw = ["alignment", "textAlign", "text_align"]
+            .iter()
+            .find_map(|key| value.get(*key))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        match raw.as_str() {
+            "left" => TextAlignment::Left,
+            "right" => TextAlignment::Right,
+            _ => TextAlignment::Center,
+        }
+    }
+
+    /// Returns the horizontal span a text box of `width_percent` occupies.
+    ///
+    /// Matches `build_drawtext_filter`: a left-aligned run starts at the anchor,
+    /// a right-aligned one ends there, and a centered one straddles it.
+    fn horizontal_span(
+        anchor_percent: f64,
+        width_percent: f64,
+        alignment: &TextAlignment,
+    ) -> (f64, f64) {
+        match alignment {
+            TextAlignment::Left => (anchor_percent, anchor_percent + width_percent),
+            TextAlignment::Right => (anchor_percent - width_percent, anchor_percent),
+            TextAlignment::Center => (
+                anchor_percent - width_percent / 2.0,
+                anchor_percent + width_percent / 2.0,
+            ),
+        }
+    }
+
+    /// Returns the vertical center of a preset anchor, as a canvas percentage.
+    ///
+    /// The renderer centers the text block on the margin line, which is why the
+    /// block can breach an edge the margin itself clears.
+    fn preset_center_y_percent(vertical: &VerticalPosition, margin_percent: f64) -> f64 {
+        match vertical {
+            VerticalPosition::Top => margin_percent,
+            VerticalPosition::Center => 50.0,
+            VerticalPosition::Bottom => 100.0 - margin_percent,
+        }
     }
 
     /// Centers a box of `size_percent` inside the safe band, without panicking
@@ -1634,15 +1709,59 @@ impl QCRule for CaptionSafeAreaRule {
                                 },
                             )
                         } else {
-                            continue;
+                            // The margin clears both bands, but it only places
+                            // the *center* of the text block: the renderer
+                            // draws a block of `font_size * line_height` around
+                            // that line, so a large enough font still breaches
+                            // the edge the margin was chosen to protect.
+                            if context.canvas_height == 0 {
+                                continue;
+                            }
+
+                            let (_, box_height) = Self::estimate_text_box_percent(
+                                clip,
+                                context.canvas_width,
+                                context.canvas_height,
+                            );
+                            let center_y = Self::preset_center_y_percent(vertical, *margin_percent);
+                            let top = center_y - box_height / 2.0;
+                            let bottom = center_y + box_height / 2.0;
+                            let upper_bound = 100.0 - action_safe_margin;
+
+                            if top >= action_safe_margin && bottom <= upper_bound {
+                                continue;
+                            }
+
+                            (
+                                severity,
+                                "Caption text extends outside the action-safe area".to_string(),
+                                format!(
+                                    "Estimated text block spans y {:.1}%-{:.1}% at {:.0}px on a {}px-tall canvas, outside the {:.1}%-{:.1}% safe band (block size is an approximation)",
+                                    top,
+                                    bottom,
+                                    Self::font_size_px(clip.caption_style.as_ref()),
+                                    context.canvas_height,
+                                    action_safe_margin,
+                                    upper_bound
+                                ),
+                                CaptionPosition::Preset {
+                                    vertical: vertical.clone(),
+                                    margin_percent: (title_safe_margin + box_height / 2.0)
+                                        .min(45.0),
+                                },
+                            )
                         }
                     }
                     CaptionPosition::Custom(custom) => {
-                        let (box_width, box_height) =
-                            Self::estimate_text_box_percent(clip, context.canvas_height);
+                        let (box_width, box_height) = Self::estimate_text_box_percent(
+                            clip,
+                            context.canvas_width,
+                            context.canvas_height,
+                        );
+                        let alignment = Self::alignment(clip.caption_style.as_ref());
 
-                        let left = custom.x_percent - box_width / 2.0;
-                        let right = custom.x_percent + box_width / 2.0;
+                        let (left, right) =
+                            Self::horizontal_span(custom.x_percent, box_width, &alignment);
                         let top = custom.y_percent - box_height / 2.0;
                         let bottom = custom.y_percent + box_height / 2.0;
 
@@ -1655,6 +1774,17 @@ impl QCRule for CaptionSafeAreaRule {
                             continue;
                         }
 
+                        // The fix has to be expressed in the same anchoring the
+                        // renderer reads, so the clamped center is converted
+                        // back into a left/right/center anchor.
+                        let clamped_center_x =
+                            Self::clamp_center((left + right) / 2.0, box_width, action_safe_margin);
+                        let fixed_x = match alignment {
+                            TextAlignment::Left => clamped_center_x - box_width / 2.0,
+                            TextAlignment::Right => clamped_center_x + box_width / 2.0,
+                            TextAlignment::Center => clamped_center_x,
+                        };
+
                         (
                             severity,
                             "Caption positioned outside the action-safe area".to_string(),
@@ -1663,11 +1793,7 @@ impl QCRule for CaptionSafeAreaRule {
                                 left, right, top, bottom, action_safe_margin, upper_bound
                             ),
                             CaptionPosition::Custom(CustomPosition {
-                                x_percent: Self::clamp_center(
-                                    custom.x_percent,
-                                    box_width,
-                                    action_safe_margin,
-                                ),
+                                x_percent: fixed_x,
                                 y_percent: Self::clamp_center(
                                     custom.y_percent,
                                     box_height,
@@ -2645,6 +2771,92 @@ mod tests {
                 .commands[0]["position"]["marginPercent"],
             10.0
         );
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_flag_preset_whose_text_block_leaves_the_canvas() {
+        // The margin itself is safe; the type is not. A preset places the
+        // block's center on the margin line, so an oversized font breaches the
+        // edge the margin was chosen to protect.
+        let sequence = sequence_with_caption(
+            "Caption set in an enormous font",
+            Some(serde_json::json!({
+                "type": "preset",
+                "vertical": "bottom",
+                "marginPercent": 10.0
+            })),
+            Some(serde_json::json!({ "fontSize": 500 })),
+        );
+        let state = ProjectState::new("QC Test");
+        let context = QCContext::from_sequence(&sequence);
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(&sequence, &state, &RuleConfig::default(), &context)
+            .await
+            .expect("rule runs");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].severity, Severity::Warning);
+        assert!(
+            violations[0]
+                .message
+                .contains("outside the action-safe area"),
+            "{}",
+            violations[0].message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_caption_safe_area_rule_should_measure_a_left_aligned_custom_anchor_from_its_edge()
+    {
+        // A left-aligned run starts at its anchor, so a 10% anchor is safe and
+        // a 90% anchor is not — the centered reading would judge both the
+        // other way round.
+        let safe = sequence_with_caption(
+            "Dr. Jane Doe",
+            Some(serde_json::json!({ "type": "custom", "xPercent": 10.0, "yPercent": 84.0 })),
+            Some(serde_json::json!({ "fontSize": 40, "alignment": "left" })),
+        );
+        let state = ProjectState::new("QC Test");
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(
+                &safe,
+                &state,
+                &RuleConfig::default(),
+                &QCContext::from_sequence(&safe),
+            )
+            .await
+            .expect("rule runs");
+        assert!(violations.is_empty(), "{violations:?}");
+
+        let overflowing = sequence_with_caption(
+            "Dr. Jane Doe",
+            Some(serde_json::json!({ "type": "custom", "xPercent": 90.0, "yPercent": 84.0 })),
+            Some(serde_json::json!({ "fontSize": 40, "alignment": "left" })),
+        );
+
+        let violations = CaptionSafeAreaRule::new()
+            .check(
+                &overflowing,
+                &state,
+                &RuleConfig::default(),
+                &QCContext::from_sequence(&overflowing),
+            )
+            .await
+            .expect("rule runs");
+        assert_eq!(violations.len(), 1);
+
+        // The fix must re-anchor in the same terms the renderer reads, so the
+        // suggested x stays a left edge rather than a center.
+        let fixed_x = violations[0]
+            .suggested_fix
+            .as_ref()
+            .expect("fix suggested")
+            .commands[0]["position"]["xPercent"]
+            .as_f64()
+            .expect("x percent");
+        assert!(fixed_x < 90.0, "{fixed_x}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -3157,11 +3157,20 @@ fn build_caption_text_effect(clip: &Clip) -> Option<Effect> {
             }
         }
 
+        // Each decoration carries its own alpha. Dropping it collapsed every
+        // translucent box or shadow to fully opaque, so a style that promised
+        // to let the footage read through hid it instead.
         if let Some(background_value) =
             get_json_field(style, &["backgroundColor", "background_color"])
         {
-            if let Some((hex, _)) = parse_caption_color(background_value) {
+            if let Some((hex, alpha)) = parse_caption_color(background_value) {
                 effect.set_param("background_color", ParamValue::String(hex));
+                if let Some(alpha) = alpha {
+                    effect.set_param(
+                        "background_opacity",
+                        ParamValue::Float(alpha.clamp(0.0, 1.0)),
+                    );
+                }
             }
         }
 
@@ -3176,14 +3185,20 @@ fn build_caption_text_effect(clip: &Clip) -> Option<Effect> {
         }
 
         if let Some(shadow_value) = get_json_field(style, &["shadowColor", "shadow_color"]) {
-            if let Some((hex, _)) = parse_caption_color(shadow_value) {
+            if let Some((hex, alpha)) = parse_caption_color(shadow_value) {
                 effect.set_param("shadow_color", ParamValue::String(hex));
+                if let Some(alpha) = alpha {
+                    effect.set_param("shadow_opacity", ParamValue::Float(alpha.clamp(0.0, 1.0)));
+                }
             }
         }
 
         if let Some(outline_value) = get_json_field(style, &["outlineColor", "outline_color"]) {
-            if let Some((hex, _)) = parse_caption_color(outline_value) {
+            if let Some((hex, alpha)) = parse_caption_color(outline_value) {
                 effect.set_param("outline_color", ParamValue::String(hex));
+                if let Some(alpha) = alpha {
+                    effect.set_param("outline_opacity", ParamValue::Float(alpha.clamp(0.0, 1.0)));
+                }
             }
         }
 
@@ -3629,14 +3644,29 @@ fn append_ass_text_style_and_event(
         "#FFFFFF",
         opacity,
     );
-    let outline_color = ass_color_param(effect, "outline_color", "#000000", opacity)
-        .unwrap_or_else(AssColor::transparent_black);
+    // Decoration alphas compose with the layer opacity, exactly as they do in
+    // the drawtext path, so both renderers read one style the same way.
+    let decoration_alpha = |name: &str, fallback: f64| {
+        effect_float_param(effect, name, fallback).clamp(0.0, 1.0) * opacity
+    };
+    let outline_color = ass_color_param(
+        effect,
+        "outline_color",
+        "#000000",
+        decoration_alpha("outline_opacity", 1.0),
+    )
+    .unwrap_or_else(AssColor::transparent_black);
     let outline_width = if effect.get_param("outline_color").is_some() {
         effect_int_param(effect, "outline_width", 2).clamp(0, 100) as f64
     } else {
         0.0
     };
-    let shadow_color = ass_color_param(effect, "shadow_color", "#000000", opacity * 0.8);
+    let shadow_color = ass_color_param(
+        effect,
+        "shadow_color",
+        "#000000",
+        decoration_alpha("shadow_opacity", 0.8),
+    );
     let has_shadow = shadow_color.is_some();
     let shadow_x = if has_shadow {
         effect_int_param(effect, "shadow_x", 0).clamp(-500, 500)
@@ -3653,7 +3683,12 @@ fn append_ass_text_style_and_event(
     } else {
         0.0
     };
-    let background_color = ass_color_param(effect, "background_color", "#000000", opacity);
+    let background_color = ass_color_param(
+        effect,
+        "background_color",
+        "#000000",
+        decoration_alpha("background_opacity", 1.0),
+    );
     let background_padding = effect_int_param(effect, "background_padding", 10).clamp(0, 500);
     let border_style = if background_color.is_some() { 3 } else { 1 };
     let style_outline_width = if background_color.is_some() {
@@ -5432,6 +5467,41 @@ mod tests {
         assert!(
             script.contains(r"\bord24.00"),
             "Expected dialogue override to preserve background padding. Got: {script}"
+        );
+    }
+
+    #[test]
+    fn test_caption_decoration_alpha_reaches_the_drawtext_filter() {
+        use crate::core::timeline::Clip;
+
+        // A translucent box is the whole point of a boxed caption style: if the
+        // alpha is dropped, the box that was supposed to let the footage read
+        // through renders as an opaque slab instead.
+        let mut caption_clip = Clip::new("caption-asset")
+            .with_source_range(0.0, 2.0)
+            .place_at(0.0);
+        caption_clip.label = Some("Translucent".to_string());
+        caption_clip.caption_style = Some(serde_json::json!({
+            "fontSize": 48,
+            "color": { "r": 255, "g": 255, "b": 255, "a": 255 },
+            "backgroundColor": { "r": 0, "g": 0, "b": 0, "a": 153 },
+            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 128 },
+        }));
+
+        let filter = build_caption_drawtext_with_enable(&caption_clip).expect("drawtext filter");
+
+        assert!(
+            filter.contains("boxcolor=0x000000@0.60"),
+            "background alpha must reach boxcolor, got: {filter}"
+        );
+        assert!(
+            filter.contains("shadowcolor=0x000000@0.50"),
+            "shadow alpha must reach shadowcolor, got: {filter}"
+        );
+        // Fully opaque text still renders without an alpha suffix.
+        assert!(
+            filter.contains("fontcolor=0xFFFFFF:"),
+            "opaque text must not gain an alpha suffix, got: {filter}"
         );
     }
 

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -3277,7 +3277,11 @@ fn build_caption_text_effect(clip: &Clip) -> Option<Effect> {
     Some(effect)
 }
 
-fn build_caption_drawtext_with_enable(clip: &Clip) -> Option<String> {
+/// Builds the time-gated `drawtext` filter a caption clip renders as.
+///
+/// Exposed to the crate so the curated caption pack contract tests can assert
+/// against the real render seam instead of a re-implementation of it.
+pub(crate) fn build_caption_drawtext_with_enable(clip: &Clip) -> Option<String> {
     let effect = build_caption_text_effect(clip)?;
 
     let start = clip.place.timeline_in_sec;

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -9,7 +9,7 @@
 
 pub mod cache;
 pub mod executor;
-mod export;
+pub(crate) mod export;
 pub mod ffmpeg_graph;
 mod ffmpeg_plan;
 pub mod graph;

--- a/src-tauri/src/core/style/caption_packs.rs
+++ b/src-tauri/src/core/style/caption_packs.rs
@@ -1,0 +1,441 @@
+//! Curated Caption Style Packs
+//!
+//! A caption pack is a named, hand-checked combination of a typed
+//! [`CaptionStyle`] and a [`CaptionPosition`]. Packs exist so an agent does not
+//! have to invent typography: picking `boxed-contrast` is one token and lands on
+//! a legible result, while assembling the same style field by field is a dozen
+//! decisions with no feedback until the render.
+//!
+//! # Guarantees
+//!
+//! Every pack in [`CAPTION_PACKS`] is verified by contract test to:
+//!
+//! - deserialize back into a typed [`CaptionStyle`] after JSON round-trip, and
+//! - produce zero `CaptionSafeAreaRule` violations on both a 1920x1080 and a
+//!   1080x1920 canvas.
+//!
+//! The safe-area guarantee is why every pack anchors with
+//! [`CaptionPosition::Preset`] at a margin at or above the 10% title-safe band:
+//! a preset margin is canvas-independent, so it holds for landscape and vertical
+//! deliveries alike.
+//!
+//! # Stability
+//!
+//! Pack ids are a public contract. The op log records the id an edit was made
+//! with, so ids are append-only: rename nothing, and add rather than repurpose.
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::captions::{
+    CaptionPosition, CaptionStyle, Color, FontWeight, TextAlignment, VerticalPosition,
+};
+
+use super::normalize_pack_id;
+
+/// Immutable definition of one curated caption style pack.
+///
+/// Held in a `const` table so the id list, the validator, and the resolved style
+/// are the same source. [`CaptionStyle`] owns a `String` font family and
+/// therefore cannot be `const` itself, so the spec stores `&'static str` and
+/// materializes the typed style on demand via [`CaptionPackSpec::style`].
+#[derive(Clone, Debug)]
+pub struct CaptionPackSpec {
+    /// Canonical, hyphenated pack identifier.
+    pub id: &'static str,
+    /// One-line description of what the pack is for.
+    pub description: &'static str,
+    /// Additional identifiers that resolve to this pack.
+    pub aliases: &'static [&'static str],
+    font_family: &'static str,
+    font_size: u32,
+    font_weight: FontWeight,
+    color: Color,
+    background_color: Option<Color>,
+    outline_color: Option<Color>,
+    outline_width: f32,
+    shadow_color: Option<Color>,
+    shadow_offset: f32,
+    alignment: TextAlignment,
+    vertical: VerticalPosition,
+    margin_percent: f64,
+}
+
+impl CaptionPackSpec {
+    /// Materializes the typed caption style for this pack.
+    pub fn style(&self) -> CaptionStyle {
+        CaptionStyle {
+            font_family: self.font_family.to_string(),
+            font_size: self.font_size,
+            font_weight: self.font_weight.clone(),
+            color: self.color.clone(),
+            background_color: self.background_color.clone(),
+            outline_color: self.outline_color.clone(),
+            outline_width: self.outline_width,
+            shadow_color: self.shadow_color.clone(),
+            shadow_offset: self.shadow_offset,
+            alignment: self.alignment.clone(),
+            italic: false,
+            underline: false,
+        }
+    }
+
+    /// Materializes the typed caption position for this pack.
+    pub fn position(&self) -> CaptionPosition {
+        CaptionPosition::Preset {
+            vertical: self.vertical.clone(),
+            margin_percent: self.margin_percent,
+        }
+    }
+
+    /// Builds the serializable descriptor used by listing surfaces.
+    pub fn descriptor(&self) -> CaptionPackDescriptor {
+        CaptionPackDescriptor {
+            id: self.id.to_string(),
+            kind: "caption".to_string(),
+            description: self.description.to_string(),
+            aliases: self.aliases.iter().map(|alias| alias.to_string()).collect(),
+            style: self.style(),
+            position: self.position(),
+        }
+    }
+}
+
+/// Serializable description of a caption pack, as returned by listing surfaces.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptionPackDescriptor {
+    /// Canonical pack identifier.
+    pub id: String,
+    /// Always `"caption"`; lets caption and transition entries share one list.
+    pub kind: String,
+    /// One-line description of what the pack is for.
+    pub description: String,
+    /// Additional identifiers that resolve to this pack.
+    pub aliases: Vec<String>,
+    /// The typed style the pack applies.
+    pub style: CaptionStyle,
+    /// The typed position the pack applies.
+    pub position: CaptionPosition,
+}
+
+/// White at full opacity.
+const WHITE: Color = Color {
+    r: 255,
+    g: 255,
+    b: 255,
+    a: 255,
+};
+
+/// Opaque black, used for outlines and shadows.
+const BLACK: Color = Color {
+    r: 0,
+    g: 0,
+    b: 0,
+    a: 255,
+};
+
+/// The canonical caption pack table.
+///
+/// This is both the validator and the listing: `packs list` prints it and
+/// [`resolve_caption_pack`] matches against it.
+pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
+    CaptionPackSpec {
+        id: "standard-outline",
+        description: "General-purpose subtitle: white text with a thin black outline and a soft \
+                      drop shadow. The safe default when the brief says nothing about styling.",
+        aliases: &["standard", "default"],
+        font_family: "Arial",
+        font_size: 48,
+        font_weight: FontWeight::Normal,
+        color: WHITE,
+        background_color: None,
+        outline_color: Some(BLACK),
+        outline_width: 2.0,
+        shadow_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 128,
+        }),
+        shadow_offset: 2.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 10.0,
+    },
+    CaptionPackSpec {
+        id: "clean-minimal",
+        description: "Unadorned white text with no outline, shadow, or box. Use only over \
+                      controlled, consistently dark footage.",
+        aliases: &["minimal", "clean"],
+        font_family: "Arial",
+        font_size: 48,
+        font_weight: FontWeight::Normal,
+        color: WHITE,
+        background_color: None,
+        outline_color: None,
+        outline_width: 0.0,
+        shadow_color: None,
+        shadow_offset: 0.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 10.0,
+    },
+    CaptionPackSpec {
+        id: "boxed-contrast",
+        description: "White text on a translucent black box. Survives busy or bright backgrounds \
+                      where an outline alone breaks down.",
+        aliases: &["boxed", "box"],
+        font_family: "Arial",
+        font_size: 48,
+        font_weight: FontWeight::Normal,
+        color: WHITE,
+        background_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 180,
+        }),
+        outline_color: None,
+        outline_width: 0.0,
+        shadow_color: None,
+        shadow_offset: 0.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 10.0,
+    },
+    CaptionPackSpec {
+        id: "yellow-classic",
+        description: "Broadcast-legacy yellow subtitle with black outline and shadow. Reads as \
+                      dialogue subtitling rather than on-screen graphics.",
+        aliases: &["yellow", "classic"],
+        font_family: "Arial",
+        font_size: 48,
+        font_weight: FontWeight::Normal,
+        color: Color {
+            r: 255,
+            g: 255,
+            b: 0,
+            a: 255,
+        },
+        background_color: None,
+        outline_color: Some(BLACK),
+        outline_width: 2.0,
+        shadow_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 128,
+        }),
+        shadow_offset: 2.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 10.0,
+    },
+    CaptionPackSpec {
+        id: "shorts-bold-outline",
+        description: "Large bold white text with a thick black outline, lifted to an 18% bottom \
+                      margin so vertical-platform UI does not cover it.",
+        aliases: &["shorts", "reels", "tiktok", "vertical"],
+        font_family: "Arial",
+        font_size: 72,
+        font_weight: FontWeight::Bold,
+        color: WHITE,
+        background_color: None,
+        outline_color: Some(BLACK),
+        outline_width: 6.0,
+        shadow_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 160,
+        }),
+        shadow_offset: 3.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 18.0,
+    },
+    CaptionPackSpec {
+        id: "broadcast-lower",
+        description: "Left-aligned boxed caption at lower-third height, for name plates and \
+                      attribution rather than dialogue.",
+        aliases: &["broadcast", "lower-third"],
+        font_family: "Arial",
+        font_size: 40,
+        font_weight: FontWeight::Bold,
+        color: WHITE,
+        background_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 200,
+        }),
+        outline_color: None,
+        outline_width: 0.0,
+        shadow_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 120,
+        }),
+        shadow_offset: 2.0,
+        alignment: TextAlignment::Left,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 14.0,
+    },
+    CaptionPackSpec {
+        id: "high-contrast-accessible",
+        description: "Oversized bold white text on a near-opaque black box. Highest legibility \
+                      floor for small screens and low-vision viewers.",
+        aliases: &["accessible", "a11y", "high-contrast"],
+        font_family: "Arial",
+        font_size: 64,
+        font_weight: FontWeight::Bold,
+        color: WHITE,
+        background_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 230,
+        }),
+        outline_color: None,
+        outline_width: 0.0,
+        shadow_color: None,
+        shadow_offset: 0.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Bottom,
+        margin_percent: 12.0,
+    },
+    CaptionPackSpec {
+        id: "caption-top",
+        description: "Outlined white text anchored to the top of frame, for shots whose action \
+                      or burned-in graphics own the lower half.",
+        aliases: &["top", "top-caption"],
+        font_family: "Arial",
+        font_size: 48,
+        font_weight: FontWeight::Normal,
+        color: WHITE,
+        background_color: None,
+        outline_color: Some(BLACK),
+        outline_width: 2.0,
+        shadow_color: Some(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 128,
+        }),
+        shadow_offset: 2.0,
+        alignment: TextAlignment::Center,
+        vertical: VerticalPosition::Top,
+        margin_percent: 12.0,
+    },
+];
+
+/// Returns every caption pack descriptor, in table order.
+pub fn list_caption_packs() -> Vec<CaptionPackDescriptor> {
+    CAPTION_PACKS
+        .iter()
+        .map(CaptionPackSpec::descriptor)
+        .collect()
+}
+
+/// Returns the canonical ids of every caption pack, in table order.
+pub fn caption_pack_ids() -> Vec<&'static str> {
+    CAPTION_PACKS.iter().map(|pack| pack.id).collect()
+}
+
+/// Resolves a caption pack id.
+///
+/// Matching is tolerant of case and of `-`, `_`, or space separators, and of the
+/// per-pack alias list. An unknown id is a hard error naming every valid id.
+pub fn resolve_caption_pack(id: &str) -> Result<&'static CaptionPackSpec, String> {
+    let normalized = normalize_pack_id(id);
+
+    CAPTION_PACKS
+        .iter()
+        .find(|pack| {
+            normalize_pack_id(pack.id) == normalized
+                || pack
+                    .aliases
+                    .iter()
+                    .any(|alias| normalize_pack_id(alias) == normalized)
+        })
+        .ok_or_else(|| {
+            format!(
+                "Unknown caption style pack '{}'. Valid packs: {}",
+                id.trim(),
+                caption_pack_ids().join(", ")
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_pack_id_is_unique_and_hyphenated() {
+        let mut seen = std::collections::HashSet::new();
+        for pack in CAPTION_PACKS {
+            assert!(seen.insert(pack.id), "duplicate pack id '{}'", pack.id);
+            assert!(
+                pack.id
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "pack id '{}' must be lowercase kebab-case",
+                pack.id
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_accepts_separator_and_case_variants() {
+        for pack in CAPTION_PACKS {
+            let underscored = pack.id.replace('-', "_");
+            let spaced = pack.id.replace('-', " ");
+            for candidate in [
+                pack.id.to_string(),
+                underscored,
+                spaced,
+                pack.id.to_ascii_uppercase(),
+                format!("  {}  ", pack.id),
+            ] {
+                let resolved = resolve_caption_pack(&candidate)
+                    .unwrap_or_else(|error| panic!("'{candidate}' must resolve: {error}"));
+                assert_eq!(resolved.id, pack.id);
+            }
+        }
+    }
+
+    #[test]
+    fn every_alias_resolves_to_its_pack() {
+        for pack in CAPTION_PACKS {
+            for alias in pack.aliases {
+                let resolved = resolve_caption_pack(alias)
+                    .unwrap_or_else(|error| panic!("alias '{alias}' must resolve: {error}"));
+                assert_eq!(resolved.id, pack.id);
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_pack_error_lists_every_valid_id() {
+        let error = resolve_caption_pack("no-such-pack").expect_err("unknown id must fail");
+        for pack in CAPTION_PACKS {
+            assert!(
+                error.contains(pack.id),
+                "error must name '{}': {error}",
+                pack.id
+            );
+        }
+    }
+
+    #[test]
+    fn descriptors_round_trip_through_json() {
+        for descriptor in list_caption_packs() {
+            let json = serde_json::to_value(&descriptor).expect("descriptor serializes");
+            let parsed: CaptionPackDescriptor =
+                serde_json::from_value(json).expect("descriptor deserializes");
+            assert_eq!(parsed, descriptor);
+        }
+    }
+}

--- a/src-tauri/src/core/style/caption_packs.rs
+++ b/src-tauri/src/core/style/caption_packs.rs
@@ -10,27 +10,60 @@
 //!
 //! Every pack in [`CAPTION_PACKS`] is verified by contract test to:
 //!
-//! - deserialize back into a typed [`CaptionStyle`] after JSON round-trip, and
+//! - deserialize back into a typed [`CaptionStyle`] after JSON round-trip,
 //! - produce zero `CaptionSafeAreaRule` violations on both a 1920x1080 and a
-//!   1080x1920 canvas.
+//!   1080x1920 canvas — the rule measures the text block against the canvas, so
+//!   the two runs are two different measurements rather than one repeated, and
+//! - reach the export `drawtext` filter with the typography it advertises.
 //!
-//! The safe-area guarantee is why every pack anchors with
-//! [`CaptionPosition::Preset`] at a margin at or above the 10% title-safe band:
-//! a preset margin is canvas-independent, so it holds for landscape and vertical
-//! deliveries alike.
+//! Most packs anchor with [`CaptionPosition::Preset`] at a margin at or above
+//! the 10% title-safe band. A pack whose alignment is not centered anchors with
+//! [`CaptionPosition::Custom`] instead, because the renderer reads a preset
+//! anchor as horizontally centered: pairing left alignment with a preset would
+//! put the text's left edge at frame center.
 //!
 //! # Stability
 //!
-//! Pack ids are a public contract. The op log records the id an edit was made
-//! with, so ids are append-only: rename nothing, and add rather than repurpose.
+//! Pack ids are a public contract, so ids are append-only: rename nothing, and
+//! add rather than repurpose. The op log records the concrete style a pack
+//! produced, not the id that produced it — replay never consults this table —
+//! so a rename cannot be repaired by rewriting history.
 
 use serde::{Deserialize, Serialize};
 
 use crate::core::captions::{
-    CaptionPosition, CaptionStyle, Color, FontWeight, TextAlignment, VerticalPosition,
+    CaptionPosition, CaptionStyle, Color, CustomPosition, FontWeight, TextAlignment,
+    VerticalPosition,
 };
 
 use super::normalize_pack_id;
+
+/// Where a pack places its captions.
+///
+/// A preset anchor is canvas-independent, which is what a centered dialogue
+/// subtitle wants. A pack that is not centered has to name its own coordinates:
+/// the render path reads every preset anchor as x = 50%, so pairing left
+/// alignment with a preset would put the text's *left edge* at frame center.
+#[derive(Clone, Debug)]
+enum PackAnchor {
+    /// Vertical preset at a margin percentage of the canvas height.
+    Preset {
+        /// Which edge the margin is measured from.
+        vertical: VerticalPosition,
+        /// Distance from that edge, as a percentage of canvas height.
+        margin_percent: f64,
+    },
+    /// Explicit canvas-percentage anchor.
+    ///
+    /// `x_percent` is the text's left edge for a left-aligned pack and its
+    /// center for a centered one, matching how `drawtext` reads the anchor.
+    Custom {
+        /// Horizontal anchor, as a percentage of canvas width.
+        x_percent: f64,
+        /// Vertical center of the text block, as a percentage of canvas height.
+        y_percent: f64,
+    },
+}
 
 /// Immutable definition of one curated caption style pack.
 ///
@@ -56,8 +89,7 @@ pub struct CaptionPackSpec {
     shadow_color: Option<Color>,
     shadow_offset: f32,
     alignment: TextAlignment,
-    vertical: VerticalPosition,
-    margin_percent: f64,
+    anchor: PackAnchor,
 }
 
 impl CaptionPackSpec {
@@ -81,9 +113,21 @@ impl CaptionPackSpec {
 
     /// Materializes the typed caption position for this pack.
     pub fn position(&self) -> CaptionPosition {
-        CaptionPosition::Preset {
-            vertical: self.vertical.clone(),
-            margin_percent: self.margin_percent,
+        match &self.anchor {
+            PackAnchor::Preset {
+                vertical,
+                margin_percent,
+            } => CaptionPosition::Preset {
+                vertical: vertical.clone(),
+                margin_percent: *margin_percent,
+            },
+            PackAnchor::Custom {
+                x_percent,
+                y_percent,
+            } => CaptionPosition::Custom(CustomPosition {
+                x_percent: *x_percent,
+                y_percent: *y_percent,
+            }),
         }
     }
 
@@ -159,8 +203,10 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         }),
         shadow_offset: 2.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 10.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Bottom,
+            margin_percent: 10.0,
+        },
     },
     CaptionPackSpec {
         id: "clean-minimal",
@@ -177,8 +223,10 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         shadow_color: None,
         shadow_offset: 0.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 10.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Bottom,
+            margin_percent: 10.0,
+        },
     },
     CaptionPackSpec {
         id: "boxed-contrast",
@@ -200,8 +248,10 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         shadow_color: None,
         shadow_offset: 0.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 10.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Bottom,
+            margin_percent: 10.0,
+        },
     },
     CaptionPackSpec {
         id: "yellow-classic",
@@ -228,8 +278,10 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         }),
         shadow_offset: 2.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 10.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Bottom,
+            margin_percent: 10.0,
+        },
     },
     CaptionPackSpec {
         id: "shorts-bold-outline",
@@ -251,12 +303,14 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         }),
         shadow_offset: 3.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 18.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Bottom,
+            margin_percent: 18.0,
+        },
     },
     CaptionPackSpec {
         id: "broadcast-lower",
-        description: "Left-aligned boxed caption at lower-third height, for name plates and \
+        description: "Left-aligned boxed name plate anchored in the lower-left third, for \
                       attribution rather than dialogue.",
         aliases: &["broadcast", "lower-third"],
         font_family: "Arial",
@@ -279,8 +333,14 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         }),
         shadow_offset: 2.0,
         alignment: TextAlignment::Left,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 14.0,
+        // The only non-centered pack, so the only one that cannot use a preset:
+        // `drawtext` puts a left-aligned run's left edge on the anchor, and a
+        // preset anchor is always x = 50%. 10% from the left is the title-safe
+        // edge, which is where a name plate belongs.
+        anchor: PackAnchor::Custom {
+            x_percent: 10.0,
+            y_percent: 84.0,
+        },
     },
     CaptionPackSpec {
         id: "high-contrast-accessible",
@@ -302,8 +362,10 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         shadow_color: None,
         shadow_offset: 0.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Bottom,
-        margin_percent: 12.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Bottom,
+            margin_percent: 12.0,
+        },
     },
     CaptionPackSpec {
         id: "caption-top",
@@ -325,8 +387,10 @@ pub const CAPTION_PACKS: &[CaptionPackSpec] = &[
         }),
         shadow_offset: 2.0,
         alignment: TextAlignment::Center,
-        vertical: VerticalPosition::Top,
-        margin_percent: 12.0,
+        anchor: PackAnchor::Preset {
+            vertical: VerticalPosition::Top,
+            margin_percent: 12.0,
+        },
     },
 ];
 
@@ -425,6 +489,25 @@ mod tests {
                 error.contains(pack.id),
                 "error must name '{}': {error}",
                 pack.id
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_centered_pack_never_anchors_with_a_preset() {
+        // The render path resolves every preset anchor to x = 50%, so left or
+        // right alignment paired with one puts the text's edge at frame center
+        // instead of where the pack says it goes.
+        for pack in CAPTION_PACKS {
+            if pack.style().alignment == TextAlignment::Center {
+                continue;
+            }
+
+            assert!(
+                matches!(pack.position(), CaptionPosition::Custom(_)),
+                "pack '{}' is {:?}-aligned, so it must name its own x anchor",
+                pack.id,
+                pack.style().alignment
             );
         }
     }

--- a/src-tauri/src/core/style/contract_tests.rs
+++ b/src-tauri/src/core/style/contract_tests.rs
@@ -1,0 +1,640 @@
+//! Contract guards for the curated style registries.
+//!
+//! A pack is only worth naming if naming it is safer than styling by hand. That
+//! promise is checked here end to end rather than asserted in prose:
+//!
+//! * every caption pack survives the real command path — payload with
+//!   `stylePack` through [`CommandPayload::parse`], execute, and back out of the
+//!   clip as typed [`CaptionStyle`] — and then draws zero `CaptionSafeAreaRule`
+//!   violations on both a 1920x1080 and a 1080x1920 canvas;
+//! * every caption pack produces a real `drawtext` filter through the render
+//!   seam, so a pack cannot be legible on paper and invisible in the export;
+//! * every transition recipe resolves through `AddEffect` and builds the FFmpeg
+//!   filter its family is supposed to build.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+
+use crate::core::captions::{CaptionPosition, CaptionStyle};
+use crate::core::commands::CommandExecutor;
+use crate::core::effects::{Effect, EffectType, IntoFFmpegFilter, ParamValue};
+use crate::core::project::ProjectState;
+use crate::core::qc::context::QCContext;
+use crate::core::qc::rules::{QCRule, RuleConfig};
+use crate::core::qc::CaptionSafeAreaRule;
+use crate::core::render::export::build_caption_drawtext_with_enable;
+use crate::core::style::{
+    caption_pack_ids, transition_recipe_ids, CAPTION_PACKS, TRANSITION_RECIPES,
+};
+use crate::core::timeline::{Clip, Sequence, SequenceFormat, Track, TrackKind};
+use crate::ipc::CommandPayload;
+
+/// Caption text long enough to exercise the safe-area width estimate.
+const CAPTION_TEXT: &str = "The quick brown fox jumps over the lazy dog";
+
+/// Builds a project holding one empty caption track and one video clip track.
+fn project_with_caption_track(format: SequenceFormat) -> (ProjectState, String, String, String) {
+    let mut state = ProjectState::new_empty("Curated Packs");
+
+    let mut sequence = Sequence::new("Main", format);
+    let mut video = Track::new_video("V1");
+    let mut clip = Clip::with_range("asset_fixture", 0.0, 10.0);
+    clip.place.timeline_in_sec = 0.0;
+    clip.place.duration_sec = 10.0;
+    let clip_id = clip.id.clone();
+    video.add_clip(clip);
+    sequence.add_track(video);
+
+    let captions = Track::new_caption("C1");
+    let caption_track_id = captions.id.clone();
+    sequence.add_track(captions);
+
+    let sequence_id = sequence.id.clone();
+    state.active_sequence_id = Some(sequence_id.clone());
+    state.sequences.insert(sequence_id.clone(), sequence);
+
+    (state, sequence_id, caption_track_id, clip_id)
+}
+
+/// Runs a command through the full strict path: parse, build, execute.
+fn execute_payload(
+    state: &mut ProjectState,
+    command_type: &str,
+    payload: Value,
+) -> Result<Vec<String>, String> {
+    let parsed = CommandPayload::parse(command_type.to_string(), payload)?;
+    let command = parsed.build_command(std::path::Path::new("."));
+    let mut executor = CommandExecutor::new();
+    executor
+        .execute(command, state)
+        .map(|result| result.created_ids)
+        .map_err(|error| error.to_string())
+}
+
+/// Returns the caption clip a `CreateCaption` produced.
+fn caption_clip<'a>(state: &'a ProjectState, sequence_id: &str, caption_id: &str) -> &'a Clip {
+    state
+        .sequences
+        .get(sequence_id)
+        .expect("sequence exists")
+        .tracks
+        .iter()
+        .filter(|track| track.kind == TrackKind::Caption)
+        .flat_map(|track| track.clips.iter())
+        .find(|clip| clip.id == caption_id)
+        .expect("caption clip exists")
+}
+
+/// Runs `CaptionSafeAreaRule` over a sequence and returns its violations.
+fn safe_area_violations(state: &ProjectState, sequence_id: &str) -> Vec<String> {
+    let sequence = state.sequences.get(sequence_id).expect("sequence exists");
+    let rule = CaptionSafeAreaRule::new();
+    let context = QCContext::from_sequence(sequence);
+    let config = RuleConfig::default();
+
+    let violations = futures::executor::block_on(rule.check(sequence, state, &config, &context))
+        .expect("safe area rule runs");
+
+    violations
+        .into_iter()
+        .map(|violation| format!("{} ({:?})", violation.message, violation.severity))
+        .collect()
+}
+
+/// Creates one caption styled by `pack_id` and returns the resulting clip state.
+fn create_caption_with_pack(format: SequenceFormat, pack_id: &str) -> (ProjectState, String, Clip) {
+    let (mut state, sequence_id, caption_track_id, _clip_id) = project_with_caption_track(format);
+
+    let created = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 1.0,
+            "endSec": 4.0,
+            "stylePack": pack_id,
+        }),
+    )
+    .unwrap_or_else(|error| panic!("pack '{pack_id}' must create a caption: {error}"));
+
+    let caption_id = created.first().expect("caption id").clone();
+    let clip = caption_clip(&state, &sequence_id, &caption_id).clone();
+
+    (state, sequence_id, clip)
+}
+
+#[test]
+fn every_caption_pack_round_trips_into_a_typed_style() {
+    for pack in CAPTION_PACKS {
+        let (_state, _sequence_id, clip) =
+            create_caption_with_pack(SequenceFormat::youtube_1080(), pack.id);
+
+        let style_json = clip
+            .caption_style
+            .as_ref()
+            .unwrap_or_else(|| panic!("pack '{}' must store a caption style", pack.id));
+        let style: CaptionStyle = serde_json::from_value(style_json.clone())
+            .unwrap_or_else(|error| panic!("pack '{}' style must be typed: {error}", pack.id));
+        assert_eq!(style, pack.style(), "pack '{}' style drifted", pack.id);
+
+        let position_json = clip
+            .caption_position
+            .as_ref()
+            .unwrap_or_else(|| panic!("pack '{}' must store a caption position", pack.id));
+        let position: CaptionPosition = serde_json::from_value(position_json.clone())
+            .unwrap_or_else(|error| panic!("pack '{}' position must be typed: {error}", pack.id));
+        assert_eq!(
+            position,
+            pack.position(),
+            "pack '{}' position drifted",
+            pack.id
+        );
+    }
+}
+
+#[test]
+fn every_caption_pack_passes_the_safe_area_rule_on_both_canvases() {
+    for pack in CAPTION_PACKS {
+        for (label, format) in [
+            ("1920x1080", SequenceFormat::youtube_1080()),
+            ("1080x1920", SequenceFormat::shorts_1080()),
+        ] {
+            let (state, sequence_id, _clip) = create_caption_with_pack(format, pack.id);
+            let violations = safe_area_violations(&state, &sequence_id);
+
+            assert!(
+                violations.is_empty(),
+                "pack '{}' must be safe at {label}, got: {}",
+                pack.id,
+                violations.join("; ")
+            );
+        }
+    }
+}
+
+#[test]
+fn every_caption_pack_renders_a_drawtext_filter() {
+    for pack in CAPTION_PACKS {
+        let (_state, _sequence_id, clip) =
+            create_caption_with_pack(SequenceFormat::youtube_1080(), pack.id);
+
+        let filter = build_caption_drawtext_with_enable(&clip)
+            .unwrap_or_else(|| panic!("pack '{}' must render a drawtext filter", pack.id));
+
+        assert!(
+            filter.starts_with("drawtext="),
+            "pack '{}' must render drawtext, got: {filter}",
+            pack.id
+        );
+        assert!(
+            filter.contains("enable='between(t,"),
+            "pack '{}' filter must be time gated, got: {filter}",
+            pack.id
+        );
+    }
+}
+
+#[test]
+fn explicit_style_field_overrides_only_that_pack_key() {
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let created = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 0.0,
+            "endSec": 2.0,
+            "stylePack": "boxed-contrast",
+            "style": { "fontSize": 96, "italic": true },
+        }),
+    )
+    .expect("pack plus overrides must execute");
+
+    let caption_id = created.first().expect("caption id");
+    let clip = caption_clip(&state, &sequence_id, caption_id);
+    let style: CaptionStyle =
+        serde_json::from_value(clip.caption_style.clone().expect("style")).expect("typed style");
+    let pack_style = crate::core::style::resolve_caption_pack("boxed-contrast")
+        .expect("pack resolves")
+        .style();
+
+    // Overridden.
+    assert_eq!(style.font_size, 96);
+    assert!(style.italic);
+    // Inherited from the pack.
+    assert_eq!(style.background_color, pack_style.background_color);
+    assert_eq!(style.font_family, pack_style.font_family);
+    assert_eq!(style.alignment, pack_style.alignment);
+}
+
+#[test]
+fn explicit_position_replaces_the_pack_anchor() {
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let created = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 0.0,
+            "endSec": 2.0,
+            "stylePack": "clean-minimal",
+            "position": { "type": "preset", "vertical": "top", "marginPercent": 25.0 },
+        }),
+    )
+    .expect("pack plus position override must execute");
+
+    let caption_id = created.first().expect("caption id");
+    let clip = caption_clip(&state, &sequence_id, caption_id);
+    let position: CaptionPosition =
+        serde_json::from_value(clip.caption_position.clone().expect("position"))
+            .expect("typed position");
+
+    assert_eq!(
+        position,
+        CaptionPosition::Preset {
+            vertical: crate::core::captions::VerticalPosition::Top,
+            margin_percent: 25.0,
+        }
+    );
+}
+
+#[test]
+fn update_caption_applies_a_pack_to_an_existing_caption() {
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let created = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 0.0,
+            "endSec": 2.0,
+        }),
+    )
+    .expect("plain caption must execute");
+    let caption_id = created.first().expect("caption id").clone();
+
+    execute_payload(
+        &mut state,
+        "UpdateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "captionId": caption_id,
+            "stylePack": "high-contrast-accessible",
+        }),
+    )
+    .expect("restyle must execute");
+
+    let clip = caption_clip(&state, &sequence_id, &caption_id);
+    let style: CaptionStyle =
+        serde_json::from_value(clip.caption_style.clone().expect("style")).expect("typed style");
+
+    assert_eq!(
+        style,
+        crate::core::style::resolve_caption_pack("high-contrast-accessible")
+            .expect("pack resolves")
+            .style()
+    );
+}
+
+#[test]
+fn import_generated_captions_applies_a_pack_to_every_cue() {
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::shorts_1080());
+
+    execute_payload(
+        &mut state,
+        "ImportGeneratedCaptions",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "stylePack": "shorts-bold-outline",
+            "segments": [
+                { "startSec": 0.0, "endSec": 1.5, "text": "First cue" },
+                { "startSec": 1.5, "endSec": 3.0, "text": "Second cue" },
+            ],
+        }),
+    )
+    .expect("import must execute");
+
+    let expected = crate::core::style::resolve_caption_pack("shorts-bold-outline")
+        .expect("pack resolves")
+        .style();
+
+    let sequence = state.sequences.get(&sequence_id).expect("sequence");
+    let captions: Vec<&Clip> = sequence
+        .tracks
+        .iter()
+        .filter(|track| track.kind == TrackKind::Caption)
+        .flat_map(|track| track.clips.iter())
+        .collect();
+
+    assert_eq!(captions.len(), 2);
+    for clip in captions {
+        let style: CaptionStyle =
+            serde_json::from_value(clip.caption_style.clone().expect("style")).expect("typed");
+        assert_eq!(style, expected);
+    }
+
+    assert!(safe_area_violations(&state, &sequence_id).is_empty());
+}
+
+#[test]
+fn unknown_caption_pack_is_rejected_with_the_valid_list() {
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let error = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 0.0,
+            "endSec": 2.0,
+            "stylePack": "not-a-pack",
+        }),
+    )
+    .expect_err("unknown pack must be rejected");
+
+    for id in caption_pack_ids() {
+        assert!(error.contains(id), "error must name '{id}': {error}");
+    }
+}
+
+#[test]
+fn every_transition_recipe_builds_its_ffmpeg_filter() {
+    for recipe in TRANSITION_RECIPES {
+        let (mut state, sequence_id, _caption_track_id, clip_id) =
+            project_with_caption_track(SequenceFormat::youtube_1080());
+        let track_id = state
+            .sequences
+            .get(&sequence_id)
+            .expect("sequence")
+            .tracks
+            .iter()
+            .find(|track| track.kind == TrackKind::Video)
+            .expect("video track")
+            .id
+            .clone();
+
+        let created = execute_payload(
+            &mut state,
+            "AddEffect",
+            json!({
+                "sequenceId": sequence_id,
+                "trackId": track_id,
+                "clipId": clip_id,
+                "recipe": recipe.id,
+            }),
+        )
+        .unwrap_or_else(|error| panic!("recipe '{}' must execute: {error}", recipe.id));
+
+        let effect_id = created.first().expect("effect id");
+        let effect: &Effect = state.effects.get(effect_id).expect("effect stored");
+
+        assert_eq!(
+            effect.effect_type, recipe.effect_type,
+            "recipe '{}' applied the wrong effect type",
+            recipe.id
+        );
+
+        let filter = effect.to_filter_string("in", "out");
+        assert!(
+            !filter.is_empty(),
+            "recipe '{}' produced an empty filter",
+            recipe.id
+        );
+
+        let expected_fragment = match recipe.effect_type {
+            EffectType::CrossDissolve => "xfade=transition=dissolve",
+            EffectType::Wipe => "xfade=transition=wipe",
+            EffectType::Slide => "xfade=transition=slide",
+            EffectType::Fade => "fade=t=",
+            EffectType::Zoom => "zoompan",
+            ref other => panic!("recipe '{}' uses unexpected type {other:?}", recipe.id),
+        };
+        assert!(
+            filter.contains(expected_fragment),
+            "recipe '{}' filter must contain '{expected_fragment}', got: {filter}",
+            recipe.id
+        );
+    }
+}
+
+#[test]
+fn explicit_param_overrides_the_recipe_duration() {
+    let (mut state, sequence_id, _caption_track_id, clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+    let track_id = state
+        .sequences
+        .get(&sequence_id)
+        .expect("sequence")
+        .tracks
+        .iter()
+        .find(|track| track.kind == TrackKind::Video)
+        .expect("video track")
+        .id
+        .clone();
+
+    let created = execute_payload(
+        &mut state,
+        "AddEffect",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "recipe": "dissolve-soft",
+            "params": { "duration": 3.0 },
+        }),
+    )
+    .expect("recipe plus override must execute");
+
+    let effect = state
+        .effects
+        .get(created.first().expect("effect id"))
+        .expect("effect stored");
+
+    assert_eq!(effect.get_float("duration"), Some(3.0));
+    assert_eq!(effect.get_float("offset"), Some(0.0));
+}
+
+#[test]
+fn recipe_conflicting_with_an_explicit_effect_type_is_rejected() {
+    let (mut state, sequence_id, _caption_track_id, clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+    let track_id = state
+        .sequences
+        .get(&sequence_id)
+        .expect("sequence")
+        .tracks
+        .iter()
+        .find(|track| track.kind == TrackKind::Video)
+        .expect("video track")
+        .id
+        .clone();
+
+    let error = execute_payload(
+        &mut state,
+        "AddEffect",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "recipe": "dissolve-soft",
+            "effectType": "wipe",
+        }),
+    )
+    .expect_err("conflicting effect type must be rejected");
+
+    assert!(error.contains("dissolve-soft"), "{error}");
+}
+
+#[test]
+fn unknown_transition_recipe_is_rejected_with_the_valid_list() {
+    let error = CommandPayload::parse(
+        "AddEffect".to_string(),
+        json!({
+            "sequenceId": "seq",
+            "trackId": "track",
+            "clipId": "clip",
+            "recipe": "not-a-recipe",
+        }),
+    )
+    .expect_err("unknown recipe must be rejected");
+
+    for id in transition_recipe_ids() {
+        assert!(error.contains(id), "error must name '{id}': {error}");
+    }
+}
+
+#[test]
+fn add_effect_without_a_type_or_recipe_is_rejected() {
+    let error = CommandPayload::parse(
+        "AddEffect".to_string(),
+        json!({
+            "sequenceId": "seq",
+            "trackId": "track",
+            "clipId": "clip",
+        }),
+    )
+    .expect_err("a typeless AddEffect must be rejected");
+
+    assert!(error.contains("effectType"), "{error}");
+    assert!(error.contains("recipe"), "{error}");
+}
+
+#[test]
+fn add_effect_still_accepts_a_plain_effect_type() {
+    let parsed = CommandPayload::parse(
+        "AddEffect".to_string(),
+        json!({
+            "sequenceId": "seq",
+            "trackId": "track",
+            "clipId": "clip",
+            "effectType": "gaussian_blur",
+            "params": { "radius": 4.0 },
+        }),
+    )
+    .expect("a plain AddEffect must still parse");
+
+    let CommandPayload::AddEffect(payload) = parsed else {
+        panic!("parsed the wrong variant");
+    };
+    assert_eq!(payload.effect_type, Some(EffectType::GaussianBlur));
+    assert_eq!(
+        payload.params.get("radius"),
+        Some(&ParamValue::Float(4.0)),
+        "explicit params must survive resolution"
+    );
+}
+
+#[test]
+fn caption_payloads_without_a_pack_are_untouched() {
+    let style = json!({ "fontSize": 21 });
+    let parsed = CommandPayload::parse(
+        "CreateCaption".to_string(),
+        json!({
+            "sequenceId": "seq",
+            "trackId": "track",
+            "text": "hello",
+            "startSec": 0.0,
+            "endSec": 1.0,
+            "style": style,
+        }),
+    )
+    .expect("plain caption payload must parse");
+
+    let CommandPayload::CreateCaption(payload) = parsed else {
+        panic!("parsed the wrong variant");
+    };
+    assert_eq!(payload.style, Some(style));
+    assert_eq!(payload.position, None);
+}
+
+#[test]
+fn resolution_survives_a_payload_round_trip() {
+    let parsed = CommandPayload::parse(
+        "CreateCaption".to_string(),
+        json!({
+            "sequenceId": "seq",
+            "trackId": "track",
+            "text": "hello",
+            "startSec": 0.0,
+            "endSec": 1.0,
+            "stylePack": "yellow-classic",
+        }),
+    )
+    .expect("pack payload must parse");
+
+    let CommandPayload::CreateCaption(payload) = parsed else {
+        panic!("parsed the wrong variant");
+    };
+    let serialized = serde_json::to_value(&payload).expect("payload serializes");
+
+    let reparsed = CommandPayload::parse("CreateCaption".to_string(), serialized)
+        .expect("resolved payload must re-parse");
+    let CommandPayload::CreateCaption(reparsed) = reparsed else {
+        panic!("parsed the wrong variant");
+    };
+
+    assert_eq!(reparsed.style, payload.style);
+    assert_eq!(reparsed.position, payload.position);
+    assert_eq!(reparsed.style_pack.as_deref(), Some("yellow-classic"));
+}
+
+#[test]
+fn recipe_params_do_not_leak_between_recipes() {
+    // A guard against a shared-mutable-table style regression: resolving one
+    // recipe must not observe another's parameters.
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for recipe in TRANSITION_RECIPES {
+        let resolved =
+            crate::core::style::resolve_effect_recipe(Some(recipe.id), None, HashMap::new())
+                .expect("resolves");
+        seen.insert(recipe.id, resolved.params.len());
+        assert_eq!(
+            resolved.params.len(),
+            recipe.params().len(),
+            "recipe '{}' gained or lost parameters",
+            recipe.id
+        );
+    }
+    assert_eq!(seen.len(), TRANSITION_RECIPES.len());
+}

--- a/src-tauri/src/core/style/contract_tests.rs
+++ b/src-tauri/src/core/style/contract_tests.rs
@@ -6,11 +6,14 @@
 //! * every caption pack survives the real command path — payload with
 //!   `stylePack` through [`CommandPayload::parse`], execute, and back out of the
 //!   clip as typed [`CaptionStyle`] — and then draws zero `CaptionSafeAreaRule`
-//!   violations on both a 1920x1080 and a 1080x1920 canvas;
-//! * every caption pack produces a real `drawtext` filter through the render
-//!   seam, so a pack cannot be legible on paper and invisible in the export;
-//! * every transition recipe resolves through `AddEffect` and builds the FFmpeg
-//!   filter its family is supposed to build.
+//!   violations on both a 1920x1080 and a 1080x1920 canvas, with a negative
+//!   control proving the rule can still fail;
+//! * every caption pack's own typography reaches the `drawtext` filter through
+//!   the render seam, so a pack cannot be legible on paper and generic in the
+//!   export;
+//! * every transition recipe resolves through `AddEffect` and builds the exact
+//!   FFmpeg transition token and duration it advertises, not merely something
+//!   from the right family.
 
 use std::collections::HashMap;
 
@@ -87,13 +90,15 @@ fn caption_clip<'a>(state: &'a ProjectState, sequence_id: &str, caption_id: &str
 }
 
 /// Runs `CaptionSafeAreaRule` over a sequence and returns its violations.
-fn safe_area_violations(state: &ProjectState, sequence_id: &str) -> Vec<String> {
+async fn safe_area_violations(state: &ProjectState, sequence_id: &str) -> Vec<String> {
     let sequence = state.sequences.get(sequence_id).expect("sequence exists");
     let rule = CaptionSafeAreaRule::new();
     let context = QCContext::from_sequence(sequence);
     let config = RuleConfig::default();
 
-    let violations = futures::executor::block_on(rule.check(sequence, state, &config, &context))
+    let violations = rule
+        .check(sequence, state, &config, &context)
+        .await
         .expect("safe area rule runs");
 
     violations
@@ -104,21 +109,31 @@ fn safe_area_violations(state: &ProjectState, sequence_id: &str) -> Vec<String> 
 
 /// Creates one caption styled by `pack_id` and returns the resulting clip state.
 fn create_caption_with_pack(format: SequenceFormat, pack_id: &str) -> (ProjectState, String, Clip) {
+    create_caption_with_pack_and_style(format, pack_id, None)
+}
+
+/// Creates one caption styled by `pack_id` plus an optional style override.
+fn create_caption_with_pack_and_style(
+    format: SequenceFormat,
+    pack_id: &str,
+    style: Option<Value>,
+) -> (ProjectState, String, Clip) {
     let (mut state, sequence_id, caption_track_id, _clip_id) = project_with_caption_track(format);
 
-    let created = execute_payload(
-        &mut state,
-        "CreateCaption",
-        json!({
-            "sequenceId": sequence_id,
-            "trackId": caption_track_id,
-            "text": CAPTION_TEXT,
-            "startSec": 1.0,
-            "endSec": 4.0,
-            "stylePack": pack_id,
-        }),
-    )
-    .unwrap_or_else(|error| panic!("pack '{pack_id}' must create a caption: {error}"));
+    let mut payload = json!({
+        "sequenceId": sequence_id,
+        "trackId": caption_track_id,
+        "text": CAPTION_TEXT,
+        "startSec": 1.0,
+        "endSec": 4.0,
+        "stylePack": pack_id,
+    });
+    if let Some(style) = style {
+        payload["style"] = style;
+    }
+
+    let created = execute_payload(&mut state, "CreateCaption", payload)
+        .unwrap_or_else(|error| panic!("pack '{pack_id}' must create a caption: {error}"));
 
     let caption_id = created.first().expect("caption id").clone();
     let clip = caption_clip(&state, &sequence_id, &caption_id).clone();
@@ -155,15 +170,15 @@ fn every_caption_pack_round_trips_into_a_typed_style() {
     }
 }
 
-#[test]
-fn every_caption_pack_passes_the_safe_area_rule_on_both_canvases() {
+#[tokio::test]
+async fn every_caption_pack_passes_the_safe_area_rule_on_both_canvases() {
     for pack in CAPTION_PACKS {
         for (label, format) in [
             ("1920x1080", SequenceFormat::youtube_1080()),
             ("1080x1920", SequenceFormat::shorts_1080()),
         ] {
             let (state, sequence_id, _clip) = create_caption_with_pack(format, pack.id);
-            let violations = safe_area_violations(&state, &sequence_id);
+            let violations = safe_area_violations(&state, &sequence_id).await;
 
             assert!(
                 violations.is_empty(),
@@ -175,11 +190,41 @@ fn every_caption_pack_passes_the_safe_area_rule_on_both_canvases() {
     }
 }
 
+#[tokio::test]
+async fn the_safe_area_guarantee_is_falsifiable() {
+    // Negative control for the test above. The rule measures the text block
+    // against the canvas, so a pack perturbed past what the canvas can hold has
+    // to fail — otherwise "every pack passes" would be a statement about the
+    // rule's blind spots rather than about the packs.
+    for pack in CAPTION_PACKS {
+        for (label, format) in [
+            ("1920x1080", SequenceFormat::youtube_1080()),
+            ("1080x1920", SequenceFormat::shorts_1080()),
+        ] {
+            let (state, sequence_id, _clip) = create_caption_with_pack_and_style(
+                format,
+                pack.id,
+                Some(json!({ "fontSize": 500 })),
+            );
+            let violations = safe_area_violations(&state, &sequence_id).await;
+
+            assert!(
+                !violations.is_empty(),
+                "pack '{}' at 500px must be reported unsafe at {label}",
+                pack.id
+            );
+        }
+    }
+}
+
 #[test]
-fn every_caption_pack_renders_a_drawtext_filter() {
+fn every_caption_pack_renders_its_own_typography_into_the_drawtext_filter() {
+    let mut filters_by_pack: Vec<(&str, String)> = Vec::new();
+
     for pack in CAPTION_PACKS {
         let (_state, _sequence_id, clip) =
             create_caption_with_pack(SequenceFormat::youtube_1080(), pack.id);
+        let style = pack.style();
 
         let filter = build_caption_drawtext_with_enable(&clip)
             .unwrap_or_else(|| panic!("pack '{}' must render a drawtext filter", pack.id));
@@ -194,6 +239,97 @@ fn every_caption_pack_renders_a_drawtext_filter() {
             "pack '{}' filter must be time gated, got: {filter}",
             pack.id
         );
+
+        // The point of the pack is its typography, so the assertion is that the
+        // pack's own values arrive — not that some drawtext filter exists.
+        assert!(
+            filter.contains(&format!("fontsize={}", style.font_size)),
+            "pack '{}' must render at {}px, got: {filter}",
+            pack.id,
+            style.font_size
+        );
+        assert!(
+            filter.contains(&format!("fontcolor={}", ffmpeg_color(&style.color))),
+            "pack '{}' must render in its own color, got: {filter}",
+            pack.id
+        );
+
+        match &style.background_color {
+            Some(background) => {
+                assert!(
+                    filter.contains("box=1")
+                        && filter.contains(&format!("boxcolor={}", ffmpeg_color(background))),
+                    "pack '{}' must render its box at alpha {}, got: {filter}",
+                    pack.id,
+                    background.a
+                );
+            }
+            None => assert!(
+                !filter.contains("boxcolor="),
+                "pack '{}' declares no box, got: {filter}",
+                pack.id
+            ),
+        }
+
+        match &style.outline_color {
+            Some(outline) => assert!(
+                filter.contains(&format!(":borderw={}", style.outline_width as i64))
+                    && filter.contains(&format!("bordercolor={}", ffmpeg_color(outline))),
+                "pack '{}' must render its outline, got: {filter}",
+                pack.id
+            ),
+            None => assert!(
+                !filter.contains("bordercolor="),
+                "pack '{}' declares no outline, got: {filter}",
+                pack.id
+            ),
+        }
+
+        assert!(
+            filter.contains(&format!("x={}", expected_x_expression(pack))),
+            "pack '{}' must anchor where it says it does, got: {filter}",
+            pack.id
+        );
+
+        filters_by_pack.push((pack.id, filter));
+    }
+
+    // Two packs that describe different looks must not compile to the same
+    // filter: identical output would mean the differences never reached it.
+    for (index, (id, filter)) in filters_by_pack.iter().enumerate() {
+        for (other_id, other_filter) in filters_by_pack.iter().skip(index + 1) {
+            assert_ne!(
+                filter, other_filter,
+                "packs '{id}' and '{other_id}' render identically"
+            );
+        }
+    }
+}
+
+/// Renders a pack color the way `hex_to_ffmpeg_color` does.
+///
+/// Full opacity has no `@alpha` suffix; anything else carries the alpha the
+/// pack declared, which is what makes a translucent box translucent.
+fn ffmpeg_color(color: &crate::core::captions::Color) -> String {
+    let hex = format!("0x{:02X}{:02X}{:02X}", color.r, color.g, color.b);
+    if color.a == 255 {
+        hex
+    } else {
+        format!("{hex}@{:.2}", f64::from(color.a) / 255.0)
+    }
+}
+
+/// The `x=` expression a pack's anchor and alignment must produce.
+fn expected_x_expression(pack: &crate::core::style::CaptionPackSpec) -> String {
+    let (x_norm, alignment) = match pack.position() {
+        CaptionPosition::Preset { .. } => (0.5, pack.style().alignment),
+        CaptionPosition::Custom(custom) => (custom.x_percent / 100.0, pack.style().alignment),
+    };
+
+    match alignment {
+        crate::core::captions::TextAlignment::Left => format!("(w*{x_norm:.4})"),
+        crate::core::captions::TextAlignment::Right => format!("(w*{x_norm:.4})-text_w"),
+        crate::core::captions::TextAlignment::Center => format!("(w*{x_norm:.4})-(text_w/2)"),
     }
 }
 
@@ -270,6 +406,101 @@ fn explicit_position_replaces_the_pack_anchor() {
 }
 
 #[test]
+fn a_type_less_custom_position_replaces_the_pack_anchor() {
+    // The CLI accepts `--position-json '{"xPercent":…,"yPercent":…}'` without a
+    // `type`, and `command execute` accepts the same object. Merging it into a
+    // preset pack anchor would keep the pack's placement and leave the caller's
+    // coordinates as keys the render path never reads.
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let created = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 0.0,
+            "endSec": 2.0,
+            "stylePack": "clean-minimal",
+            "position": { "xPercent": 25.0, "yPercent": 80.0 },
+        }),
+    )
+    .expect("pack plus a type-less custom position must execute");
+
+    let caption_id = created.first().expect("caption id");
+    let clip = caption_clip(&state, &sequence_id, caption_id);
+    let stored = clip.caption_position.clone().expect("position");
+
+    assert_eq!(stored, json!({ "xPercent": 25.0, "yPercent": 80.0 }));
+
+    // And it has to survive all the way into the filter, which is the only
+    // place the difference is observable.
+    let filter = build_caption_drawtext_with_enable(clip).expect("drawtext filter");
+    assert!(
+        filter.contains("x=(w*0.2500)"),
+        "the requested anchor must reach the filter, got: {filter}"
+    );
+}
+
+#[test]
+fn update_caption_with_only_a_pack_leaves_the_caption_where_it_is() {
+    let (mut state, sequence_id, caption_track_id, _clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let created = execute_payload(
+        &mut state,
+        "CreateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "text": CAPTION_TEXT,
+            "startSec": 0.0,
+            "endSec": 2.0,
+            "position": { "type": "preset", "vertical": "top", "marginPercent": 12.0 },
+        }),
+    )
+    .expect("caption must execute");
+    let caption_id = created.first().expect("caption id").clone();
+
+    execute_payload(
+        &mut state,
+        "UpdateCaption",
+        json!({
+            "sequenceId": sequence_id,
+            "trackId": caption_track_id,
+            "captionId": caption_id,
+            "stylePack": "boxed-contrast",
+        }),
+    )
+    .expect("restyle must execute");
+
+    let clip = caption_clip(&state, &sequence_id, &caption_id);
+    let position: CaptionPosition =
+        serde_json::from_value(clip.caption_position.clone().expect("position"))
+            .expect("typed position");
+
+    // A restyle is not a move: the caption was deliberately placed at the top,
+    // and the pack's bottom anchor must not drag it back down.
+    assert_eq!(
+        position,
+        CaptionPosition::Preset {
+            vertical: crate::core::captions::VerticalPosition::Top,
+            margin_percent: 12.0,
+        }
+    );
+    let style: CaptionStyle =
+        serde_json::from_value(clip.caption_style.clone().expect("style")).expect("typed style");
+    assert_eq!(
+        style,
+        crate::core::style::resolve_caption_pack("boxed-contrast")
+            .expect("pack resolves")
+            .style()
+    );
+}
+
+#[test]
 fn update_caption_applies_a_pack_to_an_existing_caption() {
     let (mut state, sequence_id, caption_track_id, _clip_id) =
         project_with_caption_track(SequenceFormat::youtube_1080());
@@ -312,8 +543,8 @@ fn update_caption_applies_a_pack_to_an_existing_caption() {
     );
 }
 
-#[test]
-fn import_generated_captions_applies_a_pack_to_every_cue() {
+#[tokio::test]
+async fn import_generated_captions_applies_a_pack_to_every_cue() {
     let (mut state, sequence_id, caption_track_id, _clip_id) =
         project_with_caption_track(SequenceFormat::shorts_1080());
 
@@ -351,7 +582,7 @@ fn import_generated_captions_applies_a_pack_to_every_cue() {
         assert_eq!(style, expected);
     }
 
-    assert!(safe_area_violations(&state, &sequence_id).is_empty());
+    assert!(safe_area_violations(&state, &sequence_id).await.is_empty());
 }
 
 #[test]
@@ -378,36 +609,50 @@ fn unknown_caption_pack_is_rejected_with_the_valid_list() {
     }
 }
 
+/// Adds `payload` as an `AddEffect` on the fixture's video clip.
+fn add_effect(
+    state: &mut ProjectState,
+    sequence_id: &str,
+    clip_id: &str,
+    mut payload: Value,
+) -> String {
+    let track_id = state
+        .sequences
+        .get(sequence_id)
+        .expect("sequence")
+        .tracks
+        .iter()
+        .find(|track| track.kind == TrackKind::Video)
+        .expect("video track")
+        .id
+        .clone();
+
+    payload["sequenceId"] = json!(sequence_id);
+    payload["trackId"] = json!(track_id);
+    payload["clipId"] = json!(clip_id);
+
+    let created = execute_payload(state, "AddEffect", payload).expect("AddEffect must execute");
+    created.first().expect("effect id").clone()
+}
+
 #[test]
-fn every_transition_recipe_builds_its_ffmpeg_filter() {
+fn every_transition_recipe_builds_the_exact_filter_it_advertises() {
+    // Family prefixes are useless as a guard: every wipe direction shares
+    // `xfade=transition=wipe`, and all three dissolves share
+    // `xfade=transition=dissolve`. What distinguishes one curated entry from
+    // its sibling is the direction token, the duration, or the fade side, so
+    // that is what has to be asserted.
     for recipe in TRANSITION_RECIPES {
         let (mut state, sequence_id, _caption_track_id, clip_id) =
             project_with_caption_track(SequenceFormat::youtube_1080());
-        let track_id = state
-            .sequences
-            .get(&sequence_id)
-            .expect("sequence")
-            .tracks
-            .iter()
-            .find(|track| track.kind == TrackKind::Video)
-            .expect("video track")
-            .id
-            .clone();
 
-        let created = execute_payload(
+        let effect_id = add_effect(
             &mut state,
-            "AddEffect",
-            json!({
-                "sequenceId": sequence_id,
-                "trackId": track_id,
-                "clipId": clip_id,
-                "recipe": recipe.id,
-            }),
-        )
-        .unwrap_or_else(|error| panic!("recipe '{}' must execute: {error}", recipe.id));
-
-        let effect_id = created.first().expect("effect id");
-        let effect: &Effect = state.effects.get(effect_id).expect("effect stored");
+            &sequence_id,
+            &clip_id,
+            json!({ "recipe": recipe.id }),
+        );
+        let effect: &Effect = state.effects.get(&effect_id).expect("effect stored");
 
         assert_eq!(
             effect.effect_type, recipe.effect_type,
@@ -416,26 +661,86 @@ fn every_transition_recipe_builds_its_ffmpeg_filter() {
         );
 
         let filter = effect.to_filter_string("in", "out");
-        assert!(
-            !filter.is_empty(),
-            "recipe '{}' produced an empty filter",
-            recipe.id
-        );
-
-        let expected_fragment = match recipe.effect_type {
-            EffectType::CrossDissolve => "xfade=transition=dissolve",
-            EffectType::Wipe => "xfade=transition=wipe",
-            EffectType::Slide => "xfade=transition=slide",
-            EffectType::Fade => "fade=t=",
-            EffectType::Zoom => "zoompan",
-            ref other => panic!("recipe '{}' uses unexpected type {other:?}", recipe.id),
+        let expected = match recipe.id {
+            "dissolve-soft" => "xfade=transition=dissolve:duration=0.5000:offset=0.0000",
+            "dissolve-standard" => "xfade=transition=dissolve:duration=1.0000:offset=0.0000",
+            "dissolve-long" => "xfade=transition=dissolve:duration=2.0000:offset=0.0000",
+            "fade-in" => "fade=t=in:st=0:d=1.0000",
+            // The fixture clip is 10s, so the tail anchor is 10 - 1.
+            "fade-out" => "fade=t=out:st=9.0000:d=1.0000",
+            "wipe-left" => "xfade=transition=wipeleft:duration=0.7000:offset=0.0000",
+            "wipe-right" => "xfade=transition=wiperight:duration=0.7000:offset=0.0000",
+            "wipe-up" => "xfade=transition=wipeup:duration=0.7000:offset=0.0000",
+            "wipe-down" => "xfade=transition=wipedown:duration=0.7000:offset=0.0000",
+            "slide-left" => "xfade=transition=slideleft:duration=0.5000:offset=0.0000",
+            "slide-right" => "xfade=transition=slideright:duration=0.5000:offset=0.0000",
+            other => panic!(
+                "recipe '{other}' has no expected filter; add one rather than \
+                 letting a new curated entry ship unasserted"
+            ),
         };
+
         assert!(
-            filter.contains(expected_fragment),
-            "recipe '{}' filter must contain '{expected_fragment}', got: {filter}",
+            filter.contains(expected),
+            "recipe '{}' must build '{expected}', got: {filter}",
             recipe.id
         );
     }
+}
+
+#[test]
+fn fade_out_is_anchored_on_the_clip_tail() {
+    // The filter builder measures `st` from the clip's own zero, so a fade-out
+    // that keeps the default 0 fades during the first second and holds black
+    // for the rest of the clip.
+    let (mut state, sequence_id, _caption_track_id, clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let effect_id = add_effect(
+        &mut state,
+        &sequence_id,
+        &clip_id,
+        json!({ "recipe": "fade-out" }),
+    );
+    let effect = state.effects.get(&effect_id).expect("effect stored");
+
+    assert_eq!(effect.get_float("start_time"), Some(9.0));
+    assert!(effect
+        .to_filter_string("in", "out")
+        .contains("fade=t=out:st=9.0000:d=1.0000"));
+}
+
+#[test]
+fn fade_out_longer_than_its_clip_becomes_the_whole_clip() {
+    let (mut state, sequence_id, _caption_track_id, clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let effect_id = add_effect(
+        &mut state,
+        &sequence_id,
+        &clip_id,
+        json!({ "recipe": "fade-out", "params": { "duration": 25.0 } }),
+    );
+    let effect = state.effects.get(&effect_id).expect("effect stored");
+
+    assert_eq!(effect.get_float("start_time"), Some(0.0));
+    assert_eq!(effect.get_float("duration"), Some(10.0));
+}
+
+#[test]
+fn an_explicit_fade_start_time_is_never_overwritten() {
+    let (mut state, sequence_id, _caption_track_id, clip_id) =
+        project_with_caption_track(SequenceFormat::youtube_1080());
+
+    let effect_id = add_effect(
+        &mut state,
+        &sequence_id,
+        &clip_id,
+        json!({ "recipe": "fade-out", "params": { "start_time": 2.0 } }),
+    );
+    let effect = state.effects.get(&effect_id).expect("effect stored");
+
+    assert_eq!(effect.get_float("start_time"), Some(2.0));
 }
 
 #[test]

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -25,6 +25,15 @@
 //! so an override spelled one way removes every spelling the pack contributed.
 //! Without that, a pack's `fontSize` would silently outrank a caller's
 //! `font_size`.
+//!
+//! Positions layer only within one anchoring mode. A pack anchor and a caller
+//! anchor that disagree about *how* they place the caption do not blend, so the
+//! caller's replaces the pack's outright — see [`resolve_caption_layers`].
+//!
+//! Restyling is the one place a pack is style-only: `UpdateCaption` replaces
+//! whatever position the command carries, so a pack anchor riding along with a
+//! restyle would move a caption nobody asked to move. [`resolve_caption_style`]
+//! is the entry point for that case.
 
 pub mod caption_packs;
 pub mod transition_recipes;
@@ -86,6 +95,15 @@ const CAPTION_POSITION_KEY_GROUPS: &[&[&str]] = &[
     &["yPercent", "y_percent", "y"],
 ];
 
+/// Position JSON keys that name a custom anchor's coordinates.
+///
+/// A position object carrying any of these is a custom anchor even when it
+/// omits `type`, because that is how every consumer already reads it: the CLI
+/// validator defaults a missing `type` to `custom`, and the render path falls
+/// through to the coordinate branch when no `type` is present.
+const CUSTOM_POSITION_COORDINATE_KEYS: &[&str] =
+    &["xPercent", "x_percent", "x", "yPercent", "y_percent", "y"];
+
 /// The style and position a caption command should store on its clip.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ResolvedCaptionLayers {
@@ -107,8 +125,11 @@ pub struct ResolvedEffectRecipe {
 /// Resolves a caption style pack against caller-supplied style and position.
 ///
 /// The pack is the base layer; `style` and `position` override it key by key.
-/// A position override whose `type` differs from the pack's replaces the pack
+/// A position override that anchors differently from the pack replaces the pack
 /// position outright, because a preset anchor and a custom anchor do not merge.
+/// Anchoring mode is read from `type` when present and from the coordinate keys
+/// when it is not, so `{"xPercent": 25, "yPercent": 80}` replaces a preset pack
+/// anchor rather than decorating it with keys the render path never reads.
 ///
 /// Returns an error naming every valid pack id when `style_pack` is unknown.
 pub fn resolve_caption_layers(
@@ -135,6 +156,22 @@ pub fn resolve_caption_layers(
         )),
         position: Some(merge_position_layer(pack_position, position)),
     })
+}
+
+/// Resolves a caption style pack for an edit that must not move the caption.
+///
+/// `UpdateCaption` replaces the stored anchor whenever the command carries one,
+/// so a pack anchor riding along with a restyle would silently reposition a
+/// caption that was placed deliberately — a caption lifted clear of a burned-in
+/// lower third would drop straight back into it. A pack on an update therefore
+/// contributes style only; a new anchor has to be asked for explicitly.
+///
+/// Returns an error naming every valid pack id when `style_pack` is unknown.
+pub fn resolve_caption_style(
+    style_pack: Option<&str>,
+    style: Option<Value>,
+) -> Result<Option<Value>, String> {
+    Ok(resolve_caption_layers(style_pack, style, None)?.style)
 }
 
 /// Resolves a transition recipe against a caller-supplied effect type and params.
@@ -220,23 +257,67 @@ fn merge_json_layer(base: Value, overrides: Option<Value>, groups: &[&[&str]]) -
     Value::Object(merged)
 }
 
+/// Classifies a caption position object as `preset` or `custom`.
+///
+/// `type` decides when it is present. Otherwise a coordinate key decides, which
+/// is what makes a type-less `{"xPercent": …, "yPercent": …}` a custom anchor
+/// rather than an untyped fragment. `None` means the object names neither — a
+/// partial such as `{"marginPercent": 20}`, which can only be read as an
+/// overlay on whatever it is merged onto.
+fn position_anchor_kind(value: &Value) -> Option<String> {
+    if let Some(explicit) = value.get("type").and_then(Value::as_str) {
+        return Some(explicit.trim().to_ascii_lowercase());
+    }
+
+    CUSTOM_POSITION_COORDINATE_KEYS
+        .iter()
+        .any(|key| value.get(*key).is_some())
+        .then(|| "custom".to_string())
+}
+
 /// Merges a caption position override onto a pack position.
 ///
-/// Positions only merge within one anchoring mode: an override that names a
-/// different `type` replaces the pack position instead of blending preset and
-/// custom fields into an object that means neither.
+/// Positions only merge within one anchoring mode: an override that anchors
+/// differently from the pack replaces the pack position instead of blending
+/// preset and custom fields into an object that means neither.
 fn merge_position_layer(base: Value, overrides: Option<Value>) -> Value {
     let Some(overrides) = overrides.filter(|value| !value.is_null()) else {
         return base;
     };
 
-    let base_type = base.get("type").and_then(Value::as_str);
-    let override_type = overrides.get("type").and_then(Value::as_str);
-    if override_type.is_some() && override_type != base_type {
+    let base_kind = position_anchor_kind(&base);
+    let override_kind = position_anchor_kind(&overrides);
+    if override_kind.is_some() && override_kind != base_kind {
         return overrides;
     }
 
-    merge_json_layer(base, Some(overrides), CAPTION_POSITION_KEY_GROUPS)
+    let merged = merge_json_layer(base, Some(overrides), CAPTION_POSITION_KEY_GROUPS);
+    drop_dead_preset_coordinates(merged)
+}
+
+/// Removes coordinate keys from a preset anchor.
+///
+/// The render path returns as soon as it reads `"type":"preset"`, so `xPercent`
+/// or `yPercent` sitting next to it are keys no consumer reads while looking
+/// exactly like an applied position. One object must mean one anchor.
+fn drop_dead_preset_coordinates(position: Value) -> Value {
+    let is_preset = position
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind.trim().eq_ignore_ascii_case("preset"));
+    if !is_preset {
+        return position;
+    }
+
+    match position {
+        Value::Object(mut object) => {
+            for key in CUSTOM_POSITION_COORDINATE_KEYS {
+                object.remove(*key);
+            }
+            Value::Object(object)
+        }
+        other => other,
+    }
 }
 
 #[cfg(test)]
@@ -330,6 +411,68 @@ mod tests {
             resolve_caption_layers(Some("standard-outline"), None, Some(custom.clone())).unwrap();
 
         assert_eq!(resolved.position, Some(custom));
+    }
+
+    #[test]
+    fn type_less_custom_coordinates_replace_the_pack_anchor() {
+        // The CLI accepts and range-validates this shape without stamping a
+        // `type`, so it has to read as a custom anchor here too.
+        let custom = serde_json::json!({ "xPercent": 25.0, "yPercent": 80.0 });
+        let resolved =
+            resolve_caption_layers(Some("clean-minimal"), None, Some(custom.clone())).unwrap();
+
+        assert_eq!(resolved.position, Some(custom));
+    }
+
+    #[test]
+    fn a_merged_preset_never_carries_coordinate_keys() {
+        let resolved = resolve_caption_layers(
+            Some("clean-minimal"),
+            None,
+            Some(serde_json::json!({ "type": "preset", "vertical": "top", "yPercent": 12.0 })),
+        )
+        .unwrap();
+
+        let position = resolved.position.expect("position");
+        assert!(
+            position.get("yPercent").is_none(),
+            "a preset anchor must not carry dead coordinates: {position}"
+        );
+        let typed: CaptionPosition = serde_json::from_value(position).unwrap();
+        assert!(matches!(typed, CaptionPosition::Preset { .. }));
+    }
+
+    #[test]
+    fn a_margin_only_override_still_merges_onto_a_preset_pack() {
+        let resolved = resolve_caption_layers(
+            Some("shorts-bold-outline"),
+            None,
+            Some(serde_json::json!({ "marginPercent": 22.0 })),
+        )
+        .unwrap();
+
+        let position: CaptionPosition =
+            serde_json::from_value(resolved.position.expect("position")).unwrap();
+        assert_eq!(
+            position,
+            CaptionPosition::Preset {
+                vertical: crate::core::captions::VerticalPosition::Bottom,
+                margin_percent: 22.0,
+            }
+        );
+    }
+
+    #[test]
+    fn style_only_resolution_never_produces_a_position() {
+        let style = resolve_caption_style(Some("boxed-contrast"), None)
+            .unwrap()
+            .expect("style");
+
+        let typed: CaptionStyle = serde_json::from_value(style).unwrap();
+        assert_eq!(
+            typed,
+            resolve_caption_pack("boxed-contrast").unwrap().style()
+        );
     }
 
     #[test]
@@ -431,9 +574,9 @@ mod tests {
 
     #[test]
     fn resolution_is_idempotent_for_recipes() {
-        let first = resolve_effect_recipe(Some("zoom-punch"), None, HashMap::new()).unwrap();
+        let first = resolve_effect_recipe(Some("wipe-down"), None, HashMap::new()).unwrap();
         let second = resolve_effect_recipe(
-            Some("zoom-punch"),
+            Some("wipe-down"),
             first.effect_type.clone(),
             first.params.clone(),
         )

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -29,6 +29,9 @@
 pub mod caption_packs;
 pub mod transition_recipes;
 
+#[cfg(test)]
+mod contract_tests;
+
 use std::collections::HashMap;
 
 use serde_json::{Map, Value};

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -1,0 +1,441 @@
+//! Curated Style Registries
+//!
+//! Editorial quality is mostly a question of defaults. An agent asked to caption
+//! a video can pick a font size, an outline width, a background alpha, and a
+//! margin — four independent guesses with no feedback until the render — or it
+//! can name a pack that was checked once and stays checked by contract test.
+//!
+//! This module holds those registries:
+//!
+//! - [`caption_packs`] — typed [`CaptionStyle`](crate::core::captions::CaptionStyle)
+//!   plus [`CaptionPosition`](crate::core::captions::CaptionPosition) combinations
+//!   that pass `CaptionSafeAreaRule` on both landscape and vertical canvases.
+//! - [`transition_recipes`] — transition [`EffectType`] plus the parameters the
+//!   FFmpeg filter builder actually reads.
+//!
+//! # Layering
+//!
+//! A pack is a *base layer*, never a lock. [`resolve_caption_layers`] and
+//! [`resolve_effect_recipe`] merge caller-supplied values on top of the pack
+//! key by key, so `stylePack: "boxed-contrast"` with `style: {"fontSize": 64}`
+//! is the boxed pack at 64pt rather than an either/or choice.
+//!
+//! The merge is alias-aware: caption style JSON is read by the render path
+//! through alias groups (`fontSize` or `font_size`, `alignment` or `textAlign`),
+//! so an override spelled one way removes every spelling the pack contributed.
+//! Without that, a pack's `fontSize` would silently outrank a caller's
+//! `font_size`.
+
+pub mod caption_packs;
+pub mod transition_recipes;
+
+use std::collections::HashMap;
+
+use serde_json::{Map, Value};
+
+use crate::core::effects::{EffectType, ParamValue};
+
+pub use caption_packs::{
+    caption_pack_ids, list_caption_packs, resolve_caption_pack, CaptionPackDescriptor,
+    CaptionPackSpec, CAPTION_PACKS,
+};
+pub use transition_recipes::{
+    list_transition_recipes, resolve_transition_recipe, transition_recipe_ids, RecipeParam,
+    TransitionRecipeDescriptor, TransitionRecipeSpec, TRANSITION_RECIPES,
+};
+
+/// Normalizes a pack or recipe identifier for matching.
+///
+/// Follows the same contract as `ExportPreset::from_legacy_id`: trim, lowercase,
+/// and fold `_` and spaces onto the canonical `-` separator, so `Clean_Minimal`,
+/// `clean minimal`, and `clean-minimal` are one id.
+pub(crate) fn normalize_pack_id(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase().replace(['_', ' '], "-")
+}
+
+/// Caption style JSON keys that mean the same thing to the render path.
+///
+/// The render path reads each group by trying its spellings in order, so an
+/// override must displace the whole group rather than only its own spelling.
+const CAPTION_STYLE_KEY_GROUPS: &[&[&str]] = &[
+    &["fontFamily", "font_family"],
+    &["fontSize", "font_size"],
+    &["fontWeight", "font_weight"],
+    &["backgroundColor", "background_color"],
+    &["backgroundPadding", "background_padding"],
+    &["outlineColor", "outline_color"],
+    &["outlineWidth", "outline_width"],
+    &["shadowColor", "shadow_color"],
+    &["shadowOffset", "shadow_offset"],
+    &["shadowOffsetX", "shadow_offset_x", "shadowX", "shadow_x"],
+    &["shadowOffsetY", "shadow_offset_y", "shadowY", "shadow_y"],
+    &["shadowBlur", "shadow_blur"],
+    &["lineHeight", "line_height"],
+    &["letterSpacing", "letter_spacing"],
+    &["alignment", "textAlign", "text_align"],
+    &["verticalAlign", "vertical_align"],
+];
+
+/// Caption position JSON keys that mean the same thing to the render path.
+const CAPTION_POSITION_KEY_GROUPS: &[&[&str]] = &[
+    &["marginPercent", "margin_percent"],
+    &["xPercent", "x_percent", "x"],
+    &["yPercent", "y_percent", "y"],
+];
+
+/// The style and position a caption command should store on its clip.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedCaptionLayers {
+    /// Caption style JSON, or `None` when neither a pack nor an override applied.
+    pub style: Option<Value>,
+    /// Caption position JSON, or `None` when neither a pack nor an override applied.
+    pub position: Option<Value>,
+}
+
+/// The effect type and parameters an `AddEffect` command should apply.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedEffectRecipe {
+    /// Effect type, taken from the recipe when one was named.
+    pub effect_type: Option<EffectType>,
+    /// Effect parameters: recipe values with caller overrides applied.
+    pub params: HashMap<String, ParamValue>,
+}
+
+/// Resolves a caption style pack against caller-supplied style and position.
+///
+/// The pack is the base layer; `style` and `position` override it key by key.
+/// A position override whose `type` differs from the pack's replaces the pack
+/// position outright, because a preset anchor and a custom anchor do not merge.
+///
+/// Returns an error naming every valid pack id when `style_pack` is unknown.
+pub fn resolve_caption_layers(
+    style_pack: Option<&str>,
+    style: Option<Value>,
+    position: Option<Value>,
+) -> Result<ResolvedCaptionLayers, String> {
+    let Some(pack_id) = style_pack.map(str::trim).filter(|id| !id.is_empty()) else {
+        return Ok(ResolvedCaptionLayers { style, position });
+    };
+
+    let pack = resolve_caption_pack(pack_id)?;
+
+    let pack_style = serde_json::to_value(pack.style())
+        .map_err(|error| format!("Failed to serialize caption pack style: {error}"))?;
+    let pack_position = serde_json::to_value(pack.position())
+        .map_err(|error| format!("Failed to serialize caption pack position: {error}"))?;
+
+    Ok(ResolvedCaptionLayers {
+        style: Some(merge_json_layer(
+            pack_style,
+            style,
+            CAPTION_STYLE_KEY_GROUPS,
+        )),
+        position: Some(merge_position_layer(pack_position, position)),
+    })
+}
+
+/// Resolves a transition recipe against a caller-supplied effect type and params.
+///
+/// The recipe supplies the effect type and its baseline parameters; `params`
+/// overrides individual recipe values. Naming a recipe *and* an incompatible
+/// effect type is an error rather than a silent preference, because the two
+/// express contradictory intent.
+///
+/// Returns an error naming every valid recipe id when `recipe` is unknown.
+pub fn resolve_effect_recipe(
+    recipe: Option<&str>,
+    effect_type: Option<EffectType>,
+    params: HashMap<String, ParamValue>,
+) -> Result<ResolvedEffectRecipe, String> {
+    let Some(recipe_id) = recipe.map(str::trim).filter(|id| !id.is_empty()) else {
+        return Ok(ResolvedEffectRecipe {
+            effect_type,
+            params,
+        });
+    };
+
+    let recipe = resolve_transition_recipe(recipe_id)?;
+
+    if let Some(explicit) = &effect_type {
+        if explicit != &recipe.effect_type {
+            return Err(format!(
+                "Transition recipe '{}' applies effect type {}, but effectType {} was also given. \
+                 Drop one of the two.",
+                recipe.id,
+                effect_type_label(&recipe.effect_type),
+                effect_type_label(explicit)
+            ));
+        }
+    }
+
+    let mut merged: HashMap<String, ParamValue> = recipe.params().into_iter().collect();
+    merged.extend(params);
+
+    Ok(ResolvedEffectRecipe {
+        effect_type: Some(recipe.effect_type.clone()),
+        params: merged,
+    })
+}
+
+/// Renders an effect type for an error message.
+fn effect_type_label(effect_type: &EffectType) -> String {
+    serde_json::to_value(effect_type)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{effect_type:?}"))
+}
+
+/// Merges `overrides` onto `base`, treating each alias group as one key.
+///
+/// A non-object or absent override leaves the base untouched, except that a
+/// non-null, non-object override replaces the base outright (there is nothing to
+/// merge into).
+fn merge_json_layer(base: Value, overrides: Option<Value>, groups: &[&[&str]]) -> Value {
+    let Some(overrides) = overrides.filter(|value| !value.is_null()) else {
+        return base;
+    };
+
+    let (Value::Object(base_object), Value::Object(override_object)) = (&base, &overrides) else {
+        return overrides;
+    };
+
+    let mut merged: Map<String, Value> = base_object.clone();
+    for (key, value) in override_object {
+        match groups.iter().find(|group| group.contains(&key.as_str())) {
+            Some(group) => {
+                for alias in *group {
+                    merged.remove(*alias);
+                }
+            }
+            None => {
+                merged.remove(key);
+            }
+        }
+        merged.insert(key.clone(), value.clone());
+    }
+
+    Value::Object(merged)
+}
+
+/// Merges a caption position override onto a pack position.
+///
+/// Positions only merge within one anchoring mode: an override that names a
+/// different `type` replaces the pack position instead of blending preset and
+/// custom fields into an object that means neither.
+fn merge_position_layer(base: Value, overrides: Option<Value>) -> Value {
+    let Some(overrides) = overrides.filter(|value| !value.is_null()) else {
+        return base;
+    };
+
+    let base_type = base.get("type").and_then(Value::as_str);
+    let override_type = overrides.get("type").and_then(Value::as_str);
+    if override_type.is_some() && override_type != base_type {
+        return overrides;
+    }
+
+    merge_json_layer(base, Some(overrides), CAPTION_POSITION_KEY_GROUPS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::captions::{CaptionPosition, CaptionStyle};
+
+    #[test]
+    fn absent_pack_passes_explicit_values_through_untouched() {
+        let style = serde_json::json!({ "fontSize": 30 });
+        let position = serde_json::json!({ "type": "preset", "vertical": "top" });
+
+        let resolved =
+            resolve_caption_layers(None, Some(style.clone()), Some(position.clone())).unwrap();
+
+        assert_eq!(resolved.style, Some(style));
+        assert_eq!(resolved.position, Some(position));
+    }
+
+    #[test]
+    fn pack_alone_yields_the_typed_pack_style_and_position() {
+        let resolved = resolve_caption_layers(Some("boxed-contrast"), None, None).unwrap();
+
+        let style: CaptionStyle = serde_json::from_value(resolved.style.expect("style")).unwrap();
+        let expected = resolve_caption_pack("boxed-contrast").unwrap();
+        assert_eq!(style, expected.style());
+
+        let position: CaptionPosition =
+            serde_json::from_value(resolved.position.expect("position")).unwrap();
+        assert_eq!(position, expected.position());
+    }
+
+    #[test]
+    fn explicit_style_field_overrides_only_that_key() {
+        let resolved = resolve_caption_layers(
+            Some("boxed-contrast"),
+            Some(serde_json::json!({ "fontSize": 96 })),
+            None,
+        )
+        .unwrap();
+
+        let style: CaptionStyle = serde_json::from_value(resolved.style.expect("style")).unwrap();
+        let pack = resolve_caption_pack("boxed-contrast").unwrap().style();
+
+        assert_eq!(style.font_size, 96);
+        assert_eq!(style.background_color, pack.background_color);
+        assert_eq!(style.font_family, pack.font_family);
+    }
+
+    #[test]
+    fn snake_case_override_displaces_the_packs_camel_case_key() {
+        let resolved = resolve_caption_layers(
+            Some("standard-outline"),
+            Some(serde_json::json!({ "font_size": 24 })),
+            None,
+        )
+        .unwrap();
+
+        let style = resolved.style.expect("style");
+        assert!(
+            style.get("fontSize").is_none(),
+            "the pack's camelCase spelling must not survive: {style}"
+        );
+        assert_eq!(style.get("font_size").and_then(Value::as_u64), Some(24));
+    }
+
+    #[test]
+    fn position_override_of_the_same_type_merges_key_by_key() {
+        let resolved = resolve_caption_layers(
+            Some("standard-outline"),
+            None,
+            Some(serde_json::json!({ "type": "preset", "marginPercent": 20 })),
+        )
+        .unwrap();
+
+        let position: CaptionPosition =
+            serde_json::from_value(resolved.position.expect("position")).unwrap();
+        assert_eq!(
+            position,
+            CaptionPosition::Preset {
+                vertical: crate::core::captions::VerticalPosition::Bottom,
+                margin_percent: 20.0,
+            }
+        );
+    }
+
+    #[test]
+    fn position_override_of_a_different_type_replaces_the_pack_anchor() {
+        let custom = serde_json::json!({ "type": "custom", "xPercent": 50.0, "yPercent": 40.0 });
+        let resolved =
+            resolve_caption_layers(Some("standard-outline"), None, Some(custom.clone())).unwrap();
+
+        assert_eq!(resolved.position, Some(custom));
+    }
+
+    #[test]
+    fn unknown_pack_is_rejected_with_the_valid_list() {
+        let error = resolve_caption_layers(Some("nope"), None, None).expect_err("must fail");
+        assert!(error.contains("clean-minimal"), "{error}");
+    }
+
+    #[test]
+    fn recipe_supplies_type_and_params_when_none_were_given() {
+        let resolved =
+            resolve_effect_recipe(Some("wipe-left"), None, HashMap::new()).expect("resolves");
+
+        assert_eq!(resolved.effect_type, Some(EffectType::Wipe));
+        assert_eq!(
+            resolved.params.get("direction"),
+            Some(&ParamValue::String("left".to_string()))
+        );
+        assert_eq!(
+            resolved
+                .params
+                .get("duration")
+                .and_then(ParamValue::as_float),
+            Some(0.7)
+        );
+    }
+
+    #[test]
+    fn explicit_param_overrides_the_recipe_value() {
+        let mut params = HashMap::new();
+        params.insert("duration".to_string(), ParamValue::Float(2.5));
+
+        let resolved = resolve_effect_recipe(Some("wipe-left"), None, params).expect("resolves");
+
+        assert_eq!(
+            resolved
+                .params
+                .get("duration")
+                .and_then(ParamValue::as_float),
+            Some(2.5)
+        );
+        assert_eq!(
+            resolved.params.get("direction"),
+            Some(&ParamValue::String("left".to_string()))
+        );
+    }
+
+    #[test]
+    fn matching_explicit_effect_type_is_accepted() {
+        let resolved = resolve_effect_recipe(
+            Some("dissolve-soft"),
+            Some(EffectType::CrossDissolve),
+            HashMap::new(),
+        )
+        .expect("resolves");
+
+        assert_eq!(resolved.effect_type, Some(EffectType::CrossDissolve));
+    }
+
+    #[test]
+    fn conflicting_explicit_effect_type_is_rejected() {
+        let error = resolve_effect_recipe(
+            Some("dissolve-soft"),
+            Some(EffectType::Wipe),
+            HashMap::new(),
+        )
+        .expect_err("must fail");
+
+        assert!(error.contains("dissolve-soft"), "{error}");
+        assert!(error.contains("cross_dissolve"), "{error}");
+        assert!(error.contains("wipe"), "{error}");
+    }
+
+    #[test]
+    fn unknown_recipe_is_rejected_with_the_valid_list() {
+        let error =
+            resolve_effect_recipe(Some("nope"), None, HashMap::new()).expect_err("must fail");
+        assert!(error.contains("dissolve-standard"), "{error}");
+    }
+
+    #[test]
+    fn resolution_is_idempotent_for_captions() {
+        let first = resolve_caption_layers(
+            Some("shorts-bold-outline"),
+            Some(serde_json::json!({ "italic": true })),
+            None,
+        )
+        .unwrap();
+
+        let second = resolve_caption_layers(
+            Some("shorts-bold-outline"),
+            first.style.clone(),
+            first.position.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn resolution_is_idempotent_for_recipes() {
+        let first = resolve_effect_recipe(Some("zoom-punch"), None, HashMap::new()).unwrap();
+        let second = resolve_effect_recipe(
+            Some("zoom-punch"),
+            first.effect_type.clone(),
+            first.params.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+    }
+}

--- a/src-tauri/src/core/style/transition_recipes.rs
+++ b/src-tauri/src/core/style/transition_recipes.rs
@@ -1,0 +1,392 @@
+//! Curated Transition Recipes
+//!
+//! A transition recipe is a named, hand-checked combination of a transition
+//! [`EffectType`] and the parameters the FFmpeg filter builder actually reads.
+//! Transitions in OpenReelio are ordinary effects (there is no `AddTransition`
+//! command), so a recipe is a shorthand for `AddEffect` with the right type and
+//! a duration that has been chosen rather than guessed.
+//!
+//! # Parameter contract
+//!
+//! Recipe parameters are restricted to keys the filter builder consumes:
+//!
+//! - `duration` (seconds) — every family
+//! - `offset` (seconds) — `xfade`-backed families (cross dissolve, wipe, slide)
+//! - `direction` (`left`/`right`/`up`/`down`) — wipe and slide
+//! - `fade_in` (bool) — fade
+//! - `zoom_type`, `zoom_factor` — zoom
+//!
+//! A recipe never sets a parameter it cannot know, which is why `fade-out` omits
+//! `start_time`: only the caller knows the clip's duration. Pass it explicitly
+//! alongside the recipe when the fade must land on the tail.
+//!
+//! # Stability
+//!
+//! Recipe ids are a public contract. The op log records the id an edit was made
+//! with, so ids are append-only: rename nothing, and add rather than repurpose.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::effects::{EffectType, ParamValue};
+
+use super::normalize_pack_id;
+
+/// A `const`-constructible parameter literal.
+///
+/// [`ParamValue::String`] owns a `String`, so the table stores `&'static str`
+/// and converts on demand.
+#[derive(Clone, Copy, Debug)]
+pub enum RecipeParam {
+    /// Numeric parameter (seconds, factors, ratios).
+    Float(f64),
+    /// Boolean switch.
+    Bool(bool),
+    /// Enumerated string parameter such as a direction.
+    Str(&'static str),
+}
+
+impl RecipeParam {
+    fn to_param_value(self) -> ParamValue {
+        match self {
+            Self::Float(value) => ParamValue::Float(value),
+            Self::Bool(value) => ParamValue::Bool(value),
+            Self::Str(value) => ParamValue::String(value.to_string()),
+        }
+    }
+}
+
+/// Immutable definition of one curated transition recipe.
+#[derive(Clone, Debug)]
+pub struct TransitionRecipeSpec {
+    /// Canonical, hyphenated recipe identifier.
+    pub id: &'static str,
+    /// One-line description of what the recipe is for.
+    pub description: &'static str,
+    /// Additional identifiers that resolve to this recipe.
+    pub aliases: &'static [&'static str],
+    /// The transition effect type the recipe applies.
+    pub effect_type: EffectType,
+    params: &'static [(&'static str, RecipeParam)],
+}
+
+impl TransitionRecipeSpec {
+    /// Materializes the recipe parameters as effect parameters.
+    pub fn params(&self) -> BTreeMap<String, ParamValue> {
+        self.params
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.to_param_value()))
+            .collect()
+    }
+
+    /// Builds the serializable descriptor used by listing surfaces.
+    pub fn descriptor(&self) -> TransitionRecipeDescriptor {
+        TransitionRecipeDescriptor {
+            id: self.id.to_string(),
+            kind: "transition".to_string(),
+            description: self.description.to_string(),
+            aliases: self.aliases.iter().map(|alias| alias.to_string()).collect(),
+            effect_type: self.effect_type.clone(),
+            params: self.params(),
+        }
+    }
+}
+
+/// Serializable description of a transition recipe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransitionRecipeDescriptor {
+    /// Canonical recipe identifier.
+    pub id: String,
+    /// Always `"transition"`; lets caption and transition entries share one list.
+    pub kind: String,
+    /// One-line description of what the recipe is for.
+    pub description: String,
+    /// Additional identifiers that resolve to this recipe.
+    pub aliases: Vec<String>,
+    /// The transition effect type the recipe applies.
+    pub effect_type: EffectType,
+    /// The effect parameters the recipe applies, sorted by key.
+    pub params: BTreeMap<String, ParamValue>,
+}
+
+/// The canonical transition recipe table.
+///
+/// This is both the validator and the listing: `packs list` prints it and
+/// [`resolve_transition_recipe`] matches against it.
+pub const TRANSITION_RECIPES: &[TransitionRecipeSpec] = &[
+    TransitionRecipeSpec {
+        id: "dissolve-soft",
+        description: "Half-second cross dissolve. Short enough to keep pace in a dialogue or \
+                      montage cut.",
+        aliases: &["soft-dissolve"],
+        effect_type: EffectType::CrossDissolve,
+        params: &[
+            ("duration", RecipeParam::Float(0.5)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "dissolve-standard",
+        description: "One-second cross dissolve. The default when a scene change needs a soft \
+                      handoff rather than a cut.",
+        aliases: &["dissolve", "crossfade", "cross-dissolve"],
+        effect_type: EffectType::CrossDissolve,
+        params: &[
+            ("duration", RecipeParam::Float(1.0)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "dissolve-long",
+        description: "Two-second cross dissolve for a deliberate passage-of-time feel.",
+        aliases: &["long-dissolve", "slow-dissolve"],
+        effect_type: EffectType::CrossDissolve,
+        params: &[
+            ("duration", RecipeParam::Float(2.0)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "fade-in",
+        description: "One-second fade up from black at the head of a clip.",
+        aliases: &["fadein", "fade-from-black"],
+        effect_type: EffectType::Fade,
+        params: &[
+            ("duration", RecipeParam::Float(1.0)),
+            ("fade_in", RecipeParam::Bool(true)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "fade-out",
+        description: "One-second fade down to black. Pass an explicit start_time of \
+                      (clip duration - 1.0) so the fade lands on the tail.",
+        aliases: &["fadeout", "fade-to-black"],
+        effect_type: EffectType::Fade,
+        params: &[
+            ("duration", RecipeParam::Float(1.0)),
+            ("fade_in", RecipeParam::Bool(false)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "wipe-left",
+        description: "0.7s wipe travelling left. Reads as a deliberate graphic transition, not a \
+                      cut.",
+        aliases: &["wipe"],
+        effect_type: EffectType::Wipe,
+        params: &[
+            ("direction", RecipeParam::Str("left")),
+            ("duration", RecipeParam::Float(0.7)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "wipe-right",
+        description: "0.7s wipe travelling right.",
+        aliases: &[],
+        effect_type: EffectType::Wipe,
+        params: &[
+            ("direction", RecipeParam::Str("right")),
+            ("duration", RecipeParam::Float(0.7)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "wipe-up",
+        description: "0.7s wipe travelling up.",
+        aliases: &[],
+        effect_type: EffectType::Wipe,
+        params: &[
+            ("direction", RecipeParam::Str("up")),
+            ("duration", RecipeParam::Float(0.7)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "wipe-down",
+        description: "0.7s wipe travelling down.",
+        aliases: &[],
+        effect_type: EffectType::Wipe,
+        params: &[
+            ("direction", RecipeParam::Str("down")),
+            ("duration", RecipeParam::Float(0.7)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "slide-left",
+        description: "Half-second slide pushing the outgoing shot left. Faster than a wipe and \
+                      carries direction with it.",
+        aliases: &["slide", "push-left"],
+        effect_type: EffectType::Slide,
+        params: &[
+            ("direction", RecipeParam::Str("left")),
+            ("duration", RecipeParam::Float(0.5)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "slide-right",
+        description: "Half-second slide pushing the outgoing shot right.",
+        aliases: &["push-right"],
+        effect_type: EffectType::Slide,
+        params: &[
+            ("direction", RecipeParam::Str("right")),
+            ("duration", RecipeParam::Float(0.5)),
+            ("offset", RecipeParam::Float(0.0)),
+        ],
+    },
+    TransitionRecipeSpec {
+        id: "zoom-punch",
+        description: "0.4s 1.15x zoom in. A beat-accent for social cuts, not a scene change.",
+        aliases: &["punch-in", "zoom"],
+        effect_type: EffectType::Zoom,
+        params: &[
+            ("duration", RecipeParam::Float(0.4)),
+            ("zoom_factor", RecipeParam::Float(1.15)),
+            ("zoom_type", RecipeParam::Str("in")),
+        ],
+    },
+];
+
+/// Returns every transition recipe descriptor, in table order.
+pub fn list_transition_recipes() -> Vec<TransitionRecipeDescriptor> {
+    TRANSITION_RECIPES
+        .iter()
+        .map(TransitionRecipeSpec::descriptor)
+        .collect()
+}
+
+/// Returns the canonical ids of every transition recipe, in table order.
+pub fn transition_recipe_ids() -> Vec<&'static str> {
+    TRANSITION_RECIPES.iter().map(|recipe| recipe.id).collect()
+}
+
+/// Resolves a transition recipe id.
+///
+/// Matching is tolerant of case and of `-`, `_`, or space separators, and of the
+/// per-recipe alias list. An unknown id is a hard error naming every valid id.
+pub fn resolve_transition_recipe(id: &str) -> Result<&'static TransitionRecipeSpec, String> {
+    let normalized = normalize_pack_id(id);
+
+    TRANSITION_RECIPES
+        .iter()
+        .find(|recipe| {
+            normalize_pack_id(recipe.id) == normalized
+                || recipe
+                    .aliases
+                    .iter()
+                    .any(|alias| normalize_pack_id(alias) == normalized)
+        })
+        .ok_or_else(|| {
+            format!(
+                "Unknown transition recipe '{}'. Valid recipes: {}",
+                id.trim(),
+                transition_recipe_ids().join(", ")
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::effects::EffectCategory;
+
+    #[test]
+    fn every_recipe_is_a_transition_category_effect() {
+        for recipe in TRANSITION_RECIPES {
+            assert_eq!(
+                recipe.effect_type.category(),
+                EffectCategory::Transition,
+                "recipe '{}' must use a transition effect type",
+                recipe.id
+            );
+        }
+    }
+
+    #[test]
+    fn every_recipe_id_is_unique_and_hyphenated() {
+        let mut seen = std::collections::HashSet::new();
+        for recipe in TRANSITION_RECIPES {
+            assert!(
+                seen.insert(recipe.id),
+                "duplicate recipe id '{}'",
+                recipe.id
+            );
+            assert!(
+                recipe
+                    .id
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "recipe id '{}' must be lowercase kebab-case",
+                recipe.id
+            );
+        }
+    }
+
+    #[test]
+    fn every_recipe_declares_a_positive_duration() {
+        for recipe in TRANSITION_RECIPES {
+            let params = recipe.params();
+            let duration = params
+                .get("duration")
+                .and_then(ParamValue::as_float)
+                .unwrap_or_else(|| panic!("recipe '{}' must declare a duration", recipe.id));
+            assert!(
+                duration > 0.0 && duration <= 5.0,
+                "recipe '{}' duration {duration} is out of range",
+                recipe.id
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_accepts_separator_and_case_variants() {
+        for recipe in TRANSITION_RECIPES {
+            for candidate in [
+                recipe.id.to_string(),
+                recipe.id.replace('-', "_"),
+                recipe.id.replace('-', " "),
+                recipe.id.to_ascii_uppercase(),
+            ] {
+                let resolved = resolve_transition_recipe(&candidate)
+                    .unwrap_or_else(|error| panic!("'{candidate}' must resolve: {error}"));
+                assert_eq!(resolved.id, recipe.id);
+            }
+        }
+    }
+
+    #[test]
+    fn every_alias_resolves_to_its_recipe() {
+        for recipe in TRANSITION_RECIPES {
+            for alias in recipe.aliases {
+                let resolved = resolve_transition_recipe(alias)
+                    .unwrap_or_else(|error| panic!("alias '{alias}' must resolve: {error}"));
+                assert_eq!(resolved.id, recipe.id);
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_recipe_error_lists_every_valid_id() {
+        let error = resolve_transition_recipe("no-such-recipe").expect_err("unknown id must fail");
+        for recipe in TRANSITION_RECIPES {
+            assert!(
+                error.contains(recipe.id),
+                "error must name '{}': {error}",
+                recipe.id
+            );
+        }
+    }
+
+    #[test]
+    fn descriptors_round_trip_through_json() {
+        for descriptor in list_transition_recipes() {
+            let json = serde_json::to_value(&descriptor).expect("descriptor serializes");
+            let parsed: TransitionRecipeDescriptor =
+                serde_json::from_value(json).expect("descriptor deserializes");
+            assert_eq!(parsed, descriptor);
+        }
+    }
+}

--- a/src-tauri/src/core/style/transition_recipes.rs
+++ b/src-tauri/src/core/style/transition_recipes.rs
@@ -14,16 +14,24 @@
 //! - `offset` (seconds) — `xfade`-backed families (cross dissolve, wipe, slide)
 //! - `direction` (`left`/`right`/`up`/`down`) — wipe and slide
 //! - `fade_in` (bool) — fade
-//! - `zoom_type`, `zoom_factor` — zoom
 //!
-//! A recipe never sets a parameter it cannot know, which is why `fade-out` omits
-//! `start_time`: only the caller knows the clip's duration. Pass it explicitly
-//! alongside the recipe when the fade must land on the tail.
+//! A recipe never sets a parameter it cannot know. `fade-out` therefore ships
+//! without `start_time`, which only the target clip's duration can supply;
+//! `AddEffectCommand::execute` computes it there, before the op is logged.
+//!
+//! # Admission
+//!
+//! The table is a quality floor, so an entry earns its place by rendering what
+//! its description promises. A recipe whose builder cannot produce the described
+//! result is removed rather than shipped with a caveat — an agent picking a
+//! one-token curated option must not have to know which entries are sound.
 //!
 //! # Stability
 //!
-//! Recipe ids are a public contract. The op log records the id an edit was made
-//! with, so ids are append-only: rename nothing, and add rather than repurpose.
+//! Recipe ids are a public contract, so ids are append-only: rename nothing, and
+//! add rather than repurpose. The op log records the parameters a recipe
+//! produced, not the id that produced them, so a rename would silently split
+//! one recipe into two for every surface that lists them.
 
 use std::collections::BTreeMap;
 
@@ -160,8 +168,8 @@ pub const TRANSITION_RECIPES: &[TransitionRecipeSpec] = &[
     },
     TransitionRecipeSpec {
         id: "fade-out",
-        description: "One-second fade down to black. Pass an explicit start_time of \
-                      (clip duration - 1.0) so the fade lands on the tail.",
+        description: "One-second fade down to black, anchored on the clip's tail. Pass an \
+                      explicit start_time to move the fade somewhere else in the clip.",
         aliases: &["fadeout", "fade-to-black"],
         effect_type: EffectType::Fade,
         params: &[
@@ -235,17 +243,6 @@ pub const TRANSITION_RECIPES: &[TransitionRecipeSpec] = &[
             ("direction", RecipeParam::Str("right")),
             ("duration", RecipeParam::Float(0.5)),
             ("offset", RecipeParam::Float(0.0)),
-        ],
-    },
-    TransitionRecipeSpec {
-        id: "zoom-punch",
-        description: "0.4s 1.15x zoom in. A beat-accent for social cuts, not a scene change.",
-        aliases: &["punch-in", "zoom"],
-        effect_type: EffectType::Zoom,
-        params: &[
-            ("duration", RecipeParam::Float(0.4)),
-            ("zoom_factor", RecipeParam::Float(1.15)),
-            ("zoom_type", RecipeParam::Str("in")),
         ],
     },
 ];

--- a/src-tauri/src/ipc/commands/ai_legacy.rs
+++ b/src-tauri/src/ipc/commands/ai_legacy.rs
@@ -1368,8 +1368,12 @@ pub async fn apply_edit_script(
                 Box::new(ReorderTracksCommand::new(&p.sequence_id, p.new_order))
             }
             CommandPayload::AddEffect(p) => {
-                let mut cmd =
-                    AddEffectCommand::new(&p.sequence_id, &p.track_id, &p.clip_id, p.effect_type);
+                let mut cmd = AddEffectCommand::with_optional_type(
+                    &p.sequence_id,
+                    &p.track_id,
+                    &p.clip_id,
+                    p.effect_type,
+                );
                 for (key, value) in p.params {
                     cmd = cmd.with_param(key, value);
                 }

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -1556,34 +1556,34 @@ impl CommandPayload {
     fn resolve_curated_packs(&mut self) -> Result<(), String> {
         use crate::core::style::{resolve_caption_layers, resolve_effect_recipe};
 
+        /// Applies a caption pack in place, leaving explicit values on top.
+        fn apply_caption_pack(
+            style_pack: Option<&str>,
+            style: &mut Option<serde_json::Value>,
+            position: &mut Option<serde_json::Value>,
+        ) -> Result<(), String> {
+            let resolved = resolve_caption_layers(style_pack, style.take(), position.take())?;
+            *style = resolved.style;
+            *position = resolved.position;
+            Ok(())
+        }
+
         match self {
-            Self::CreateCaption(payload) => {
-                let resolved = resolve_caption_layers(
-                    payload.style_pack.as_deref(),
-                    payload.style.take(),
-                    payload.position.take(),
-                )?;
-                payload.style = resolved.style;
-                payload.position = resolved.position;
-            }
-            Self::UpdateCaption(payload) => {
-                let resolved = resolve_caption_layers(
-                    payload.style_pack.as_deref(),
-                    payload.style.take(),
-                    payload.position.take(),
-                )?;
-                payload.style = resolved.style;
-                payload.position = resolved.position;
-            }
-            Self::ImportGeneratedCaptions(payload) => {
-                let resolved = resolve_caption_layers(
-                    payload.style_pack.as_deref(),
-                    payload.style.take(),
-                    payload.position.take(),
-                )?;
-                payload.style = resolved.style;
-                payload.position = resolved.position;
-            }
+            Self::CreateCaption(payload) => apply_caption_pack(
+                payload.style_pack.as_deref(),
+                &mut payload.style,
+                &mut payload.position,
+            )?,
+            Self::UpdateCaption(payload) => apply_caption_pack(
+                payload.style_pack.as_deref(),
+                &mut payload.style,
+                &mut payload.position,
+            )?,
+            Self::ImportGeneratedCaptions(payload) => apply_caption_pack(
+                payload.style_pack.as_deref(),
+                &mut payload.style,
+                &mut payload.position,
+            )?,
             Self::AddEffect(payload) => {
                 let resolved = resolve_effect_recipe(
                     payload.recipe.as_deref(),

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -651,6 +651,9 @@ pub struct UpdateCaptionPayload {
     // Keep them to avoid rejecting payloads during strict parsing.
     pub style: Option<serde_json::Value>,
     pub position: Option<serde_json::Value>,
+    /// Curated caption pack id, resolved into `style` + `position`.
+    #[serde(default)]
+    pub style_pack: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, specta::Type)]
@@ -667,6 +670,9 @@ pub struct CreateCaptionPayload {
     // applied by core command logic yet.
     pub style: Option<serde_json::Value>,
     pub position: Option<serde_json::Value>,
+    /// Curated caption pack id, resolved into `style` + `position`.
+    #[serde(default)]
+    pub style_pack: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, specta::Type)]
@@ -691,6 +697,9 @@ pub struct ImportGeneratedCaptionsPayload {
     pub segments: Vec<GeneratedCaptionSegmentPayload>,
     pub style: Option<serde_json::Value>,
     pub position: Option<serde_json::Value>,
+    /// Curated caption pack id, resolved into `style` + `position`.
+    #[serde(default)]
+    pub style_pack: Option<String>,
     #[serde(default)]
     pub replace_existing: bool,
 }
@@ -709,13 +718,23 @@ pub struct DeleteCaptionPayload {
 // =============================================================================
 
 /// Payload for adding an effect to a clip.
+///
+/// Either `effectType` or `recipe` must be present. A curated transition recipe
+/// (see `core::style::transition_recipes`) supplies the effect type and its
+/// baseline parameters; anything in `params` overrides the recipe key by key.
+/// `CommandPayload::parse` performs that resolution, so a payload that reaches
+/// command construction always carries an explicit effect type.
 #[derive(Debug, Serialize, Deserialize, Clone, specta::Type)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AddEffectPayload {
     pub sequence_id: SequenceId,
     pub track_id: TrackId,
     pub clip_id: ClipId,
-    pub effect_type: EffectType,
+    #[serde(default)]
+    pub effect_type: Option<EffectType>,
+    /// Curated transition recipe id, resolved into `effectType` + `params`.
+    #[serde(default)]
+    pub recipe: Option<String>,
     #[serde(default, alias = "parameters")]
     pub params: HashMap<String, ParamValue>,
     #[serde(default)]
@@ -1517,7 +1536,73 @@ impl CommandPayload {
             "commandType": command_type_trimmed,
             "payload": payload
         });
-        serde_json::from_value(raw_request).map_err(|e| format!("Invalid command payload: {}", e))
+        let mut parsed: Self = serde_json::from_value(raw_request)
+            .map_err(|e| format!("Invalid command payload: {}", e))?;
+        parsed.resolve_curated_packs()?;
+        Ok(parsed)
+    }
+
+    /// Expands curated caption packs and transition recipes into explicit values.
+    ///
+    /// This runs at the single strict-parsing chokepoint every JSON entry point
+    /// shares — GUI IPC, `command execute`, `plan execute`, agent steps — so a
+    /// pack id is resolved once, before the command is built, and the op log
+    /// records the concrete style or effect type it produced alongside the id
+    /// that produced it.
+    ///
+    /// The resolution is idempotent: re-parsing an already-resolved payload
+    /// yields the same values, because the explicit fields it wrote fully cover
+    /// the pack layer underneath.
+    fn resolve_curated_packs(&mut self) -> Result<(), String> {
+        use crate::core::style::{resolve_caption_layers, resolve_effect_recipe};
+
+        match self {
+            Self::CreateCaption(payload) => {
+                let resolved = resolve_caption_layers(
+                    payload.style_pack.as_deref(),
+                    payload.style.take(),
+                    payload.position.take(),
+                )?;
+                payload.style = resolved.style;
+                payload.position = resolved.position;
+            }
+            Self::UpdateCaption(payload) => {
+                let resolved = resolve_caption_layers(
+                    payload.style_pack.as_deref(),
+                    payload.style.take(),
+                    payload.position.take(),
+                )?;
+                payload.style = resolved.style;
+                payload.position = resolved.position;
+            }
+            Self::ImportGeneratedCaptions(payload) => {
+                let resolved = resolve_caption_layers(
+                    payload.style_pack.as_deref(),
+                    payload.style.take(),
+                    payload.position.take(),
+                )?;
+                payload.style = resolved.style;
+                payload.position = resolved.position;
+            }
+            Self::AddEffect(payload) => {
+                let resolved = resolve_effect_recipe(
+                    payload.recipe.as_deref(),
+                    payload.effect_type.take(),
+                    std::mem::take(&mut payload.params),
+                )?;
+                payload.effect_type = resolved.effect_type;
+                payload.params = resolved.params;
+
+                if payload.effect_type.is_none() {
+                    return Err(
+                        "AddEffect requires effectType, or a recipe that supplies one".to_string(),
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
     }
 
     /// Converts a validated `CommandPayload` into an executable `Command` trait object.
@@ -1987,8 +2072,14 @@ impl CommandPayload {
                 .with_position(p.position),
             ),
             CommandPayload::AddEffect(p) => {
-                let mut cmd =
-                    AddEffectCommand::new(&p.sequence_id, &p.track_id, &p.clip_id, p.effect_type);
+                // `parse` has already folded any recipe into `effect_type`; an
+                // absent type is rejected there and again at execute.
+                let mut cmd = AddEffectCommand::with_optional_type(
+                    &p.sequence_id,
+                    &p.track_id,
+                    &p.clip_id,
+                    p.effect_type,
+                );
                 for (key, value) in p.params {
                     cmd = cmd.with_param(key, value);
                 }

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -651,7 +651,11 @@ pub struct UpdateCaptionPayload {
     // Keep them to avoid rejecting payloads during strict parsing.
     pub style: Option<serde_json::Value>,
     pub position: Option<serde_json::Value>,
-    /// Curated caption pack id, resolved into `style` + `position`.
+    /// Curated caption pack id, resolved into `style` only.
+    ///
+    /// An update replaces the stored anchor whenever it carries one, so a pack
+    /// on an update restyles without moving the caption. Pass `position` to
+    /// move it.
     #[serde(default)]
     pub style_pack: Option<String>,
 }
@@ -1546,15 +1550,23 @@ impl CommandPayload {
     ///
     /// This runs at the single strict-parsing chokepoint every JSON entry point
     /// shares — GUI IPC, `command execute`, `plan execute`, agent steps — so a
-    /// pack id is resolved once, before the command is built, and the op log
-    /// records the concrete style or effect type it produced alongside the id
-    /// that produced it.
+    /// pack id is resolved once, before the command is built. What reaches the
+    /// op log is the concrete style or effect type the pack produced; the id
+    /// itself is not persisted, which is what makes replay independent of the
+    /// pack table rather than a lookup into a registry that may have moved.
     ///
     /// The resolution is idempotent: re-parsing an already-resolved payload
     /// yields the same values, because the explicit fields it wrote fully cover
     /// the pack layer underneath.
+    ///
+    /// `UpdateCaption` is the one asymmetric case: a pack there contributes
+    /// style only. The command replaces the stored anchor whenever it carries
+    /// one, so inheriting the pack anchor would move a caption whose placement
+    /// the caller never mentioned.
     fn resolve_curated_packs(&mut self) -> Result<(), String> {
-        use crate::core::style::{resolve_caption_layers, resolve_effect_recipe};
+        use crate::core::style::{
+            resolve_caption_layers, resolve_caption_style, resolve_effect_recipe,
+        };
 
         /// Applies a caption pack in place, leaving explicit values on top.
         fn apply_caption_pack(
@@ -1574,11 +1586,10 @@ impl CommandPayload {
                 &mut payload.style,
                 &mut payload.position,
             )?,
-            Self::UpdateCaption(payload) => apply_caption_pack(
-                payload.style_pack.as_deref(),
-                &mut payload.style,
-                &mut payload.position,
-            )?,
+            Self::UpdateCaption(payload) => {
+                payload.style =
+                    resolve_caption_style(payload.style_pack.as_deref(), payload.style.take())?;
+            }
             Self::ImportGeneratedCaptions(payload) => apply_caption_pack(
                 payload.style_pack.as_deref(),
                 &mut payload.style,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -9181,7 +9181,11 @@ export type UpdateAgentRunPhaseInput = { runId: string; phase: string; traceId: 
 export type UpdateAssetPayload = { assetId: string; name: string | null; tags: string[] | null; license: LicenseInfo | null; thumbnailUrl: string | null; proxyStatus: ProxyStatus | null; proxyUrl: string | null; uri: string | null; durationSec: number | null; fileSize: number | null; video: VideoInfo | null; audio: AudioInfo | null; relativePath: string | null; workspaceManaged: boolean | null; missing: boolean | null }
 export type UpdateCaptionPayload = { sequenceId: string; trackId: string; captionId: string; text: string | null; startSec: number | null; endSec: number | null; style: JsonValue | null; position: JsonValue | null; 
 /**
- * Curated caption pack id, resolved into `style` + `position`.
+ * Curated caption pack id, resolved into `style` only.
+ * 
+ * An update replaces the stored anchor whenever it carries one, so a pack
+ * on an update restyles without moving the caption. Pass `position` to
+ * move it.
  */
 stylePack?: string | null }
 /**

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -3072,8 +3072,18 @@ export type AISettingsDto = { assistantRuntime?: AssistantRuntimeDto; codexModel
 export type AddAudioKeyframePayload = { sequenceId: string; trackId: string; clipId: string; timeOffset: number; valueDb: number; interpolation?: KeyframeInterpolation }
 /**
  * Payload for adding an effect to a clip.
+ * 
+ * Either `effectType` or `recipe` must be present. A curated transition recipe
+ * (see `core::style::transition_recipes`) supplies the effect type and its
+ * baseline parameters; anything in `params` overrides the recipe key by key.
+ * `CommandPayload::parse` performs that resolution, so a payload that reaches
+ * command construction always carries an explicit effect type.
  */
-export type AddEffectPayload = { sequenceId: string; trackId: string; clipId: string; effectType: EffectType; params?: { [key in string]: ParamValue }; keyframes?: { [key in string]: Keyframe[] }; 
+export type AddEffectPayload = { sequenceId: string; trackId: string; clipId: string; effectType?: EffectType | null; 
+/**
+ * Curated transition recipe id, resolved into `effectType` + `params`.
+ */
+recipe?: string | null; params?: { [key in string]: ParamValue }; keyframes?: { [key in string]: Keyframe[] }; 
 /**
  * Optional position in the effect list (None = append at end)
  */
@@ -4938,7 +4948,11 @@ export type CreateAdjustmentLayerPayload = { sequenceId: string; trackId: string
  * Input payload for creating an agent session kernel row.
  */
 export type CreateAgentSessionInputDto = { projectId: string; sequenceId: string | null; title: string | null; runtimeKind: string | null; agentProfileId: string | null; sessionMode: string | null; parentSessionId: string | null; branchFromSessionId: string | null; rootSessionId: string | null; modelProvider: string | null; modelId: string | null; id: string | null }
-export type CreateCaptionPayload = { sequenceId: string; trackId: string; text: string; startSec: number; endSec: number; style: JsonValue | null; position: JsonValue | null }
+export type CreateCaptionPayload = { sequenceId: string; trackId: string; text: string; startSec: number; endSec: number; style: JsonValue | null; position: JsonValue | null; 
+/**
+ * Curated caption pack id, resolved into `style` + `position`.
+ */
+stylePack?: string | null }
 /**
  * Arguments for creating a compound clip from selected clips.
  */
@@ -5801,7 +5815,11 @@ undoCount: number;
  */
 redoCount: number }
 export type ImportAssetPayload = { name: string; uri: string }
-export type ImportGeneratedCaptionsPayload = { sequenceId: string; trackId: string; segments: GeneratedCaptionSegmentPayload[]; style: JsonValue | null; position: JsonValue | null; replaceExisting?: boolean }
+export type ImportGeneratedCaptionsPayload = { sequenceId: string; trackId: string; segments: GeneratedCaptionSegmentPayload[]; style: JsonValue | null; position: JsonValue | null; 
+/**
+ * Curated caption pack id, resolved into `style` + `position`.
+ */
+stylePack?: string | null; replaceExisting?: boolean }
 export type InsertClipPayload = { sequenceId: string; trackId: string; assetId: string; 
 /**
  * Timeline position to insert at.
@@ -9161,7 +9179,11 @@ export type UnnestCompoundClipPayload = { sequenceId: string; trackId: string; c
  */
 export type UpdateAgentRunPhaseInput = { runId: string; phase: string; traceId: string | null; toolCallsUsed: number | null; plannedStepCount: number | null; completedStepCount: number | null; outputMessageId: string | null; rollbackReportJson: string | null; errorCode: string | null; errorMessage: string | null; currentPlanId: string | null; pendingApprovalId: string | null; activeCheckpointId: string | null; permissionStateVersion: number | null; compactionVersion: number | null; resumeCursorVersion: number | null; lastCompactedAt: number | null; lastResumedAt: number | null; endedAt: number | null }
 export type UpdateAssetPayload = { assetId: string; name: string | null; tags: string[] | null; license: LicenseInfo | null; thumbnailUrl: string | null; proxyStatus: ProxyStatus | null; proxyUrl: string | null; uri: string | null; durationSec: number | null; fileSize: number | null; video: VideoInfo | null; audio: AudioInfo | null; relativePath: string | null; workspaceManaged: boolean | null; missing: boolean | null }
-export type UpdateCaptionPayload = { sequenceId: string; trackId: string; captionId: string; text: string | null; startSec: number | null; endSec: number | null; style: JsonValue | null; position: JsonValue | null }
+export type UpdateCaptionPayload = { sequenceId: string; trackId: string; captionId: string; text: string | null; startSec: number | null; endSec: number | null; style: JsonValue | null; position: JsonValue | null; 
+/**
+ * Curated caption pack id, resolved into `style` + `position`.
+ */
+stylePack?: string | null }
 /**
  * DTO for update check result
  */


### PR DESCRIPTION
### **User description**
## Description

PR 3 of the edit-quality roadmap (`docs/QUALITY_ROADMAP_PLAN.md`): the curated pack layer. Agents are measurably worst at numeric parameter choice and aesthetic judgment, so quality comes from selecting human-authored components instead of inventing 21 free-form numbers per caption. This PR adds the first two pack registries and wires them through every headless surface.

- **8 caption style packs** (`standard-outline`, `clean-minimal`, `boxed-contrast`, `yellow-classic`, `shorts-bold-outline`, `broadcast-lower`, `high-contrast-accessible`, `caption-top`) — typed `CaptionStyle` + `CaptionPosition`, every pack proven by contract test to pass `CaptionSafeAreaRule` at both 1920×1080 and 1080×1920.
- **12 transition recipes** (`dissolve-soft/standard/long`, `fade-in/out`, `wipe-left/right/up/down`, `slide-left/right`, `zoom-punch`) — parameters matched to what the FFmpeg filter builder actually reads, so a recipe never silently degrades to defaults. Wipes and slides finally get directions; the agent surface no longer hardcodes `wipeleft@1.0s`.
- **Resolution at the command chokepoint** (`CommandPayload::parse`): `stylePack` on the caption payloads and `recipe` on `AddEffect` resolve to concrete values before the op is logged, so **replay never depends on the pack table** — pack ids are an append-only contract, and the ops log stays self-contained. Explicit fields override pack values key-by-key (alias-aware: `font_size` displaces the pack's `fontSize`).
- **Surfaces**: CLI `packs list [--kind caption|transition|all]` (the const table is both validator and listing, like `render presets`), `--style-pack` on `caption add/update/import`, MCP payload hints reading id lists from the registries, help_json, skills docs (`captions/`, `editing/`), and `docs/AGENT_GUIDE.md`.

Scope note: the in-app TypeScript agent-tool enum params are deferred to the execute_plan-revival PR; resolution at the shared chokepoint means CLI, MCP, `command execute`, and `plan execute` all benefit now. `src/bindings.ts` was regenerated (mechanical; CI enforces binding sync) — no hand-written TS changed.

## Related Issue

Part of the edit-quality roadmap (no standalone issue).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test update

## Changes Made

- New `src-tauri/src/core/style/` module: const pack/recipe registries, `from_legacy_id`-style resolvers (normalize, aliases, hard error listing valid ids), serde-friendly descriptors ready for future JSON pack files.
- `stylePack: Option<String>` on Create/Update/ImportGeneratedCaptions payloads; `recipe: Option<String>` on `AddEffectPayload` (`effect_type` became `Option<EffectType>`, validated at execute — a recipe supplies the type).
- CLI `packs list`, `--style-pack` flags, MCP hints, help_json entries.
- Skills + AGENT_GUIDE document the pack-first styling rule ("packs are the quality floor; free-form styling only when a pack cannot express the brief").

## Screenshots / Videos

N/A (CLI/backend + docs).

## Testing

### Test Environment

- OS: Windows 11 Pro
- Node.js version: n/a (bindings regenerated only)
- Rust version: workspace toolchain

### Tests Performed

- [x] Unit tests pass (`pnpm test`) — no hand-written TS changes
- [x] Rust tests pass (`cargo test`)
- [x] Manual testing performed
- [x] New tests added for changes

17 contract tests (`core/style/contract_tests.rs`) + 26 registry unit tests + 5 CLI integration + 2 CLI unit tests. Contracts: every pack round-trips payload → `CommandPayload::parse` → execute → clip JSON → `CaptionStyle` → safe-area rule at both canvases and builds a real caption drawtext; every recipe resolves → executes → produces a valid filter for its family; override semantics (explicit beats pack, alias-aware); unknown ids error listing valid ids. Full runs: src-tauri lib 3683 passed, `openreelio-cli` 178 + 129 passed; clippy `-D warnings` and fmt clean; help_json parity green; bindings in sync.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

An adversarial review workflow is running against this branch in parallel with CI (same discipline as #791/#792); any confirmed findings will be fixed on this branch before merge.


___

### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Introduces curated caption style packs and transition recipes to standardize aesthetic quality.

- Resolves pack IDs into concrete parameters at the command parsing chokepoint.

- Adds `packs list` CLI command for discovering available styles and recipes.

- Updates MCP and agent documentation to prioritize curated packs over manual parameter tuning.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Input
    C1["CLI/MCP/IPC"] -- "stylePack / recipe ID" --> P1["CommandPayload::parse"]
  end
  subgraph Resolution
    P1 -- "Lookup" --> R1["Style Registries"]
    R1 -- "Merge Overrides" --> P2["Resolved Payload"]
  end
  subgraph Execution
    P2 -- "Build" --> E1["Command Executor"]
    E1 -- "Persist" --> O1["Ops Log (Concrete Values)"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Core logic for resolving and layering curated styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-47e6ce163a52918435baefc0d2172b11a6d35ecd7a778a2a143573a0c50ac7b9">+444/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>caption_packs.rs</strong><dd><code>Registry of 8 curated caption style packs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-3cdcf97b8373a1cbf55df807d7c81f7ff3ab12a75ec0cf759093957401e9ec6b">+441/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>transition_recipes.rs</strong><dd><code>Registry of 12 curated transition recipes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-f5819ad85261b5cb708fd339495be62a44b3592f40ff791ba9d29fba0f0d8a67">+392/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>payloads.rs</strong><dd><code>Integrate style resolution into the command parsing chokepoint</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-1efed79e6d1ef23a178231ecb231d1034cfafe2660c00fc389179577224de950">+95/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>packs.rs</strong><dd><code>Implementation of the `packs list` CLI command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-a40237998947712d49d137d4202b35f26d1590dc08222b7063a99181e4ec6626">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>effect.rs</strong><dd><code>Make effect type optional to support recipe resolution</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-bd92cccaca84e049d5f03fd8f267e684400e99711a3b847bb0fd21720cc906fe">+38/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp.rs</strong><dd><code>Expose curated pack hints to MCP agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+76/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bindings.ts</strong><dd><code>Update TypeScript types for stylePack and recipe fields</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+26/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>caption.rs</strong><dd><code>Add --style-pack support to caption CLI verbs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-57ce46b7a549091037f84030307fe41615baba99edaf2ead0fa5ad01e8d1eda8">+40/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>contract_tests.rs</strong><dd><code>End-to-end contract tests for style safety and rendering</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-9484776ca7f8039103d73d2c198793894cddc692f41b83fbf87088a1485614a2">+640/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>integration.rs</strong><dd><code>Integration tests for pack listing and application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+238/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>help_json.rs</strong><dd><code>Update CLI schema documentation for curated packs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+44/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Update agent skills documentation for curated packs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-4847e139fc42c0e90126f03bf18157a06f87f753f4f196fc25f670c7733b598f">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>export.rs</strong><dd><code>Expose caption filter builder for contract testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Register the new style module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-2e54fa69a6cc2c4a47431aaa1543f7324a2e84beb82f894757985d0e63b93662">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-5b9d832050317ee19c5b11dfd82342a39d32e794582b5e554fee74ab8c753827">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-3108771c2d44e2b7db9e9097acfa4590082bf896c1561d2cc81899e9fbbfb0f3">+45/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-cc3496de9305713d70667351fab7c5a60539b3fbb1dd4940b15419d868b1f1bb">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT_GUIDE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-609f4b6b6395bee5b56f2cb041c6803bc2afd043dbb10d33c31349b6e8c96a26">+45/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ai_legacy.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/793/files#diff-845d6b859f348138f8dfb2cd2ddca34ee0cd7284e6f2e34350cf24495507ee05">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added curated caption style packs for creating, updating, and importing captions.
  * Added curated transition recipes with configurable parameters, including dissolve, fade, wipe, and slide effects.
  * Added `packs list` to discover available caption packs and transition recipes.
  * Explicit styles, positions, and effect types can override pack or recipe defaults.
* **Bug Fixes**
  * Improved caption safe-area positioning and transparency rendering.
  * Improved validation and error messages for unknown packs, recipes, and incomplete effect definitions.
* **Documentation**
  * Updated CLI help, workflow guidance, and examples with pack and recipe usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->