### PR TITLE
refactor(core): unify the text preset catalog into one core registry

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Generated from src-tauri/src/core/style/text_presets.rs by
+# `cargo test -p openreelio --lib regenerate_text_preset_manifest -- --ignored`.
+# Reformatting it here would only churn against the generator.
+src/data/textPresets.manifest.json

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -3,10 +3,34 @@
 //! This enables AI agents to discover and use the CLI without parsing --help text.
 //! The schema includes command names, descriptions, parameters, types, and examples.
 
+use openreelio_core::style::{text_preset_ids, NO_TEXT_PRESET, TEXT_PRESETS};
+
 use crate::output;
 
 pub fn execute() -> anyhow::Result<()> {
     output::print_json_pretty(&build_schema())
+}
+
+/// Every accepted `text add --preset` value, in registry order.
+///
+/// Built from the core registry rather than restated, because a hand-kept list
+/// here is exactly how the schema came to advertise `quote`, `watermark`, and
+/// `countdown` while the parser rejected all three.
+fn text_preset_enum() -> Vec<String> {
+    std::iter::once(NO_TEXT_PRESET.to_string())
+        .chain(text_preset_ids().into_iter().map(str::to_string))
+        .collect()
+}
+
+/// One-line `--preset` description naming the registry as the source of ids.
+fn text_preset_desc() -> String {
+    format!(
+        "Curated text preset id or alias, or '{}' for none. {} presets; each supplies typography, \
+         anchor, starter copy, and a default duration. Run 'packs list --kind text' for the full \
+         entries",
+        NO_TEXT_PRESET,
+        TEXT_PRESETS.len()
+    )
 }
 
 pub(crate) fn build_schema() -> serde_json::Value {
@@ -316,9 +340,9 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli caption add --path ./project --text \"Hello\" --start 0.0 --end 3.0"
             },
             "packs.list": {
-                "description": "List curated caption style packs and transition recipes. Packs are the quality floor: name one instead of assembling typography or a transition duration by hand. Every listed id is accepted by caption --style-pack, by stylePack on CreateCaption/UpdateCaption/ImportGeneratedCaptions, and by recipe on AddEffect",
+                "description": "List curated caption style packs, transition recipes, and text presets. Packs are the quality floor: name one instead of assembling typography or a transition duration by hand. Every listed id is accepted by caption --style-pack, by stylePack on CreateCaption/UpdateCaption/ImportGeneratedCaptions, by recipe on AddEffect, and by text add --preset / preset on AddTextClip",
                 "params": {
-                    "kind": { "type": "string", "required": false, "desc": "Registry to list: caption, transition, or all (default: all)" }
+                    "kind": { "type": "string", "required": false, "desc": "Registry to list: caption, transition, text, or all (default: all)", "enum": ["caption", "transition", "text", "all"] }
                 },
                 "example": "openreelio-cli packs list --kind caption"
             },
@@ -435,7 +459,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "text": { "type": "string", "required": true, "desc": "Text content" },
                     "start": { "type": "number", "required": true, "desc": "Timeline start time in seconds" },
                     "duration": { "type": "number", "required": false, "desc": "Clip duration in seconds. Defaults to the selected preset's recommended duration." },
-                    "preset": { "type": "string", "required": false, "desc": "default, title, centered-title, epic-title, chapter-title, lower-third, lower-third-news, lower-third-name-role, subtitle, callout, callout-stat, credits, credit-line, logo-bug, social-handle, quote, watermark, or countdown" },
+                    "preset": { "type": "string", "required": false, "desc": text_preset_desc(), "enum": text_preset_enum() },
                     "text-json": { "type": "string", "required": false, "desc": "Full TextClipData JSON object" },
                     "style-json": { "type": "string", "required": false, "desc": "Full TextStyle JSON object" },
                     "position-json": { "type": "string", "required": false, "desc": "Text position JSON object" },
@@ -557,7 +581,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
                 "example": "openreelio-cli plan template --type split-and-move"
             },
             "command.execute": {
-                "description": "Execute any supported backend edit command using the shared CommandPayload parser. Curated packs are resolved by that parser, so CreateCaption/UpdateCaption/ImportGeneratedCaptions accept stylePack and AddEffect accepts recipe; see packs.list for the ids",
+                "description": "Execute any supported backend edit command using the shared CommandPayload parser. Curated packs are resolved by that parser, so CreateCaption/UpdateCaption/ImportGeneratedCaptions accept stylePack, AddEffect accepts recipe, and AddTextClip accepts preset (its textData then carries only the overrides); see packs.list for the ids",
                 "params": {
                     "path": { "type": "string", "required": true, "desc": "Project directory path" },
                     "type": { "type": "string", "required": true, "desc": "Backend command type, e.g. SplitClip or AddMask" },
@@ -712,7 +736,7 @@ pub(crate) fn build_schema() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use super::build_schema;
+    use super::{build_schema, text_preset_ids, NO_TEXT_PRESET};
     use crate::commands::Cli;
     use clap::{Command, CommandFactory};
 
@@ -814,6 +838,35 @@ mod tests {
             execute_description.contains("recipe"),
             "{execute_description}"
         );
+        assert!(
+            execute_description.contains("preset"),
+            "{execute_description}"
+        );
+    }
+
+    #[test]
+    fn build_schema_advertises_exactly_the_text_presets_the_parser_accepts() {
+        // The bug this replaces: the schema listed quote, watermark, and
+        // countdown while `text add --preset quote` answered "Unsupported text
+        // preset". A hand-kept list cannot be checked, so there is none.
+        let schema = build_schema();
+        let advertised: Vec<String> = schema["commands"]["text.add"]["params"]["preset"]["enum"]
+            .as_array()
+            .expect("preset enum must be an array")
+            .iter()
+            .map(|value| value.as_str().expect("preset id").to_string())
+            .collect();
+
+        let mut expected = vec![NO_TEXT_PRESET.to_string()];
+        expected.extend(text_preset_ids().into_iter().map(str::to_string));
+        assert_eq!(advertised, expected);
+
+        for id in &advertised {
+            assert!(
+                crate::commands::text::preset_is_accepted(id),
+                "advertised preset '{id}' must be accepted by text add --preset"
+            );
+        }
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -41,7 +41,9 @@ use crate::{
 use clap::Args;
 use openreelio_core::commands::{get_text_data, is_text_clip, InsertMediaCommand};
 use openreelio_core::ipc::CommandPayload;
-use openreelio_core::style::{caption_pack_ids, transition_recipe_ids};
+use openreelio_core::style::{
+    caption_pack_ids, text_preset_keys, transition_recipe_ids, TextPresetCategory, TEXT_PRESETS,
+};
 use openreelio_core::timeline::TrackKind;
 use serde_json::Value;
 use std::io::{BufRead, Write};
@@ -1374,12 +1376,55 @@ fn load_annotation_for_asset(
         })
 }
 
+/// Text preset ids whose anchor is part of the template, not a suggestion.
+///
+/// Smart placement moves an overlay it believes is a title, a lower third, a
+/// subtitle, or a callout. Everything else — credits, brand marks, creative
+/// treatments — was placed deliberately by the preset, so the category decides
+/// this rather than a hand-kept list of ids.
+fn template_placement_text_preset_ids() -> Vec<&'static str> {
+    TEXT_PRESETS
+        .iter()
+        .filter(|preset| {
+            matches!(
+                preset.category,
+                TextPresetCategory::Credit
+                    | TextPresetCategory::Brand
+                    | TextPresetCategory::Creative
+            )
+        })
+        .map(|preset| preset.id)
+        .collect()
+}
+
+/// One line per text preset: what it is for, and how long it usually runs.
+///
+/// Reading the catalog out of the registry is what keeps a hint from
+/// advertising a preset the parser rejects.
+fn text_preset_catalog_line() -> Vec<String> {
+    TEXT_PRESETS
+        .iter()
+        .map(|preset| {
+            format!(
+                "{} ({}, ~{}s): {}",
+                preset.id,
+                preset.category.as_str(),
+                preset.default_duration_sec,
+                preset.description
+            )
+        })
+        .collect()
+}
+
 fn build_command_schema() -> Value {
     // Read the curated ids from the core registries rather than restating them:
     // a pack added to core shows up in the hints, and a hint can never name an
     // id the validator would reject.
     let caption_style_pack_ids = caption_pack_ids();
     let transition_recipe_ids = transition_recipe_ids();
+    let text_preset_keys = text_preset_keys();
+    let template_placement_preset_ids = template_placement_text_preset_ids();
+    let text_preset_catalog = text_preset_catalog_line();
 
     serde_json::json!({
         "commands": CommandPayload::SUPPORTED_COMMAND_TYPES,
@@ -1438,8 +1483,11 @@ fn build_command_schema() -> Value {
             },
             "AddTextClip": {
                 "required": ["sequenceId", "trackId", "timelineIn", "duration", "textData"],
+                "optional": ["preset"],
                 "textDataShape": "TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/backgroundPadding/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow(color/offsetX/offsetY/blur), outline(color/width), rotation, and opacity.",
-                "presetHints": "Production presets supported by UI/agent/CLI include title, centered-title, epic-title, chapter-title, lower-third, lower-third-news, lower-third-name-role, subtitle, callout, callout-stat, credits, credit-line, logo-bug, social-handle, quote, watermark, and countdown.",
+                "presetHints": text_preset_keys,
+                "presetShape": "preset names a curated text preset that supplies the whole TextClipData; textData then carries only what overrides it, commonly just content. Every id and alias listed here is accepted by this payload and by `text add --preset`.",
+                "presetCatalog": text_preset_catalog,
                 "note": "Text clips must be placed on a video or overlay track. Use SetClipTransform after creation when scale or anchor must be exact."
             },
             "UpdateTextClip": {
@@ -1465,7 +1513,7 @@ fn build_command_schema() -> Value {
                 "Read annotation.read for overlapping source assets when placement should avoid faces, objects, or OCR text.",
                 "CreateTrack(kind=\"video\" or \"overlay\") when there is no unlocked non-overlapping text track above the media.",
                 "AddTextClip with complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity.",
-                "Use production text presets for common work: credits for end cards, logo-bug for channel marks, social-handle for creator IDs, lower-third-name-role for interviews, and callout-stat for numeric emphasis.",
+                "Prefer preset plus a content override over hand-assembled typography; see presetCatalog under payloadHints.AddTextClip for what each id is for.",
                 "SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor."
             ],
             "timedSubtitles": [
@@ -1481,7 +1529,10 @@ fn build_command_schema() -> Value {
                 "subtitle": "Bottom center around y=0.85 with outline/shadow unless it covers important visual content.",
                 "title": "Center or upper third depending on the shot composition.",
                 "lowerThird": "Lower-left or lower-center with enough safe margin and readable contrast.",
-                "creditBrand": "Credits, credit lines, logo bugs, social handles, quote, and watermark presets preserve their template position unless the user asks for automatic placement."
+                "creditBrand": format!(
+                    "These presets preserve their template position unless the user asks for automatic placement: {}.",
+                    template_placement_preset_ids.join(", ")
+                )
             }
         },
         "payloadFormat": {
@@ -2376,6 +2427,39 @@ mod tests {
             )
             .unwrap_or_else(|error| panic!("advertised recipe '{recipe_id}' must parse: {error}"));
         }
+    }
+
+    #[test]
+    fn should_advertise_text_preset_ids_from_the_core_registry() {
+        let schema = build_command_schema();
+
+        let hints = schema["payloadHints"]["AddTextClip"]["presetHints"]
+            .as_array()
+            .expect("AddTextClip must advertise presetHints");
+        let advertised: Vec<&str> = hints.iter().filter_map(Value::as_str).collect();
+        assert_eq!(advertised, text_preset_keys());
+
+        // Every advertised spelling must round-trip through the strict parser.
+        // The bug this closes advertised quote, watermark, and countdown while
+        // the parser rejected all three.
+        for key in text_preset_keys() {
+            CommandPayload::parse(
+                "AddTextClip".to_string(),
+                serde_json::json!({
+                    "sequenceId": "seq",
+                    "trackId": "track",
+                    "timelineIn": 0.0,
+                    "duration": 3.0,
+                    "preset": key,
+                }),
+            )
+            .unwrap_or_else(|error| panic!("advertised preset '{key}' must parse: {error}"));
+        }
+
+        let catalog = schema["payloadHints"]["AddTextClip"]["presetCatalog"]
+            .as_array()
+            .expect("AddTextClip must describe what each preset is for");
+        assert_eq!(catalog.len(), TEXT_PRESETS.len());
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -1482,13 +1482,13 @@ fn build_command_schema() -> Value {
                 "note": "Use this read-only MCP tool to check whether local Whisper is compiled in and which model files are installed."
             },
             "AddTextClip": {
-                "required": ["sequenceId", "trackId", "timelineIn", "duration", "textData"],
-                "optional": ["preset"],
+                "required": ["sequenceId", "trackId", "timelineIn", "duration"],
+                "optional": ["preset", "textData"],
                 "textDataShape": "TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/backgroundPadding/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow(color/offsetX/offsetY/blur), outline(color/width), rotation, and opacity.",
                 "presetHints": text_preset_keys,
-                "presetShape": "preset names a curated text preset that supplies the whole TextClipData; textData then carries only what overrides it, commonly just content. Every id and alias listed here is accepted by this payload and by `text add --preset`.",
+                "presetShape": "preset names a curated text preset that supplies the whole TextClipData; textData then carries only what overrides it, commonly just content, and may be omitted entirely. Every id and alias listed here is accepted by this payload and by `text add --preset`. Nested layers merge key by key, so {\"style\":{\"bold\":false}} or {\"shadow\":{\"offsetX\":2}} keeps everything else the preset chose.",
                 "presetCatalog": text_preset_catalog,
-                "note": "Text clips must be placed on a video or overlay track. Use SetClipTransform after creation when scale or anchor must be exact."
+                "note": "Either preset or textData must be present: without a preset, textData is required and must be complete. Text clips must be placed on a video or overlay track. Use SetClipTransform after creation when scale or anchor must be exact."
             },
             "UpdateTextClip": {
                 "required": ["sequenceId", "trackId", "clipId", "textData"],
@@ -1512,7 +1512,7 @@ fn build_command_schema() -> Value {
                 "Read timeline.snapshot to find the active sequence, existing text clips, and usable video/overlay tracks.",
                 "Read annotation.read for overlapping source assets when placement should avoid faces, objects, or OCR text.",
                 "CreateTrack(kind=\"video\" or \"overlay\") when there is no unlocked non-overlapping text track above the media.",
-                "AddTextClip with complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity.",
+                "AddTextClip with a preset id, or with a complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity when no preset fits.",
                 "Prefer preset plus a content override over hand-assembled typography; see presetCatalog under payloadHints.AddTextClip for what each id is for.",
                 "SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor."
             ],
@@ -2460,6 +2460,63 @@ mod tests {
             .as_array()
             .expect("AddTextClip must describe what each preset is for");
         assert_eq!(catalog.len(), TEXT_PRESETS.len());
+    }
+
+    #[test]
+    fn should_declare_the_add_text_clip_fields_the_parser_actually_requires() {
+        // A hint is only worth reading if it matches the wire shape. `textData`
+        // was left in `required` when `preset` was added, which tells a client
+        // to hand-assemble the typography the preset field exists to replace.
+        let schema = build_command_schema();
+        let hint = &schema["payloadHints"]["AddTextClip"];
+
+        let required: Vec<&str> = hint["required"]
+            .as_array()
+            .expect("required list")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        let optional: Vec<&str> = hint["optional"]
+            .as_array()
+            .expect("optional list")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+
+        assert!(
+            !required.contains(&"textData"),
+            "textData is optional once a preset is named: {required:?}"
+        );
+        assert!(optional.contains(&"textData") && optional.contains(&"preset"));
+
+        // The payload built from exactly the required fields plus a preset is
+        // the one the hint promises works.
+        let mut payload = serde_json::Map::new();
+        for field in &required {
+            payload.insert(
+                (*field).to_string(),
+                match *field {
+                    "timelineIn" => serde_json::json!(0.0),
+                    "duration" => serde_json::json!(3.0),
+                    other => serde_json::json!(other),
+                },
+            );
+        }
+        payload.insert("preset".to_string(), serde_json::json!("centered-title"));
+        CommandPayload::parse("AddTextClip".to_string(), Value::Object(payload))
+            .expect("the advertised required set plus a preset must parse");
+
+        // And without either half it must still fail, which is what the note says.
+        CommandPayload::parse(
+            "AddTextClip".to_string(),
+            serde_json::json!({
+                "sequenceId": "seq",
+                "trackId": "track",
+                "timelineIn": 0.0,
+                "duration": 3.0,
+            }),
+        )
+        .expect_err("neither preset nor textData must be rejected");
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/mod.rs
+++ b/crates/openreelio-cli/src/commands/mod.rs
@@ -77,7 +77,7 @@ pub enum Commands {
         action: caption::CaptionAction,
     },
 
-    /// Curated caption style packs and transition recipes
+    /// Curated caption style packs, transition recipes, and text presets
     Packs {
         #[command(subcommand)]
         action: packs::PacksAction,

--- a/crates/openreelio-cli/src/commands/packs.rs
+++ b/crates/openreelio-cli/src/commands/packs.rs
@@ -1,13 +1,13 @@
 //! Curated style pack listing.
 //!
-//! Packs are the quality floor for captions and transitions: a named,
-//! hand-checked style beats a guessed one, and the id is the whole payload. This
-//! verb is the discovery half of that — the same `const` tables that validate a
-//! `--style-pack` or a `recipe` are what it prints, so a listed id is by
-//! construction an accepted id.
+//! Packs are the quality floor for captions, transitions, and text overlays: a
+//! named, hand-checked style beats a guessed one, and the id is the whole
+//! payload. This verb is the discovery half of that — the same `const` tables
+//! that validate a `--style-pack`, a `recipe`, or a `--preset` are what it
+//! prints, so a listed id is by construction an accepted id.
 
 use clap::{Subcommand, ValueEnum};
-use openreelio_core::style::{list_caption_packs, list_transition_recipes};
+use openreelio_core::style::{list_caption_packs, list_text_presets, list_transition_recipes};
 use serde_json::Value;
 
 use crate::output;
@@ -19,7 +19,9 @@ pub enum PackKind {
     Caption,
     /// Transition recipes only.
     Transition,
-    /// Both registries.
+    /// Text overlay presets only.
+    Text,
+    /// Every registry.
     #[default]
     All,
 }
@@ -29,6 +31,7 @@ impl PackKind {
         match self {
             Self::Caption => "caption",
             Self::Transition => "transition",
+            Self::Text => "text",
             Self::All => "all",
         }
     }
@@ -36,9 +39,9 @@ impl PackKind {
 
 #[derive(Subcommand)]
 pub enum PacksAction {
-    /// List curated caption style packs and transition recipes
+    /// List curated caption style packs, transition recipes, and text presets
     List {
-        /// Which registry to list: caption, transition, or all
+        /// Which registry to list: caption, transition, text, or all
         #[arg(long, value_enum, default_value_t = PackKind::All)]
         kind: PackKind,
     },
@@ -61,6 +64,14 @@ pub fn execute(action: PacksAction) -> anyhow::Result<()> {
                 for descriptor in list_transition_recipes() {
                     packs.push(serde_json::to_value(descriptor).map_err(|error| {
                         anyhow::anyhow!("Failed to serialize transition recipe: {}", error)
+                    })?);
+                }
+            }
+
+            if matches!(kind, PackKind::Text | PackKind::All) {
+                for descriptor in list_text_presets() {
+                    packs.push(serde_json::to_value(descriptor).map_err(|error| {
+                        anyhow::anyhow!("Failed to serialize text preset: {}", error)
                     })?);
                 }
             }

--- a/crates/openreelio-cli/src/commands/text.rs
+++ b/crates/openreelio-cli/src/commands/text.rs
@@ -7,9 +7,10 @@ use openreelio_core::commands::{
     get_text_data, is_text_clip, AddTextClipCommand, AddTrackCommand, MoveClipCommand,
     RemoveTextClipCommand, SetClipTransformCommand, TrimClipCommand, UpdateTextCommand,
 };
+use openreelio_core::style::{resolve_text_preset, text_preset_ids, NO_TEXT_PRESET};
 use openreelio_core::timeline::{Sequence, Track, TrackKind, Transform};
 use openreelio_core::{
-    text::{TextAlignment, TextClipData, TextOutline, TextPosition, TextShadow, TextStyle},
+    text::{TextAlignment, TextClipData, TextPosition, TextStyle},
     ActiveProject, Point2D,
 };
 use std::path::PathBuf;
@@ -38,8 +39,7 @@ pub enum TextAction {
         #[arg(long)]
         duration: Option<f64>,
 
-        /// Preset: default, title, lower-third, subtitle, callout, credits, credit-line, logo-bug, social-handle
-        #[arg(long)]
+        #[arg(long, help = text_preset_help())]
         preset: Option<String>,
 
         /// Full TextClipData JSON object. CLI flags are applied after this object.
@@ -427,304 +427,77 @@ fn text_data_for_clip(
         .ok_or_else(|| anyhow::anyhow!("TextOverlay effect not found on clip '{}'", clip_id))
 }
 
+/// Help text for `--preset`, built from the core registry.
+///
+/// The list used to be a doc comment, which is how it came to advertise nine
+/// presets while the parser accepted fourteen and the UI shipped twenty-two.
+pub(crate) fn text_preset_help() -> String {
+    format!(
+        "Text preset id or alias, or '{}' for none. Ids: {}",
+        NO_TEXT_PRESET,
+        text_preset_ids().join(", ")
+    )
+}
+
+/// Normalizes a `--preset` value, defaulting an absent flag to `default`.
+///
+/// Matching itself belongs to the core registry, which folds case, `-`, `_`,
+/// and spaces onto one key; this only supplies the "no preset named" sentinel.
 fn normalize_text_preset_key(preset: Option<&str>) -> String {
-    preset.unwrap_or("default").to_lowercase().replace('_', "-")
+    preset
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(NO_TEXT_PRESET)
+        .to_lowercase()
+        .replace(['_', ' '], "-")
 }
 
+/// True when the value names no preset at all.
+fn is_no_preset(preset: Option<&str>) -> bool {
+    normalize_text_preset_key(preset) == NO_TEXT_PRESET
+}
+
+/// True when `text add --preset <value>` would be accepted.
+///
+/// Exposed so the surfaces that advertise preset ids can assert they advertise
+/// only ids this parser takes.
+#[cfg(test)]
+pub(crate) fn preset_is_accepted(preset: &str) -> bool {
+    parse_text_preset(Some(preset.to_string()), "probe").is_ok()
+}
+
+/// Suggested clip duration for a preset, used when `--duration` is omitted.
+///
+/// The durations live with the presets in the core registry, so a preset added
+/// there arrives here with its own timing rather than silently taking the
+/// three-second fallback.
 fn text_preset_default_duration(preset: Option<&str>) -> f64 {
-    match normalize_text_preset_key(preset).as_str() {
-        "lower-third"
-        | "lowerthird"
-        | "lower-third-name-role"
-        | "interview-lower-third"
-        | "speaker-id"
-        | "name-role"
-        | "credit-line"
-        | "source-credit"
-        | "attribution"
-        | "social-handle"
-        | "handle"
-        | "social" => 5.0,
-        "lower-third-news"
-        | "broadcast-lower-third"
-        | "news-lower-third"
-        | "end-card-title"
-        | "end-card"
-        | "outro-title" => 6.0,
-        "credits" | "credits-block" | "credit-block" | "end-credits" => 8.0,
-        "logo-bug" | "bug" | "channel-bug" | "brand-bug" => 10.0,
-        "countdown" | "timer" => 1.0,
-        "title" | "centered-title" | "tech-style" | "tech" | "terminal" => 4.0,
-        _ => 3.0,
+    const FALLBACK_DURATION_SEC: f64 = 3.0;
+
+    if is_no_preset(preset) {
+        return FALLBACK_DURATION_SEC;
     }
+
+    preset
+        .and_then(|value| resolve_text_preset(value).ok())
+        .map(|spec| spec.default_duration_sec)
+        .unwrap_or(FALLBACK_DURATION_SEC)
 }
 
+/// Builds the base text clip data a `--preset` names.
+///
+/// Delegates to the core registry so the CLI accepts exactly the presets every
+/// other surface advertises. An unknown id fails here with the valid list
+/// rather than silently rendering something else.
 fn parse_text_preset(preset: Option<String>, content: &str) -> anyhow::Result<TextClipData> {
-    let normalized = normalize_text_preset_key(preset.as_deref());
-
-    match normalized.as_str() {
-        "default" => Ok(TextClipData::new(content)),
-        "title" => Ok(TextClipData::title(content)),
-        "centered-title" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle::default().with_font_size(72).with_bold(true),
-            position: TextPosition::new(0.5, 0.5),
-            shadow: Some(TextShadow {
-                color: "#000000".to_string(),
-                offset_x: 3,
-                offset_y: 3,
-                blur: 8,
-            }),
-            outline: None,
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "epic-title" | "impact-title" | "hero-title" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle::default()
-                .with_font_family("Impact")
-                .with_font_size(96)
-                .with_bold(true),
-            position: TextPosition::new(0.5, 0.5),
-            shadow: Some(TextShadow {
-                color: "#000000".to_string(),
-                offset_x: 4,
-                offset_y: 4,
-                blur: 12,
-            }),
-            outline: Some(TextOutline {
-                color: "#000000".to_string(),
-                width: 3,
-            }),
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "chapter-title" | "chapter" | "chapter-card" | "section-title" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle {
-                font_family: "Georgia".to_string(),
-                font_size: 62,
-                font_weight: 700,
-                color: "#F8FAFC".to_string(),
-                background_color: None,
-                background_padding: 0,
-                alignment: TextAlignment::Center,
-                bold: true,
-                italic: false,
-                underline: false,
-                line_height: 1.18,
-                letter_spacing: 2,
-            },
-            position: TextPosition::new(0.5, 0.45),
-            shadow: Some(TextShadow {
-                color: "#00000099".to_string(),
-                offset_x: 2,
-                offset_y: 3,
-                blur: 8,
-            }),
-            outline: None,
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "lower-third" | "lowerthird" => Ok(TextClipData::lower_third(content)),
-        "lower-third-news" | "broadcast-lower-third" | "news-lower-third" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle {
-                font_family: "Arial".to_string(),
-                font_size: 40,
-                font_weight: 700,
-                color: "#FFFFFF".to_string(),
-                background_color: Some("#123E7CCC".to_string()),
-                background_padding: 14,
-                alignment: TextAlignment::Left,
-                bold: true,
-                italic: false,
-                underline: false,
-                line_height: 1.15,
-                letter_spacing: 1,
-            },
-            position: TextPosition::new(0.07, 0.78),
-            shadow: Some(TextShadow {
-                color: "#00000080".to_string(),
-                offset_x: 1,
-                offset_y: 2,
-                blur: 3,
-            }),
-            outline: None,
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "lower-third-name-role" | "interview-lower-third" | "speaker-id" | "name-role" => {
-            Ok(TextClipData {
-                content: content.to_string(),
-                style: TextStyle {
-                    font_family: "Helvetica".to_string(),
-                    font_size: 38,
-                    font_weight: 700,
-                    color: "#F8FAFC".to_string(),
-                    background_color: Some("#111827D9".to_string()),
-                    background_padding: 10,
-                    alignment: TextAlignment::Left,
-                    bold: true,
-                    italic: false,
-                    underline: false,
-                    line_height: 1.25,
-                    letter_spacing: 1,
-                },
-                position: TextPosition::new(0.08, 0.84),
-                shadow: None,
-                outline: Some(TextOutline {
-                    color: "#00000066".to_string(),
-                    width: 1,
-                }),
-                rotation: 0.0,
-                opacity: 1.0,
-            })
-        }
-        "subtitle" => Ok(TextClipData::subtitle(content)),
-        "callout" | "emphasis" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle::default()
-                .with_font_size(48)
-                .with_font_weight(700)
-                .with_color("#FFD700"),
-            position: TextPosition::new(0.5, 0.35),
-            shadow: Some(TextShadow {
-                color: "#000000".to_string(),
-                offset_x: 2,
-                offset_y: 2,
-                blur: 6,
-            }),
-            outline: Some(TextOutline {
-                color: "#000000".to_string(),
-                width: 2,
-            }),
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "callout-stat" | "stat" | "number-callout" | "price-callout" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle::default()
-                .with_font_size(82)
-                .with_font_weight(700)
-                .with_color("#38BDF8"),
-            position: TextPosition::new(0.5, 0.42),
-            shadow: Some(TextShadow {
-                color: "#000000".to_string(),
-                offset_x: 3,
-                offset_y: 4,
-                blur: 8,
-            }),
-            outline: Some(TextOutline {
-                color: "#082F49".to_string(),
-                width: 2,
-            }),
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "credits" | "credits-block" | "credit-block" | "end-credits" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle {
-                font_family: "Georgia".to_string(),
-                font_size: 34,
-                font_weight: 400,
-                color: "#F8FAFC".to_string(),
-                background_color: None,
-                background_padding: 0,
-                alignment: TextAlignment::Center,
-                bold: false,
-                italic: false,
-                underline: false,
-                line_height: 1.45,
-                letter_spacing: 1,
-            },
-            position: TextPosition::new(0.5, 0.52),
-            shadow: Some(TextShadow {
-                color: "#000000AA".to_string(),
-                offset_x: 1,
-                offset_y: 2,
-                blur: 5,
-            }),
-            outline: None,
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        "credit-line" | "source-credit" | "attribution" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle {
-                font_family: "Arial".to_string(),
-                font_size: 24,
-                font_weight: 400,
-                color: "#E5E7EB".to_string(),
-                background_color: Some("#00000080".to_string()),
-                background_padding: 6,
-                alignment: TextAlignment::Right,
-                bold: false,
-                italic: false,
-                underline: false,
-                line_height: 1.2,
-                letter_spacing: 0,
-            },
-            position: TextPosition::new(0.94, 0.92),
-            shadow: None,
-            outline: None,
-            rotation: 0.0,
-            opacity: 0.9,
-        }),
-        "logo-bug" | "bug" | "channel-bug" | "brand-bug" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle {
-                font_family: "Arial".to_string(),
-                font_size: 24,
-                font_weight: 700,
-                color: "#FFFFFF".to_string(),
-                background_color: Some("#0F766ECC".to_string()),
-                background_padding: 8,
-                alignment: TextAlignment::Right,
-                bold: true,
-                italic: false,
-                underline: false,
-                line_height: 1.15,
-                letter_spacing: 1,
-            },
-            position: TextPosition::new(0.94, 0.08),
-            shadow: None,
-            outline: None,
-            rotation: 0.0,
-            opacity: 0.85,
-        }),
-        "social-handle" | "handle" | "social" => Ok(TextClipData {
-            content: content.to_string(),
-            style: TextStyle {
-                font_family: "Arial".to_string(),
-                font_size: 30,
-                font_weight: 700,
-                color: "#FFFFFF".to_string(),
-                background_color: Some("#7C3AEDCC".to_string()),
-                background_padding: 10,
-                alignment: TextAlignment::Left,
-                bold: true,
-                italic: false,
-                underline: false,
-                line_height: 1.2,
-                letter_spacing: 0,
-            },
-            position: TextPosition::new(0.07, 0.91),
-            shadow: Some(TextShadow {
-                color: "#00000099".to_string(),
-                offset_x: 1,
-                offset_y: 2,
-                blur: 4,
-            }),
-            outline: None,
-            rotation: 0.0,
-            opacity: 1.0,
-        }),
-        other => Err(anyhow::anyhow!(
-            "Unsupported text preset '{}'. Use: default, title, centered-title, epic-title, chapter-title, lower-third, lower-third-news, lower-third-name-role, subtitle, callout, callout-stat, credits, credit-line, logo-bug, social-handle",
-            other
-        )),
+    if is_no_preset(preset.as_deref()) {
+        return Ok(TextClipData::new(content));
     }
+
+    let spec = resolve_text_preset(preset.as_deref().unwrap_or_default())
+        .map_err(|error| anyhow::anyhow!("{} (or '{}' for none)", error, NO_TEXT_PRESET))?;
+
+    Ok(spec.clip_data(content))
 }
 
 fn parse_json_object<T>(label: &str, raw: &str) -> anyhow::Result<T>
@@ -1371,5 +1144,98 @@ mod tests {
         assert_eq!(text_preset_default_duration(Some("logo_bug")), 10.0);
         assert_eq!(text_preset_default_duration(Some("callout")), 3.0);
         assert_eq!(text_preset_default_duration(None), 3.0);
+    }
+
+    #[test]
+    fn should_accept_every_preset_the_registry_defines() {
+        // The regression this closes: the CLI carried its own table of 14 while
+        // the UI shipped 22 and the hints advertised 17, so `--preset quote`
+        // was documented and rejected at the same time.
+        for spec in openreelio_core::style::TEXT_PRESETS {
+            let clip = parse_text_preset(Some(spec.id.to_string()), "Copy")
+                .unwrap_or_else(|error| panic!("preset '{}' must parse: {error}", spec.id));
+            assert_eq!(clip, spec.clip_data("Copy"));
+
+            for alias in spec.aliases {
+                let aliased = parse_text_preset(Some((*alias).to_string()), "Copy")
+                    .unwrap_or_else(|error| panic!("alias '{alias}' must parse: {error}"));
+                assert_eq!(aliased, clip, "alias '{alias}' must match its preset");
+            }
+        }
+    }
+
+    #[test]
+    fn should_add_the_presets_the_old_inline_table_rejected() {
+        for id in ["quote", "watermark", "countdown", "tech-style", "label"] {
+            let clip = parse_text_preset(Some(id.to_string()), "Copy")
+                .unwrap_or_else(|error| panic!("preset '{id}' must parse: {error}"));
+            assert_eq!(clip.content, "Copy");
+        }
+    }
+
+    #[test]
+    fn should_reject_an_unknown_preset_with_the_valid_list() {
+        let error = parse_text_preset(Some("not-a-preset".to_string()), "Copy")
+            .expect_err("unknown preset must fail")
+            .to_string();
+
+        for spec in openreelio_core::style::TEXT_PRESETS {
+            assert!(
+                error.contains(spec.id),
+                "error must name '{}': {error}",
+                spec.id
+            );
+        }
+        assert!(error.contains(NO_TEXT_PRESET), "{error}");
+    }
+
+    #[test]
+    fn should_treat_an_absent_or_default_preset_as_no_preset() {
+        let plain = TextClipData::new("Copy");
+        assert_eq!(parse_text_preset(None, "Copy").unwrap(), plain);
+        assert_eq!(
+            parse_text_preset(Some("default".to_string()), "Copy").unwrap(),
+            plain
+        );
+        assert_eq!(
+            parse_text_preset(Some("  DEFAULT ".to_string()), "Copy").unwrap(),
+            plain
+        );
+    }
+
+    #[test]
+    fn should_let_explicit_flags_override_preset_values() {
+        // Preset first, flags second: the flag override contract does not
+        // change now that the base comes from the core registry.
+        let base = parse_text_preset(Some("quote".to_string()), "Copy").unwrap();
+        let patched = apply_patch(
+            base,
+            TextPatch {
+                font_size: Some(96),
+                color: Some("#FF0000".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("patch applies");
+
+        assert_eq!(patched.style.font_size, 96);
+        assert_eq!(patched.style.color, "#FF0000");
+        // Untouched preset values survive the patch.
+        assert_eq!(patched.style.font_family, "Georgia");
+        assert!(patched.style.italic);
+        assert!((patched.opacity - 0.95).abs() < 0.001);
+    }
+
+    #[test]
+    fn preset_help_lists_every_id_the_parser_accepts() {
+        let help = text_preset_help();
+        for spec in openreelio_core::style::TEXT_PRESETS {
+            assert!(
+                help.contains(spec.id),
+                "help must name '{}': {help}",
+                spec.id
+            );
+        }
+        assert!(help.contains(NO_TEXT_PRESET), "{help}");
     }
 }

--- a/crates/openreelio-cli/src/commands/text.rs
+++ b/crates/openreelio-cli/src/commands/text.rs
@@ -7,7 +7,9 @@ use openreelio_core::commands::{
     get_text_data, is_text_clip, AddTextClipCommand, AddTrackCommand, MoveClipCommand,
     RemoveTextClipCommand, SetClipTransformCommand, TrimClipCommand, UpdateTextCommand,
 };
-use openreelio_core::style::{resolve_text_preset, text_preset_ids, NO_TEXT_PRESET};
+use openreelio_core::style::{
+    reconcile_bold_and_font_weight, resolve_text_preset, text_preset_ids, NO_TEXT_PRESET,
+};
 use openreelio_core::timeline::{Sequence, Track, TrackKind, Transform};
 use openreelio_core::{
     text::{TextAlignment, TextClipData, TextPosition, TextStyle},
@@ -557,6 +559,13 @@ fn merge_style(base: &mut TextStyle, style_json: &str) -> anyhow::Result<()> {
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("--style-json must be a JSON object"))?;
 
+    // `bold` and `fontWeight` are one decision, so which half the caller named
+    // decides which one follows the other. Recorded before the fields are
+    // written and settled afterwards by the shared core reconciler, so this
+    // patch and the `preset` merge at the payload boundary cannot disagree.
+    let bold_was_named = object.contains_key("bold");
+    let font_weight_was_named = style_field(object, "fontWeight", "font_weight").is_some();
+
     if let Some(value) = style_field(object, "fontFamily", "font_family") {
         base.font_family = json_string(value, "fontFamily")?;
     }
@@ -565,7 +574,6 @@ fn merge_style(base: &mut TextStyle, style_json: &str) -> anyhow::Result<()> {
     }
     if let Some(value) = style_field(object, "fontWeight", "font_weight") {
         base.font_weight = json_number::<u16>(value, "fontWeight")?.clamp(100, 900);
-        base.bold = base.font_weight >= 600;
     }
     if let Some(value) = object.get("color") {
         base.color = json_string(value, "color")?;
@@ -585,7 +593,6 @@ fn merge_style(base: &mut TextStyle, style_json: &str) -> anyhow::Result<()> {
     }
     if let Some(value) = object.get("bold") {
         base.bold = json_bool(value, "bold")?;
-        base.font_weight = if base.bold { 700 } else { 400 };
     }
     if let Some(value) = object.get("italic") {
         base.italic = json_bool(value, "italic")?;
@@ -599,6 +606,8 @@ fn merge_style(base: &mut TextStyle, style_json: &str) -> anyhow::Result<()> {
     if let Some(value) = style_field(object, "letterSpacing", "letter_spacing") {
         base.letter_spacing = json_i32(value, "letterSpacing")?;
     }
+
+    reconcile_bold_and_font_weight(base, bold_was_named, font_weight_was_named);
 
     Ok(())
 }
@@ -616,6 +625,11 @@ fn parse_alignment(value: &str) -> anyhow::Result<TextAlignment> {
 }
 
 fn apply_patch(mut text_data: TextClipData, patch: TextPatch) -> anyhow::Result<TextClipData> {
+    // Flags outrank `--style-json`, so the pair is settled once, from the flags,
+    // after everything else has been written. See `reconcile_bold_and_font_weight`.
+    let bold_was_named = patch.bold.is_some();
+    let font_weight_was_named = patch.font_weight.is_some();
+
     if let Some(raw) = patch.text_json {
         text_data = parse_json_object("--text-json", &raw)?;
     }
@@ -650,7 +664,6 @@ fn apply_patch(mut text_data: TextClipData, patch: TextPatch) -> anyhow::Result<
     }
     if let Some(value) = patch.font_weight {
         text_data.style.font_weight = value.clamp(100, 900);
-        text_data.style.bold = text_data.style.font_weight >= 600;
     }
     if let Some(value) = patch.color {
         text_data.style.color = value;
@@ -663,7 +676,6 @@ fn apply_patch(mut text_data: TextClipData, patch: TextPatch) -> anyhow::Result<
     }
     if let Some(value) = patch.bold {
         text_data.style.bold = value;
-        text_data.style.font_weight = if value { 700 } else { 400 };
     }
     if let Some(value) = patch.italic {
         text_data.style.italic = value;
@@ -692,6 +704,8 @@ fn apply_patch(mut text_data: TextClipData, patch: TextPatch) -> anyhow::Result<
     if let Some(value) = patch.opacity {
         text_data.opacity = value;
     }
+
+    reconcile_bold_and_font_weight(&mut text_data.style, bold_was_named, font_weight_was_named);
 
     text_data.validate().map_err(anyhow::Error::msg)?;
     Ok(text_data)
@@ -1224,6 +1238,96 @@ mod tests {
         assert_eq!(patched.style.font_family, "Georgia");
         assert!(patched.style.italic);
         assert!((patched.opacity - 0.95).abs() < 0.001);
+    }
+
+    #[test]
+    fn should_settle_the_weight_pair_the_way_the_payload_boundary_does() {
+        // `text add --preset X --style-json '{"bold":false}'` and the same
+        // logical input through `AddTextClip` must produce one overlay: both
+        // route the pair through the shared core reconciler.
+        let flags_and_json: [(TextPatch, serde_json::Value); 3] = [
+            (
+                TextPatch {
+                    style_json: Some(r#"{"bold":false}"#.to_string()),
+                    ..Default::default()
+                },
+                serde_json::json!({ "style": { "bold": false } }),
+            ),
+            (
+                TextPatch {
+                    style_json: Some(r#"{"fontWeight":400}"#.to_string()),
+                    ..Default::default()
+                },
+                serde_json::json!({ "style": { "fontWeight": 400 } }),
+            ),
+            (
+                TextPatch {
+                    style_json: Some(r#"{"bold":true,"fontWeight":900}"#.to_string()),
+                    ..Default::default()
+                },
+                serde_json::json!({ "style": { "bold": true, "fontWeight": 900 } }),
+            ),
+        ];
+
+        for (patch, text_data) in flags_and_json {
+            let described = format!("{text_data}");
+            let base = parse_text_preset(Some("centered-title".to_string()), "Copy").unwrap();
+            let patched = apply_patch(base, patch).expect("patch applies");
+
+            let mut text_data = text_data;
+            text_data["content"] = serde_json::json!("Copy");
+            let resolved = openreelio_core::style::resolve_text_clip_data(
+                Some("centered-title"),
+                Some(text_data),
+            )
+            .expect("payload resolves");
+
+            assert_eq!(
+                (patched.style.bold, patched.style.font_weight),
+                (resolved.style.bold, resolved.style.font_weight),
+                "the CLI and the payload boundary disagree on {described}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_let_the_named_half_of_the_weight_pair_decide_the_other() {
+        // Turning bold off must drop the preset's derived 700, or the render
+        // paths OR it straight back on and the readback lies about the frame.
+        let unbolded = apply_patch(
+            parse_text_preset(Some("centered-title".to_string()), "Copy").unwrap(),
+            TextPatch {
+                bold: Some(false),
+                ..Default::default()
+            },
+        )
+        .expect("patch applies");
+        assert!(!unbolded.style.bold);
+        assert_eq!(unbolded.style.font_weight, 400);
+
+        let lightened = apply_patch(
+            parse_text_preset(Some("centered-title".to_string()), "Copy").unwrap(),
+            TextPatch {
+                font_weight: Some(400),
+                ..Default::default()
+            },
+        )
+        .expect("patch applies");
+        assert!(!lightened.style.bold);
+        assert_eq!(lightened.style.font_weight, 400);
+
+        // Naming both leaves both alone: there is nothing left to infer.
+        let explicit = apply_patch(
+            parse_text_preset(Some("subtitle".to_string()), "Copy").unwrap(),
+            TextPatch {
+                bold: Some(true),
+                font_weight: Some(900),
+                ..Default::default()
+            },
+        )
+        .expect("patch applies");
+        assert!(explicit.style.bold);
+        assert_eq!(explicit.style.font_weight, 900);
     }
 
     #[test]

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -5724,7 +5724,7 @@ fn test_agent_perception_loop_end_to_end() {
 // ============================================================================
 
 #[test]
-fn test_packs_list_returns_both_registries() {
+fn test_packs_list_returns_every_registry() {
     let all = run_cli_ok(&["packs", "list"]);
     assert_eq!(all["status"], "ok");
     assert_eq!(all["kind"], "all");
@@ -5766,6 +5766,12 @@ fn test_packs_list_returns_both_registries() {
                 assert!(pack["effectType"].is_string(), "{pack}");
                 assert!(pack["params"].is_object(), "{pack}");
             }
+            Some("text") => {
+                assert!(pack["category"].is_string(), "{pack}");
+                assert!(pack["defaultDurationSec"].is_number(), "{pack}");
+                assert!(pack["clip"]["style"].is_object(), "{pack}");
+                assert!(pack["clip"]["position"].is_object(), "{pack}");
+            }
             other => panic!("unexpected pack kind {other:?}"),
         }
     }
@@ -5789,9 +5795,38 @@ fn test_packs_list_filters_by_kind() {
         .iter()
         .all(|pack| pack["kind"] == "transition"));
 
+    let texts = run_cli_ok(&["packs", "list", "--kind", "text"]);
+    assert_eq!(texts["kind"], "text");
+    let text_packs = texts["packs"].as_array().expect("packs");
+    assert_eq!(texts["count"].as_u64().unwrap() as usize, text_packs.len());
+    assert!(text_packs.iter().all(|pack| pack["kind"] == "text"));
+
+    let text_ids: Vec<&str> = text_packs
+        .iter()
+        .filter_map(|pack| pack["id"].as_str())
+        .collect();
+    // Presets the CLI used to reject outright.
+    for id in ["quote", "watermark", "countdown", "label", "tech-style"] {
+        assert!(text_ids.contains(&id), "{text_ids:?}");
+    }
+
+    let quote = text_packs
+        .iter()
+        .find(|pack| pack["id"] == "quote")
+        .expect("quote preset");
+    assert_eq!(quote["category"], "creative");
+    assert_eq!(quote["defaultDurationSec"], 5.0);
+    assert_eq!(quote["clip"]["style"]["fontFamily"], "Georgia");
+    assert_eq!(quote["clip"]["style"]["italic"], true);
+    assert!(quote["aliases"]
+        .as_array()
+        .expect("aliases")
+        .iter()
+        .any(|alias| alias == "pull_quote"));
+
     let (_stdout, stderr) = run_cli_err(&["packs", "list", "--kind", "nonsense"]);
     assert!(
-        stderr.contains("caption") && stderr.contains("transition"),
+        stderr.contains("caption") && stderr.contains("transition") && stderr.contains("text"),
         "clap must list the valid kinds, got: {stderr}"
     );
 }
@@ -6049,4 +6084,189 @@ fn test_caption_style_pack_never_overrides_an_explicit_placement() {
     assert_eq!(restyled["position"]["xPercent"], 25.0);
     assert_eq!(restyled["position"]["yPercent"], 80.0);
     assert_eq!(restyled["style"]["backgroundColor"]["a"], 180);
+}
+
+#[test]
+fn test_text_add_accepts_every_curated_preset() {
+    // Before the catalog was unified, `--preset quote` answered "Unsupported
+    // text preset" while help-json and the MCP hints advertised it. Every id
+    // the registry publishes now has to survive an actual add.
+    let dir = create_temp_project("text_preset_catalog_test");
+    let path = project_path(&dir, "text_preset_catalog_test");
+
+    let listing = run_cli_ok(&["packs", "list", "--kind", "text"]);
+    let presets = listing["packs"].as_array().expect("packs").clone();
+    assert!(presets.len() >= 22, "{} presets listed", presets.len());
+
+    for (index, preset) in presets.iter().enumerate() {
+        let id = preset["id"].as_str().expect("preset id");
+        let start = (index as f64) * 20.0;
+        let add = run_cli_ok(&[
+            "text",
+            "add",
+            "--path",
+            &path,
+            "--text",
+            "Catalog Probe",
+            "--start",
+            &start.to_string(),
+            "--preset",
+            id,
+        ]);
+        assert_eq!(add["status"], "ok", "preset '{id}' must add");
+    }
+
+    let list = run_cli_ok(&["text", "list", "--path", &path]);
+    assert_eq!(list["count"].as_u64().unwrap() as usize, presets.len());
+}
+
+#[test]
+fn test_text_add_preset_supplies_style_and_default_duration() {
+    let dir = create_temp_project("text_preset_defaults_test");
+    let path = project_path(&dir, "text_preset_defaults_test");
+
+    let add = run_cli_ok(&[
+        "text",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "\"Cut the noise\"",
+        "--start",
+        "3",
+        "--preset",
+        "quote",
+    ]);
+    assert_eq!(add["status"], "ok");
+
+    let list = run_cli_ok(&["text", "list", "--path", &path]);
+    let clip = &list["clips"][0];
+    // The preset's own typography, not a generic default.
+    assert_eq!(clip["textData"]["style"]["fontFamily"], "Georgia");
+    assert_eq!(clip["textData"]["style"]["fontSize"], 42);
+    assert_eq!(clip["textData"]["style"]["italic"], true);
+    assert_eq!(clip["textData"]["opacity"], 0.95);
+    // ...and the preset's suggested duration, since --duration was omitted.
+    assert_eq!(clip["durationSec"], 5.0);
+
+    // An explicit flag still wins over the preset value.
+    let dir2 = create_temp_project("text_preset_override_test");
+    let path2 = project_path(&dir2, "text_preset_override_test");
+    run_cli_ok(&[
+        "text",
+        "add",
+        "--path",
+        &path2,
+        "--text",
+        "Override",
+        "--start",
+        "0",
+        "--preset",
+        "quote",
+        "--font-size",
+        "96",
+        "--duration",
+        "2",
+    ]);
+    let list2 = run_cli_ok(&["text", "list", "--path", &path2]);
+    assert_eq!(list2["clips"][0]["textData"]["style"]["fontSize"], 96);
+    assert_eq!(
+        list2["clips"][0]["textData"]["style"]["fontFamily"],
+        "Georgia"
+    );
+    assert_eq!(list2["clips"][0]["durationSec"], 2.0);
+}
+
+#[test]
+fn test_text_add_rejects_an_unknown_preset_with_the_valid_list() {
+    let dir = create_temp_project("text_preset_unknown_test");
+    let path = project_path(&dir, "text_preset_unknown_test");
+
+    let (_stdout, stderr) = run_cli_err(&[
+        "text",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "Nope",
+        "--start",
+        "0",
+        "--preset",
+        "not-a-preset",
+    ]);
+
+    assert!(stderr.contains("Unknown text preset"), "{stderr}");
+    for id in ["lower-third", "quote", "watermark", "countdown"] {
+        assert!(stderr.contains(id), "error must name '{id}': {stderr}");
+    }
+    assert!(stderr.contains("default"), "{stderr}");
+}
+
+#[test]
+fn test_command_execute_resolves_a_text_preset_into_concrete_values() {
+    let dir = create_temp_project("text_preset_command_test");
+    let path = project_path(&dir, "text_preset_command_test");
+
+    let info = run_cli_ok(&["timeline", "info", "--path", &path]);
+    let sequence_id = info["sequenceId"]
+        .as_str()
+        .expect("sequence id")
+        .to_string();
+
+    let track = run_cli_ok(&[
+        "timeline",
+        "add-track",
+        "--path",
+        &path,
+        "--kind",
+        "video",
+        "--name",
+        "Text",
+    ]);
+    let track_id = track["createdIds"][0]
+        .as_str()
+        .expect("track id")
+        .to_string();
+
+    let payload = serde_json::json!({
+        "sequenceId": sequence_id,
+        "trackId": track_id,
+        "timelineIn": 2.0,
+        "duration": 6.0,
+        "preset": "logo-bug",
+        "textData": { "content": "OPENREELIO" },
+    })
+    .to_string();
+
+    let executed = run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "AddTextClip",
+        "--payload",
+        &payload,
+    ]);
+    assert_eq!(executed["status"], "ok");
+
+    let list = run_cli_ok(&["text", "list", "--path", &path]);
+    let clip = &list["clips"][0];
+    assert_eq!(clip["textData"]["content"], "OPENREELIO");
+    assert_eq!(clip["textData"]["style"]["backgroundColor"], "#0F766ECC");
+    assert_eq!(clip["textData"]["position"]["x"], 0.94);
+    assert_eq!(clip["textData"]["opacity"], 0.85);
+
+    // The op log records what the preset produced, never the id that produced
+    // it, so replay does not depend on the registry.
+    let ops = run_cli_ok(&["state", "ops", "--path", &path]);
+    let raw = ops.to_string();
+    assert!(
+        !raw.contains("logo-bug"),
+        "the op log must not name a preset"
+    );
+    assert!(
+        raw.contains("#0F766ECC"),
+        "the op log must carry the values"
+    );
 }

--- a/distribution/skills/skills/openreelio/SKILL.md
+++ b/distribution/skills/skills/openreelio/SKILL.md
@@ -34,7 +34,8 @@ Treat the binary as the source of truth, not this skill.
 `openreelio-cli <verb> --help` is authoritative for any single verb. `help-json`
 is roughly 68 KB — fetch per-verb help instead of loading all of it. Use
 `openreelio-cli command schema` for the 79 backend command types, and
-`openreelio-cli packs list` for the curated caption styles and transitions.
+`openreelio-cli packs list` for the curated caption styles, transition
+recipes, and text presets (`--kind caption|transition|text`).
 
 Its *examples* are not copy-paste ready: IDs are readable placeholders
 (`asset_001`) rather than the ULIDs the CLI actually returns, and some spell a
@@ -68,8 +69,8 @@ recipes; reach every backend command; run atomic batches. Load
 
 ## Captions and text
 
-Add subtitles and styled text overlays with curated style packs, import/export
-SRT and VTT, and generate transcripts locally. Load
+Add subtitles with curated caption packs and text overlays with curated text
+presets, import/export SRT and VTT, and generate transcripts locally. Load
 [Captions](./captions/REFERENCE.md).
 
 ## Render

--- a/distribution/skills/skills/openreelio/captions/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/captions/REFERENCE.md
@@ -115,8 +115,10 @@ openreelio-cli packs list --kind text
 ```
 
 Each entry prints its `category`, `defaultDurationSec`, aliases, and the full
-`clip` it produces, so nothing has to be guessed. Categories group the catalog:
-`lower-third`, `title`, `subtitle`, `callout`, `credit`, `brand`, `creative`.
+`clip` it produces, so nothing has to be guessed. Categories group the catalog
+and decide placement: `lower-third`, `title`, `subtitle`, and `callout` may be
+moved by smart placement, while `credit`, `brand`, and `creative` keep the
+anchor the preset chose.
 Ids tolerate `_`, spaces, and case (`lower_third`, `Lower Third`), and short
 aliases (`title`, `credits`, `stat`, `timer`, `handle`) resolve too. `default`
 means "no preset".
@@ -129,7 +131,8 @@ openreelio-cli text add --path ./demo --text '"Cut the noise"' --start 12 \
 ```
 
 The same catalog is reachable from the backend command as `preset`, which fills
-in everything `textData` leaves out:
+in everything `textData` leaves out — including all of it, when `textData` is
+omitted:
 
 ```bash
 openreelio-cli command execute --path ./demo --type AddTextClip --payload \
@@ -137,9 +140,31 @@ openreelio-cli command execute --path ./demo --type AddTextClip --payload \
     "preset":"logo-bug","textData":{"content":"OPENREELIO"}}'
 ```
 
+Nested layers merge key by key, so `{"style":{"bold":false}}` un-bolds a bold
+preset and `{"shadow":{"offsetX":2}}` nudges the shadow without restating it —
+on every preset, including those that declare no shadow of their own.
+
 The op log records the concrete values the preset produced, never the id, so a
 project replays identically even if the catalog later changes. An unknown id is
 rejected with the full list of valid ids.
+
+### Three ids changed meaning
+
+Unifying the CLI table onto the app's catalog changed what `title`,
+`lower-third`, and `subtitle` produce. Existing projects replay unchanged (the
+op log holds concrete values), but a script that names one of these renders
+differently than it used to:
+
+| Id | Was | Now |
+|----|-----|-----|
+| `title` (alias of `centered-title`) | upper third, y=0.15 | frame center, y=0.5 |
+| `lower-third` | centered (0.5, 0.80), 36pt, regular, no shadow | left-aligned (0.08, 0.82), 42pt, bold, with shadow |
+| `subtitle` | y=0.85, thin outline, background `#000000AA` | y=0.9, no outline, background `#00000099` |
+
+No id reproduces the old layouts; re-anchor with flags where the placement
+mattered, e.g. `--preset title --y 0.15`, or
+`--preset lower-third --x 0.5 --y 0.8 --align center --font-size 36 --style-json '{"bold":false}'`.
+Preset ids are append-only from here on.
 
 ## Transcription
 

--- a/distribution/skills/skills/openreelio/captions/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/captions/REFERENCE.md
@@ -99,6 +99,48 @@ than guessing — the flag list is the largest in the CLI.
 
 Positions are normalized (`0.0`–`1.0`) fractions of the canvas.
 
+### Text presets
+
+`--preset` is the text equivalent of a caption pack: one id supplies typography,
+anchor, starter copy, and a suggested duration (used when `--duration` is
+omitted). The catalog is one registry shared by the CLI, the MCP tools, the
+agent tools, and the app — the CLI, the prompts, and the UI no longer disagree
+about which ids exist, so `quote`, `watermark`, `countdown`, `label`,
+`tech-style`, `callout-warning`, `subtitle-outline`, `end-card-title`, and
+`lower-third-minimal` all work where they were previously advertised and
+rejected.
+
+```bash
+openreelio-cli packs list --kind text
+```
+
+Each entry prints its `category`, `defaultDurationSec`, aliases, and the full
+`clip` it produces, so nothing has to be guessed. Categories group the catalog:
+`lower-third`, `title`, `subtitle`, `callout`, `credit`, `brand`, `creative`.
+Ids tolerate `_`, spaces, and case (`lower_third`, `Lower Third`), and short
+aliases (`title`, `credits`, `stat`, `timer`, `handle`) resolve too. `default`
+means "no preset".
+
+A preset is a **base layer, not a lock** — explicit flags override it:
+
+```bash
+openreelio-cli text add --path ./demo --text '"Cut the noise"' --start 12 \
+  --preset quote --font-size 96
+```
+
+The same catalog is reachable from the backend command as `preset`, which fills
+in everything `textData` leaves out:
+
+```bash
+openreelio-cli command execute --path ./demo --type AddTextClip --payload \
+  '{"sequenceId":"seq_1","trackId":"v2","timelineIn":90,"duration":6,
+    "preset":"logo-bug","textData":{"content":"OPENREELIO"}}'
+```
+
+The op log records the concrete values the preset produced, never the id, so a
+project replays identically even if the catalog later changes. An unknown id is
+rejected with the full list of valid ids.
+
 ## Transcription
 
 Speech-to-text runs locally with Whisper. Check readiness first; the model is a

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -534,9 +534,40 @@ A preset is a base layer, not a lock: explicit flags override it, so
 `--preset quote --font-size 96` is the quote preset at 96pt. The same field is
 `preset` on `AddTextClip`, so `command execute`, `plan execute`, and MCP clients
 get it too, and `textData` there carries only the overrides (commonly just
-`content`). The op log records the concrete values, never the preset id, so
-replay never depends on the catalog. An unknown id is rejected with the full
-valid list; `default` means no preset.
+`content`) or may be omitted entirely. Nested layers merge key by key, so
+`{"style":{"bold":false}}` un-bolds a bold preset and leaves everything else
+alone. The op log records the concrete values, never the preset id, so replay
+never depends on the catalog. An unknown id is rejected with the full valid
+list; `default` means no preset.
+
+**Changed geometry.** Unifying on the app's catalog changed what three
+already-shipped spellings produce. Existing projects replay unchanged, because
+the op log stores concrete values — only new runs of a script that names one of
+these is affected:
+
+| Id | Was | Now |
+|----|-----|-----|
+| `title` (alias of `centered-title`) | upper third, y=0.15, 72pt bold | frame center, y=0.5, 72pt bold with wider letter spacing |
+| `lower-third` | centered (0.5, 0.80), 36pt, regular, no shadow | left-aligned (0.08, 0.82), 42pt, bold, with shadow |
+| `subtitle` | y=0.85 with a thin outline, background `#000000AA` | y=0.9, no outline, background `#00000099` |
+
+No id reproduces the old layouts, so re-anchor with flags where the previous
+placement mattered:
+
+```bash
+# the old upper-third title
+openreelio-cli text add --path ./demo --text "Chapter One" --start 0 --preset title --y 0.15
+# the old centered lower third
+openreelio-cli text add --path ./demo --text "Name" --start 0 --preset lower-third \
+  --x 0.5 --y 0.8 --align center --font-size 36 --style-json '{"bold":false}'
+# the old outlined subtitle
+openreelio-cli text add --path ./demo --text "Line" --start 0 --preset subtitle --y 0.85 \
+  --background-color "#000000AA" --outline-json '{"color":"#000000","width":1}'
+```
+
+Preset ids are append-only from here — see the stability note in
+`src-tauri/src/core/style/text_presets.rs`, which a contract test now enforces
+for these three.
 
 Speech-to-text is local (Whisper); `--import` writes the result straight into a
 caption track.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -86,7 +86,8 @@ everywhere rather than tracking the exceptions.
 it into a context window. Fetch help per verb instead
 (`openreelio-cli verify --help`, `openreelio-cli frame extract --help`), use
 `openreelio-cli command schema` for the 79 backend command types, and
-`openreelio-cli packs list` for the curated caption styles and transitions.
+`openreelio-cli packs list` for the curated caption styles, transition recipes,
+and text presets (`--kind caption|transition|text`).
 
 ### Self-diagnosis
 
@@ -475,7 +476,7 @@ openreelio-cli caption remove --path ./demo --id <CAPTION_ID>
 openreelio-cli caption import --path ./demo --file subs.srt [--format srt|vtt|transcript-json]
 openreelio-cli caption export --path ./demo --format srt --output subs.srt
 
-openreelio-cli text add       --path ./demo --text "Title" --start 0 --duration 3 [--preset credits]
+openreelio-cli text add       --path ./demo --text "Title" --start 0 [--duration 3] [--preset <PRESET_ID>]
 openreelio-cli text update    --path ./demo --id <CLIP_ID> --text "New"
 openreelio-cli text transform --path ./demo --id <CLIP_ID> --x 0.38 --y 0.42 --scale-x 1.2
 openreelio-cli text list      --path ./demo
@@ -510,6 +511,32 @@ On an **update** a pack restyles without moving the caption: `caption update
 --style-pack …` keeps the anchor the caption already has, because an update
 replaces whatever position it carries. Pass `--position` when you do want it
 moved.
+
+### Text presets
+
+`--preset` is the same idea for text overlays: one id supplies typography,
+anchor, starter copy, and a suggested duration (used when `--duration` is
+omitted).
+
+```bash
+openreelio-cli packs list --kind text
+```
+
+One registry serves the CLI, MCP, the agent tools, and the app, so the ids the
+hints advertise are exactly the ids the parser accepts — `quote`, `watermark`,
+`countdown`, `label`, `tech-style`, `callout-warning`, `subtitle-outline`,
+`end-card-title`, and `lower-third-minimal` used to be advertised and rejected,
+and now work. Entries print `category` (`lower-third`, `title`, `subtitle`,
+`callout`, `credit`, `brand`, `creative`), `defaultDurationSec`, aliases, and
+the full `clip`.
+
+A preset is a base layer, not a lock: explicit flags override it, so
+`--preset quote --font-size 96` is the quote preset at 96pt. The same field is
+`preset` on `AddTextClip`, so `command execute`, `plan execute`, and MCP clients
+get it too, and `textData` there carries only the overrides (commonly just
+`content`). The op log records the concrete values, never the preset id, so
+replay never depends on the catalog. An unknown id is rejected with the full
+valid list; `default` means no preset.
 
 Speech-to-text is local (Whisper); `--import` writes the result straight into a
 caption track.

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -3401,7 +3401,11 @@ pub(super) fn append_text_clip_overlays(
     )
 }
 
-fn build_text_clip_drawtext_with_enable(
+/// Builds the time-gated `drawtext` filter a text overlay clip renders as.
+///
+/// Exposed to the crate so the curated text preset contract tests can assert a
+/// preset's typography survives all the way to the filter string.
+pub(crate) fn build_text_clip_drawtext_with_enable(
     clip: &Clip,
     effects: &HashMap<String, Effect>,
 ) -> Result<String, ExportError> {

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -3743,7 +3743,11 @@ fn append_ass_text_style_and_event(
     }
 }
 
-fn build_ass_text_overlay_script(
+/// Builds the ASS script the libass export path burns text overlays with.
+///
+/// Exposed to the crate so the curated text preset contract tests can assert a
+/// resolved style reaches the second render path as well as `drawtext`.
+pub(crate) fn build_ass_text_overlay_script(
     sequence: &Sequence,
     effects: &HashMap<String, Effect>,
     output_width: u32,

--- a/src-tauri/src/core/style/contract_tests.rs
+++ b/src-tauri/src/core/style/contract_tests.rs
@@ -1430,8 +1430,13 @@ fn every_text_preset_renders_its_own_typography_into_the_drawtext_filter() {
     let mut filters_by_preset: Vec<(&str, String)> = Vec::new();
 
     for preset in TEXT_PRESETS {
-        let (state, clip) = add_text_clip_with_preset(preset.id, None);
-        let clip_data = preset.default_clip_data();
+        // Every preset renders the same copy. The content is the first field of
+        // the filter body, so leaving each preset its own starter string would
+        // make the pairwise comparison below pass on the text alone and never
+        // exercise the styling it exists to separate.
+        let (state, clip) =
+            add_text_clip_with_preset(preset.id, Some(json!({ "content": TEXT_OVERLAY_CONTENT })));
+        let clip_data = preset.clip_data(TEXT_OVERLAY_CONTENT);
 
         let filter = crate::core::render::export::build_text_clip_drawtext_with_enable(
             &clip,
@@ -1447,6 +1452,13 @@ fn every_text_preset_renders_its_own_typography_into_the_drawtext_filter() {
         assert!(
             filter.contains("enable='between(t,"),
             "preset '{}' filter must be time gated, got: {filter}",
+            preset.id
+        );
+        // Holding the copy constant is what makes the pairwise check below
+        // about styling, so the constant has to actually reach the filter.
+        assert!(
+            filter.contains(&format!("text='{TEXT_OVERLAY_CONTENT}'")),
+            "preset '{}' must render the shared copy, got: {filter}",
             preset.id
         );
 
@@ -1536,7 +1548,9 @@ fn every_text_preset_renders_its_own_typography_into_the_drawtext_filter() {
     }
 
     // Two presets that describe different looks must not compile to the same
-    // filter: identical output would mean the differences never reached it.
+    // filter. With the copy held constant, only styling can separate them, so
+    // a collision here means two catalog entries are one preset wearing two
+    // ids — which the listing surfaces would advertise as a real choice.
     for (index, (id, filter)) in filters_by_preset.iter().enumerate() {
         for (other_id, other_filter) in filters_by_preset.iter().skip(index + 1) {
             assert_ne!(
@@ -1544,6 +1558,85 @@ fn every_text_preset_renders_its_own_typography_into_the_drawtext_filter() {
                 "presets '{id}' and '{other_id}' render identically"
             );
         }
+    }
+}
+
+#[test]
+fn the_repurposed_preset_spellings_stay_pinned_to_their_current_geometry() {
+    // `title`, `lower-third`, and `subtitle` are the three spellings whose
+    // meaning changed when the CLI's inline table gave way to this registry, so
+    // they are the three most likely to be quietly repurposed a second time.
+    // The module doc states "ids are append-only: rename nothing, and add rather
+    // than repurpose"; these numbers are that contract in executable form.
+    // Changing one is a breaking change for every existing script that names it,
+    // so update the docs and the release notes along with this list.
+    struct PinnedGeometry {
+        key: &'static str,
+        id: &'static str,
+        x: f64,
+        y: f64,
+        font_size: u32,
+        bold: bool,
+        alignment: crate::core::text::TextAlignment,
+    }
+
+    let pinned = [
+        PinnedGeometry {
+            key: "title",
+            id: "centered-title",
+            x: 0.5,
+            y: 0.5,
+            font_size: 72,
+            bold: true,
+            alignment: crate::core::text::TextAlignment::Center,
+        },
+        PinnedGeometry {
+            key: "lower-third",
+            id: "lower-third",
+            x: 0.08,
+            y: 0.82,
+            font_size: 42,
+            bold: true,
+            alignment: crate::core::text::TextAlignment::Left,
+        },
+        PinnedGeometry {
+            key: "subtitle",
+            id: "subtitle",
+            x: 0.5,
+            y: 0.9,
+            font_size: 32,
+            bold: false,
+            alignment: crate::core::text::TextAlignment::Center,
+        },
+    ];
+
+    for expected in pinned {
+        let preset = crate::core::style::resolve_text_preset(expected.key)
+            .unwrap_or_else(|error| panic!("'{}' must resolve: {error}", expected.key));
+        assert_eq!(
+            preset.id, expected.id,
+            "'{}' must keep resolving to the same preset",
+            expected.key
+        );
+
+        let clip = preset.default_clip_data();
+        assert_eq!(
+            (clip.position.x, clip.position.y),
+            (expected.x, expected.y),
+            "'{}' moved",
+            expected.key
+        );
+        assert_eq!(
+            clip.style.font_size, expected.font_size,
+            "'{}'",
+            expected.key
+        );
+        assert_eq!(clip.style.bold, expected.bold, "'{}'", expected.key);
+        assert_eq!(
+            clip.style.alignment, expected.alignment,
+            "'{}'",
+            expected.key
+        );
     }
 }
 

--- a/src-tauri/src/core/style/contract_tests.rs
+++ b/src-tauri/src/core/style/contract_tests.rs
@@ -13,7 +13,13 @@
 //!   export;
 //! * every transition recipe resolves through `AddEffect` and builds the exact
 //!   FFmpeg transition token and duration it advertises, not merely something
-//!   from the right family.
+//!   from the right family;
+//! * every text preset — and every alias of one — survives `AddTextClip`,
+//!   stores the exact [`TextClipData`](crate::core::text::TextClipData) the
+//!   registry declares, leaves no preset id behind in the logged op, and
+//!   renders its own typography into the overlay `drawtext` filter;
+//! * `src/data/textPresets.manifest.json` still equals this registry, which is
+//!   what stops the TypeScript catalog from drifting away from it.
 
 use std::collections::HashMap;
 
@@ -28,7 +34,7 @@ use crate::core::qc::rules::{QCRule, RuleConfig};
 use crate::core::qc::CaptionSafeAreaRule;
 use crate::core::render::export::build_caption_drawtext_with_enable;
 use crate::core::style::{
-    caption_pack_ids, transition_recipe_ids, CAPTION_PACKS, TRANSITION_RECIPES,
+    caption_pack_ids, transition_recipe_ids, CAPTION_PACKS, TEXT_PRESETS, TRANSITION_RECIPES,
 };
 use crate::core::timeline::{Clip, Sequence, SequenceFormat, Track, TrackKind};
 use crate::ipc::CommandPayload;
@@ -942,4 +948,429 @@ fn recipe_params_do_not_leak_between_recipes() {
         );
     }
     assert_eq!(seen.len(), TRANSITION_RECIPES.len());
+}
+
+// =============================================================================
+// Curated text presets
+// =============================================================================
+
+/// Copy short enough to stay legible and distinct from any preset's own text.
+const TEXT_OVERLAY_CONTENT: &str = "Contract Text";
+
+/// Builds a project holding one video track and returns its ids.
+fn project_with_video_track() -> (ProjectState, String, String) {
+    let mut state = ProjectState::new_empty("Curated Text Presets");
+
+    let mut sequence = Sequence::new("Main", SequenceFormat::youtube_1080());
+    let video = Track::new_video("V1");
+    let track_id = video.id.clone();
+    sequence.add_track(video);
+
+    let sequence_id = sequence.id.clone();
+    state.active_sequence_id = Some(sequence_id.clone());
+    state.sequences.insert(sequence_id.clone(), sequence);
+
+    (state, sequence_id, track_id)
+}
+
+/// Adds one text clip from `preset` and returns the resulting project and clip.
+fn add_text_clip_with_preset(preset_id: &str, text_data: Option<Value>) -> (ProjectState, Clip) {
+    let (mut state, sequence_id, track_id) = project_with_video_track();
+
+    let mut payload = json!({
+        "sequenceId": sequence_id,
+        "trackId": track_id,
+        "timelineIn": 1.0,
+        "duration": 4.0,
+        "preset": preset_id,
+    });
+    if let Some(text_data) = text_data {
+        payload["textData"] = text_data;
+    }
+
+    let created = execute_payload(&mut state, "AddTextClip", payload)
+        .unwrap_or_else(|error| panic!("preset '{preset_id}' must add a text clip: {error}"));
+    let clip_id = created.first().expect("clip id").clone();
+
+    let clip = state
+        .sequences
+        .get(&sequence_id)
+        .expect("sequence exists")
+        .tracks
+        .iter()
+        .flat_map(|track| track.clips.iter())
+        .find(|clip| clip.id == clip_id)
+        .expect("text clip exists")
+        .clone();
+
+    (state, clip)
+}
+
+/// Renders a preset color the way `hex_to_ffmpeg_color` does.
+///
+/// Full opacity has no `@alpha` suffix. Only the RGB triplet is read, which is
+/// why an `#RRGGBBAA` background's own alpha does not appear here: the drawtext
+/// path composes alpha from the clip opacity instead.
+fn ffmpeg_hex_color(hex: &str, opacity: f64) -> String {
+    let clean = hex.trim().trim_start_matches('#');
+    let rgb = &clean[0..6];
+    let opacity = opacity.clamp(0.0, 1.0);
+    if (opacity - 1.0).abs() < 0.001 {
+        format!("0x{}", rgb.to_ascii_uppercase())
+    } else {
+        format!("0x{}@{:.2}", rgb.to_ascii_uppercase(), opacity)
+    }
+}
+
+/// The `x=` expression a preset's anchor and alignment must produce.
+fn expected_text_x_expression(clip_data: &crate::core::text::TextClipData) -> String {
+    let x = clip_data.position.x;
+    match clip_data.style.alignment {
+        crate::core::text::TextAlignment::Left => format!("(w*{x:.4})"),
+        crate::core::text::TextAlignment::Right => format!("(w*{x:.4})-text_w"),
+        crate::core::text::TextAlignment::Center => format!("(w*{x:.4})-(text_w/2)"),
+    }
+}
+
+#[test]
+fn every_text_preset_round_trips_into_typed_clip_data() {
+    for preset in TEXT_PRESETS {
+        let (state, clip) = add_text_clip_with_preset(preset.id, None);
+
+        assert!(
+            crate::core::commands::is_text_clip(&clip),
+            "preset '{}' must produce a text clip",
+            preset.id
+        );
+
+        let stored = crate::core::commands::get_text_data(&clip, &state)
+            .unwrap_or_else(|| panic!("preset '{}' must store text data", preset.id));
+
+        assert_eq!(
+            stored,
+            preset.default_clip_data(),
+            "preset '{}' drifted between the registry and the clip",
+            preset.id
+        );
+    }
+}
+
+#[test]
+fn every_text_preset_alias_resolves_to_the_same_clip_data() {
+    for preset in TEXT_PRESETS {
+        let expected = preset.default_clip_data();
+        for alias in preset.aliases {
+            let (state, clip) = add_text_clip_with_preset(alias, None);
+            let stored = crate::core::commands::get_text_data(&clip, &state)
+                .unwrap_or_else(|| panic!("alias '{alias}' must store text data"));
+            assert_eq!(
+                stored, expected,
+                "alias '{alias}' must produce the '{}' overlay",
+                preset.id
+            );
+        }
+    }
+}
+
+#[test]
+fn explicit_text_data_overrides_the_preset_key_by_key() {
+    let (state, clip) = add_text_clip_with_preset(
+        "quote",
+        Some(json!({
+            "content": TEXT_OVERLAY_CONTENT,
+            "style": { "fontSize": 64 },
+        })),
+    );
+
+    let stored = crate::core::commands::get_text_data(&clip, &state).expect("text data");
+    let preset = crate::core::style::resolve_text_preset("quote").expect("preset");
+
+    assert_eq!(stored.content, TEXT_OVERLAY_CONTENT);
+    assert_eq!(stored.style.font_size, 64);
+    // Everything the caller did not mention still comes from the preset.
+    assert_eq!(stored.style.font_family, preset.style().font_family);
+    assert!(stored.style.italic, "the quote preset is italic");
+    assert_eq!(stored.opacity, preset.default_clip_data().opacity);
+    assert_eq!(stored.shadow, preset.default_clip_data().shadow);
+}
+
+#[test]
+fn an_explicit_null_layer_clears_the_preset_layer() {
+    let (state, clip) = add_text_clip_with_preset(
+        "epic-title",
+        Some(json!({ "content": TEXT_OVERLAY_CONTENT, "outline": null })),
+    );
+
+    let stored = crate::core::commands::get_text_data(&clip, &state).expect("text data");
+    assert!(
+        stored.outline.is_none(),
+        "an explicit null must drop the preset's outline"
+    );
+    assert!(
+        stored.shadow.is_some(),
+        "clearing one layer must not clear another"
+    );
+}
+
+#[test]
+fn the_resolved_text_payload_never_carries_the_preset_id() {
+    // The op log has to be readable without the registry: what a preset
+    // produced is recorded, not which preset produced it.
+    let parsed = CommandPayload::parse(
+        "AddTextClip".to_string(),
+        json!({
+            "sequenceId": "seq_1",
+            "trackId": "track_1",
+            "timelineIn": 0.0,
+            "duration": 4.0,
+            "preset": "logo-bug",
+        }),
+    )
+    .expect("preset payload must parse");
+
+    let CommandPayload::AddTextClip(payload) = parsed else {
+        panic!("parsed the wrong variant");
+    };
+    assert!(payload.preset.is_none());
+
+    let serialized = serde_json::to_value(&payload).expect("payload serializes");
+    assert!(
+        serialized.get("preset").is_none(),
+        "a logged op must not name a preset: {serialized}"
+    );
+    assert_eq!(
+        serialized["textData"]["style"]["backgroundColor"],
+        json!("#0F766ECC")
+    );
+
+    // Re-parsing what was logged is a no-op, which is what makes replay stable.
+    let reparsed = CommandPayload::parse("AddTextClip".to_string(), serialized)
+        .expect("resolved payload must re-parse");
+    let CommandPayload::AddTextClip(reparsed) = reparsed else {
+        panic!("parsed the wrong variant");
+    };
+    assert_eq!(reparsed.text_data, payload.text_data);
+}
+
+#[test]
+fn an_unknown_text_preset_is_rejected_with_the_valid_list() {
+    let error = CommandPayload::parse(
+        "AddTextClip".to_string(),
+        json!({
+            "sequenceId": "seq_1",
+            "trackId": "track_1",
+            "timelineIn": 0.0,
+            "duration": 4.0,
+            "preset": "no-such-preset",
+        }),
+    )
+    .expect_err("unknown preset must fail");
+
+    for preset in TEXT_PRESETS {
+        assert!(
+            error.contains(preset.id),
+            "error must name '{}': {error}",
+            preset.id
+        );
+    }
+}
+
+#[test]
+fn text_data_is_still_required_without_a_preset() {
+    let error = CommandPayload::parse(
+        "AddTextClip".to_string(),
+        json!({
+            "sequenceId": "seq_1",
+            "trackId": "track_1",
+            "timelineIn": 0.0,
+            "duration": 4.0,
+        }),
+    )
+    .expect_err("a payload with neither preset nor textData must fail");
+
+    assert!(error.contains("textData"), "{error}");
+}
+
+#[test]
+fn every_text_preset_renders_its_own_typography_into_the_drawtext_filter() {
+    let mut filters_by_preset: Vec<(&str, String)> = Vec::new();
+
+    for preset in TEXT_PRESETS {
+        let (state, clip) = add_text_clip_with_preset(preset.id, None);
+        let clip_data = preset.default_clip_data();
+
+        let filter = crate::core::render::export::build_text_clip_drawtext_with_enable(
+            &clip,
+            &state.effects,
+        )
+        .unwrap_or_else(|error| panic!("preset '{}' must render: {error}", preset.id));
+
+        assert!(
+            filter.starts_with("drawtext="),
+            "preset '{}' must render drawtext, got: {filter}",
+            preset.id
+        );
+        assert!(
+            filter.contains("enable='between(t,"),
+            "preset '{}' filter must be time gated, got: {filter}",
+            preset.id
+        );
+
+        // The point of a preset is its own look, so each assertion names a
+        // value this preset declares rather than checking that some filter came
+        // out the other end.
+        assert!(
+            filter.contains(&format!("fontsize={}", clip_data.style.font_size)),
+            "preset '{}' must render at {}px, got: {filter}",
+            preset.id,
+            clip_data.style.font_size
+        );
+        assert!(
+            filter.contains(&format!(
+                "fontcolor={}",
+                ffmpeg_hex_color(&clip_data.style.color, clip_data.opacity)
+            )),
+            "preset '{}' must render in its own color at its own opacity, got: {filter}",
+            preset.id
+        );
+        assert!(
+            filter.contains(&format!("x={}", expected_text_x_expression(&clip_data))),
+            "preset '{}' must anchor where it says it does, got: {filter}",
+            preset.id
+        );
+        assert!(
+            filter.contains(&format!("y=(h*{:.4})-(text_h/2)", clip_data.position.y)),
+            "preset '{}' must sit at y={}, got: {filter}",
+            preset.id,
+            clip_data.position.y
+        );
+
+        match &clip_data.style.background_color {
+            Some(background) => assert!(
+                filter.contains("box=1")
+                    && filter.contains(&format!(
+                        "boxcolor={}",
+                        ffmpeg_hex_color(background, clip_data.opacity)
+                    ))
+                    && filter.contains(&format!(
+                        "boxborderw={}",
+                        clip_data.style.background_padding
+                    )),
+                "preset '{}' must render its box with {}px padding, got: {filter}",
+                preset.id,
+                clip_data.style.background_padding
+            ),
+            None => assert!(
+                !filter.contains("boxcolor="),
+                "preset '{}' declares no box, got: {filter}",
+                preset.id
+            ),
+        }
+
+        match &clip_data.outline {
+            Some(outline) => assert!(
+                filter.contains(&format!("borderw={}", outline.width))
+                    && filter.contains(&format!(
+                        "bordercolor={}",
+                        ffmpeg_hex_color(&outline.color, clip_data.opacity)
+                    )),
+                "preset '{}' must render its outline, got: {filter}",
+                preset.id
+            ),
+            None => assert!(
+                !filter.contains("bordercolor="),
+                "preset '{}' declares no outline, got: {filter}",
+                preset.id
+            ),
+        }
+
+        match &clip_data.shadow {
+            Some(shadow) => assert!(
+                filter.contains(&format!("shadowx={}", shadow.offset_x))
+                    && filter.contains(&format!("shadowy={}", shadow.offset_y)),
+                "preset '{}' must render its shadow offset, got: {filter}",
+                preset.id
+            ),
+            None => assert!(
+                !filter.contains("shadowcolor="),
+                "preset '{}' declares no shadow, got: {filter}",
+                preset.id
+            ),
+        }
+
+        filters_by_preset.push((preset.id, filter));
+    }
+
+    // Two presets that describe different looks must not compile to the same
+    // filter: identical output would mean the differences never reached it.
+    for (index, (id, filter)) in filters_by_preset.iter().enumerate() {
+        for (other_id, other_filter) in filters_by_preset.iter().skip(index + 1) {
+            assert_ne!(
+                filter, other_filter,
+                "presets '{id}' and '{other_id}' render identically"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// TypeScript parity manifest
+// =============================================================================
+
+/// Location of the manifest that pins the TypeScript catalog to this registry.
+fn text_preset_manifest_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("src")
+        .join("data")
+        .join("textPresets.manifest.json")
+}
+
+/// The manifest content this registry implies.
+fn text_preset_manifest_json() -> String {
+    let value = serde_json::to_value(crate::core::style::list_text_presets())
+        .expect("text presets serialize");
+    let mut json = serde_json::to_string_pretty(&value).expect("manifest serializes");
+    json.push('\n');
+    json
+}
+
+/// How to bring the manifest back in line after editing the registry.
+const REGENERATE_MANIFEST_HINT: &str =
+    "cargo test -p openreelio --lib regenerate_text_preset_manifest -- --ignored";
+
+#[test]
+fn the_text_preset_manifest_matches_the_registry() {
+    let path = text_preset_manifest_path();
+    let contents = std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "{} is missing ({error}). Regenerate it with: {REGENERATE_MANIFEST_HINT}",
+            path.display()
+        )
+    });
+
+    let recorded: Value = serde_json::from_str(&contents).unwrap_or_else(|error| {
+        panic!(
+            "{} is not valid JSON ({error}). Regenerate it with: {REGENERATE_MANIFEST_HINT}",
+            path.display()
+        )
+    });
+    let expected: Value =
+        serde_json::from_str(&text_preset_manifest_json()).expect("manifest is valid JSON");
+
+    assert_eq!(
+        recorded,
+        expected,
+        "{} is stale, so the TypeScript catalog and this registry disagree. \
+         Regenerate it with: {REGENERATE_MANIFEST_HINT}",
+        path.display()
+    );
+}
+
+#[test]
+#[ignore = "regeneration helper: rewrites src/data/textPresets.manifest.json"]
+fn regenerate_text_preset_manifest() {
+    let path = text_preset_manifest_path();
+    std::fs::write(&path, text_preset_manifest_json())
+        .unwrap_or_else(|error| panic!("failed to write {}: {error}", path.display()));
 }

--- a/src-tauri/src/core/style/contract_tests.rs
+++ b/src-tauri/src/core/style/contract_tests.rs
@@ -1022,6 +1022,39 @@ fn ffmpeg_hex_color(hex: &str, opacity: f64) -> String {
     }
 }
 
+/// The ASS script the libass export path burns this project's overlays with.
+fn ass_script_for(state: &ProjectState) -> String {
+    let sequence_id = state
+        .active_sequence_id
+        .clone()
+        .expect("the fixture sets an active sequence");
+    let sequence = state.sequences.get(&sequence_id).expect("sequence exists");
+    crate::core::render::export::build_ass_text_overlay_script(sequence, &state.effects, 1920, 1080)
+        .expect("the ASS script must build")
+        .expect("a text overlay must produce an ASS script")
+}
+
+/// The preview render spec the graph hands the compositor for the text clip.
+fn preview_text_render_spec(state: &ProjectState) -> crate::core::render::graph::TextRenderSpec {
+    let sequence_id = state
+        .active_sequence_id
+        .clone()
+        .expect("the fixture sets an active sequence");
+    let graph = crate::core::render::graph::build_render_graph(state, &sequence_id)
+        .expect("the render graph must build");
+
+    graph
+        .visual_layers
+        .iter()
+        .find_map(|layer| match &layer.source {
+            crate::core::render::graph::VisualRenderSource::Text { render_spec, .. } => {
+                render_spec.clone()
+            }
+            _ => None,
+        })
+        .expect("the text clip must reach the preview graph with a render spec")
+}
+
 /// The `x=` expression a preset's anchor and alignment must produce.
 fn expected_text_x_expression(clip_data: &crate::core::text::TextClipData) -> String {
     let x = clip_data.position.x;
@@ -1092,6 +1125,109 @@ fn explicit_text_data_overrides_the_preset_key_by_key() {
     assert!(stored.style.italic, "the quote preset is italic");
     assert_eq!(stored.opacity, preset.default_clip_data().opacity);
     assert_eq!(stored.shadow, preset.default_clip_data().shadow);
+}
+
+/// Asserts every render path agrees the overlay is regular weight, not bold.
+///
+/// `bold` and `fontWeight` are two spellings of one decision, and each render
+/// path reconciles them by OR-ing, so a stored pair that disagrees renders bold
+/// no matter which half said otherwise. Checking the merged JSON alone would
+/// miss exactly that.
+fn assert_renders_regular_weight(state: &ProjectState, clip: &Clip, case: &str) {
+    let stored = crate::core::commands::get_text_data(clip, state)
+        .unwrap_or_else(|| panic!("{case}: the clip must store text data"));
+    assert!(!stored.style.bold, "{case}: readback must not claim bold");
+    assert_eq!(
+        stored.style.font_weight, 400,
+        "{case}: readback weight must agree with the readback bold flag"
+    );
+
+    // drawtext expresses bold through the fontconfig style suffix.
+    let filter =
+        crate::core::render::export::build_text_clip_drawtext_with_enable(clip, &state.effects)
+            .unwrap_or_else(|error| panic!("{case}: the filter must build: {error}"));
+    assert!(
+        !filter.contains(":style=Bold"),
+        "{case}: drawtext must not select a bold face, got: {filter}"
+    );
+
+    // The ASS export carries the weight into every dialogue line.
+    let script = ass_script_for(state);
+    assert!(
+        script.contains(r"\b400") && !script.contains(r"\b700"),
+        "{case}: the ASS event must carry weight 400, got: {script}"
+    );
+
+    // The preview graph reconciles the same pair for the canvas compositor.
+    let spec = preview_text_render_spec(state);
+    assert!(
+        !spec.style.bold,
+        "{case}: the preview spec must not be bold, got: {spec:?}"
+    );
+    assert_eq!(
+        spec.style.font_weight, 400,
+        "{case}: the preview spec weight must agree with its bold flag"
+    );
+}
+
+#[test]
+fn turning_bold_off_on_a_bold_preset_renders_regular_everywhere() {
+    // `centered-title` is bold, so its serialized base carries fontWeight 700.
+    // A caller who never mentions fontWeight must still get a regular overlay.
+    let (state, clip) = add_text_clip_with_preset(
+        "centered-title",
+        Some(json!({
+            "content": TEXT_OVERLAY_CONTENT,
+            "style": { "bold": false },
+        })),
+    );
+
+    assert_renders_regular_weight(&state, &clip, "bold:false");
+
+    // Nothing else about the preset moved.
+    let preset = crate::core::style::resolve_text_preset("centered-title").expect("preset");
+    let stored = crate::core::commands::get_text_data(&clip, &state).expect("text data");
+    assert_eq!(stored.style.font_size, preset.style().font_size);
+    assert_eq!(stored.position, preset.position());
+}
+
+#[test]
+fn lowering_the_font_weight_on_a_bold_preset_renders_regular_everywhere() {
+    // The symmetric case: naming only the numeric half must drop `bold` too,
+    // or the effect layer promotes the weight straight back to 700.
+    let (state, clip) = add_text_clip_with_preset(
+        "centered-title",
+        Some(json!({
+            "content": TEXT_OVERLAY_CONTENT,
+            "style": { "fontWeight": 400 },
+        })),
+    );
+
+    assert_renders_regular_weight(&state, &clip, "fontWeight:400");
+}
+
+#[test]
+fn naming_both_halves_of_the_weight_pair_keeps_both() {
+    // With both named there is nothing to infer, so neither is rewritten —
+    // which is also what makes replaying a resolved op idempotent.
+    let (state, clip) = add_text_clip_with_preset(
+        "subtitle",
+        Some(json!({
+            "content": TEXT_OVERLAY_CONTENT,
+            "style": { "bold": true, "fontWeight": 900 },
+        })),
+    );
+
+    let stored = crate::core::commands::get_text_data(&clip, &state).expect("text data");
+    assert!(stored.style.bold);
+    assert_eq!(stored.style.font_weight, 900);
+
+    let filter =
+        crate::core::render::export::build_text_clip_drawtext_with_enable(&clip, &state.effects)
+            .expect("filter builds");
+    assert!(filter.contains(":style=Bold"), "got: {filter}");
+    assert!(ass_script_for(&state).contains(r"\b900"));
+    assert!(preview_text_render_spec(&state).style.bold);
 }
 
 #[test]

--- a/src-tauri/src/core/style/contract_tests.rs
+++ b/src-tauri/src/core/style/contract_tests.rs
@@ -1249,6 +1249,104 @@ fn an_explicit_null_layer_clears_the_preset_layer() {
 }
 
 #[test]
+fn a_partial_shadow_override_merges_on_every_preset() {
+    // `epic-title` declares a shadow, `watermark` does not. The same fragment
+    // has to mean the same thing on both, or an agent that learned the pattern
+    // from one preset gets a parse error about a field it never named.
+    for (preset_id, declares_shadow) in [("epic-title", true), ("watermark", false)] {
+        let (state, clip) = add_text_clip_with_preset(
+            preset_id,
+            Some(json!({
+                "content": TEXT_OVERLAY_CONTENT,
+                "shadow": { "offsetX": 7 },
+            })),
+        );
+
+        let stored = crate::core::commands::get_text_data(&clip, &state)
+            .unwrap_or_else(|| panic!("preset '{preset_id}' must store text data"));
+        let shadow = stored
+            .shadow
+            .unwrap_or_else(|| panic!("preset '{preset_id}' must carry the merged shadow"));
+
+        assert_eq!(shadow.offset_x, 7, "preset '{preset_id}'");
+
+        let base = crate::core::style::resolve_text_preset(preset_id)
+            .expect("preset")
+            .default_clip_data()
+            .shadow
+            .unwrap_or_default();
+        assert_eq!(
+            (shadow.color.as_str(), shadow.offset_y, shadow.blur),
+            (base.color.as_str(), base.offset_y, base.blur),
+            "preset '{preset_id}' must keep the rest of the layer \
+             (declared: {declares_shadow})"
+        );
+    }
+}
+
+#[test]
+fn a_partial_outline_override_merges_on_every_preset() {
+    for preset_id in ["epic-title", "subtitle"] {
+        let (state, clip) = add_text_clip_with_preset(
+            preset_id,
+            Some(json!({
+                "content": TEXT_OVERLAY_CONTENT,
+                "outline": { "width": 3 },
+            })),
+        );
+
+        let stored = crate::core::commands::get_text_data(&clip, &state)
+            .unwrap_or_else(|| panic!("preset '{preset_id}' must store text data"));
+        let outline = stored
+            .outline
+            .unwrap_or_else(|| panic!("preset '{preset_id}' must carry the merged outline"));
+
+        assert_eq!(outline.width, 3, "preset '{preset_id}'");
+
+        let base = crate::core::style::resolve_text_preset(preset_id)
+            .expect("preset")
+            .default_clip_data()
+            .outline
+            .unwrap_or_default();
+        assert_eq!(
+            outline.color, base.color,
+            "preset '{preset_id}' must keep the color it did not name"
+        );
+    }
+}
+
+#[test]
+fn seeding_a_missing_layer_does_not_resurrect_a_cleared_one() {
+    // The seed only applies to a layer the caller is actually merging into, so
+    // an explicit null still clears and an untouched layer stays absent.
+    let (state, clip) = add_text_clip_with_preset(
+        "epic-title",
+        Some(json!({
+            "content": TEXT_OVERLAY_CONTENT,
+            "outline": null,
+            "shadow": { "blur": 12 },
+        })),
+    );
+
+    let stored = crate::core::commands::get_text_data(&clip, &state).expect("text data");
+    assert!(
+        stored.outline.is_none(),
+        "an explicit null must still clear"
+    );
+    assert_eq!(stored.shadow.expect("shadow merged").blur, 12);
+
+    let (state, clip) = add_text_clip_with_preset(
+        "watermark",
+        Some(json!({ "content": TEXT_OVERLAY_CONTENT })),
+    );
+    let stored = crate::core::commands::get_text_data(&clip, &state).expect("text data");
+    assert!(
+        stored.shadow.is_none() && stored.outline.is_none(),
+        "a preset that declares no decoration must not gain one"
+    );
+}
+
+#[test]
 fn the_resolved_text_payload_never_carries_the_preset_id() {
     // The op log has to be readable without the registry: what a preset
     // produced is recorded, not which preset produced it.

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -81,13 +81,39 @@ const BOLD_FONT_WEIGHT_THRESHOLD: u16 = 600;
 /// spelling every other surface teaches.
 pub const NO_TEXT_PRESET: &str = "default";
 
-/// Normalizes a pack or recipe identifier for matching.
+/// Normalizes a pack, recipe, or preset identifier for matching.
 ///
-/// Follows the same contract as `ExportPreset::from_legacy_id`: trim, lowercase,
-/// and fold `_` and spaces onto the canonical `-` separator, so `Clean_Minimal`,
-/// `clean minimal`, and `clean-minimal` are one id.
+/// Trim, lowercase, then collapse each run of whitespace or `_` onto a single
+/// canonical `-`, so `Clean_Minimal`, `clean minimal`, and `clean-minimal` are
+/// one id. This is the TypeScript `normalizeTextPresetKey`
+/// (`.trim().toLowerCase().replace(/[\s_]+/g, '-')`) transcribed: the catalog is
+/// shared with the app, so a key one half accepts must not be a key the other
+/// half rejects. Substituting per character instead of per run would turn
+/// `lower  third` into `lower--third` and fail on a spelling the app resolves.
 pub(crate) fn normalize_pack_id(raw: &str) -> String {
-    raw.trim().to_ascii_lowercase().replace(['_', ' '], "-")
+    let lowered = raw.trim().to_lowercase();
+    let mut normalized = String::with_capacity(lowered.len());
+    let mut pending_separator = false;
+
+    for character in lowered.chars() {
+        if character == '_' || character.is_whitespace() {
+            pending_separator = true;
+            continue;
+        }
+        if pending_separator {
+            normalized.push('-');
+            pending_separator = false;
+        }
+        normalized.push(character);
+    }
+
+    // A trailing run is a separator too: `trim` clears trailing whitespace but
+    // not a trailing `_`, and the regex would have replaced it.
+    if pending_separator {
+        normalized.push('-');
+    }
+
+    normalized
 }
 
 /// Caption style JSON keys that mean the same thing to the render path.

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -50,7 +50,7 @@ use std::collections::HashMap;
 use serde_json::{Map, Value};
 
 use crate::core::effects::{EffectType, ParamValue};
-use crate::core::text::TextClipData;
+use crate::core::text::{TextClipData, TextStyle};
 
 pub use caption_packs::{
     caption_pack_ids, list_caption_packs, resolve_caption_pack, CaptionPackDescriptor,
@@ -64,6 +64,15 @@ pub use transition_recipes::{
     list_transition_recipes, resolve_transition_recipe, transition_recipe_ids, RecipeParam,
     TransitionRecipeDescriptor, TransitionRecipeSpec, TRANSITION_RECIPES,
 };
+
+/// The numeric weight a bold text style carries.
+const BOLD_FONT_WEIGHT: u16 = 700;
+
+/// The numeric weight a regular text style carries.
+const REGULAR_FONT_WEIGHT: u16 = 400;
+
+/// The weight at and above which every render path reads a style as bold.
+const BOLD_FONT_WEIGHT_THRESHOLD: u16 = 600;
 
 /// The preset id that means "no preset", accepted everywhere a preset is named.
 ///
@@ -242,8 +251,13 @@ pub fn resolve_effect_recipe(
 /// `null` clears an optional layer, so `{"shadow":null}` drops the preset's
 /// shadow.
 ///
+/// `bold` and `fontWeight` are reconciled after the merge, because they are one
+/// decision spelled two ways — see [`reconcile_bold_and_font_weight`].
+///
 /// Without a preset this is just the strict `TextClipData` parse the payload
-/// always did, so `text_data` stays required in that case.
+/// always did, so `text_data` stays required in that case. Reconciliation is
+/// likewise skipped there: with no base layer underneath, nothing the caller
+/// left out was filled in on its behalf.
 ///
 /// Returns an error naming every valid preset id when `preset` is unknown.
 pub fn resolve_text_clip_data(
@@ -263,13 +277,68 @@ pub fn resolve_text_clip_data(
     };
 
     let preset = resolve_text_preset(preset_id)?;
+    let overrides = text_data.filter(|value| !value.is_null());
+    let (bold_was_named, font_weight_was_named) = named_bold_and_font_weight(overrides.as_ref());
 
     let mut base = serde_json::to_value(preset.default_clip_data())
         .map_err(|error| format!("Failed to serialize text preset: {error}"))?;
-    merge_json_deep(&mut base, text_data.filter(|value| !value.is_null()));
+    merge_json_deep(&mut base, overrides);
 
-    serde_json::from_value(base)
-        .map_err(|error| format!("Invalid textData for preset '{}': {error}", preset.id))
+    let mut resolved: TextClipData = serde_json::from_value(base)
+        .map_err(|error| format!("Invalid textData for preset '{}': {error}", preset.id))?;
+    reconcile_bold_and_font_weight(&mut resolved.style, bold_was_named, font_weight_was_named);
+
+    Ok(resolved)
+}
+
+/// Reconciles the paired `bold` and `fontWeight` fields after a layered override.
+///
+/// The two are one decision spelled two ways: every render path reads bold as
+/// `bold || fontWeight >= 600`, so a caller who layers `{"bold": false}` onto a
+/// base that carries `fontWeight: 700` gets an overlay that renders bold, reads
+/// back as regular, and matches neither the base nor the request. Whichever half
+/// the caller named wins and the other follows it; naming both keeps both, since
+/// then there is nothing left to infer.
+///
+/// Every surface that layers a style onto a base — the payload boundary's preset
+/// merge and the CLI's `--style-json` patch — routes through here, so the two
+/// cannot answer identical input differently.
+pub fn reconcile_bold_and_font_weight(
+    style: &mut TextStyle,
+    bold_was_named: bool,
+    font_weight_was_named: bool,
+) {
+    match (bold_was_named, font_weight_was_named) {
+        (true, false) => {
+            style.font_weight = if style.bold {
+                BOLD_FONT_WEIGHT
+            } else {
+                REGULAR_FONT_WEIGHT
+            };
+        }
+        (false, true) => {
+            style.bold = style.font_weight >= BOLD_FONT_WEIGHT_THRESHOLD;
+        }
+        _ => {}
+    }
+}
+
+/// Reports which half of the bold/`fontWeight` pair a `textData` override named.
+///
+/// Only the spelling the [`TextStyle`] deserializer actually reads counts:
+/// `font_weight` is dropped on the floor by serde, so treating it as named would
+/// make `bold` follow a value that never landed.
+fn named_bold_and_font_weight(text_data: Option<&Value>) -> (bool, bool) {
+    let Some(style) = text_data
+        .and_then(Value::as_object)
+        .and_then(|object| object.get("style"))
+        .and_then(Value::as_object)
+    else {
+        return (false, false);
+    };
+
+    let named = |key: &str| style.get(key).is_some_and(|value| !value.is_null());
+    (named("bold"), named("fontWeight"))
 }
 
 /// Merges `overrides` onto `base` recursively, key by key.

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -12,6 +12,9 @@
 //!   that pass `CaptionSafeAreaRule` on both landscape and vertical canvases.
 //! - [`transition_recipes`] — transition [`EffectType`] plus the parameters the
 //!   FFmpeg filter builder actually reads.
+//! - [`text_presets`] — typed [`TextClipData`](crate::core::text::TextClipData)
+//!   overlays: typography, anchor, shadow, outline, starter copy, and a
+//!   suggested duration.
 //!
 //! # Layering
 //!
@@ -36,6 +39,7 @@
 //! is the entry point for that case.
 
 pub mod caption_packs;
+pub mod text_presets;
 pub mod transition_recipes;
 
 #[cfg(test)]
@@ -46,15 +50,27 @@ use std::collections::HashMap;
 use serde_json::{Map, Value};
 
 use crate::core::effects::{EffectType, ParamValue};
+use crate::core::text::TextClipData;
 
 pub use caption_packs::{
     caption_pack_ids, list_caption_packs, resolve_caption_pack, CaptionPackDescriptor,
     CaptionPackSpec, CAPTION_PACKS,
 };
+pub use text_presets::{
+    list_text_presets, resolve_text_preset, text_preset_ids, text_preset_keys, TextPresetCategory,
+    TextPresetDescriptor, TextPresetSpec, TEXT_PRESETS,
+};
 pub use transition_recipes::{
     list_transition_recipes, resolve_transition_recipe, transition_recipe_ids, RecipeParam,
     TransitionRecipeDescriptor, TransitionRecipeSpec, TRANSITION_RECIPES,
 };
+
+/// The preset id that means "no preset", accepted everywhere a preset is named.
+///
+/// The CLI has always defaulted `--preset` to this word and the agent tool enums
+/// advertise it, so the payload boundary accepts it too rather than rejecting a
+/// spelling every other surface teaches.
+pub const NO_TEXT_PRESET: &str = "default";
 
 /// Normalizes a pack or recipe identifier for matching.
 ///
@@ -215,6 +231,71 @@ pub fn resolve_effect_recipe(
         effect_type: Some(recipe.effect_type.clone()),
         params: merged,
     })
+}
+
+/// Resolves a text preset against caller-supplied text clip data.
+///
+/// The preset is the base layer; `text_data` overrides it field by field, and
+/// nested objects (`style`, `position`, `shadow`, `outline`) merge key by key
+/// rather than replacing wholesale — `{"style":{"fontSize":64}}` on top of
+/// `quote` is the quote preset at 64pt, not a style with one field. An explicit
+/// `null` clears an optional layer, so `{"shadow":null}` drops the preset's
+/// shadow.
+///
+/// Without a preset this is just the strict `TextClipData` parse the payload
+/// always did, so `text_data` stays required in that case.
+///
+/// Returns an error naming every valid preset id when `preset` is unknown.
+pub fn resolve_text_clip_data(
+    preset: Option<&str>,
+    text_data: Option<Value>,
+) -> Result<TextClipData, String> {
+    let preset_id = preset
+        .map(str::trim)
+        .filter(|id| !id.is_empty() && !normalize_pack_id(id).eq(NO_TEXT_PRESET));
+
+    let Some(preset_id) = preset_id else {
+        let text_data = text_data
+            .filter(|value| !value.is_null())
+            .ok_or_else(|| "textData is required unless a preset is named".to_string())?;
+        return serde_json::from_value(text_data)
+            .map_err(|error| format!("Invalid textData: {error}"));
+    };
+
+    let preset = resolve_text_preset(preset_id)?;
+
+    let mut base = serde_json::to_value(preset.default_clip_data())
+        .map_err(|error| format!("Failed to serialize text preset: {error}"))?;
+    merge_json_deep(&mut base, text_data.filter(|value| !value.is_null()));
+
+    serde_json::from_value(base)
+        .map_err(|error| format!("Invalid textData for preset '{}': {error}", preset.id))
+}
+
+/// Merges `overrides` onto `base` recursively, key by key.
+///
+/// Objects merge; everything else replaces, so an explicit `null` clears the
+/// key it names and a scalar wins outright.
+fn merge_json_deep(base: &mut Value, overrides: Option<Value>) {
+    let Some(overrides) = overrides else {
+        return;
+    };
+
+    match (base, overrides) {
+        (Value::Object(base_object), Value::Object(override_object)) => {
+            for (key, value) in override_object {
+                match base_object.get_mut(&key) {
+                    Some(existing) if existing.is_object() && value.is_object() => {
+                        merge_json_deep(existing, Some(value));
+                    }
+                    _ => {
+                        base_object.insert(key, value);
+                    }
+                }
+            }
+        }
+        (base, overrides) => *base = overrides,
+    }
 }
 
 /// Renders an effect type for an error message.
@@ -579,6 +660,69 @@ mod tests {
             Some("wipe-down"),
             first.effect_type.clone(),
             first.params.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn absent_text_preset_parses_the_given_clip_data_unchanged() {
+        let text_data = serde_json::json!({
+            "content": "Hand assembled",
+            "style": { "fontFamily": "Arial", "fontSize": 30, "color": "#FFFFFF" },
+            "position": { "x": 0.2, "y": 0.7 },
+        });
+
+        let resolved = resolve_text_clip_data(None, Some(text_data)).expect("resolves");
+
+        assert_eq!(resolved.content, "Hand assembled");
+        assert_eq!(resolved.style.font_size, 30);
+        assert_eq!(resolved.position.x, 0.2);
+    }
+
+    #[test]
+    fn the_no_preset_sentinel_is_accepted_in_every_spelling() {
+        let text_data = serde_json::json!({
+            "content": "Plain",
+            "style": { "fontFamily": "Arial", "fontSize": 30, "color": "#FFFFFF" },
+            "position": { "x": 0.5, "y": 0.5 },
+        });
+
+        for spelling in ["default", "DEFAULT", "  default  "] {
+            let resolved = resolve_text_clip_data(Some(spelling), Some(text_data.clone()))
+                .unwrap_or_else(|error| panic!("'{spelling}' must resolve: {error}"));
+            assert_eq!(resolved.style.font_size, 30);
+        }
+    }
+
+    #[test]
+    fn a_nested_text_override_merges_instead_of_replacing_its_object() {
+        // A partial style has to leave the rest of the preset's typography
+        // intact; replacing the object outright would fail to deserialize and,
+        // worse, would silently drop the look the caller asked for by name.
+        let resolved = resolve_text_clip_data(
+            Some("tech-style"),
+            Some(serde_json::json!({ "style": { "color": "#FF00FF" } })),
+        )
+        .expect("resolves");
+
+        assert_eq!(resolved.style.color, "#FF00FF");
+        assert_eq!(resolved.style.font_family, "Courier New");
+        assert_eq!(resolved.style.font_size, 36);
+    }
+
+    #[test]
+    fn resolution_is_idempotent_for_text_presets() {
+        let first = resolve_text_clip_data(
+            Some("credits-block"),
+            Some(serde_json::json!({ "content": "Directed by" })),
+        )
+        .unwrap();
+
+        let second = resolve_text_clip_data(
+            Some("credits-block"),
+            Some(serde_json::to_value(&first).unwrap()),
         )
         .unwrap();
 

--- a/src-tauri/src/core/style/mod.rs
+++ b/src-tauri/src/core/style/mod.rs
@@ -50,7 +50,7 @@ use std::collections::HashMap;
 use serde_json::{Map, Value};
 
 use crate::core::effects::{EffectType, ParamValue};
-use crate::core::text::{TextClipData, TextStyle};
+use crate::core::text::{TextClipData, TextOutline, TextShadow, TextStyle};
 
 pub use caption_packs::{
     caption_pack_ids, list_caption_packs, resolve_caption_pack, CaptionPackDescriptor,
@@ -251,6 +251,11 @@ pub fn resolve_effect_recipe(
 /// `null` clears an optional layer, so `{"shadow":null}` drops the preset's
 /// shadow.
 ///
+/// `shadow` and `outline` are optional, so roughly half the catalog declares
+/// neither and there would be nothing for a partial override to merge into.
+/// Those two merge onto their type defaults instead of demanding a complete
+/// layer, so `{"shadow":{"offsetX":2}}` means the same thing on every preset.
+///
 /// `bold` and `fontWeight` are reconciled after the merge, because they are one
 /// decision spelled two ways — see [`reconcile_bold_and_font_weight`].
 ///
@@ -282,6 +287,7 @@ pub fn resolve_text_clip_data(
 
     let mut base = serde_json::to_value(preset.default_clip_data())
         .map_err(|error| format!("Failed to serialize text preset: {error}"))?;
+    seed_optional_text_layers(&mut base, overrides.as_ref());
     merge_json_deep(&mut base, overrides);
 
     let mut resolved: TextClipData = serde_json::from_value(base)
@@ -289,6 +295,43 @@ pub fn resolve_text_clip_data(
     reconcile_bold_and_font_weight(&mut resolved.style, bold_was_named, font_weight_was_named);
 
     Ok(resolved)
+}
+
+/// Gives a partial `shadow` or `outline` override a layer to merge into.
+///
+/// Both are `Option` on [`TextClipData`] and skipped when absent, so on the
+/// roughly half of the catalog that declares neither, `merge_json_deep` would
+/// install the caller's fragment as the whole layer and the parse would fail on
+/// a field the caller never meant to set. Seeding the type's defaults first
+/// makes `{"shadow":{"offsetX":2}}` mean the same thing on every preset, which
+/// is what the documented key-by-key contract promises.
+fn seed_optional_text_layers(base: &mut Value, overrides: Option<&Value>) {
+    let (Some(base_object), Some(override_object)) =
+        (base.as_object_mut(), overrides.and_then(Value::as_object))
+    else {
+        return;
+    };
+
+    for (key, value) in override_object {
+        if !value.is_object() {
+            continue;
+        }
+        if base_object.get(key).is_some_and(|layer| !layer.is_null()) {
+            continue;
+        }
+        if let Some(defaults) = default_optional_text_layer(key) {
+            base_object.insert(key.clone(), defaults);
+        }
+    }
+}
+
+/// The base layer a partial override of `key` merges onto, when there is one.
+fn default_optional_text_layer(key: &str) -> Option<Value> {
+    match key {
+        "shadow" => serde_json::to_value(TextShadow::default()).ok(),
+        "outline" => serde_json::to_value(TextOutline::default()).ok(),
+        _ => None,
+    }
 }
 
 /// Reconciles the paired `bold` and `fontWeight` fields after a layered override.

--- a/src-tauri/src/core/style/text_presets.rs
+++ b/src-tauri/src/core/style/text_presets.rs
@@ -369,7 +369,10 @@ pub const TEXT_PRESETS: &[TextPresetSpec] = &[
         id: "label",
         name: "Label",
         description: "Simple label for annotations",
-        category: TextPresetCategory::LowerThird,
+        // Anchored top-left, so it is a corner annotation rather than a name
+        // plate. Category decides placement, and `lower-third` sent it to the
+        // bottom of the frame — the one place a corner label must not go.
+        category: TextPresetCategory::Callout,
         aliases: &["annotation_label", "tag"],
         default_content: "Label",
         default_duration_sec: 3.0,

--- a/src-tauri/src/core/style/text_presets.rs
+++ b/src-tauri/src/core/style/text_presets.rs
@@ -1,0 +1,1120 @@
+//! Curated Text Presets
+//!
+//! A text preset is a named, hand-checked [`TextClipData`]: typography, canvas
+//! anchor, shadow, outline, opacity, a starter string, and a suggested duration.
+//! Naming one is a single token; assembling the same overlay field by field is a
+//! dozen decisions with no feedback until the render.
+//!
+//! # One catalog
+//!
+//! This table is the *only* text preset catalog in the Rust tree. Before it
+//! existed the CLI carried its own inline table of 14 presets while the agent
+//! prose advertised 17 and the TypeScript UI shipped 22, so `--preset quote` was
+//! documented and rejected in the same breath. Every Rust surface — the CLI
+//! `text add --preset`, `packs list --kind text`, the `preset` field on
+//! `AddTextClip`, the MCP payload hints, and `help-json` — now reads from
+//! [`TEXT_PRESETS`], and `src/data/textPresets.manifest.json` pins the
+//! TypeScript catalog to it by test on both sides.
+//!
+//! # Guarantees
+//!
+//! Every preset in [`TEXT_PRESETS`] is verified by contract test to:
+//!
+//! - resolve from its id, its display name, and each of its aliases,
+//! - survive the real command path — `AddTextClip` with `preset` through
+//!   `CommandPayload::parse`, execute, and back out of the clip as typed
+//!   [`TextClipData`] — and
+//! - reach the export `drawtext` filter with the typography it advertises.
+//!
+//! # Stability
+//!
+//! Preset ids are a public contract, so ids are append-only: rename nothing, and
+//! add rather than repurpose. The op log records the concrete [`TextClipData`] a
+//! preset produced, not the id that produced it — replay never consults this
+//! table — so a rename cannot be repaired by rewriting history.
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::text::{
+    TextAlignment, TextClipData, TextOutline, TextPosition, TextShadow, TextStyle,
+};
+
+use super::normalize_pack_id;
+
+/// Editorial role a preset plays, and the placement intent that follows from it.
+///
+/// The agent text tools read this to decide whether an overlay may be moved by
+/// smart placement (`title`, `lower-third`, `subtitle`, `callout`) or must keep
+/// the anchor the template chose (`credit`, `brand`, `creative`), so a category
+/// is behavior rather than a label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TextPresetCategory {
+    /// Name plates and speaker identification.
+    LowerThird,
+    /// Full-frame titles and chapter cards.
+    Title,
+    /// Dialogue-style bottom text.
+    Subtitle,
+    /// Attention-grabbing emphasis, stats, warnings, counters.
+    Callout,
+    /// Attribution and end credits.
+    Credit,
+    /// Channel bugs and social handles.
+    Brand,
+    /// Stylistic treatments that own their placement.
+    Creative,
+}
+
+impl TextPresetCategory {
+    /// Returns the serialized spelling of this category.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LowerThird => "lower-third",
+            Self::Title => "title",
+            Self::Subtitle => "subtitle",
+            Self::Callout => "callout",
+            Self::Credit => "credit",
+            Self::Brand => "brand",
+            Self::Creative => "creative",
+        }
+    }
+}
+
+/// A preset's drop shadow, in `const`-friendly form.
+#[derive(Clone, Copy, Debug)]
+struct PresetShadow {
+    color: &'static str,
+    offset_x: i32,
+    offset_y: i32,
+    blur: u32,
+}
+
+/// A preset's outline, in `const`-friendly form.
+#[derive(Clone, Copy, Debug)]
+struct PresetOutline {
+    color: &'static str,
+    width: u32,
+}
+
+/// Immutable definition of one curated text preset.
+///
+/// Held in a `const` table so the id list, the validator, and the resolved clip
+/// data are the same source. [`TextClipData`] owns `String` fields and therefore
+/// cannot be `const` itself, so the spec stores `&'static str` and materializes
+/// the typed clip on demand via [`TextPresetSpec::clip_data`].
+#[derive(Clone, Debug)]
+pub struct TextPresetSpec {
+    /// Canonical, hyphenated preset identifier.
+    pub id: &'static str,
+    /// Human-readable display name, as shown in the UI picker.
+    pub name: &'static str,
+    /// One-line description of what the preset is for.
+    pub description: &'static str,
+    /// Editorial role, which also decides placement handling.
+    pub category: TextPresetCategory,
+    /// Additional identifiers that resolve to this preset.
+    pub aliases: &'static [&'static str],
+    /// Starter copy, used when a caller names a preset without text.
+    pub default_content: &'static str,
+    /// Suggested clip duration in seconds.
+    pub default_duration_sec: f64,
+    font_family: &'static str,
+    font_size: u32,
+    color: &'static str,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    alignment: TextAlignment,
+    line_height: f64,
+    letter_spacing: i32,
+    background_color: Option<&'static str>,
+    background_padding: u32,
+    x: f64,
+    y: f64,
+    shadow: Option<PresetShadow>,
+    outline: Option<PresetOutline>,
+    rotation: f64,
+    opacity: f64,
+}
+
+impl TextPresetSpec {
+    /// Materializes the typed style for this preset.
+    ///
+    /// `font_weight` is derived from `bold` rather than stored, because the two
+    /// are one decision: the render path treats any weight at or above 600 as
+    /// bold, so a preset that says bold and carries weight 400 would render one
+    /// way and read the other.
+    pub fn style(&self) -> TextStyle {
+        TextStyle {
+            font_family: self.font_family.to_string(),
+            font_size: self.font_size,
+            font_weight: if self.bold { 700 } else { 400 },
+            color: self.color.to_string(),
+            background_color: self.background_color.map(str::to_string),
+            background_padding: self.background_padding,
+            alignment: self.alignment.clone(),
+            bold: self.bold,
+            italic: self.italic,
+            underline: self.underline,
+            line_height: self.line_height,
+            letter_spacing: self.letter_spacing,
+        }
+    }
+
+    /// Materializes the typed canvas anchor for this preset.
+    pub fn position(&self) -> TextPosition {
+        TextPosition {
+            x: self.x,
+            y: self.y,
+        }
+    }
+
+    /// Materializes the typed clip data for this preset with the given content.
+    pub fn clip_data(&self, content: impl Into<String>) -> TextClipData {
+        TextClipData {
+            content: content.into(),
+            style: self.style(),
+            position: self.position(),
+            shadow: self.shadow.map(|shadow| TextShadow {
+                color: shadow.color.to_string(),
+                offset_x: shadow.offset_x,
+                offset_y: shadow.offset_y,
+                blur: shadow.blur,
+            }),
+            outline: self.outline.map(|outline| TextOutline {
+                color: outline.color.to_string(),
+                width: outline.width,
+            }),
+            rotation: self.rotation,
+            opacity: self.opacity,
+        }
+    }
+
+    /// Materializes the typed clip data carrying the preset's starter copy.
+    pub fn default_clip_data(&self) -> TextClipData {
+        self.clip_data(self.default_content)
+    }
+
+    /// Builds the serializable descriptor used by listing surfaces.
+    pub fn descriptor(&self) -> TextPresetDescriptor {
+        TextPresetDescriptor {
+            id: self.id.to_string(),
+            kind: "text".to_string(),
+            name: self.name.to_string(),
+            category: self.category,
+            description: self.description.to_string(),
+            aliases: self.aliases.iter().map(|alias| alias.to_string()).collect(),
+            default_duration_sec: self.default_duration_sec,
+            clip: self.default_clip_data(),
+        }
+    }
+}
+
+/// Serializable description of a text preset, as returned by listing surfaces.
+///
+/// This is also the shape pinned into `src/data/textPresets.manifest.json`, so
+/// the TypeScript catalog and this table cannot drift without a test failing on
+/// one side or the other.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextPresetDescriptor {
+    /// Canonical preset identifier.
+    pub id: String,
+    /// Always `"text"`; lets text, caption, and transition entries share one list.
+    pub kind: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// Editorial role, which also decides placement handling.
+    pub category: TextPresetCategory,
+    /// One-line description of what the preset is for.
+    pub description: String,
+    /// Additional identifiers that resolve to this preset.
+    pub aliases: Vec<String>,
+    /// Suggested clip duration in seconds.
+    pub default_duration_sec: f64,
+    /// The typed clip data the preset applies, carrying its starter copy.
+    pub clip: TextClipData,
+}
+
+/// The canonical text preset table.
+///
+/// This is both the validator and the listing: `packs list --kind text` prints
+/// it and [`resolve_text_preset`] matches against it.
+pub const TEXT_PRESETS: &[TextPresetSpec] = &[
+    // -------------------------------------------------------------------------
+    // Lower thirds
+    // -------------------------------------------------------------------------
+    TextPresetSpec {
+        id: "lower-third",
+        name: "Lower Third",
+        description: "Classic lower third for names and titles",
+        category: TextPresetCategory::LowerThird,
+        aliases: &["lower_third", "lowerthird", "name_title"],
+        default_content: "Speaker Name\nTitle or Role",
+        default_duration_sec: 5.0,
+        font_family: "Arial",
+        font_size: 42,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.2,
+        letter_spacing: 1,
+        background_color: Some("#000000B3"),
+        background_padding: 12,
+        x: 0.08,
+        y: 0.82,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 2,
+            offset_y: 2,
+            blur: 4,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "lower-third-minimal",
+        name: "Lower Third Minimal",
+        description: "Clean minimal lower third",
+        category: TextPresetCategory::LowerThird,
+        aliases: &["minimal_lower_third"],
+        default_content: "Speaker Name",
+        default_duration_sec: 4.0,
+        font_family: "Helvetica",
+        font_size: 36,
+        color: "#FFFFFF",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.3,
+        letter_spacing: 2,
+        background_color: None,
+        background_padding: 0,
+        x: 0.05,
+        y: 0.88,
+        shadow: None,
+        outline: Some(PresetOutline {
+            color: "#000000",
+            width: 1,
+        }),
+        rotation: 0.0,
+        opacity: 0.95,
+    },
+    TextPresetSpec {
+        id: "lower-third-news",
+        name: "News Lower Third",
+        description: "Broadcast-style lower third with a strong title band",
+        category: TextPresetCategory::LowerThird,
+        aliases: &["broadcast_lower_third", "news-lower-third"],
+        default_content: "Breaking Story\nLocation",
+        default_duration_sec: 6.0,
+        font_family: "Arial",
+        font_size: 40,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.15,
+        letter_spacing: 1,
+        background_color: Some("#123E7CCC"),
+        background_padding: 14,
+        x: 0.07,
+        y: 0.78,
+        shadow: Some(PresetShadow {
+            color: "#00000080",
+            offset_x: 1,
+            offset_y: 2,
+            blur: 3,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "lower-third-name-role",
+        name: "Name + Role",
+        description: "Interview lower third with compact name and role styling",
+        category: TextPresetCategory::LowerThird,
+        aliases: &["interview_lower_third", "speaker_id", "name_role"],
+        default_content: "Jane Doe\nCreative Director",
+        default_duration_sec: 5.0,
+        font_family: "Helvetica",
+        font_size: 38,
+        color: "#F8FAFC",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.25,
+        letter_spacing: 1,
+        background_color: Some("#111827D9"),
+        background_padding: 10,
+        x: 0.08,
+        y: 0.84,
+        shadow: None,
+        outline: Some(PresetOutline {
+            color: "#00000066",
+            width: 1,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "label",
+        name: "Label",
+        description: "Simple label for annotations",
+        category: TextPresetCategory::LowerThird,
+        aliases: &["annotation_label", "tag"],
+        default_content: "Label",
+        default_duration_sec: 3.0,
+        font_family: "Arial",
+        font_size: 24,
+        color: "#FFFFFF",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.3,
+        letter_spacing: 0,
+        background_color: Some("#333333"),
+        background_padding: 6,
+        x: 0.1,
+        y: 0.1,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 0.9,
+    },
+    // -------------------------------------------------------------------------
+    // Centered titles
+    // -------------------------------------------------------------------------
+    TextPresetSpec {
+        id: "centered-title",
+        name: "Centered Title",
+        description: "Bold centered title for intros",
+        category: TextPresetCategory::Title,
+        aliases: &["title"],
+        default_content: "Main Title",
+        default_duration_sec: 4.0,
+        font_family: "Arial",
+        font_size: 72,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.1,
+        letter_spacing: 4,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.5,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 3,
+            offset_y: 3,
+            blur: 8,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "epic-title",
+        name: "Epic Title",
+        description: "Large dramatic title for impact",
+        category: TextPresetCategory::Title,
+        aliases: &["impact_title", "hero_title"],
+        default_content: "Big Moment",
+        default_duration_sec: 3.0,
+        font_family: "Impact",
+        font_size: 96,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.0,
+        letter_spacing: 6,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.5,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 4,
+            offset_y: 4,
+            blur: 12,
+        }),
+        outline: Some(PresetOutline {
+            color: "#000000",
+            width: 3,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "chapter-title",
+        name: "Chapter Title",
+        description: "Editorial chapter card with title and subtitle",
+        category: TextPresetCategory::Title,
+        aliases: &["chapter", "chapter_card", "section_title"],
+        default_content: "Chapter One\nThe Setup",
+        default_duration_sec: 5.0,
+        font_family: "Georgia",
+        font_size: 62,
+        color: "#F8FAFC",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.18,
+        letter_spacing: 2,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.45,
+        shadow: Some(PresetShadow {
+            color: "#00000099",
+            offset_x: 2,
+            offset_y: 3,
+            blur: 8,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "end-card-title",
+        name: "End Card",
+        description: "Centered end screen title for channels and credits",
+        category: TextPresetCategory::Title,
+        aliases: &["end_card", "outro_title"],
+        default_content: "Thanks for Watching",
+        default_duration_sec: 6.0,
+        font_family: "Arial",
+        font_size: 58,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.25,
+        letter_spacing: 1,
+        background_color: Some("#111827CC"),
+        background_padding: 18,
+        x: 0.5,
+        y: 0.5,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    // -------------------------------------------------------------------------
+    // Subtitles
+    // -------------------------------------------------------------------------
+    TextPresetSpec {
+        id: "subtitle",
+        name: "Subtitle",
+        description: "Standard subtitle/caption style",
+        category: TextPresetCategory::Subtitle,
+        aliases: &["caption", "subtitles"],
+        default_content: "Subtitle text",
+        default_duration_sec: 3.0,
+        font_family: "Arial",
+        font_size: 32,
+        color: "#FFFFFF",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.4,
+        letter_spacing: 0,
+        background_color: Some("#00000099"),
+        background_padding: 8,
+        x: 0.5,
+        y: 0.9,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "subtitle-outline",
+        name: "Subtitle Outline",
+        description: "Subtitle with outline (no background)",
+        category: TextPresetCategory::Subtitle,
+        aliases: &["outlined_subtitle"],
+        default_content: "Subtitle text",
+        default_duration_sec: 3.0,
+        font_family: "Arial",
+        font_size: 34,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.4,
+        letter_spacing: 0,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.9,
+        shadow: None,
+        outline: Some(PresetOutline {
+            color: "#000000",
+            width: 2,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    // -------------------------------------------------------------------------
+    // Callouts
+    // -------------------------------------------------------------------------
+    TextPresetSpec {
+        id: "callout",
+        name: "Callout",
+        description: "Attention-grabbing callout text",
+        category: TextPresetCategory::Callout,
+        aliases: &["emphasis"],
+        default_content: "Key Point",
+        default_duration_sec: 3.0,
+        font_family: "Arial",
+        font_size: 48,
+        color: "#FFD700",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.2,
+        letter_spacing: 2,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.35,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 2,
+            offset_y: 2,
+            blur: 6,
+        }),
+        outline: Some(PresetOutline {
+            color: "#000000",
+            width: 2,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "callout-stat",
+        name: "Stat Callout",
+        description: "Large numeric callout for data, prices, and milestones",
+        category: TextPresetCategory::Callout,
+        aliases: &["stat", "number_callout", "price_callout"],
+        default_content: "42%",
+        default_duration_sec: 3.0,
+        font_family: "Arial",
+        font_size: 82,
+        color: "#38BDF8",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.0,
+        letter_spacing: 1,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.42,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 3,
+            offset_y: 4,
+            blur: 8,
+        }),
+        outline: Some(PresetOutline {
+            color: "#082F49",
+            width: 2,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "callout-warning",
+        name: "Warning Callout",
+        description: "High-contrast warning or safety note",
+        category: TextPresetCategory::Callout,
+        aliases: &["warning", "important_callout"],
+        default_content: "Important",
+        default_duration_sec: 3.0,
+        font_family: "Arial",
+        font_size: 46,
+        color: "#111827",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.15,
+        letter_spacing: 1,
+        background_color: Some("#FACC15E6"),
+        background_padding: 14,
+        x: 0.5,
+        y: 0.22,
+        shadow: None,
+        outline: Some(PresetOutline {
+            color: "#FFFFFF",
+            width: 1,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "countdown",
+        name: "Countdown",
+        description: "Bold countdown/timer style",
+        category: TextPresetCategory::Callout,
+        aliases: &["timer"],
+        default_content: "3",
+        default_duration_sec: 1.0,
+        font_family: "Impact",
+        font_size: 120,
+        color: "#FF0000",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.0,
+        letter_spacing: 0,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.5,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 4,
+            offset_y: 4,
+            blur: 8,
+        }),
+        outline: Some(PresetOutline {
+            color: "#FFFFFF",
+            width: 4,
+        }),
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    // -------------------------------------------------------------------------
+    // Credits and brand
+    // -------------------------------------------------------------------------
+    TextPresetSpec {
+        id: "credits-block",
+        name: "Credits Block",
+        description: "Centered credit block for ending cards",
+        category: TextPresetCategory::Credit,
+        aliases: &["credits", "credit_block", "end_credits"],
+        default_content: "Directed by\nJane Doe\n\nProduced by\nOpenReelio",
+        default_duration_sec: 8.0,
+        font_family: "Georgia",
+        font_size: 34,
+        color: "#F8FAFC",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.45,
+        letter_spacing: 1,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.52,
+        shadow: Some(PresetShadow {
+            color: "#000000AA",
+            offset_x: 1,
+            offset_y: 2,
+            blur: 5,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "credit-line",
+        name: "Credit Line",
+        description: "Small single-line attribution or source credit",
+        category: TextPresetCategory::Credit,
+        aliases: &["source_credit", "attribution"],
+        default_content: "Source: OpenReelio",
+        default_duration_sec: 5.0,
+        font_family: "Arial",
+        font_size: 24,
+        color: "#E5E7EB",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Right,
+        line_height: 1.2,
+        letter_spacing: 0,
+        background_color: Some("#00000080"),
+        background_padding: 6,
+        x: 0.94,
+        y: 0.92,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 0.9,
+    },
+    TextPresetSpec {
+        id: "logo-bug",
+        name: "Logo Bug",
+        description: "Subtle top-right brand bug or channel label",
+        category: TextPresetCategory::Brand,
+        aliases: &["bug", "channel_bug", "brand_bug"],
+        default_content: "OPEN",
+        default_duration_sec: 10.0,
+        font_family: "Arial",
+        font_size: 24,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Right,
+        line_height: 1.15,
+        letter_spacing: 1,
+        background_color: Some("#0F766ECC"),
+        background_padding: 8,
+        x: 0.94,
+        y: 0.08,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 0.85,
+    },
+    TextPresetSpec {
+        id: "social-handle",
+        name: "Social Handle",
+        description: "Creator handle or social profile lower bug",
+        category: TextPresetCategory::Brand,
+        aliases: &["handle", "social"],
+        default_content: "@openreelio",
+        default_duration_sec: 5.0,
+        font_family: "Arial",
+        font_size: 30,
+        color: "#FFFFFF",
+        bold: true,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.2,
+        letter_spacing: 0,
+        background_color: Some("#7C3AEDCC"),
+        background_padding: 10,
+        x: 0.07,
+        y: 0.91,
+        shadow: Some(PresetShadow {
+            color: "#00000099",
+            offset_x: 1,
+            offset_y: 2,
+            blur: 4,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    // -------------------------------------------------------------------------
+    // Creative treatments
+    // -------------------------------------------------------------------------
+    TextPresetSpec {
+        id: "quote",
+        name: "Quote",
+        description: "Elegant quote style with italics",
+        category: TextPresetCategory::Creative,
+        aliases: &["pull_quote"],
+        default_content: "\"Pull quote goes here\"",
+        default_duration_sec: 5.0,
+        font_family: "Georgia",
+        font_size: 42,
+        color: "#FFFFFF",
+        bold: false,
+        italic: true,
+        underline: false,
+        alignment: TextAlignment::Center,
+        line_height: 1.6,
+        letter_spacing: 1,
+        background_color: None,
+        background_padding: 0,
+        x: 0.5,
+        y: 0.5,
+        shadow: Some(PresetShadow {
+            color: "#000000",
+            offset_x: 1,
+            offset_y: 1,
+            blur: 3,
+        }),
+        outline: None,
+        rotation: 0.0,
+        opacity: 0.95,
+    },
+    TextPresetSpec {
+        id: "tech-style",
+        name: "Tech Style",
+        description: "Modern monospace tech aesthetic",
+        category: TextPresetCategory::Creative,
+        aliases: &["tech", "terminal"],
+        default_content: "SYSTEM READY",
+        default_duration_sec: 4.0,
+        font_family: "Courier New",
+        font_size: 36,
+        color: "#00FF00",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Left,
+        line_height: 1.4,
+        letter_spacing: 0,
+        background_color: Some("#000000CC"),
+        background_padding: 10,
+        x: 0.05,
+        y: 0.05,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 1.0,
+    },
+    TextPresetSpec {
+        id: "watermark",
+        name: "Watermark",
+        description: "Subtle watermark/branding text",
+        category: TextPresetCategory::Creative,
+        aliases: &[],
+        default_content: "Brand",
+        default_duration_sec: 10.0,
+        font_family: "Arial",
+        font_size: 24,
+        color: "#FFFFFF",
+        bold: false,
+        italic: false,
+        underline: false,
+        alignment: TextAlignment::Right,
+        line_height: 1.2,
+        letter_spacing: 0,
+        background_color: None,
+        background_padding: 0,
+        x: 0.95,
+        y: 0.95,
+        shadow: None,
+        outline: None,
+        rotation: 0.0,
+        opacity: 0.4,
+    },
+];
+
+/// Returns every text preset descriptor, in table order.
+pub fn list_text_presets() -> Vec<TextPresetDescriptor> {
+    TEXT_PRESETS
+        .iter()
+        .map(TextPresetSpec::descriptor)
+        .collect()
+}
+
+/// Returns the canonical ids of every text preset, in table order.
+pub fn text_preset_ids() -> Vec<&'static str> {
+    TEXT_PRESETS.iter().map(|preset| preset.id).collect()
+}
+
+/// Returns every accepted spelling: ids first, then aliases, in table order.
+///
+/// This is what agent-facing surfaces advertise, because an alias an agent read
+/// in a hint has to be an alias the parser accepts.
+pub fn text_preset_keys() -> Vec<&'static str> {
+    let mut keys: Vec<&'static str> = text_preset_ids();
+    for preset in TEXT_PRESETS {
+        for alias in preset.aliases {
+            if !keys.contains(alias) {
+                keys.push(alias);
+            }
+        }
+    }
+    keys
+}
+
+/// Resolves a text preset id, display name, or alias.
+///
+/// Matching is tolerant of case and of `-`, `_`, or space separators, matching
+/// the TypeScript `normalizeTextPresetKey` contract exactly, so `Lower_Third`,
+/// `lower third`, and `lower-third` are one preset. An unknown id is a hard
+/// error naming every valid id.
+pub fn resolve_text_preset(id: &str) -> Result<&'static TextPresetSpec, String> {
+    let normalized = normalize_pack_id(id);
+
+    TEXT_PRESETS
+        .iter()
+        .find(|preset| {
+            normalize_pack_id(preset.id) == normalized
+                || normalize_pack_id(preset.name) == normalized
+                || preset
+                    .aliases
+                    .iter()
+                    .any(|alias| normalize_pack_id(alias) == normalized)
+        })
+        .ok_or_else(|| {
+            format!(
+                "Unknown text preset '{}'. Valid presets: {}",
+                id.trim(),
+                text_preset_ids().join(", ")
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_preset_id_is_unique_and_hyphenated() {
+        let mut seen = std::collections::HashSet::new();
+        for preset in TEXT_PRESETS {
+            assert!(
+                seen.insert(preset.id),
+                "duplicate preset id '{}'",
+                preset.id
+            );
+            assert!(
+                preset
+                    .id
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "preset id '{}' must be lowercase kebab-case",
+                preset.id
+            );
+        }
+    }
+
+    #[test]
+    fn the_catalog_holds_every_ported_preset() {
+        assert_eq!(
+            TEXT_PRESETS.len(),
+            22,
+            "the catalog is the union of the former CLI, prose, and UI lists"
+        );
+    }
+
+    #[test]
+    fn resolve_accepts_separator_and_case_variants() {
+        for preset in TEXT_PRESETS {
+            let underscored = preset.id.replace('-', "_");
+            let spaced = preset.id.replace('-', " ");
+            for candidate in [
+                preset.id.to_string(),
+                underscored,
+                spaced,
+                preset.id.to_ascii_uppercase(),
+                format!("  {}  ", preset.id),
+            ] {
+                let resolved = resolve_text_preset(&candidate)
+                    .unwrap_or_else(|error| panic!("'{candidate}' must resolve: {error}"));
+                assert_eq!(resolved.id, preset.id);
+            }
+        }
+    }
+
+    #[test]
+    fn every_alias_and_display_name_resolves_to_its_own_preset() {
+        for preset in TEXT_PRESETS {
+            for key in preset.aliases.iter().copied().chain([preset.name]) {
+                let resolved = resolve_text_preset(key)
+                    .unwrap_or_else(|error| panic!("key '{key}' must resolve: {error}"));
+                assert_eq!(
+                    resolved.id, preset.id,
+                    "key '{key}' belongs to '{}' but resolved to '{}'",
+                    preset.id, resolved.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_key_is_claimed_by_two_presets() {
+        // An ambiguous alias silently hands the caller a different overlay than
+        // the one it named, which is worse than rejecting the alias outright.
+        let mut owners: std::collections::HashMap<String, &str> = std::collections::HashMap::new();
+        for preset in TEXT_PRESETS {
+            for key in preset
+                .aliases
+                .iter()
+                .copied()
+                .chain([preset.id, preset.name])
+            {
+                let normalized = normalize_pack_id(key);
+                if let Some(existing) = owners.insert(normalized.clone(), preset.id) {
+                    assert_eq!(
+                        existing, preset.id,
+                        "key '{normalized}' is claimed by both '{existing}' and '{}'",
+                        preset.id
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_preset_error_lists_every_valid_id() {
+        let error = resolve_text_preset("no-such-preset").expect_err("unknown id must fail");
+        for preset in TEXT_PRESETS {
+            assert!(
+                error.contains(preset.id),
+                "error must name '{}': {error}",
+                preset.id
+            );
+        }
+    }
+
+    #[test]
+    fn every_preset_carries_starter_copy_and_a_usable_duration() {
+        for preset in TEXT_PRESETS {
+            assert!(
+                !preset.default_content.trim().is_empty(),
+                "preset '{}' must suggest starter copy",
+                preset.id
+            );
+            assert!(
+                preset.default_duration_sec.is_finite() && preset.default_duration_sec > 0.0,
+                "preset '{}' must suggest a positive duration",
+                preset.id
+            );
+        }
+    }
+
+    #[test]
+    fn every_preset_produces_valid_clip_data() {
+        for preset in TEXT_PRESETS {
+            let clip = preset.default_clip_data();
+            clip.validate()
+                .unwrap_or_else(|error| panic!("preset '{}' must validate: {error}", preset.id));
+            assert_eq!(clip.content, preset.default_content);
+            assert_eq!(clip.style.bold, clip.style.font_weight >= 600);
+        }
+    }
+
+    #[test]
+    fn descriptors_round_trip_through_json() {
+        for descriptor in list_text_presets() {
+            let json = serde_json::to_value(&descriptor).expect("descriptor serializes");
+            let parsed: TextPresetDescriptor =
+                serde_json::from_value(json).expect("descriptor deserializes");
+            assert_eq!(parsed, descriptor);
+        }
+    }
+
+    #[test]
+    fn preset_keys_list_ids_before_aliases_without_duplicates() {
+        let keys = text_preset_keys();
+        let unique: std::collections::HashSet<_> = keys.iter().collect();
+        assert_eq!(unique.len(), keys.len(), "keys must not repeat");
+        assert_eq!(&keys[..TEXT_PRESETS.len()], &text_preset_ids()[..]);
+    }
+}

--- a/src-tauri/src/core/style/text_presets.rs
+++ b/src-tauri/src/core/style/text_presets.rs
@@ -944,10 +944,11 @@ pub fn text_preset_keys() -> Vec<&'static str> {
 
 /// Resolves a text preset id, display name, or alias.
 ///
-/// Matching is tolerant of case and of `-`, `_`, or space separators, matching
-/// the TypeScript `normalizeTextPresetKey` contract exactly, so `Lower_Third`,
-/// `lower third`, and `lower-third` are one preset. An unknown id is a hard
-/// error naming every valid id.
+/// Matching is tolerant of case and of `-`, `_`, or whitespace separators, so
+/// `Lower_Third`, `lower third`, and `lower-third` are one preset. Separator
+/// runs collapse, which is what makes this the same acceptance set as the
+/// TypeScript `normalizeTextPresetKey` — see [`normalize_pack_id`](super::normalize_pack_id).
+/// An unknown id is a hard error naming every valid id.
 pub fn resolve_text_preset(id: &str) -> Result<&'static TextPresetSpec, String> {
     let normalized = normalize_pack_id(id);
 
@@ -1019,6 +1020,24 @@ mod tests {
                     .unwrap_or_else(|error| panic!("'{candidate}' must resolve: {error}"));
                 assert_eq!(resolved.id, preset.id);
             }
+        }
+    }
+
+    #[test]
+    fn resolve_collapses_separator_runs_like_the_typescript_normalizer() {
+        // The TypeScript half resolves every one of these through
+        // `.replace(/[\s_]+/g, '-')`. A per-character substitution would turn
+        // the doubled forms into `lower--third` and reject a key the app takes.
+        for candidate in [
+            "lower  third",
+            "lower\tthird",
+            "lower _ third",
+            "lower__third",
+            "Lower \u{00A0}Third",
+        ] {
+            let resolved = resolve_text_preset(candidate)
+                .unwrap_or_else(|error| panic!("'{candidate}' must resolve: {error}"));
+            assert_eq!(resolved.id, "lower-third");
         }
     }
 

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -957,6 +957,11 @@ pub struct RemoveMaskPayload {
 /// Creates a new clip with a virtual text asset and applies a TextOverlay
 /// effect containing the text styling data.
 ///
+/// A curated text preset id may stand in for most of `textData`; explicit
+/// fields override the preset key by key. The preset is resolved during
+/// deserialization, so what reaches the op log is the concrete `TextClipData`
+/// the preset produced and never the id — replay does not consult the registry.
+///
 /// # Example
 ///
 /// ```json
@@ -975,18 +980,79 @@ pub struct RemoveMaskPayload {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone, specta::Type)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+///
+/// The same clip from a preset, where only the copy is the caller's business:
+///
+/// ```json
+/// {
+///     "sequenceId": "seq_001",
+///     "trackId": "video_001",
+///     "timelineIn": 5.0,
+///     "duration": 3.0,
+///     "preset": "quote",
+///     "textData": { "content": "Hello World" }
+/// }
+/// ```
+///
+/// Unknown fields are rejected by the wire shape this deserializes from, and
+/// `timelineStart` is accepted there as an alias for `timelineIn`.
+#[derive(Debug, Serialize, Clone, specta::Type)]
+#[serde(rename_all = "camelCase")]
 pub struct AddTextClipPayload {
     pub sequence_id: SequenceId,
     pub track_id: TrackId,
     /// Timeline position to insert the text clip at (seconds)
-    #[serde(alias = "timelineStart")]
     pub timeline_in: TimeSec,
     /// Duration of the text clip (seconds)
     pub duration: TimeSec,
+    /// Curated text preset id or alias, resolved into `text_data` on parse.
+    ///
+    /// Always `None` after deserialization: the preset has been expanded into
+    /// concrete values by then, and keeping the id would put a registry lookup
+    /// between the op log and the clip it describes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preset: Option<String>,
     /// Text content and styling data
+    ///
+    /// Required unless `preset` names a preset, in which case it carries only
+    /// the fields that override the preset.
     pub text_data: TextClipData,
+}
+
+impl<'de> Deserialize<'de> for AddTextClipPayload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        /// The wire shape, where `textData` may be partial or absent.
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            sequence_id: SequenceId,
+            track_id: TrackId,
+            #[serde(alias = "timelineStart")]
+            timeline_in: TimeSec,
+            duration: TimeSec,
+            #[serde(default)]
+            preset: Option<String>,
+            #[serde(default)]
+            text_data: Option<serde_json::Value>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let text_data =
+            crate::core::style::resolve_text_clip_data(wire.preset.as_deref(), wire.text_data)
+                .map_err(serde::de::Error::custom)?;
+
+        Ok(Self {
+            sequence_id: wire.sequence_id,
+            track_id: wire.track_id,
+            timeline_in: wire.timeline_in,
+            duration: wire.duration,
+            preset: None,
+            text_data,
+        })
+    }
 }
 
 /// Payload for updating a text clip's content and styling.

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -12,6 +12,15 @@
  */
 
 import { buildToolOutputContractSection } from '@/agents/toolOutputContracts';
+import { TEXT_PRESETS } from '@/data/textPresets';
+
+/**
+ * Text preset ids, read from the catalog the tools validate against.
+ *
+ * A prompt that lists presets by hand drifts from the parser that accepts them;
+ * this list came to advertise ids the CLI rejected outright.
+ */
+const TEXT_PRESET_IDS = TEXT_PRESETS.map((preset) => preset.id).join(', ');
 
 // =============================================================================
 // Role type (duplicated from system.ts to avoid circular dependency)
@@ -131,7 +140,7 @@ Editable text overlays default to the active sequence when sequenceId is omitted
 - Use caption-track actions for semantic timed subtitles/captions and AI transcript import.
 - list_text_clips() → inspect editable text overlay clips with textData, style, transform, trackId, and clipId
 - add_text_clip(text, startTime, duration?, endTime?, trackId?, preset?, style?, position?, x?, y?, xPercent?, yPercent?, shadow?, outline?, transform?, autoPlacement?, placementIntent?) → add editable on-video text; video text track auto-created if needed. Auto-placement is on by default when no explicit position is supplied.
-- Text presets: title/centered-title, epic-title, chapter-title, lower_third/lower-third, lower-third-news, lower-third-name-role, subtitle, callout, callout-stat, credits/credits-block, credit-line, logo-bug, social-handle, quote, watermark, countdown.
+- Text presets (each supplies typography, placement, and a default duration): ${TEXT_PRESET_IDS}. Common aliases resolve too (title, lower_third, credits, stat, timer).
 - update_text_clip(clipId, text?, style?, fontFamily?, fontSize?, fontWeight?, color?, backgroundColor?, backgroundPadding?, alignment?, bold?, italic?, underline?, lineHeight?, letterSpacing?, position?, x?, y?, shadow?, outline?, clearShadow?, clearOutline?, clearBackground?, opacity?, rotation?, transform?, autoPlacement?) → edit text content, font, size, weight, color, outline, shadow, background, rotation, opacity, and transform
 - set_text_transform(clipId, transform? or transformX/transformY/scaleX/scaleY/rotationDeg/anchorX/anchorY) → move, resize, rotate, or re-anchor a text clip
 - delete_text_clip(clipId) → remove an editable text overlay clip
@@ -146,7 +155,7 @@ Editable text overlays default to the active sequence when sequenceId is omitted
 - auto_transcribe_sequence(sequenceId?, language?, model?) → transcribe the audible edited timeline mix into TIMELINE-relative segments that are safe to pass straight to add_captions_from_transcription. Default path for creating captions. Language is auto-detected by default; pass \`language\` only as an optional override when the user explicitly states the spoken language.
 - add_captions_from_transcription(segments, trackId?, replaceExisting?, clipId?, style?, position?) → create captions from timed transcript segments as one atomic caption import. Provide clipId only when segments come from auto_transcribe (source-relative); omit it for auto_transcribe_sequence (already timeline-relative). Pass style/position to apply a consistent look; omit them to use the track default.
 - import_captions_from_file(relativePath, format?, trackId?) → import SRT/VTT subtitle files from the workspace
-- Placement defaults: add_text_clip auto-places title/lower-third/subtitle/callout presets when no exact position is supplied, scoring default candidate regions against available faces/objects/OCR annotations and existing text. Credit, brand, watermark, and quote presets preserve their template position unless autoPlacement:true or a placement override is supplied.`;
+- Placement defaults: add_text_clip auto-places presets in the title, lower-third, subtitle, and callout categories when no exact position is supplied, scoring default candidate regions against available faces/objects/OCR annotations and existing text. Presets in the credit, brand, and creative categories preserve their template position unless autoPlacement:true or a placement override is supplied.`;
 
 const GENERATE_ACTIONS = `## Generate Actions (meta-tool: generate)
 - generate_timeline_media(prompt, mediaType?, provider?, sequenceId?, trackId?, timelineStart?) → submit provider-neutral generation or SFX discovery; video jobs can create a pending marker and auto-place when ready
@@ -209,7 +218,7 @@ const COMMON_WORKFLOWS = `## Common Workflows
 11. Generative edit: generate_timeline_media with sequenceId/trackId/timelineStart creates a pending timeline marker and stores placement intent; the generation store imports and places the asset when the provider job completes. Use resolve_generation_job for explicit status checks.
 12. SFX discovery/import: search_sound_for_scene → present usable candidates and license policy → import_asset_candidate only with licenseAck=true → insert_clip on an audio track.
 13. AI subtitles: transcription_status() FIRST — when only weak models (tiny/base/small) are installed and the recommended model is missing, do not silently transcribe; run install_whisper_model(large-v3-turbo-q5_0) before transcribing, especially for non-English/sung/music content → install_whisper_model(model?) when approved and needed → auto_transcribe_sequence(sequenceId?) is the DEFAULT path; its segments are timeline-relative and pass straight to add_captions_from_transcription. Use auto_transcribe(assetId) for source-asset analysis only — its times are source-relative; first call find_clips_by_asset(assetId) → take data[0].id as the clipId → pass that clipId to add_captions_from_transcription(..., clipId) so the times get mapped to timeline time. → inspect returned segments → add_captions_from_transcription(segments, replaceExisting?) → style_caption for readable typography when needed.
-14. Editable on-video text: list_text_clips when editing existing text, otherwise add_text_clip with preset and style. Use production presets for common jobs: credits for end cards, logo-bug for channel marks, social-handle for creator IDs, lower-third-name-role for interviews, and callout-stat for numeric emphasis → set_text_transform for exact preview position/size/rotation.
+14. Editable on-video text: list_text_clips when editing existing text, otherwise add_text_clip with preset and style. Name a preset from the Text Actions list instead of assembling typography field by field; each one carries a checked look, an anchor, and a default duration → set_text_transform for exact preview position/size/rotation.
 15. If the user asks to save the analysis as a file but does not specify a location, do not add a separate write step: source-analysis tools already save "<asset-name>.analysis.md" beside the asset by default. Use write_workspace_document only for a custom second copy/path.`;
 
 const CLI_REFERENCE = `## CLI (headless alternative)

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -4150,15 +4150,15 @@ function buildCommandSchema(): CodexJsonObject {
         note: 'Use this read-only tool before ImportGeneratedCaptions. Set sequenceAudio=true (default captioning path) for the edited timeline mix; its captionSegments are TIMELINE-relative and pass straight to ImportGeneratedCaptions. assetId transcription is SOURCE-relative (0-based to the asset) and is not safe as direct timeline caption times; pass clipId plus sequenceId/trackId to receive timelineCaptionSegments remapped onto a timeline clip.',
       },
       AddTextClip: {
-        required: ['sequenceId', 'trackId', 'timelineIn', 'duration', 'textData'],
-        optional: ['preset'],
+        required: ['sequenceId', 'trackId', 'timelineIn', 'duration'],
+        optional: ['preset', 'textData'],
         textDataShape:
           'TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/backgroundPadding/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow(color/offsetX/offsetY/blur), outline(color/width), rotation, and opacity.',
         presetHints: textPresetKeys(),
         presetShape:
-          'preset names a curated text preset that supplies the whole TextClipData; textData then carries only what overrides it, commonly just content. Every id and alias listed here is accepted.',
+          'preset names a curated text preset that supplies the whole TextClipData; textData then carries only what overrides it, commonly just content, and may be omitted entirely. Every id and alias listed here is accepted. Nested layers merge key by key, so {"style":{"bold":false}} or {"shadow":{"offsetX":2}} keeps everything else the preset chose.',
         presetCatalog: textPresetCatalog(),
-        note: 'Text clips must be placed on a top/front video or overlay track above the base video. The Codex bridge will correct below-base text tracks when possible. Use SetClipTransform after creation when scale or anchor must be exact.',
+        note: 'Either preset or textData must be present: without a preset, textData is required and must be complete. Text clips must be placed on a top/front video or overlay track above the base video. The Codex bridge will correct below-base text tracks when possible. Use SetClipTransform after creation when scale or anchor must be exact.',
       },
       UpdateTextClip: {
         required: ['sequenceId', 'trackId', 'clipId', 'textData'],
@@ -4259,7 +4259,7 @@ function buildCommandSchema(): CodexJsonObject {
         'Read timeline_snapshot to find active sequence, existing text clips, and usable video/overlay tracks.',
         'Read annotation_read for overlapping source assets when placement should avoid faces, objects, or OCR text.',
         'CreateTrack(kind="video" or "overlay", position=0) when there is no unlocked non-overlapping text track above the media.',
-        'AddTextClip with complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity.',
+        'AddTextClip with a preset id, or with a complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity when no preset fits.',
         'Prefer preset plus a content override over hand-assembled typography; presetCatalog under payloadHints.AddTextClip says what each id is for.',
         'SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor.',
         'SetClipMotionKeyframes for editable text or media motion presets such as zoom in, zoom out, and Ken Burns.',

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -22,6 +22,7 @@ import {
 } from '@/bindings';
 
 import { hasActiveTimeRemap, type TimeRemapCurve } from '@/types';
+import { TEXT_PRESETS } from '@/data/textPresets';
 import type { ExternalAgentApprovalDecisionProvider, ExternalAgentApprovalRequest } from '../types';
 import { isCodexDynamicToolCallOutputTextItem } from './CodexAppServerClient';
 import type {
@@ -4054,6 +4055,40 @@ function validateContextToken(
   return { valid: true, record };
 }
 
+/**
+ * Every text preset spelling this bridge accepts: ids first, then aliases.
+ *
+ * Read from the catalog rather than restated, because a hint that names a
+ * preset the parser rejects is worse than no hint at all.
+ */
+function textPresetKeys(): string[] {
+  return [
+    ...TEXT_PRESETS.map((preset) => preset.id),
+    ...TEXT_PRESETS.flatMap((preset) => preset.aliases ?? []),
+  ];
+}
+
+/**
+ * Text preset ids whose anchor is part of the template, not a suggestion.
+ *
+ * Smart placement moves a title, lower third, subtitle, or callout. Everything
+ * else was placed deliberately by the preset, so the category decides this
+ * rather than a hand-kept list of ids.
+ */
+function templatePlacementTextPresetIds(): string[] {
+  return TEXT_PRESETS.filter((preset) =>
+    ['credit', 'brand', 'creative'].includes(preset.category),
+  ).map((preset) => preset.id);
+}
+
+/** One line per text preset: what it is for, and how long it usually runs. */
+function textPresetCatalog(): string[] {
+  return TEXT_PRESETS.map(
+    (preset) =>
+      `${preset.id} (${preset.category}, ~${preset.defaultDurationSec ?? 3}s): ${preset.description}`,
+  );
+}
+
 function buildCommandSchema(): CodexJsonObject {
   return {
     commands: OPENREELIO_COMMAND_TYPES,
@@ -4116,10 +4151,13 @@ function buildCommandSchema(): CodexJsonObject {
       },
       AddTextClip: {
         required: ['sequenceId', 'trackId', 'timelineIn', 'duration', 'textData'],
+        optional: ['preset'],
         textDataShape:
           'TextClipData includes content, style(fontFamily/fontSize/fontWeight/color/backgroundColor/backgroundPadding/alignment/bold/italic/underline/lineHeight/letterSpacing), position(x/y 0..1), shadow(color/offsetX/offsetY/blur), outline(color/width), rotation, and opacity.',
-        presetHints:
-          'Production presets supported by UI/agent/CLI include title, centered-title, epic-title, chapter-title, lower-third, lower-third-news, lower-third-name-role, subtitle, callout, callout-stat, credits, credit-line, logo-bug, social-handle, quote, watermark, and countdown.',
+        presetHints: textPresetKeys(),
+        presetShape:
+          'preset names a curated text preset that supplies the whole TextClipData; textData then carries only what overrides it, commonly just content. Every id and alias listed here is accepted.',
+        presetCatalog: textPresetCatalog(),
         note: 'Text clips must be placed on a top/front video or overlay track above the base video. The Codex bridge will correct below-base text tracks when possible. Use SetClipTransform after creation when scale or anchor must be exact.',
       },
       UpdateTextClip: {
@@ -4222,7 +4260,7 @@ function buildCommandSchema(): CodexJsonObject {
         'Read annotation_read for overlapping source assets when placement should avoid faces, objects, or OCR text.',
         'CreateTrack(kind="video" or "overlay", position=0) when there is no unlocked non-overlapping text track above the media.',
         'AddTextClip with complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity.',
-        'Use production text presets for common work: credits for end cards, logo-bug for channel marks, social-handle for creator IDs, lower-third-name-role for interviews, and callout-stat for numeric emphasis.',
+        'Prefer preset plus a content override over hand-assembled typography; presetCatalog under payloadHints.AddTextClip says what each id is for.',
         'SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor.',
         'SetClipMotionKeyframes for editable text or media motion presets such as zoom in, zoom out, and Ken Burns.',
       ],
@@ -4247,8 +4285,7 @@ function buildCommandSchema(): CodexJsonObject {
           'Bottom center around y=0.85 with outline/shadow unless it covers important visual content.',
         title: 'Center or upper third depending on the shot composition.',
         lowerThird: 'Lower-left or lower-center with enough safe margin and readable contrast.',
-        creditBrand:
-          'Credits, credit lines, logo bugs, social handles, quote, and watermark presets preserve their template position unless the user asks for automatic placement.',
+        creditBrand: `These presets preserve their template position unless the user asks for automatic placement: ${templatePlacementTextPresetIds().join(', ')}.`,
       },
     },
   };

--- a/src/agents/tools/metaTools.test.ts
+++ b/src/agents/tools/metaTools.test.ts
@@ -10,6 +10,7 @@ import {
   unregisterMetaTools,
 } from './metaTools';
 import { setFeatureFlag, resetFeatureFlags } from '@/config/featureFlags';
+import { TEXT_PRESETS } from '@/data/textPresets';
 
 describe('metaTools', () => {
   beforeEach(() => {
@@ -81,6 +82,41 @@ describe('metaTools', () => {
     expect(properties.autoPlacement).toBeDefined();
     expect(properties.placementIntent).toBeDefined();
     expect(properties.safeMargin).toBeDefined();
+  });
+
+  it('offers the whole text preset catalog through the text meta-tool, not a sample', () => {
+    // The meta-tool is the only text surface the model sees when USE_META_TOOLS
+    // is on. A four-value enum here made eighteen shipped presets unreachable
+    // no matter what add_text_clip itself accepted.
+    const metaPreset = globalToolRegistry.get('text')?.parameters.properties?.preset as
+      | { enum?: string[] }
+      | undefined;
+    const toolPreset = globalToolRegistry.get('add_text_clip')?.parameters.properties?.preset as
+      | { enum?: string[] }
+      | undefined;
+
+    expect(metaPreset?.enum).toEqual(toolPreset?.enum);
+    expect(metaPreset?.enum).toEqual(expect.arrayContaining(TEXT_PRESETS.map((p) => p.id)));
+    expect(metaPreset?.enum).toContain('default');
+    // Presets the previous four-value enum hid from the model.
+    expect(metaPreset?.enum).toEqual(
+      expect.arrayContaining(['quote', 'watermark', 'countdown', 'callout-stat', 'logo-bug']),
+    );
+  });
+
+  it('accepts a preset the old meta-tool enum rejected', () => {
+    const adapter = createToolRegistryAdapter(globalToolRegistry);
+
+    const valid = adapter.validateArgs('text', {
+      action: 'add_text_clip',
+      sequenceId: 'seq-1',
+      text: 'Pull quote',
+      startTime: 0,
+      duration: 5,
+      preset: 'quote',
+    });
+
+    expect(valid.valid).toBe(true);
   });
 
   it('routes get_caption_style through the text meta-tool', () => {

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -29,7 +29,11 @@ import { getAudioToolNames } from './audioTools';
 import { getEffectToolNames } from './effectTools';
 import { getTransitionToolNames } from './transitionTools';
 import { getCaptionToolNames } from './captionTools';
-import { getTextToolNames } from './textTools';
+import {
+  getTextToolNames,
+  AGENT_TEXT_PRESET_DESCRIPTION,
+  AGENT_TEXT_PRESET_VALUES,
+} from './textTools';
 import { getGenerationToolNames } from './generationTools';
 import { getGenerativeTimelineToolNames } from './generativeTimelineTools';
 import {
@@ -638,9 +642,12 @@ const META_TOOLS: ToolDefinition[] = [
           description: 'Editable text clip duration in seconds; use endTime for captions',
         },
         preset: {
+          // The full catalog, not a four-value sample of it: a meta-tool enum
+          // narrower than the tool it dispatches to makes the other eighteen
+          // presets unreachable through the surface the model actually sees.
           type: 'string',
-          description: 'Editable text starter preset: default, title, lower_third, or subtitle',
-          enum: ['default', 'title', 'lower_third', 'subtitle'],
+          description: AGENT_TEXT_PRESET_DESCRIPTION,
+          enum: AGENT_TEXT_PRESET_VALUES,
         },
         segments: {
           type: 'array',

--- a/src/agents/tools/textTools.ts
+++ b/src/agents/tools/textTools.ts
@@ -56,9 +56,26 @@ const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})
 
 type TextPlacementPresetName = 'default' | 'title' | 'lower_third' | 'subtitle' | 'callout';
 
-const AGENT_TEXT_PRESET_VALUES = Array.from(
+/**
+ * Every text preset spelling an agent may pass: ids, aliases, and `default`.
+ *
+ * Derived from the catalog rather than restated, and exported so the meta-tool
+ * boundary advertises the same set instead of a hand-copied subset of it.
+ */
+export const AGENT_TEXT_PRESET_VALUES = Array.from(
   new Set(['default', ...TEXT_PRESETS.flatMap((preset) => [preset.id, ...(preset.aliases ?? [])])]),
 );
+
+/**
+ * Shared `preset` parameter description, built from the catalog.
+ *
+ * The ids are spelled out because a model reads the description before it reads
+ * the enum; listing them by hand is how the CLI, the prompts, and the UI came
+ * to advertise three different catalogs.
+ */
+export const AGENT_TEXT_PRESET_DESCRIPTION = `Optional starter text preset supplying typography, placement, and a suggested duration. Ids: ${TEXT_PRESETS.map(
+  (preset) => preset.id,
+).join(', ')}. Aliases in the enum resolve to these ids; use default for an unstyled overlay.`;
 
 const TEXT_STYLE_PARAMETER_PROPERTIES = {
   fontFamily: { type: 'string', description: 'Font family name' },
@@ -1108,8 +1125,7 @@ const TEXT_TOOLS: ToolDefinition[] = [
         preset: {
           type: 'string',
           enum: AGENT_TEXT_PRESET_VALUES,
-          description:
-            'Optional starter text preset. Supports preset IDs plus aliases such as title, lower_third, credits, logo_bug, and social_handle.',
+          description: AGENT_TEXT_PRESET_DESCRIPTION,
         },
         style: { type: 'object', description: 'Text style overrides' },
         ...TEXT_STYLE_PARAMETER_PROPERTIES,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -3148,6 +3148,11 @@ trackingSourceId?: string | null }
  * Creates a new clip with a virtual text asset and applies a TextOverlay
  * effect containing the text styling data.
  * 
+ * A curated text preset id may stand in for most of `textData`; explicit
+ * fields override the preset key by key. The preset is resolved during
+ * deserialization, so what reaches the op log is the concrete `TextClipData`
+ * the preset produced and never the id — replay does not consult the registry.
+ * 
  * # Example
  * 
  * ```json
@@ -3166,6 +3171,22 @@ trackingSourceId?: string | null }
  * }
  * }
  * ```
+ * 
+ * The same clip from a preset, where only the copy is the caller's business:
+ * 
+ * ```json
+ * {
+ * "sequenceId": "seq_001",
+ * "trackId": "video_001",
+ * "timelineIn": 5.0,
+ * "duration": 3.0,
+ * "preset": "quote",
+ * "textData": { "content": "Hello World" }
+ * }
+ * ```
+ * 
+ * Unknown fields are rejected by the wire shape this deserializes from, and
+ * `timelineStart` is accepted there as an alias for `timelineIn`.
  */
 export type AddTextClipPayload = { sequenceId: string; trackId: string; 
 /**
@@ -3177,7 +3198,18 @@ timelineIn: number;
  */
 duration: number; 
 /**
+ * Curated text preset id or alias, resolved into `text_data` on parse.
+ * 
+ * Always `None` after deserialization: the preset has been expanded into
+ * concrete values by then, and keeping the id would put a registry lookup
+ * between the op log and the clip it describes.
+ */
+preset?: string | null; 
+/**
  * Text content and styling data
+ * 
+ * Required unless `preset` names a preset, in which case it carries only
+ * the fields that override the preset.
  */
 textData: TextClipData }
 /**

--- a/src/data/textPresets.manifest.json
+++ b/src/data/textPresets.manifest.json
@@ -164,7 +164,7 @@
       "annotation_label",
       "tag"
     ],
-    "category": "lower-third",
+    "category": "callout",
     "clip": {
       "content": "Label",
       "opacity": 0.9,

--- a/src/data/textPresets.manifest.json
+++ b/src/data/textPresets.manifest.json
@@ -1,0 +1,856 @@
+[
+  {
+    "aliases": [
+      "lower_third",
+      "lowerthird",
+      "name_title"
+    ],
+    "category": "lower-third",
+    "clip": {
+      "content": "Speaker Name\nTitle or Role",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.08,
+        "y": 0.82
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 4,
+        "color": "#000000",
+        "offsetX": 2,
+        "offsetY": 2
+      },
+      "style": {
+        "alignment": "left",
+        "backgroundColor": "#000000B3",
+        "backgroundPadding": 12,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 42,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.2,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 5.0,
+    "description": "Classic lower third for names and titles",
+    "id": "lower-third",
+    "kind": "text",
+    "name": "Lower Third"
+  },
+  {
+    "aliases": [
+      "minimal_lower_third"
+    ],
+    "category": "lower-third",
+    "clip": {
+      "content": "Speaker Name",
+      "opacity": 0.95,
+      "outline": {
+        "color": "#000000",
+        "width": 1
+      },
+      "position": {
+        "x": 0.05,
+        "y": 0.88
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "left",
+        "backgroundPadding": 0,
+        "bold": false,
+        "color": "#FFFFFF",
+        "fontFamily": "Helvetica",
+        "fontSize": 36,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 2,
+        "lineHeight": 1.3,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 4.0,
+    "description": "Clean minimal lower third",
+    "id": "lower-third-minimal",
+    "kind": "text",
+    "name": "Lower Third Minimal"
+  },
+  {
+    "aliases": [
+      "broadcast_lower_third",
+      "news-lower-third"
+    ],
+    "category": "lower-third",
+    "clip": {
+      "content": "Breaking Story\nLocation",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.07,
+        "y": 0.78
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 3,
+        "color": "#00000080",
+        "offsetX": 1,
+        "offsetY": 2
+      },
+      "style": {
+        "alignment": "left",
+        "backgroundColor": "#123E7CCC",
+        "backgroundPadding": 14,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 40,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.15,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 6.0,
+    "description": "Broadcast-style lower third with a strong title band",
+    "id": "lower-third-news",
+    "kind": "text",
+    "name": "News Lower Third"
+  },
+  {
+    "aliases": [
+      "interview_lower_third",
+      "speaker_id",
+      "name_role"
+    ],
+    "category": "lower-third",
+    "clip": {
+      "content": "Jane Doe\nCreative Director",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#00000066",
+        "width": 1
+      },
+      "position": {
+        "x": 0.08,
+        "y": 0.84
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "left",
+        "backgroundColor": "#111827D9",
+        "backgroundPadding": 10,
+        "bold": true,
+        "color": "#F8FAFC",
+        "fontFamily": "Helvetica",
+        "fontSize": 38,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.25,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 5.0,
+    "description": "Interview lower third with compact name and role styling",
+    "id": "lower-third-name-role",
+    "kind": "text",
+    "name": "Name + Role"
+  },
+  {
+    "aliases": [
+      "annotation_label",
+      "tag"
+    ],
+    "category": "lower-third",
+    "clip": {
+      "content": "Label",
+      "opacity": 0.9,
+      "position": {
+        "x": 0.1,
+        "y": 0.1
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "left",
+        "backgroundColor": "#333333",
+        "backgroundPadding": 6,
+        "bold": false,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 24,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.3,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "Simple label for annotations",
+    "id": "label",
+    "kind": "text",
+    "name": "Label"
+  },
+  {
+    "aliases": [
+      "title"
+    ],
+    "category": "title",
+    "clip": {
+      "content": "Main Title",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.5,
+        "y": 0.5
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 8,
+        "color": "#000000",
+        "offsetX": 3,
+        "offsetY": 3
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 72,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 4,
+        "lineHeight": 1.1,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 4.0,
+    "description": "Bold centered title for intros",
+    "id": "centered-title",
+    "kind": "text",
+    "name": "Centered Title"
+  },
+  {
+    "aliases": [
+      "impact_title",
+      "hero_title"
+    ],
+    "category": "title",
+    "clip": {
+      "content": "Big Moment",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#000000",
+        "width": 3
+      },
+      "position": {
+        "x": 0.5,
+        "y": 0.5
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 12,
+        "color": "#000000",
+        "offsetX": 4,
+        "offsetY": 4
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Impact",
+        "fontSize": 96,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 6,
+        "lineHeight": 1.0,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "Large dramatic title for impact",
+    "id": "epic-title",
+    "kind": "text",
+    "name": "Epic Title"
+  },
+  {
+    "aliases": [
+      "chapter",
+      "chapter_card",
+      "section_title"
+    ],
+    "category": "title",
+    "clip": {
+      "content": "Chapter One\nThe Setup",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.5,
+        "y": 0.45
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 8,
+        "color": "#00000099",
+        "offsetX": 2,
+        "offsetY": 3
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#F8FAFC",
+        "fontFamily": "Georgia",
+        "fontSize": 62,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 2,
+        "lineHeight": 1.18,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 5.0,
+    "description": "Editorial chapter card with title and subtitle",
+    "id": "chapter-title",
+    "kind": "text",
+    "name": "Chapter Title"
+  },
+  {
+    "aliases": [
+      "end_card",
+      "outro_title"
+    ],
+    "category": "title",
+    "clip": {
+      "content": "Thanks for Watching",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.5,
+        "y": 0.5
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "center",
+        "backgroundColor": "#111827CC",
+        "backgroundPadding": 18,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 58,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.25,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 6.0,
+    "description": "Centered end screen title for channels and credits",
+    "id": "end-card-title",
+    "kind": "text",
+    "name": "End Card"
+  },
+  {
+    "aliases": [
+      "caption",
+      "subtitles"
+    ],
+    "category": "subtitle",
+    "clip": {
+      "content": "Subtitle text",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.5,
+        "y": 0.9
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "center",
+        "backgroundColor": "#00000099",
+        "backgroundPadding": 8,
+        "bold": false,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 32,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.4,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "Standard subtitle/caption style",
+    "id": "subtitle",
+    "kind": "text",
+    "name": "Subtitle"
+  },
+  {
+    "aliases": [
+      "outlined_subtitle"
+    ],
+    "category": "subtitle",
+    "clip": {
+      "content": "Subtitle text",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#000000",
+        "width": 2
+      },
+      "position": {
+        "x": 0.5,
+        "y": 0.9
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 34,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.4,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "Subtitle with outline (no background)",
+    "id": "subtitle-outline",
+    "kind": "text",
+    "name": "Subtitle Outline"
+  },
+  {
+    "aliases": [
+      "emphasis"
+    ],
+    "category": "callout",
+    "clip": {
+      "content": "Key Point",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#000000",
+        "width": 2
+      },
+      "position": {
+        "x": 0.5,
+        "y": 0.35
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 6,
+        "color": "#000000",
+        "offsetX": 2,
+        "offsetY": 2
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#FFD700",
+        "fontFamily": "Arial",
+        "fontSize": 48,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 2,
+        "lineHeight": 1.2,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "Attention-grabbing callout text",
+    "id": "callout",
+    "kind": "text",
+    "name": "Callout"
+  },
+  {
+    "aliases": [
+      "stat",
+      "number_callout",
+      "price_callout"
+    ],
+    "category": "callout",
+    "clip": {
+      "content": "42%",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#082F49",
+        "width": 2
+      },
+      "position": {
+        "x": 0.5,
+        "y": 0.42
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 8,
+        "color": "#000000",
+        "offsetX": 3,
+        "offsetY": 4
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#38BDF8",
+        "fontFamily": "Arial",
+        "fontSize": 82,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.0,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "Large numeric callout for data, prices, and milestones",
+    "id": "callout-stat",
+    "kind": "text",
+    "name": "Stat Callout"
+  },
+  {
+    "aliases": [
+      "warning",
+      "important_callout"
+    ],
+    "category": "callout",
+    "clip": {
+      "content": "Important",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#FFFFFF",
+        "width": 1
+      },
+      "position": {
+        "x": 0.5,
+        "y": 0.22
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "center",
+        "backgroundColor": "#FACC15E6",
+        "backgroundPadding": 14,
+        "bold": true,
+        "color": "#111827",
+        "fontFamily": "Arial",
+        "fontSize": 46,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.15,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 3.0,
+    "description": "High-contrast warning or safety note",
+    "id": "callout-warning",
+    "kind": "text",
+    "name": "Warning Callout"
+  },
+  {
+    "aliases": [
+      "timer"
+    ],
+    "category": "callout",
+    "clip": {
+      "content": "3",
+      "opacity": 1.0,
+      "outline": {
+        "color": "#FFFFFF",
+        "width": 4
+      },
+      "position": {
+        "x": 0.5,
+        "y": 0.5
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 8,
+        "color": "#000000",
+        "offsetX": 4,
+        "offsetY": 4
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": true,
+        "color": "#FF0000",
+        "fontFamily": "Impact",
+        "fontSize": 120,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.0,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 1.0,
+    "description": "Bold countdown/timer style",
+    "id": "countdown",
+    "kind": "text",
+    "name": "Countdown"
+  },
+  {
+    "aliases": [
+      "credits",
+      "credit_block",
+      "end_credits"
+    ],
+    "category": "credit",
+    "clip": {
+      "content": "Directed by\nJane Doe\n\nProduced by\nOpenReelio",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.5,
+        "y": 0.52
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 5,
+        "color": "#000000AA",
+        "offsetX": 1,
+        "offsetY": 2
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": false,
+        "color": "#F8FAFC",
+        "fontFamily": "Georgia",
+        "fontSize": 34,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.45,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 8.0,
+    "description": "Centered credit block for ending cards",
+    "id": "credits-block",
+    "kind": "text",
+    "name": "Credits Block"
+  },
+  {
+    "aliases": [
+      "source_credit",
+      "attribution"
+    ],
+    "category": "credit",
+    "clip": {
+      "content": "Source: OpenReelio",
+      "opacity": 0.9,
+      "position": {
+        "x": 0.94,
+        "y": 0.92
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "right",
+        "backgroundColor": "#00000080",
+        "backgroundPadding": 6,
+        "bold": false,
+        "color": "#E5E7EB",
+        "fontFamily": "Arial",
+        "fontSize": 24,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.2,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 5.0,
+    "description": "Small single-line attribution or source credit",
+    "id": "credit-line",
+    "kind": "text",
+    "name": "Credit Line"
+  },
+  {
+    "aliases": [
+      "bug",
+      "channel_bug",
+      "brand_bug"
+    ],
+    "category": "brand",
+    "clip": {
+      "content": "OPEN",
+      "opacity": 0.85,
+      "position": {
+        "x": 0.94,
+        "y": 0.08
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "right",
+        "backgroundColor": "#0F766ECC",
+        "backgroundPadding": 8,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 24,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 1,
+        "lineHeight": 1.15,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 10.0,
+    "description": "Subtle top-right brand bug or channel label",
+    "id": "logo-bug",
+    "kind": "text",
+    "name": "Logo Bug"
+  },
+  {
+    "aliases": [
+      "handle",
+      "social"
+    ],
+    "category": "brand",
+    "clip": {
+      "content": "@openreelio",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.07,
+        "y": 0.91
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 4,
+        "color": "#00000099",
+        "offsetX": 1,
+        "offsetY": 2
+      },
+      "style": {
+        "alignment": "left",
+        "backgroundColor": "#7C3AEDCC",
+        "backgroundPadding": 10,
+        "bold": true,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 30,
+        "fontWeight": 700,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.2,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 5.0,
+    "description": "Creator handle or social profile lower bug",
+    "id": "social-handle",
+    "kind": "text",
+    "name": "Social Handle"
+  },
+  {
+    "aliases": [
+      "pull_quote"
+    ],
+    "category": "creative",
+    "clip": {
+      "content": "\"Pull quote goes here\"",
+      "opacity": 0.95,
+      "position": {
+        "x": 0.5,
+        "y": 0.5
+      },
+      "rotation": 0.0,
+      "shadow": {
+        "blur": 3,
+        "color": "#000000",
+        "offsetX": 1,
+        "offsetY": 1
+      },
+      "style": {
+        "alignment": "center",
+        "backgroundPadding": 0,
+        "bold": false,
+        "color": "#FFFFFF",
+        "fontFamily": "Georgia",
+        "fontSize": 42,
+        "fontWeight": 400,
+        "italic": true,
+        "letterSpacing": 1,
+        "lineHeight": 1.6,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 5.0,
+    "description": "Elegant quote style with italics",
+    "id": "quote",
+    "kind": "text",
+    "name": "Quote"
+  },
+  {
+    "aliases": [
+      "tech",
+      "terminal"
+    ],
+    "category": "creative",
+    "clip": {
+      "content": "SYSTEM READY",
+      "opacity": 1.0,
+      "position": {
+        "x": 0.05,
+        "y": 0.05
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "left",
+        "backgroundColor": "#000000CC",
+        "backgroundPadding": 10,
+        "bold": false,
+        "color": "#00FF00",
+        "fontFamily": "Courier New",
+        "fontSize": 36,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.4,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 4.0,
+    "description": "Modern monospace tech aesthetic",
+    "id": "tech-style",
+    "kind": "text",
+    "name": "Tech Style"
+  },
+  {
+    "aliases": [],
+    "category": "creative",
+    "clip": {
+      "content": "Brand",
+      "opacity": 0.4,
+      "position": {
+        "x": 0.95,
+        "y": 0.95
+      },
+      "rotation": 0.0,
+      "style": {
+        "alignment": "right",
+        "backgroundPadding": 0,
+        "bold": false,
+        "color": "#FFFFFF",
+        "fontFamily": "Arial",
+        "fontSize": 24,
+        "fontWeight": 400,
+        "italic": false,
+        "letterSpacing": 0,
+        "lineHeight": 1.2,
+        "underline": false
+      }
+    },
+    "defaultDurationSec": 10.0,
+    "description": "Subtle watermark/branding text",
+    "id": "watermark",
+    "kind": "text",
+    "name": "Watermark"
+  }
+]

--- a/src/data/textPresets.test.ts
+++ b/src/data/textPresets.test.ts
@@ -69,7 +69,6 @@ describe('textPresets', () => {
       const ids = lowerThirds.map((p) => p.id);
       expect(ids).toContain('lower-third');
       expect(ids).toContain('lower-third-minimal');
-      expect(ids).toContain('label');
     });
 
     it('should assign title presets correctly', () => {
@@ -91,6 +90,9 @@ describe('textPresets', () => {
       const ids = callouts.map((p) => p.id);
       expect(ids).toContain('callout');
       expect(ids).toContain('countdown');
+      // `label` is anchored top-left, so smart placement must treat it as a
+      // corner annotation rather than relocating it to the lower third.
+      expect(ids).toContain('label');
     });
 
     it('should assign creative presets correctly', () => {

--- a/src/data/textPresets.test.ts
+++ b/src/data/textPresets.test.ts
@@ -246,6 +246,18 @@ describe('textPresets', () => {
       },
     );
 
+    it('should accept the separator spellings the core normalizer accepts', () => {
+      // normalize_pack_id in src-tauri/src/core/style/mod.rs collapses runs of
+      // whitespace or underscores onto one hyphen, exactly as
+      // normalizeTextPresetKey does. Both halves must take the same keys, or a
+      // spelling the app resolves is a hard error on the CLI.
+      ['lower  third', 'lower\tthird', 'lower _ third', 'lower__third', 'Lower  Third'].forEach(
+        (key) => {
+          expect(getPresetByKey(key)?.id, key).toBe('lower-third');
+        },
+      );
+    });
+
     it('should resolve every core alias to the same preset', () => {
       textPresetManifest.forEach((entry) => {
         entry.aliases.forEach((alias) => {

--- a/src/data/textPresets.test.ts
+++ b/src/data/textPresets.test.ts
@@ -8,10 +8,12 @@ import { describe, it, expect } from 'vitest';
 import {
   TEXT_PRESETS,
   getPresetById,
+  getPresetByKey,
   getPresetsByCategory,
   presetToTextClipData,
   type TextPresetCategory,
 } from './textPresets';
+import textPresetManifest from './textPresets.manifest.json';
 
 // =============================================================================
 // Tests
@@ -192,6 +194,66 @@ describe('textPresets', () => {
       expect(clipData.style.fontFamily).toBe('Courier New');
       expect(clipData.style.color).toBe('#00FF00');
       expect(clipData.style.fontSize).toBe(36);
+    });
+  });
+
+  // ===========================================================================
+  // Rust core registry parity
+  // ===========================================================================
+
+  describe('core registry parity', () => {
+    // The manifest is generated from src-tauri/src/core/style/text_presets.rs,
+    // which is what the CLI, MCP, and the AddTextClip `preset` field read. When
+    // this catalog and that registry disagree, an agent is told about presets
+    // the backend rejects — the exact bug this pairing exists to prevent.
+    const REGENERATE_HINT =
+      'Update src-tauri/src/core/style/text_presets.rs, then run: ' +
+      'cargo test -p openreelio --lib regenerate_text_preset_manifest -- --ignored';
+
+    const manifestById = new Map(textPresetManifest.map((entry) => [entry.id, entry]));
+
+    it('should cover exactly the presets the core registry defines', () => {
+      const uiIds = TEXT_PRESETS.map((preset) => preset.id).sort();
+      const coreIds = textPresetManifest.map((entry) => entry.id).sort();
+      expect(uiIds, REGENERATE_HINT).toEqual(coreIds);
+    });
+
+    it.each(TEXT_PRESETS.map((preset) => [preset.id, preset] as const))(
+      'should match the core registry for %s',
+      (id, preset) => {
+        const entry = manifestById.get(id);
+        expect(entry, REGENERATE_HINT).toBeDefined();
+        if (!entry) return;
+
+        expect(entry.kind).toBe('text');
+        expect(preset.name).toBe(entry.name);
+        expect(preset.description).toBe(entry.description);
+        expect(preset.category).toBe(entry.category);
+        expect(preset.aliases ?? []).toEqual(entry.aliases);
+        expect(preset.defaultDurationSec).toBe(entry.defaultDurationSec);
+        expect(preset.defaultContent).toBe(entry.clip.content);
+
+        // fontWeight is derived from `bold` on the Rust side rather than stored
+        // here, so it is checked against the derivation instead of compared.
+        const { fontWeight, ...style } = entry.clip.style as Record<string, unknown> & {
+          fontWeight: number;
+        };
+        expect(fontWeight).toBe(preset.style.bold ? 700 : 400);
+        expect(presetToTextClipData(preset, entry.clip.content)).toEqual({
+          ...entry.clip,
+          style,
+        });
+      },
+    );
+
+    it('should resolve every core alias to the same preset', () => {
+      textPresetManifest.forEach((entry) => {
+        entry.aliases.forEach((alias) => {
+          expect(getPresetByKey(alias)?.id, `alias ${alias}`).toBe(entry.id);
+        });
+        expect(getPresetByKey(entry.id)?.id).toBe(entry.id);
+        expect(getPresetByKey(entry.name)?.id).toBe(entry.id);
+      });
     });
   });
 });

--- a/src/data/textPresets.ts
+++ b/src/data/textPresets.ts
@@ -2,7 +2,15 @@
  * Text Presets Data
  *
  * Pre-configured text styles for common video text use cases.
- * Used by TextPresetPicker component in TextInspector.
+ * Used by the TextPresetPicker component in TextInspector and by the agent text
+ * tools.
+ *
+ * This catalog is one half of a pair: the Rust core registry in
+ * `src-tauri/src/core/style/text_presets.rs` serves the CLI, MCP, and the
+ * `preset` field on `AddTextClip`, and `textPresets.manifest.json` — generated
+ * from that registry — pins the two together. A change here that is not made
+ * there (or the reverse) fails `textPresets.test.ts` on this side and
+ * `the_text_preset_manifest_matches_the_registry` on the other.
  *
  * @module data/textPresets
  */
@@ -89,7 +97,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 1.0,
     defaultContent: 'Speaker Name\nTitle or Role',
     defaultDurationSec: 5,
-    aliases: ['lower_third', 'name_title', 'name-role'],
+    aliases: ['lower_third', 'lowerthird', 'name_title'],
   },
   {
     id: 'lower-third-minimal',
@@ -117,7 +125,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 0.95,
     defaultContent: 'Speaker Name',
     defaultDurationSec: 4,
-    aliases: ['minimal_lower_third', 'minimal-lower-third'],
+    aliases: ['minimal_lower_third'],
   },
   {
     id: 'lower-third-news',
@@ -357,7 +365,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 1.0,
     defaultContent: 'Subtitle text',
     defaultDurationSec: 3,
-    aliases: ['outlined_subtitle', 'subtitle_outline'],
+    aliases: ['outlined_subtitle'],
   },
 
   // -------------------------------------------------------------------------
@@ -395,7 +403,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 1.0,
     defaultContent: 'Key Point',
     defaultDurationSec: 3,
-    aliases: ['callout', 'emphasis'],
+    aliases: ['emphasis'],
   },
   {
     id: 'label',
@@ -598,7 +606,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 1,
     defaultContent: '@openreelio',
     defaultDurationSec: 5,
-    aliases: ['handle', 'social', 'social_handle'],
+    aliases: ['handle', 'social'],
   },
 
   // -------------------------------------------------------------------------
@@ -632,7 +640,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 0.95,
     defaultContent: '"Pull quote goes here"',
     defaultDurationSec: 5,
-    aliases: ['pull_quote', 'quote'],
+    aliases: ['pull_quote'],
   },
   {
     id: 'tech-style',
@@ -681,7 +689,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 0.4,
     defaultContent: 'Brand',
     defaultDurationSec: 10,
-    aliases: ['watermark'],
+    aliases: [],
   },
   {
     id: 'countdown',
@@ -715,7 +723,7 @@ export const TEXT_PRESETS: TextPreset[] = [
     opacity: 1.0,
     defaultContent: '3',
     defaultDurationSec: 1,
-    aliases: ['timer', 'countdown'],
+    aliases: ['timer'],
   },
 ];
 

--- a/src/data/textPresets.ts
+++ b/src/data/textPresets.ts
@@ -409,7 +409,10 @@ export const TEXT_PRESETS: TextPreset[] = [
     id: 'label',
     name: 'Label',
     description: 'Simple label for annotations',
-    category: 'lower-third',
+    // Anchored top-left, so it is a corner annotation rather than a name plate.
+    // The category drives smart placement, and 'lower-third' relocated it to
+    // the bottom of the frame.
+    category: 'callout',
     style: {
       fontSize: 24,
       fontFamily: 'Arial',


### PR DESCRIPTION
### **User description**
## Description

PR 4 of the edit-quality roadmap (`docs/QUALITY_ROADMAP_PLAN.md`): one text-preset catalog. The same design content lived in five hand-maintained places that had already diverged — the TypeScript registry shipped 22 presets, the CLI's inline table only 14, and the prose hints advertised 17 including `quote`/`watermark`/`countdown`, **which the CLI rejected** ("Unsupported text preset"). This PR makes the divergence structurally impossible.

- **One registry**: all 22 presets (content ported verbatim from the richer TS side) live in `src-tauri/src/core/style/text_presets.rs`, following the PR #793 pack patterns — const table, alias-tolerant resolver, `packs list --kind text`.
- **CLI delegates**: the ~270-line inline table in `text.rs` is deleted; `text add --preset quote` (previously rejected) now works, with flag-override semantics unchanged and extended to all 22.
- **Chokepoint resolution**: `AddTextClipPayload` gains `preset`, resolved during deserialization to concrete `TextClipData` (deep per-key merge; explicit `null` clears a layer; the logged op carries only concrete values — replay never depends on the table). MCP, plans, and `command execute` gain preset access for free.
- **The drift class is closed, not patched**: every Rust hint (`help_json`, MCP `presetHints`/catalog) is generated from the registry at runtime — no hand-maintained list survives anywhere (verified by grep). The TS side is held in parity by a generated manifest (`src/data/textPresets.manifest.json`) guarded by tests on **both** sides: a registry edit without regeneration fails Rust CI; a TS drift fails vitest.
- The `text` meta-tool's 4-value preset enum (a regression that hid 18 presets from the in-app LLM) now imports the full list.

The unification surfaced a real latent bug of exactly the class it targets: the alias `name-role` meant **different overlays on different surfaces** (TS resolved it to `lower-third`, the CLI to `lower-third-name-role`). It is now unambiguous (kept on `lower-third-name-role`, matching the CLI and the preset's own name) and a registry test fails on any future ambiguous key.

## Related Issue

Part of the edit-quality roadmap (no standalone issue).

## Type of Change

- [x] Refactoring (no functional changes) — for the catalog consolidation
- [x] Bug fix (non-breaking change which fixes an issue) — advertised presets now work; ambiguous alias resolved
- [x] Documentation update
- [x] Test update

## Changes Made

- New `core/style/text_presets.rs` (22 presets, typed `TextClipData`, categories preserved for placement logic).
- `text.rs` CLI delegation; `packs list --kind text`; registry-generated help_json/MCP hints.
- `AddTextClipPayload.preset` with deserialization-time resolution; `src/bindings.ts` regenerated.
- Parity manifest + Rust guard test + TS parity test; `.prettierignore` entry for the generated manifest.
- `metaTools.ts` full preset enum (imported, not copied); `toolReference.ts` / Codex adapter lists built from `TEXT_PRESETS`.
- Skills (`captions/REFERENCE.md`) + `docs/AGENT_GUIDE.md` updated.

## Screenshots / Videos

N/A.

## Testing

### Test Environment

- OS: Windows 11 Pro
- Node.js version: project toolchain (affected vitest files run)
- Rust version: workspace toolchain

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [x] Manual testing performed
- [x] New tests added for changes

Rust: lib 3720 passed, `openreelio-cli` 186 + 134 passed; clippy `-D warnings` + fmt clean; help_json parity green; bundler feature-set check (`--no-default-features --features bundled-ffmpeg --all-targets`) clean. TS: 247 tests across 15 affected files + `tsc --noEmit` + eslint clean. Contract tests: every preset and every alias through `CommandPayload::parse` → execute → drawtext filter with per-preset distinctive assertions and pairwise uniqueness; CLI `text add` for all 22; unknown-preset error lists valid ids; both-side parity tests; alias-ambiguity guard.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- Behavior change (intended): `title`, `lower-third`, `subtitle` now mean the TS geometry everywhere (the old thinner CLI-only variants are gone) — the CLI and app previously produced different overlays for the same preset name.
- An adversarial review workflow is running against this branch in parallel with CI (same discipline as #791–#793); confirmed findings will be fixed here before merge.


___

### **PR Type**
Enhancement, Refactor, Documentation, Tests


___

### **Description**
- Unifies text presets into a single core registry.

- Ensures CLI, MCP, and UI use identical presets.

- Resolves presets into concrete values during command parsing.

- Adds comprehensive contract tests for preset rendering parity.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Registry["Core Registry (Rust)"]
    R1["text_presets.rs"]
  end
  subgraph Consumers["Consumers"]
    C1["CLI (text add)"]
    C2["MCP / Agents"]
    C3["TypeScript UI"]
  end
  subgraph Sync["Sync Mechanism"]
    S1["Manifest JSON"]
  end
  R1 -- "Direct Import" --> C1
  R1 -- "Direct Import" --> C2
  R1 -- "Test-Guarded Export" --> S1
  S1 -- "Import" --> C3
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>text_presets.rs</strong><dd><code>Define the single source of truth for text presets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-e790991345bdf77161dd123a9c2a3490f82d52eee37e24a8ec10f75bc57fadde">+1120/-0</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Implement deep merging for preset overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-47e6ce163a52918435baefc0d2172b11a6d35ecd7a778a2a143573a0c50ac7b9">+144/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>openreelioCodexTools.ts</strong><dd><code>Expose full preset catalog to Codex agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-78b40377e0e9fccbf98b98f67b7c52e322184ae79113f5293cc6ad0e085d548d">+42/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bindings.ts</strong><dd><code>Update AddTextClipPayload with preset field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactor</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>text.rs</strong><dd><code>Delegate CLI text preset logic to core registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-6667fe2834f6efa61450b5c1e7d9805286a98f1224ffa7a6853f2c0a03ce57f5">+158/-292</a></td>

</tr>

<tr>
  <td><strong>textPresets.ts</strong><dd><code>Align TypeScript presets with core registry aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-bbd2b3b208b50b75e530a482e8b518bf34b5c0b66925375dfa6cbd9392cd4214">+17/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>contract_tests.rs</strong><dd><code>Add E2E tests for preset rendering and parity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-9484776ca7f8039103d73d2c198793894cddc692f41b83fbf87088a1485614a2">+433/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>textPresets.test.ts</strong><dd><code>Verify UI parity with Rust manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-9752b1d989cec9717492a8c1bca7ac19096cbfd66745493c32b899c4a4d1845b">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration.rs</strong><dd><code>Test CLI preset application and listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+222/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>toolReference.ts</strong><dd><code>Update agent prompts with dynamic preset IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>.prettierignore</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>help_json.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+58/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+88/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>packs.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-a40237998947712d49d137d4202b35f26d1590dc08222b7063a99181e4ec6626">+20/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-4847e139fc42c0e90126f03bf18157a06f87f753f4f196fc25f670c7733b598f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-3108771c2d44e2b7db9e9097acfa4590082bf896c1561d2cc81899e9fbbfb0f3">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT_GUIDE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-609f4b6b6395bee5b56f2cb041c6803bc2afd043dbb10d33c31349b6e8c96a26">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>payloads.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-1efed79e6d1ef23a178231ecb231d1034cfafe2660c00fc389179577224de950">+69/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-fba7abc9f4898abb5634a8c17070efef12feabcf68d91924e06c08e62de4e01e">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-842f7132c091ca5476d87b73a280cb7192ba997487dfea06a0bd4e097e1a19b7">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>textTools.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-b0b4a063ada79baf234334dea412b7938775274b8387b4201156c3927324b686">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>textPresets.manifest.json</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/794/files#diff-fcdb6f2052dec87d7abf257d49a713b955e47161407152aaec4dce48afa3f7e8">+856/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 22 curated text presets for titles, subtitles, lower thirds, credits, branding, and creative overlays.
  * Presets include starter content, typography, positioning, visual effects, and default durations.
  * Discover presets through pack listings and agent tools, with aliases and normalized names.
  * Custom text values and options can override preset defaults.
  * Unknown preset errors list valid available options.
  * Preset-based text workflows now support replayable, concrete clip values.

* **Documentation**
  * Updated CLI, agent, and caption documentation with text preset discovery and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->