### PR TITLE
feat(ai): revive execute_plan as a first-class atomic batch surface

### DIFF
--- a/crates/openreelio-cli/src/commands/plan.rs
+++ b/crates/openreelio-cli/src/commands/plan.rs
@@ -24,10 +24,9 @@ use std::path::{Path, PathBuf};
 
 /// Upper bound on the steps a single plan may carry.
 ///
-/// A backstop against runaway generation, not a capacity limit: an agent that
-/// emits thousands of steps in one plan has lost the thread, and the damage of
-/// letting that run is far larger than the cost of refusing it.
-pub const MAX_PLAN_STEPS: usize = 1000;
+/// Owned by core so every plan surface (CLI, MCP, backend `execute_agent_plan`
+/// and the in-app `execute_plan` meta-tool) refuses the same plan size.
+pub use openreelio_core::ai::MAX_PLAN_STEPS;
 
 /// Exit code for a plan that was rejected, or failed and rolled back cleanly.
 const EXIT_PLAN_FAILED: i32 = 1;

--- a/src-tauri/src/core/ai/mod.rs
+++ b/src-tauri/src/core/ai/mod.rs
@@ -15,6 +15,7 @@ pub mod knowledge;
 pub mod knowledge_commands;
 pub mod memory;
 pub mod plan_executor;
+pub mod plan_runner;
 pub mod proposal;
 pub mod provider;
 pub mod providers;
@@ -54,7 +55,11 @@ pub use gateway::{
 };
 pub use knowledge::{KnowledgeDb, KnowledgeRow};
 pub use memory::{AgentMemoryDb, MemoryEntry};
-pub use plan_executor::{resolve_step_references, PlanExecutor};
+pub use plan_executor::{resolve_step_references, PlanExecutor, MAX_PLAN_STEPS};
+pub use plan_runner::{
+    execute_prepared_plan, run_agent_plan, NullPlanStepReporter, PlanStepCompleteEvent,
+    PlanStepEvent, PlanStepFailedEvent, PlanStepReporter,
+};
 pub use proposal::{Proposal, ProposalManager, ProposalStatus};
 pub use provider::{
     AIIntent, AIIntentType, AIProvider, AIResponse, CompletionRequest, CompletionResponse,

--- a/src-tauri/src/core/ai/plan_executor.rs
+++ b/src-tauri/src/core/ai/plan_executor.rs
@@ -9,6 +9,22 @@ use std::collections::HashMap;
 use super::agent_plan::{AgentPlan, PlanStep, RollbackReport, StepResult};
 
 // =============================================================================
+// Limits
+// =============================================================================
+
+/// Upper bound on the steps a single plan may carry, shared by every plan
+/// surface (backend `execute_agent_plan`, CLI `plan execute`, MCP `plan.apply`
+/// and the in-app `execute_plan` meta-tool).
+///
+/// A backstop against runaway generation, not a capacity limit: an agent that
+/// emits thousands of steps in one plan has lost the thread, and the damage of
+/// letting that run is far larger than the cost of refusing it.
+///
+/// The TypeScript intercept pins the same value in
+/// `src/agents/engine/adapters/tools/BackendToolExecutor.ts`.
+pub const MAX_PLAN_STEPS: usize = 1000;
+
+// =============================================================================
 // PlanExecutor
 // =============================================================================
 
@@ -35,9 +51,21 @@ impl PlanExecutor {
     }
 
     /// Validates the plan structure and returns execution order as step
-    /// indices. Returns an error if circular dependencies are detected
-    /// or a `depends_on` reference points to a non-existent step.
+    /// indices. Returns an error if the plan exceeds [`MAX_PLAN_STEPS`],
+    /// if circular dependencies are detected, or if a `depends_on` reference
+    /// points to a non-existent step.
+    ///
+    /// Callers run this before touching the project, so an over-cap plan is
+    /// refused before any step mutates state.
     pub fn validate_and_prepare(&self) -> Result<Vec<usize>, String> {
+        if self.plan.steps.len() > MAX_PLAN_STEPS {
+            return Err(format!(
+                "Plan has {} steps, which exceeds the maximum of {}",
+                self.plan.steps.len(),
+                MAX_PLAN_STEPS
+            ));
+        }
+
         topological_sort(&self.plan.steps)
     }
 
@@ -901,5 +929,48 @@ mod tests {
             .expect("Should undo step-1 (insert)");
         // After undoing first insert: 0 clips remain
         assert_eq!(state.sequences[&seq_id].tracks[0].clips.len(), 0);
+    }
+
+    // =========================================================================
+    // 9. Step cap
+    // =========================================================================
+
+    fn make_capped_plan(step_count: usize) -> AgentPlan {
+        AgentPlan {
+            id: "plan-cap".to_string(),
+            goal: "Step cap probe".to_string(),
+            steps: (0..step_count)
+                .map(|index| make_step(&format!("step-{index}"), vec![]))
+                .collect(),
+            approval_granted: true,
+            approval_proof: None,
+            session_id: None,
+        }
+    }
+
+    #[test]
+    fn validate_and_prepare_rejects_a_plan_over_the_step_cap() {
+        let executor = PlanExecutor::new(make_capped_plan(MAX_PLAN_STEPS + 1));
+
+        let error = executor
+            .validate_and_prepare()
+            .expect_err("an over-cap plan must be refused before any step runs");
+
+        assert!(
+            error.contains(&(MAX_PLAN_STEPS + 1).to_string())
+                && error.contains(&MAX_PLAN_STEPS.to_string()),
+            "the rejection must report the actual and the maximum step count: {error}"
+        );
+    }
+
+    #[test]
+    fn validate_and_prepare_accepts_a_plan_at_the_step_cap() {
+        let executor = PlanExecutor::new(make_capped_plan(MAX_PLAN_STEPS));
+
+        let order = executor
+            .validate_and_prepare()
+            .expect("a plan exactly at the cap is still valid");
+
+        assert_eq!(order.len(), MAX_PLAN_STEPS);
     }
 }

--- a/src-tauri/src/core/ai/plan_runner.rs
+++ b/src-tauri/src/core/ai/plan_runner.rs
@@ -1,0 +1,621 @@
+//! Agent Plan Runner
+//!
+//! Executes an [`AgentPlan`] atomically against an open project: every step is
+//! applied through the `CommandExecutor`, and the first failure unwinds all the
+//! work the plan already applied — both the in-memory undo stack and the
+//! persisted ops log.
+//!
+//! The runner is Tauri-free on purpose. Step lifecycle progress is delivered
+//! through the [`PlanStepReporter`] port, so the GUI can forward it to the
+//! frontend as Tauri events while headless callers and tests use their own
+//! sink. That keeps the atomicity guarantee under test without an `AppHandle`.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use super::agent_plan::{AgentPlan, AgentPlanResult, RollbackReport, StepResult};
+use super::plan_executor::{resolve_step_references, PlanExecutor};
+use crate::ipc::CommandPayload;
+use crate::ActiveProject;
+
+// =============================================================================
+// Progress reporting port
+// =============================================================================
+
+/// Progress payload emitted when a plan step starts.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanStepEvent {
+    pub plan_id: String,
+    pub step_id: String,
+    pub step_index: usize,
+    pub total_steps: usize,
+}
+
+/// Progress payload emitted when a plan step completes successfully.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanStepCompleteEvent {
+    pub plan_id: String,
+    pub step_id: String,
+    pub step_index: usize,
+    pub total_steps: usize,
+    pub operation_id: Option<String>,
+    pub duration_ms: u64,
+}
+
+/// Progress payload emitted when a plan step fails.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanStepFailedEvent {
+    pub plan_id: String,
+    pub step_id: String,
+    pub step_index: usize,
+    pub total_steps: usize,
+    pub error: String,
+}
+
+/// Sink for plan step lifecycle progress.
+///
+/// Reporting is best-effort and must never influence execution: an
+/// implementation that fails to deliver a message swallows the error.
+pub trait PlanStepReporter {
+    /// Called immediately before a step is applied.
+    fn step_start(&self, event: PlanStepEvent);
+
+    /// Called after a step was applied successfully.
+    fn step_complete(&self, event: PlanStepCompleteEvent);
+
+    /// Called after a step failed, before the rollback runs.
+    fn step_failed(&self, event: PlanStepFailedEvent);
+}
+
+/// Reporter that drops every message. Used by headless callers and tests.
+pub struct NullPlanStepReporter;
+
+impl PlanStepReporter for NullPlanStepReporter {
+    fn step_start(&self, _event: PlanStepEvent) {}
+    fn step_complete(&self, _event: PlanStepCompleteEvent) {}
+    fn step_failed(&self, _event: PlanStepFailedEvent) {}
+}
+
+// =============================================================================
+// Runner
+// =============================================================================
+
+/// Executes `plan` against `project`, rolling back completely on the first
+/// failure.
+///
+/// Returns `Err` when the plan itself is unusable (over the step cap, cyclic,
+/// or referencing a step that does not exist) — nothing is applied in that
+/// case. A step failure is reported as `Ok` with `success: false` and a
+/// [`RollbackReport`], because the project was mutated and then restored.
+///
+/// Callers that must reject an invalid plan *before* acquiring side effects of
+/// their own (a project lock, an approval-proof consumption) can run
+/// [`PlanExecutor::validate_and_prepare`] first; re-validating here is O(steps)
+/// and keeps this entry point safe to call standalone.
+pub fn run_agent_plan(
+    project: &mut ActiveProject,
+    plan: &AgentPlan,
+    reporter: &dyn PlanStepReporter,
+    start: Instant,
+) -> Result<AgentPlanResult, String> {
+    let executor = PlanExecutor::new(plan.clone());
+    let execution_order = executor
+        .validate_and_prepare()
+        .map_err(|e| format!("Plan validation failed: {e}"))?;
+
+    Ok(execute_prepared_plan(
+        project,
+        plan,
+        &executor,
+        &execution_order,
+        reporter,
+        start,
+    ))
+}
+
+/// Executes a plan whose dependency graph was already validated.
+///
+/// `execution_order` must come from [`PlanExecutor::validate_and_prepare`] for
+/// the same plan.
+pub fn execute_prepared_plan(
+    project: &mut ActiveProject,
+    plan: &AgentPlan,
+    executor: &PlanExecutor,
+    execution_order: &[usize],
+    reporter: &dyn PlanStepReporter,
+    start: Instant,
+) -> AgentPlanResult {
+    let plan_id = plan.id.clone();
+    let total_steps = plan.steps.len();
+    let project_path = project.path.clone();
+
+    // Rollback unwinds the executor's in-memory undo stack, and that stack is
+    // capped for interactive use — far below the plan step cap. Without this, a
+    // plan that fails deep enough has already had its earliest steps evicted
+    // and could not undo them.
+    project.executor.ensure_history_capacity(total_steps);
+
+    let mut step_results: Vec<StepResult> = Vec::with_capacity(total_steps);
+    let mut results_by_id: HashMap<String, StepResult> = HashMap::new();
+    let mut operation_ids: Vec<String> = Vec::new();
+    let mut steps_completed: usize = 0;
+
+    tracing::info!(
+        plan_id = %plan_id,
+        total_steps = total_steps,
+        "Executing agent plan"
+    );
+
+    for &step_idx in execution_order {
+        let step = &plan.steps[step_idx];
+        let step_start = Instant::now();
+
+        reporter.step_start(PlanStepEvent {
+            plan_id: plan_id.clone(),
+            step_id: step.id.clone(),
+            step_index: step_idx,
+            total_steps,
+        });
+
+        // Resolve $fromStep/$path references in step params
+        let resolved_params = match resolve_step_references(&step.params, &results_by_id) {
+            Ok(params) => params,
+            Err(e) => {
+                let duration_ms = step_start.elapsed().as_millis() as u64;
+                let error_msg = format!("Reference resolution failed: {e}");
+
+                reporter.step_failed(PlanStepFailedEvent {
+                    plan_id: plan_id.clone(),
+                    step_id: step.id.clone(),
+                    step_index: step_idx,
+                    total_steps,
+                    error: error_msg.clone(),
+                });
+
+                step_results.push(StepResult {
+                    step_id: step.id.clone(),
+                    success: false,
+                    data: None,
+                    error: Some(error_msg),
+                    duration_ms,
+                    operation_id: None,
+                });
+
+                let rollback_report = rollback_steps(project, executor, step_idx, &step_results);
+
+                return AgentPlanResult {
+                    plan_id,
+                    success: false,
+                    total_steps,
+                    steps_completed,
+                    step_results,
+                    operation_ids,
+                    rollback_report: Some(rollback_report),
+                    error_message: Some(format!(
+                        "Step '{}' failed: reference resolution error",
+                        step.id
+                    )),
+                    execution_time_ms: start.elapsed().as_millis() as u64,
+                };
+            }
+        };
+
+        // Parse tool_name + resolved_params into a CommandPayload
+        let typed_payload = match CommandPayload::parse(step.tool_name.clone(), resolved_params) {
+            Ok(payload) => payload,
+            Err(e) => {
+                let duration_ms = step_start.elapsed().as_millis() as u64;
+                let error_msg = format!("Invalid command '{}': {e}", step.tool_name);
+
+                reporter.step_failed(PlanStepFailedEvent {
+                    plan_id: plan_id.clone(),
+                    step_id: step.id.clone(),
+                    step_index: step_idx,
+                    total_steps,
+                    error: error_msg.clone(),
+                });
+
+                step_results.push(StepResult {
+                    step_id: step.id.clone(),
+                    success: false,
+                    data: None,
+                    error: Some(error_msg),
+                    duration_ms,
+                    operation_id: None,
+                });
+
+                let rollback_report = rollback_steps(project, executor, step_idx, &step_results);
+
+                return AgentPlanResult {
+                    plan_id,
+                    success: false,
+                    total_steps,
+                    steps_completed,
+                    step_results,
+                    operation_ids,
+                    rollback_report: Some(rollback_report),
+                    error_message: Some(format!("Step '{}' failed: invalid command", step.id)),
+                    execution_time_ms: start.elapsed().as_millis() as u64,
+                };
+            }
+        };
+
+        // Build and execute the command
+        let command = typed_payload.build_command(&project_path);
+        match project.executor.execute(command, &mut project.state) {
+            Ok(cmd_result) => {
+                let duration_ms = step_start.elapsed().as_millis() as u64;
+                let op_id = cmd_result.op_id.clone();
+
+                let step_data = serde_json::json!({
+                    "operationId": op_id,
+                    "createdIds": cmd_result.created_ids,
+                    "deletedIds": cmd_result.deleted_ids,
+                });
+
+                let result = StepResult {
+                    step_id: step.id.clone(),
+                    success: true,
+                    data: Some(step_data),
+                    error: None,
+                    duration_ms,
+                    operation_id: Some(op_id.clone()),
+                };
+
+                reporter.step_complete(PlanStepCompleteEvent {
+                    plan_id: plan_id.clone(),
+                    step_id: step.id.clone(),
+                    step_index: step_idx,
+                    total_steps,
+                    operation_id: Some(op_id.clone()),
+                    duration_ms,
+                });
+
+                operation_ids.push(op_id);
+                results_by_id.insert(step.id.clone(), result.clone());
+                step_results.push(result);
+                steps_completed += 1;
+
+                tracing::debug!(
+                    step_id = %step.id,
+                    step_index = step_idx,
+                    duration_ms = duration_ms,
+                    "Plan step completed successfully"
+                );
+            }
+            Err(e) => {
+                let duration_ms = step_start.elapsed().as_millis() as u64;
+                let error_msg = format!("Command execution failed: {e}");
+
+                reporter.step_failed(PlanStepFailedEvent {
+                    plan_id: plan_id.clone(),
+                    step_id: step.id.clone(),
+                    step_index: step_idx,
+                    total_steps,
+                    error: error_msg.clone(),
+                });
+
+                step_results.push(StepResult {
+                    step_id: step.id.clone(),
+                    success: false,
+                    data: None,
+                    error: Some(error_msg),
+                    duration_ms,
+                    operation_id: None,
+                });
+
+                tracing::warn!(
+                    step_id = %step.id,
+                    step_index = step_idx,
+                    error = %e,
+                    "Plan step failed, initiating rollback"
+                );
+
+                let rollback_report = rollback_steps(project, executor, step_idx, &step_results);
+
+                return AgentPlanResult {
+                    plan_id,
+                    success: false,
+                    total_steps,
+                    steps_completed,
+                    step_results,
+                    operation_ids,
+                    rollback_report: Some(rollback_report),
+                    error_message: Some(format!("Step '{}' failed during execution", step.id)),
+                    execution_time_ms: start.elapsed().as_millis() as u64,
+                };
+            }
+        }
+    }
+
+    tracing::info!(
+        plan_id = %plan_id,
+        steps_completed = steps_completed,
+        elapsed_ms = start.elapsed().as_millis(),
+        "Agent plan executed successfully"
+    );
+
+    AgentPlanResult {
+        plan_id,
+        success: true,
+        total_steps,
+        steps_completed,
+        step_results,
+        operation_ids,
+        rollback_report: None,
+        error_message: None,
+        execution_time_ms: start.elapsed().as_millis() as u64,
+    }
+}
+
+/// Rolls back completed steps in reverse order and excludes their persisted ops
+/// from history replay.
+fn rollback_steps(
+    project: &mut ActiveProject,
+    executor: &PlanExecutor,
+    failed_index: usize,
+    step_results: &[StepResult],
+) -> RollbackReport {
+    // Build the initial report (with candidate steps identified)
+    let mut report = executor.build_rollback_report(failed_index, step_results);
+
+    if !report.attempted {
+        return report;
+    }
+
+    // Undo completed operations in reverse order via the CommandExecutor's undo stack
+    let mut succeeded = 0usize;
+    let mut failed = 0usize;
+    let mut rollback_errors = Vec::new();
+    let completed_operation_ids = step_results
+        .iter()
+        .filter_map(|result| result.operation_id.clone())
+        .collect::<Vec<_>>();
+
+    for step_id in &report.rolled_back_steps.clone() {
+        match project.executor.undo(&mut project.state) {
+            Ok(()) => {
+                succeeded += 1;
+                tracing::debug!(step_id = %step_id, "Rolled back step successfully");
+            }
+            Err(e) => {
+                failed += 1;
+                let error_msg = format!("Failed to undo step '{}': {}", step_id, e);
+                tracing::error!("{}", error_msg);
+                rollback_errors.push(error_msg);
+                // Stop rollback on first undo failure to avoid inconsistent state
+                break;
+            }
+        }
+    }
+
+    if !completed_operation_ids.is_empty() {
+        match project.discard_persisted_operations(&completed_operation_ids) {
+            Ok(still_applied) => {
+                if still_applied.is_empty() {
+                    tracing::debug!(
+                        discarded_ops = completed_operation_ids.len(),
+                        "Discarded rolled-back agent plan operations from persisted history"
+                    );
+                } else {
+                    // Protected operations stay applied and return on the next
+                    // open, so this rollback did not put the project back.
+                    let error_msg = format!(
+                        "Rollback could not discard protected operation(s) [{}]: they stay in the \
+                         project's applied history and will be present on the next open",
+                        still_applied.join(", ")
+                    );
+                    tracing::error!("{}", error_msg);
+                    rollback_errors.push(error_msg);
+                    failed = failed.max(1);
+                }
+            }
+            Err(e) => {
+                let error_msg =
+                    format!("Failed to discard rolled-back operations from persisted history: {e}");
+                tracing::error!("{}", error_msg);
+                rollback_errors.push(error_msg);
+                failed = failed.max(1);
+            }
+        }
+    }
+
+    report.succeeded_count = succeeded;
+    report.failed_count = failed;
+    report.rollback_errors = rollback_errors;
+
+    report
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ai::agent_plan::{PlanRiskLevel, PlanStep};
+    use crate::core::ai::plan_executor::MAX_PLAN_STEPS;
+    use tempfile::TempDir;
+
+    /// Records every reported lifecycle event so tests can assert that a
+    /// rejected plan never reached a step.
+    #[derive(Default)]
+    struct RecordingReporter {
+        started: std::cell::RefCell<Vec<String>>,
+        failed: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl PlanStepReporter for RecordingReporter {
+        fn step_start(&self, event: PlanStepEvent) {
+            self.started.borrow_mut().push(event.step_id);
+        }
+        fn step_complete(&self, _event: PlanStepCompleteEvent) {}
+        fn step_failed(&self, event: PlanStepFailedEvent) {
+            self.failed.borrow_mut().push(event.step_id);
+        }
+    }
+
+    fn add_track_step(id: &str, sequence_id: &str, name: &str) -> PlanStep {
+        PlanStep {
+            id: id.to_string(),
+            tool_name: "addTrack".to_string(),
+            params: serde_json::json!({
+                "sequenceId": sequence_id,
+                "kind": "video",
+                "name": name,
+            }),
+            description: format!("Add track {name}"),
+            risk_level: PlanRiskLevel::Low,
+            depends_on: vec![],
+            optional: false,
+        }
+    }
+
+    fn plan_with(steps: Vec<PlanStep>) -> AgentPlan {
+        AgentPlan {
+            id: "plan-runner-test".to_string(),
+            goal: "Runner test".to_string(),
+            steps,
+            approval_granted: true,
+            approval_proof: None,
+            session_id: None,
+        }
+    }
+
+    fn open_project(dir: &TempDir) -> ActiveProject {
+        let mut project = ActiveProject::create("Runner Test", dir.path().to_path_buf())
+            .expect("project creation must succeed");
+        // Every step targets the active sequence, so one must exist.
+        if project.state.active_sequence_id.is_none() {
+            let sequence_id = project
+                .state
+                .sequences
+                .keys()
+                .next()
+                .cloned()
+                .expect("a new project must have a sequence");
+            project.state.active_sequence_id = Some(sequence_id);
+        }
+        project
+    }
+
+    #[test]
+    fn run_agent_plan_rejects_an_over_cap_plan_before_running_any_step() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut project = open_project(&dir);
+        let sequence_id = project
+            .state
+            .active_sequence_id
+            .clone()
+            .expect("active sequence");
+        let tracks_before = project.state.sequences[&sequence_id].tracks.len();
+
+        let plan = plan_with(
+            (0..=MAX_PLAN_STEPS)
+                .map(|index| {
+                    add_track_step(
+                        &format!("step-{index}"),
+                        &sequence_id,
+                        &format!("Track {index}"),
+                    )
+                })
+                .collect(),
+        );
+        let reporter = RecordingReporter::default();
+
+        let error = run_agent_plan(&mut project, &plan, &reporter, Instant::now())
+            .expect_err("an over-cap plan must be refused");
+
+        assert!(
+            error.contains(&MAX_PLAN_STEPS.to_string()),
+            "the rejection must name the cap: {error}"
+        );
+        assert!(
+            reporter.started.borrow().is_empty(),
+            "no step may start when the plan is refused"
+        );
+        assert_eq!(
+            project.state.sequences[&sequence_id].tracks.len(),
+            tracks_before,
+            "a refused plan must not mutate the project"
+        );
+        assert_eq!(project.executor.undo_count(), 0);
+    }
+
+    #[test]
+    fn run_agent_plan_rolls_back_a_batch_longer_than_the_interactive_undo_cap() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut project = open_project(&dir);
+        let sequence_id = project
+            .state
+            .active_sequence_id
+            .clone()
+            .expect("active sequence");
+        let tracks_before = project.state.sequences[&sequence_id].tracks.len();
+
+        // Longer than DEFAULT_MAX_HISTORY_SIZE (100) so the undo stack would
+        // evict the earliest steps without an explicit capacity bump.
+        let applied_step_count = 150;
+        let mut steps: Vec<PlanStep> = (0..applied_step_count)
+            .map(|index| {
+                add_track_step(
+                    &format!("step-{index}"),
+                    &sequence_id,
+                    &format!("Track {index}"),
+                )
+            })
+            .collect();
+        // A step the payload parser rejects: it fails after everything before it
+        // was already applied and persisted.
+        steps.push(PlanStep {
+            id: "step-boom".to_string(),
+            tool_name: "addTrack".to_string(),
+            params: serde_json::json!({ "trackType": "not-a-track-type" }),
+            description: "Invalid step".to_string(),
+            risk_level: PlanRiskLevel::Low,
+            depends_on: vec![],
+            optional: false,
+        });
+
+        let plan = plan_with(steps);
+        let reporter = RecordingReporter::default();
+
+        let result = run_agent_plan(&mut project, &plan, &reporter, Instant::now())
+            .expect("a step failure is reported as a failed result, not an error");
+
+        assert!(!result.success, "the plan must fail");
+        assert_eq!(result.steps_completed, applied_step_count);
+        assert_eq!(reporter.failed.borrow().as_slice(), ["step-boom"]);
+
+        let report = result.rollback_report.expect("a rollback report");
+        assert_eq!(
+            report.succeeded_count, applied_step_count,
+            "every applied step must unwind, not just the last {} \
+             the interactive cap would hold",
+            report.succeeded_count
+        );
+        assert!(
+            report.rollback_errors.is_empty(),
+            "rollback must complete cleanly: {:?}",
+            report.rollback_errors
+        );
+        assert_eq!(
+            project.state.sequences[&sequence_id].tracks.len(),
+            tracks_before,
+            "the project must be back where it started"
+        );
+
+        // Every applied op must be discarded from persisted history, otherwise
+        // reopening the project resurrects the rolled-back work.
+        let reopened = ActiveProject::open(dir.path().to_path_buf()).expect("reopen");
+        assert_eq!(
+            reopened.state.sequences[&sequence_id].tracks.len(),
+            tracks_before,
+            "rolled-back plan work must not survive a reopen"
+        );
+    }
+}

--- a/src-tauri/src/ipc/commands/agent.rs
+++ b/src-tauri/src/ipc/commands/agent.rs
@@ -9,13 +9,15 @@ use std::sync::OnceLock;
 use tauri::State;
 use tokio::sync::Mutex;
 
-use std::collections::HashMap;
-
 use tauri::Emitter;
 
-use crate::core::ai::agent_plan::{AgentPlan, AgentPlanResult, StepResult};
+use crate::core::ai::agent_plan::{AgentPlan, AgentPlanResult};
 use crate::core::ai::memory::{AgentMemoryDb, MemoryEntry};
-use crate::core::ai::plan_executor::{resolve_step_references, PlanExecutor};
+use crate::core::ai::plan_executor::PlanExecutor;
+use crate::core::ai::plan_runner::{
+    execute_prepared_plan, PlanStepCompleteEvent, PlanStepEvent, PlanStepFailedEvent,
+    PlanStepReporter,
+};
 use crate::core::assets::{
     evaluate_license_policy, LicenseInfo, LicensePolicyContext, LicensePolicyDecision,
     LicensePolicyStatus,
@@ -32,7 +34,6 @@ use crate::core::{
     fs::{validate_path_id_component, write_bytes_atomic_no_symlink},
     CoreError,
 };
-use crate::ipc::payloads::CommandPayload;
 use crate::AppState;
 
 // =============================================================================
@@ -344,37 +345,23 @@ pub async fn read_agent_trace(
 // Plan Execution
 // =============================================================================
 
-/// Tauri event payload for plan step progress.
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PlanStepEvent {
-    plan_id: String,
-    step_id: String,
-    step_index: usize,
-    total_steps: usize,
+/// Forwards plan step progress to the frontend as Tauri events.
+struct TauriPlanStepReporter<'a> {
+    app: &'a tauri::AppHandle,
 }
 
-/// Tauri event payload for plan step completion.
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PlanStepCompleteEvent {
-    plan_id: String,
-    step_id: String,
-    step_index: usize,
-    total_steps: usize,
-    operation_id: Option<String>,
-    duration_ms: u64,
-}
+impl PlanStepReporter for TauriPlanStepReporter<'_> {
+    fn step_start(&self, event: PlanStepEvent) {
+        let _ = self.app.emit("agent:plan_step_start", event);
+    }
 
-/// Tauri event payload for plan step failure.
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PlanStepFailedEvent {
-    plan_id: String,
-    step_id: String,
-    step_index: usize,
-    total_steps: usize,
-    error: String,
+    fn step_complete(&self, event: PlanStepCompleteEvent) {
+        let _ = self.app.emit("agent:plan_step_complete", event);
+    }
+
+    fn step_failed(&self, event: PlanStepFailedEvent) {
+        let _ = self.app.emit("agent:plan_step_failed", event);
+    }
 }
 
 fn build_agent_plan_failure(
@@ -477,11 +464,12 @@ fn plan_requires_backend_approval_proof(plan: &AgentPlan) -> bool {
 /// respecting step dependencies via topological sort and resolving
 /// `$fromStep`/`$path` references between steps.
 ///
-/// On failure, rolls back completed steps in reverse order and marks their
-/// persisted operation IDs as discarded so the append-only ops log cannot
-/// resurrect partial plan work on reopen or history sync. Emits Tauri events
-/// for each step's lifecycle (`agent:plan_step_start`,
-/// `agent:plan_step_complete`, `agent:plan_step_failed`).
+/// This is the Tauri shell around [`execute_prepared_plan`]: it checks
+/// approval, validates the plan *before* consuming the approval proof, locks
+/// the project, and forwards step lifecycle progress to the frontend as
+/// `agent:plan_step_start` / `agent:plan_step_complete` /
+/// `agent:plan_step_failed`. Execution, rollback and persisted-op discarding
+/// live in the Tauri-free runner.
 #[tauri::command]
 #[specta::specta]
 #[tracing::instrument(skip(app, state), fields(plan_id = %plan.id))]
@@ -530,318 +518,16 @@ pub async fn execute_agent_plan(
     {
         return Ok(build_agent_plan_failure(plan_id, total_steps, start, error));
     }
-    let project_path = project.path.clone();
 
-    let mut step_results: Vec<StepResult> = Vec::with_capacity(total_steps);
-    let mut results_by_id: HashMap<String, StepResult> = HashMap::new();
-    let mut operation_ids: Vec<String> = Vec::new();
-    let mut steps_completed: usize = 0;
-
-    tracing::info!(
-        plan_id = %plan_id,
-        total_steps = total_steps,
-        "Executing agent plan"
-    );
-
-    for &step_idx in &execution_order {
-        let step = &plan.steps[step_idx];
-        let step_start = std::time::Instant::now();
-
-        // Emit step start event
-        let _ = app.emit(
-            "agent:plan_step_start",
-            PlanStepEvent {
-                plan_id: plan_id.clone(),
-                step_id: step.id.clone(),
-                step_index: step_idx,
-                total_steps,
-            },
-        );
-
-        // Resolve $fromStep/$path references in step params
-        let resolved_params = match resolve_step_references(&step.params, &results_by_id) {
-            Ok(params) => params,
-            Err(e) => {
-                let duration_ms = step_start.elapsed().as_millis() as u64;
-                let error_msg = format!("Reference resolution failed: {e}");
-
-                let _ = app.emit(
-                    "agent:plan_step_failed",
-                    PlanStepFailedEvent {
-                        plan_id: plan_id.clone(),
-                        step_id: step.id.clone(),
-                        step_index: step_idx,
-                        total_steps,
-                        error: error_msg.clone(),
-                    },
-                );
-
-                let result = StepResult {
-                    step_id: step.id.clone(),
-                    success: false,
-                    data: None,
-                    error: Some(error_msg),
-                    duration_ms,
-                    operation_id: None,
-                };
-                step_results.push(result);
-
-                // Rollback completed steps
-                let rollback_report = rollback_steps(project, &executor, step_idx, &step_results);
-
-                return Ok(AgentPlanResult {
-                    plan_id,
-                    success: false,
-                    total_steps,
-                    steps_completed,
-                    step_results,
-                    operation_ids,
-                    rollback_report: Some(rollback_report),
-                    error_message: Some(format!(
-                        "Step '{}' failed: reference resolution error",
-                        step.id
-                    )),
-                    execution_time_ms: start.elapsed().as_millis() as u64,
-                });
-            }
-        };
-
-        // Parse tool_name + resolved_params into a CommandPayload
-        let typed_payload = match CommandPayload::parse(step.tool_name.clone(), resolved_params) {
-            Ok(payload) => payload,
-            Err(e) => {
-                let duration_ms = step_start.elapsed().as_millis() as u64;
-                let error_msg = format!("Invalid command '{}': {e}", step.tool_name);
-
-                let _ = app.emit(
-                    "agent:plan_step_failed",
-                    PlanStepFailedEvent {
-                        plan_id: plan_id.clone(),
-                        step_id: step.id.clone(),
-                        step_index: step_idx,
-                        total_steps,
-                        error: error_msg.clone(),
-                    },
-                );
-
-                let result = StepResult {
-                    step_id: step.id.clone(),
-                    success: false,
-                    data: None,
-                    error: Some(error_msg),
-                    duration_ms,
-                    operation_id: None,
-                };
-                step_results.push(result);
-
-                let rollback_report = rollback_steps(project, &executor, step_idx, &step_results);
-
-                return Ok(AgentPlanResult {
-                    plan_id,
-                    success: false,
-                    total_steps,
-                    steps_completed,
-                    step_results,
-                    operation_ids,
-                    rollback_report: Some(rollback_report),
-                    error_message: Some(format!("Step '{}' failed: invalid command", step.id)),
-                    execution_time_ms: start.elapsed().as_millis() as u64,
-                });
-            }
-        };
-
-        // Build and execute the command
-        let command = typed_payload.build_command(&project_path);
-        match project.executor.execute(command, &mut project.state) {
-            Ok(cmd_result) => {
-                let duration_ms = step_start.elapsed().as_millis() as u64;
-                let op_id = cmd_result.op_id.clone();
-
-                let step_data = serde_json::json!({
-                    "operationId": op_id,
-                    "createdIds": cmd_result.created_ids,
-                    "deletedIds": cmd_result.deleted_ids,
-                });
-
-                let result = StepResult {
-                    step_id: step.id.clone(),
-                    success: true,
-                    data: Some(step_data),
-                    error: None,
-                    duration_ms,
-                    operation_id: Some(op_id.clone()),
-                };
-
-                let _ = app.emit(
-                    "agent:plan_step_complete",
-                    PlanStepCompleteEvent {
-                        plan_id: plan_id.clone(),
-                        step_id: step.id.clone(),
-                        step_index: step_idx,
-                        total_steps,
-                        operation_id: Some(op_id.clone()),
-                        duration_ms,
-                    },
-                );
-
-                operation_ids.push(op_id);
-                results_by_id.insert(step.id.clone(), result.clone());
-                step_results.push(result);
-                steps_completed += 1;
-
-                tracing::debug!(
-                    step_id = %step.id,
-                    step_index = step_idx,
-                    duration_ms = duration_ms,
-                    "Plan step completed successfully"
-                );
-            }
-            Err(e) => {
-                let duration_ms = step_start.elapsed().as_millis() as u64;
-                let error_msg = format!("Command execution failed: {e}");
-
-                let _ = app.emit(
-                    "agent:plan_step_failed",
-                    PlanStepFailedEvent {
-                        plan_id: plan_id.clone(),
-                        step_id: step.id.clone(),
-                        step_index: step_idx,
-                        total_steps,
-                        error: error_msg.clone(),
-                    },
-                );
-
-                let result = StepResult {
-                    step_id: step.id.clone(),
-                    success: false,
-                    data: None,
-                    error: Some(error_msg),
-                    duration_ms,
-                    operation_id: None,
-                };
-                step_results.push(result);
-
-                tracing::warn!(
-                    step_id = %step.id,
-                    step_index = step_idx,
-                    error = %e,
-                    "Plan step failed, initiating rollback"
-                );
-
-                // Rollback completed steps
-                let rollback_report = rollback_steps(project, &executor, step_idx, &step_results);
-
-                return Ok(AgentPlanResult {
-                    plan_id,
-                    success: false,
-                    total_steps,
-                    steps_completed,
-                    step_results,
-                    operation_ids,
-                    rollback_report: Some(rollback_report),
-                    error_message: Some(format!("Step '{}' failed during execution", step.id)),
-                    execution_time_ms: start.elapsed().as_millis() as u64,
-                });
-            }
-        }
-    }
-
-    tracing::info!(
-        plan_id = %plan_id,
-        steps_completed = steps_completed,
-        elapsed_ms = start.elapsed().as_millis(),
-        "Agent plan executed successfully"
-    );
-
-    Ok(AgentPlanResult {
-        plan_id,
-        success: true,
-        total_steps,
-        steps_completed,
-        step_results,
-        operation_ids,
-        rollback_report: None,
-        error_message: None,
-        execution_time_ms: start.elapsed().as_millis() as u64,
-    })
-}
-
-/// Rollback completed steps in reverse order and exclude their persisted ops from history replay.
-fn rollback_steps(
-    project: &mut crate::ActiveProject,
-    executor: &PlanExecutor,
-    failed_index: usize,
-    step_results: &[StepResult],
-) -> crate::core::ai::agent_plan::RollbackReport {
-    // Build the initial report (with candidate steps identified)
-    let mut report = executor.build_rollback_report(failed_index, step_results);
-
-    if !report.attempted {
-        return report;
-    }
-
-    // Undo completed operations in reverse order via the CommandExecutor's undo stack
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
-    let mut rollback_errors = Vec::new();
-    let completed_operation_ids = step_results
-        .iter()
-        .filter_map(|result| result.operation_id.clone())
-        .collect::<Vec<_>>();
-
-    for step_id in &report.rolled_back_steps.clone() {
-        match project.executor.undo(&mut project.state) {
-            Ok(()) => {
-                succeeded += 1;
-                tracing::debug!(step_id = %step_id, "Rolled back step successfully");
-            }
-            Err(e) => {
-                failed += 1;
-                let error_msg = format!("Failed to undo step '{}': {}", step_id, e);
-                tracing::error!("{}", error_msg);
-                rollback_errors.push(error_msg);
-                // Stop rollback on first undo failure to avoid inconsistent state
-                break;
-            }
-        }
-    }
-
-    if !completed_operation_ids.is_empty() {
-        match project.discard_persisted_operations(&completed_operation_ids) {
-            Ok(still_applied) => {
-                if still_applied.is_empty() {
-                    tracing::debug!(
-                        discarded_ops = completed_operation_ids.len(),
-                        "Discarded rolled-back agent plan operations from persisted history"
-                    );
-                } else {
-                    // Protected operations stay applied and return on the next
-                    // open, so this rollback did not put the project back.
-                    let error_msg = format!(
-                        "Rollback could not discard protected operation(s) [{}]: they stay in the \
-                         project's applied history and will be present on the next open",
-                        still_applied.join(", ")
-                    );
-                    tracing::error!("{}", error_msg);
-                    rollback_errors.push(error_msg);
-                    failed = failed.max(1);
-                }
-            }
-            Err(e) => {
-                let error_msg =
-                    format!("Failed to discard rolled-back operations from persisted history: {e}");
-                tracing::error!("{}", error_msg);
-                rollback_errors.push(error_msg);
-                failed = failed.max(1);
-            }
-        }
-    }
-
-    report.succeeded_count = succeeded;
-    report.failed_count = failed;
-    report.rollback_errors = rollback_errors;
-
-    report
+    let reporter = TauriPlanStepReporter { app: &app };
+    Ok(execute_prepared_plan(
+        project,
+        &plan,
+        &executor,
+        &execution_order,
+        &reporter,
+        start,
+    ))
 }
 
 // =============================================================================

--- a/src/agents/engine/AgenticEngine.test.ts
+++ b/src/agents/engine/AgenticEngine.test.ts
@@ -943,6 +943,62 @@ describe('AgenticEngine', () => {
       expect(mockToolExecutor.getExecutionCount()).toBe(0);
     });
 
+    it('Given a batch tool that charges what it applied, When the next step runs, Then it sees the smaller remaining budget', async () => {
+      // A batch tool hides many edits behind one plan step, so the budget it
+      // reads has to be live: frozen per iteration, every batch call in the run
+      // is offered the same full remainder.
+      const planWithTwoSteps: Plan = {
+        goal: 'Two batches',
+        steps: [
+          {
+            id: 'step-1',
+            tool: 'split_clip',
+            args: { clipId: 'clip-1', position: 5 },
+            description: 'First batch',
+            riskLevel: 'low',
+            estimatedDuration: 10,
+          },
+          {
+            id: 'step-2',
+            tool: 'split_clip',
+            args: { clipId: 'clip-1', position: 9 },
+            description: 'Second batch',
+            riskLevel: 'low',
+            estimatedDuration: 10,
+            dependsOn: ['step-1'],
+          },
+        ],
+        estimatedTotalDuration: 20,
+        requiresApproval: false,
+        rollbackStrategy: 'Undo operations',
+      };
+
+      let structuredCallCount = 0;
+      vi.spyOn(mockLLM, 'generateStructured').mockImplementation(async () => {
+        structuredCallCount += 1;
+        if (structuredCallCount === 1) return mockThought;
+        if (structuredCallCount === 2) return planWithTwoSteps;
+        return mockObservation;
+      });
+
+      const observedBudgets: Array<number | undefined> = [];
+      const baseExecute = mockToolExecutor.execute.bind(mockToolExecutor);
+      vi.spyOn(mockToolExecutor, 'execute').mockImplementation(async (tool, args, context) => {
+        observedBudgets.push(context.remainingStepBudget);
+        context.chargeStepBudget?.(40);
+        return baseExecute(tool, args, context);
+      });
+
+      const budgetEngine = createAgenticEngine(mockLLM, mockToolExecutor, {
+        enableFastPath: false,
+        maxStepsPerRun: 60,
+      });
+
+      await budgetEngine.run('Run two batches', agentContext, executionContext);
+
+      expect(observedBudgets).toEqual([58, 18]);
+    });
+
     it('Given a destructive fast-path request, When guardrail is enabled, Then approval is required', async () => {
       agentContext.sequenceId = 'sequence-1';
 

--- a/src/agents/engine/AgenticEngine.ts
+++ b/src/agents/engine/AgenticEngine.ts
@@ -107,6 +107,16 @@ export interface AgentRunResult {
   trace?: AgentTrace;
 }
 
+/**
+ * Steps a run has spent against `maxStepsPerRun`.
+ *
+ * Mutable and shared with the run's execution contexts, because a batch tool
+ * applies many edits behind a single plan step and has to charge them back.
+ */
+interface RunStepBudget {
+  spent: number;
+}
+
 // =============================================================================
 // AgenticEngine Class
 // =============================================================================
@@ -221,7 +231,7 @@ export class AgenticEngine {
 
     const startTime = Date.now();
     const executionResults: ExecutionResult[] = [];
-    let plannedStepCount = 0;
+    const stepBudget: RunStepBudget = { spent: 0 };
     let toolCallsUsed = 0;
 
     let contextWithTools = await this.hydrateContextWithMemory(agentContext);
@@ -405,7 +415,7 @@ export class AgenticEngine {
 
         plan = this.enforceDestructiveApproval(plan);
 
-        const attemptedStepCount = plannedStepCount + plan.steps.length;
+        const attemptedStepCount = stepBudget.spent + plan.steps.length;
         if (attemptedStepCount > this.config.maxStepsPerRun) {
           const err = new StepBudgetExceededError(this.config.maxStepsPerRun, attemptedStepCount);
           state.error = err;
@@ -423,7 +433,7 @@ export class AgenticEngine {
             trace: tracer?.finalize(false, err.message),
           });
         }
-        plannedStepCount = attemptedStepCount;
+        stepBudget.spent = attemptedStepCount;
 
         state.plan = plan;
         tracer?.endPhase();
@@ -533,12 +543,14 @@ export class AgenticEngine {
         tracer?.startPhase('executing');
 
         const stepById = new Map<string, PlanStep>(plan.steps.map((s) => [s.id, s]));
-        const executionContextForIteration: ExecutionContext = {
-          ...executionContext,
-          expectedStateVersion:
-            state.context.projectStateVersion ?? executionContext.expectedStateVersion,
-          remainingStepBudget: Math.max(0, this.config.maxStepsPerRun - plannedStepCount),
-        };
+        const executionContextForIteration = this.withStepBudget(
+          {
+            ...executionContext,
+            expectedStateVersion:
+              state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+          },
+          stepBudget,
+        );
         const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
 
         if (remainingToolCalls <= 0) {
@@ -1057,12 +1069,14 @@ export class AgenticEngine {
       tracer?.startPhase('executing');
 
       const stepById = new Map<string, PlanStep>(plan.steps.map((step) => [step.id, step]));
-      const executionContextForIteration: ExecutionContext = {
-        ...executionContext,
-        expectedStateVersion:
-          state.context.projectStateVersion ?? executionContext.expectedStateVersion,
-        remainingStepBudget: Math.max(0, this.config.maxStepsPerRun - plan.steps.length),
-      };
+      const executionContextForIteration = this.withStepBudget(
+        {
+          ...executionContext,
+          expectedStateVersion:
+            state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+        },
+        { spent: plan.steps.length },
+      );
       const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
 
       if (remainingToolCalls <= 0) {
@@ -1507,12 +1521,14 @@ export class AgenticEngine {
     tracer?.startPhase('executing');
 
     const stepById = new Map<string, PlanStep>(plan.steps.map((step) => [step.id, step]));
-    const executionContextForIteration: ExecutionContext = {
-      ...executionContext,
-      expectedStateVersion:
-        state.context.projectStateVersion ?? executionContext.expectedStateVersion,
-      remainingStepBudget: Math.max(0, this.config.maxStepsPerRun - plan.steps.length),
-    };
+    const executionContextForIteration = this.withStepBudget(
+      {
+        ...executionContext,
+        expectedStateVersion:
+          state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+      },
+      { spent: plan.steps.length },
+    );
     const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
 
     if (remainingToolCalls <= 0) {
@@ -1808,6 +1824,31 @@ export class AgenticEngine {
         trace: tracer?.finalize(observation.goalAchieved),
       },
     );
+  }
+
+  /**
+   * Attach live per-run step accounting to an execution context.
+   *
+   * `remainingStepBudget` is a getter rather than a snapshot so that a batch
+   * tool charging what it applied immediately shrinks the budget the next call
+   * sees. Frozen as a number it bounded a single call, and N batch calls in one
+   * run were each offered the whole remainder.
+   */
+  private withStepBudget(context: ExecutionContext, budget: RunStepBudget): ExecutionContext {
+    const maxStepsPerRun = this.config.maxStepsPerRun;
+
+    return {
+      ...context,
+      get remainingStepBudget(): number {
+        return Math.max(0, maxStepsPerRun - budget.spent);
+      },
+      chargeStepBudget: (steps: number): void => {
+        if (!Number.isFinite(steps) || steps <= 0) {
+          return;
+        }
+        budget.spent += Math.trunc(steps);
+      },
+    };
   }
 
   private enforceDestructiveApproval(plan: Plan): Plan {

--- a/src/agents/engine/AgenticEngine.ts
+++ b/src/agents/engine/AgenticEngine.ts
@@ -537,6 +537,7 @@ export class AgenticEngine {
           ...executionContext,
           expectedStateVersion:
             state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+          remainingStepBudget: Math.max(0, this.config.maxStepsPerRun - plannedStepCount),
         };
         const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
 
@@ -1060,6 +1061,7 @@ export class AgenticEngine {
         ...executionContext,
         expectedStateVersion:
           state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+        remainingStepBudget: Math.max(0, this.config.maxStepsPerRun - plan.steps.length),
       };
       const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
 
@@ -1509,6 +1511,7 @@ export class AgenticEngine {
       ...executionContext,
       expectedStateVersion:
         state.context.projectStateVersion ?? executionContext.expectedStateVersion,
+      remainingStepBudget: Math.max(0, this.config.maxStepsPerRun - plan.steps.length),
     };
     const remainingToolCalls = this.config.maxToolCallsPerRun - toolCallsUsed;
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.backendSafety.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.backendSafety.test.ts
@@ -16,9 +16,11 @@ import { registerAllTools, unregisterAllTools } from '@/agents/tools';
 import { getMetaToolNames } from '@/agents/tools/metaTools';
 import { resetFeatureFlags, setFeatureFlag } from '@/config/featureFlags';
 import { isMutatingToolName } from '@/agents/engine/core/toolSemantics';
+import { getToolOutputContract } from '@/agents/toolOutputContracts';
 import {
   getBackendDirectToolNames,
   hasCompoundExpander,
+  normalizeBackendSingleStepData,
   MAX_PLAN_STEPS,
 } from './BackendToolExecutor';
 import { registerDefaultCompoundExpanders } from './registerDefaultCompoundExpanders';
@@ -54,6 +56,9 @@ const FRONTEND_ONLY_MUTATING_TOOLS: Readonly<Record<string, string>> = {
   delete_text_clip: 'resolves sequence/track from the clip id',
   set_text_transform: 'composes against the transform currently on the clip',
   insert_clip_from_file: 'resolves the workspace file, then refreshes to learn the assetId',
+  insert_clip:
+    'result contract (linkedAudio/durationSec/sourceIn/sourceOut) is reconstructed from the ' +
+    'refreshed snapshot; backend CommandResult does not carry it',
 
   // Not a CommandPayload at all.
   delete_transcript_range: 'dedicated IPC, no command payload',
@@ -138,7 +143,6 @@ describe('BackendToolExecutor backend safety', () => {
       'create_workspace_folder',
       'delete_clip',
       'delete_workspace_entry',
-      'insert_clip',
       'move_clip',
       'move_workspace_entry',
       'mute_clip',
@@ -153,6 +157,127 @@ describe('BackendToolExecutor backend safety', () => {
       'trim_clip',
       'update_mask',
     ]);
+  });
+});
+
+/**
+ * Files that promise result paths to the model: the machine-readable contracts
+ * and the two prompts that quote them in prose.
+ */
+const PROMISED_PATH_SOURCES = [
+  '../../../toolOutputContracts.ts',
+  '../../prompts/toolReference.ts',
+  '../../phases/Planner.ts',
+] as const;
+
+/** Every `data.*` path any contract or prompt names, in any form. */
+function collectPromisedResultPaths(): string[] {
+  const paths = new Set<string>();
+
+  for (const relativePath of PROMISED_PATH_SOURCES) {
+    const source = readFileSync(resolve(__dirname, relativePath), 'utf-8');
+    for (const match of source.matchAll(/\bdata(?:\.[A-Za-z_][A-Za-z0-9_]*|\[\d+\])+/g)) {
+      paths.add(match[0]);
+    }
+  }
+
+  return [...paths].sort();
+}
+
+function resolveResultPath(root: unknown, path: string): unknown {
+  const segments = path.match(/[A-Za-z_][A-Za-z0-9_]*|\[\d+\]/g) ?? [];
+  let current: unknown = { data: root };
+
+  for (const segment of segments) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+
+    if (segment.startsWith('[')) {
+      if (!Array.isArray(current)) {
+        return undefined;
+      }
+      current = current[Number(segment.slice(1, -1))];
+      continue;
+    }
+
+    if (typeof current !== 'object' || Array.isArray(current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+describe('backend route result fidelity', () => {
+  /**
+   * A backend-routed tool returns the backend `CommandResult` reshaped by
+   * `normalizeBackendSingleStepData` — never anything read back from the
+   * refreshed store. So every result path its output contract accepts has to
+   * exist in that shape, or a chained `$fromStep` reference passes plan-time
+   * validation and then fails at runtime with the earlier edit already applied.
+   */
+  it('satisfies every result path the contracts and prompts promise', () => {
+    const promisedPaths = collectPromisedResultPaths();
+    const canonicalStepData = {
+      operationId: 'op-1',
+      createdIds: ['created-1', 'created-2'],
+      deletedIds: ['deleted-1'],
+    };
+    const canonicalParams = {
+      sequenceId: 'seq-1',
+      trackId: 'track-1',
+      clipId: 'clip-1',
+      assetId: 'asset-1',
+    };
+
+    const unmet: string[] = [];
+    for (const toolName of getBackendDirectToolNames()) {
+      const contract = getToolOutputContract(toolName);
+      if (!contract) {
+        continue;
+      }
+
+      const normalized = normalizeBackendSingleStepData(
+        toolName,
+        canonicalParams,
+        canonicalStepData,
+      );
+      const accepted = new Set([
+        ...contract.examples,
+        ...(contract.validatePath
+          ? promisedPaths.filter((path) => contract.validatePath!(path))
+          : []),
+      ]);
+
+      for (const path of [...accepted].sort()) {
+        if (resolveResultPath(normalized, path) === undefined) {
+          unmet.push(`${toolName} -> ${path}`);
+        }
+      }
+    }
+
+    expect(
+      unmet,
+      'These backend routes promise result paths their backend result does not carry:\n' +
+        `  ${unmet.join('\n  ')}\n` +
+        'Pick one:\n' +
+        '  - map the field in normalizeBackendSingleStepData (only possible from the ' +
+        'CommandResult ids the backend already returns)\n' +
+        '  - surface the field through the backend CommandResult itself\n' +
+        '  - drop the BACKEND_DIRECT_ROUTES entry and record the tool in ' +
+        'FRONTEND_ONLY_MUTATING_TOOLS with the contract as the reason.',
+    ).toEqual([]);
+  });
+
+  it('collects the promised paths it claims to check', () => {
+    // A silently empty corpus would make the guard above pass vacuously.
+    const promisedPaths = collectPromisedResultPaths();
+
+    expect(promisedPaths).toContain('data.linkedAudio.clipId');
+    expect(promisedPaths).toContain('data.newClipId');
+    expect(promisedPaths).toContain('data.createdIds[0]');
   });
 });
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.backendSafety.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.backendSafety.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Cross-surface guards for the atomic batch plan path.
+ *
+ * `execute_plan` promotes a batch of tool calls into one atomic backend plan,
+ * so every mutating tool must carry an explicit decision about whether it can
+ * ride that path. This guard fails when a newly registered mutating tool has no
+ * decision recorded — the point is to force the choice, not to let a tool
+ * silently default to "frontend only" and quietly stay out of every batch.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { globalToolRegistry } from '@/agents/ToolRegistry';
+import { registerAllTools, unregisterAllTools } from '@/agents/tools';
+import { getMetaToolNames } from '@/agents/tools/metaTools';
+import { resetFeatureFlags, setFeatureFlag } from '@/config/featureFlags';
+import { isMutatingToolName } from '@/agents/engine/core/toolSemantics';
+import {
+  getBackendDirectToolNames,
+  hasCompoundExpander,
+  MAX_PLAN_STEPS,
+} from './BackendToolExecutor';
+import { registerDefaultCompoundExpanders } from './registerDefaultCompoundExpanders';
+
+/**
+ * Mutating tools that deliberately stay on the frontend, with the reason.
+ *
+ * Each of these does work the backend command does not: it resolves a name,
+ * reads the timeline snapshot, or issues more than one command. Moving one here
+ * to a backend route means proving the backend command alone is equivalent.
+ */
+const FRONTEND_ONLY_MUTATING_TOOLS: Readonly<Record<string, string>> = {
+  // Fan out over clips read from the timeline snapshot.
+  mute_track: 'expands to one SetClipMute per clip on the track',
+  delete_clips_in_range: 'selects the overlapping clips from the snapshot',
+  split_timeline_by_interval: 'enumerates split boundaries from the snapshot',
+  copy_effects: "enumerates the source clip's effects from the snapshot",
+  reset_effects: "enumerates the target clip's effect ids from the snapshot",
+  freeze_frame: 'derives frame duration from clip speed/frameRate, then 4 commands',
+  remove_transition: 'scans the track to find the clip owning the effect',
+  adjust_volume: 'branches clip vs track and converts percent to dB',
+  normalize_audio: 'synthesizes a loudness_normalize effect with clamped params',
+
+  // Resolve ids or merge against current state before the command.
+  add_caption: 'ensures the caption track exists, which may add a track first',
+  update_caption: 'resolves the caption track id from the sequence',
+  delete_caption: 'resolves the caption track id from the sequence',
+  style_caption: 'folds ~20 flat args into one style object',
+  add_captions_from_transcription: 'maps source time to timeline time, then sets track language',
+  import_captions_from_file: 'reads a workspace file and parses SRT/VTT',
+  add_text_clip: 'ensures a text track, auto-places, then sets the transform',
+  update_text_clip: "merges flat args onto the clip's existing textData",
+  delete_text_clip: 'resolves sequence/track from the clip id',
+  set_text_transform: 'composes against the transform currently on the clip',
+  insert_clip_from_file: 'resolves the workspace file, then refreshes to learn the assetId',
+
+  // Not a CommandPayload at all.
+  delete_transcript_range: 'dedicated IPC, no command payload',
+  apply_editing_style: 'generates a plan backend-side and executes it itself',
+  write_workspace_document: 'document IPC, no command payload',
+  replace_workspace_document_text: 'read-modify-write against document content',
+  generate_timeline_media: 'generation job API plus placement intent',
+  resolve_generation_job: 'generation job polling API',
+  import_asset_candidate: 'license-gated download and import',
+  generate_video: 'generation job API',
+  cancel_generation: 'generation job API',
+};
+
+describe('BackendToolExecutor backend safety', () => {
+  beforeAll(() => {
+    globalToolRegistry.clear();
+    // Audit the full surface, including the flag-gated generation tools.
+    setFeatureFlag('USE_VIDEO_GENERATION', true);
+    registerAllTools();
+    registerDefaultCompoundExpanders();
+  });
+
+  afterAll(() => {
+    unregisterAllTools();
+    globalToolRegistry.clear();
+    resetFeatureFlags();
+  });
+
+  it('records a backend-safety decision for every registered mutating tool', () => {
+    const metaToolNames = new Set(getMetaToolNames());
+    const backendDirect = new Set(getBackendDirectToolNames());
+
+    const undecided = globalToolRegistry
+      .listAll()
+      .filter((tool) => !metaToolNames.has(tool.name))
+      .filter((tool) => isMutatingToolName(tool.name, tool.category))
+      .map((tool) => tool.name)
+      .filter(
+        (name) =>
+          !backendDirect.has(name) &&
+          !hasCompoundExpander(name) &&
+          !(name in FRONTEND_ONLY_MUTATING_TOOLS),
+      );
+
+    expect(
+      undecided,
+      `These mutating tools have no backend-safety decision: ${undecided.join(', ')}.\n` +
+        'Pick one:\n' +
+        '  - args map 1:1 onto a CommandPayload with no frontend orchestration ' +
+        '=> add a BACKEND_DIRECT_ROUTES entry in BackendToolExecutor.ts\n' +
+        '  - the transform into commands is deterministic and state-free but not 1:1 ' +
+        '=> add a route with mapParams, or a compound expander for multi-command cases\n' +
+        '  - it resolves names, reads the store, or is not a command at all ' +
+        '=> add it to FRONTEND_ONLY_MUTATING_TOOLS in this file with the reason.',
+    ).toEqual([]);
+  });
+
+  it('keeps every recorded decision pointing at a tool that still exists', () => {
+    const registered = new Set(globalToolRegistry.listAll().map((tool) => tool.name));
+
+    const staleFrontendOnly = Object.keys(FRONTEND_ONLY_MUTATING_TOOLS).filter(
+      (name) => !registered.has(name),
+    );
+    const staleBackendDirect = getBackendDirectToolNames().filter((name) => !registered.has(name));
+
+    expect(staleFrontendOnly, 'frontend-only entries for tools that no longer exist').toEqual([]);
+    expect(staleBackendDirect, 'backend routes for tools that no longer exist').toEqual([]);
+  });
+
+  it('routes exactly the audited tool set to the backend', () => {
+    // Pinned explicitly: growing this list is a decision, not a side effect.
+    expect([...getBackendDirectToolNames()].sort()).toEqual([
+      'add_effect',
+      'add_fade_in',
+      'add_fade_out',
+      'add_marker',
+      'add_mask',
+      'add_track',
+      'add_transition',
+      'adjust_effect_param',
+      'change_clip_speed',
+      'create_workspace_folder',
+      'delete_clip',
+      'delete_workspace_entry',
+      'insert_clip',
+      'move_clip',
+      'move_workspace_entry',
+      'mute_clip',
+      'remove_effect',
+      'remove_marker',
+      'remove_mask',
+      'remove_track',
+      'rename_track',
+      'rename_workspace_entry',
+      'set_transition_duration',
+      'split_clip',
+      'trim_clip',
+      'update_mask',
+    ]);
+  });
+});
+
+describe('plan step cap', () => {
+  it('pins the same cap the Rust plan surfaces enforce', () => {
+    // A cap that disagrees across surfaces is worse than no cap: the same plan
+    // would be accepted by one entry point and refused by another.
+    const planExecutorSource = readFileSync(
+      resolve(__dirname, '../../../../../src-tauri/src/core/ai/plan_executor.rs'),
+      'utf-8',
+    );
+
+    const match = planExecutorSource.match(/pub const MAX_PLAN_STEPS: usize = (\d+);/);
+
+    expect(match, 'MAX_PLAN_STEPS must stay declared in plan_executor.rs').not.toBeNull();
+    expect(Number(match![1])).toBe(MAX_PLAN_STEPS);
+    expect(MAX_PLAN_STEPS).toBe(1000);
+  });
+});

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.backendSafety.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.backendSafety.test.ts
@@ -18,6 +18,7 @@ import { resetFeatureFlags, setFeatureFlag } from '@/config/featureFlags';
 import { isMutatingToolName } from '@/agents/engine/core/toolSemantics';
 import { getToolOutputContract } from '@/agents/toolOutputContracts';
 import {
+  buildBackendRoutePayload,
   getBackendDirectToolNames,
   hasCompoundExpander,
   normalizeBackendSingleStepData,
@@ -157,6 +158,131 @@ describe('BackendToolExecutor backend safety', () => {
       'trim_clip',
       'update_mask',
     ]);
+  });
+
+  it('pins the backend command every route emits', () => {
+    // The command name is a plain string on both sides, so nothing but this
+    // catches a rename. A wrong name fails at CommandPayload::parse mid-plan,
+    // after the earlier steps applied and had to be rolled back.
+    const commandTypeByToolName = Object.fromEntries(
+      getBackendDirectToolNames().map((toolName) => [
+        toolName,
+        buildBackendRoutePayload(toolName, {})?.commandType,
+      ]),
+    );
+
+    expect(commandTypeByToolName).toEqual({
+      add_effect: 'addEffect',
+      add_fade_in: 'setClipAudio',
+      add_fade_out: 'setClipAudio',
+      add_marker: 'addMarker',
+      add_mask: 'addMask',
+      add_track: 'addTrack',
+      add_transition: 'addEffect',
+      adjust_effect_param: 'updateEffect',
+      change_clip_speed: 'changeClipSpeed',
+      create_workspace_folder: 'createFolder',
+      delete_clip: 'deleteClip',
+      delete_workspace_entry: 'deleteFile',
+      move_clip: 'moveClip',
+      move_workspace_entry: 'moveFile',
+      mute_clip: 'setClipMute',
+      remove_effect: 'removeEffect',
+      remove_marker: 'removeMarker',
+      remove_mask: 'removeMask',
+      remove_track: 'removeTrack',
+      rename_track: 'renameTrack',
+      rename_workspace_entry: 'renameFile',
+      set_transition_duration: 'updateEffect',
+      split_clip: 'splitClip',
+      trim_clip: 'trimClip',
+      update_mask: 'updateMask',
+    });
+  });
+
+  it('pins the payload every param-transforming route emits', () => {
+    // These payload structs deny unknown fields, so an added or renamed key is
+    // a hard parse rejection. Golden inputs make the transform reviewable.
+    expect(
+      buildBackendRoutePayload('add_transition', {
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        clipId: 'clip-1',
+        transitionType: 'dissolve',
+        duration: 1,
+      }),
+    ).toEqual({
+      commandType: 'addEffect',
+      params: {
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        clipId: 'clip-1',
+        effectType: 'cross_dissolve',
+        params: { duration: 1 },
+      },
+    });
+
+    expect(
+      buildBackendRoutePayload('set_transition_duration', {
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        transitionId: 'effect-1',
+        duration: 1,
+      }),
+    ).toEqual({
+      commandType: 'updateEffect',
+      params: { effectId: 'effect-1', params: { duration: 1 } },
+    });
+
+    expect(
+      buildBackendRoutePayload('adjust_effect_param', {
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        clipId: 'clip-1',
+        effectId: 'effect-1',
+        paramName: 'opacity',
+        paramValue: 0.5,
+      }),
+    ).toEqual({
+      commandType: 'updateEffect',
+      params: { effectId: 'effect-1', params: { opacity: 0.5 } },
+    });
+
+    expect(
+      buildBackendRoutePayload('add_fade_in', {
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        clipId: 'clip-1',
+        duration: 1.5,
+      }),
+    ).toEqual({
+      commandType: 'setClipAudio',
+      params: { sequenceId: 'seq-1', trackId: 'track-1', clipId: 'clip-1', fadeInSec: 1.5 },
+    });
+
+    expect(
+      buildBackendRoutePayload('add_fade_out', {
+        sequenceId: 'seq-1',
+        trackId: 'track-1',
+        clipId: 'clip-1',
+        duration: 1.5,
+      }),
+    ).toEqual({
+      commandType: 'setClipAudio',
+      params: { sequenceId: 'seq-1', trackId: 'track-1', clipId: 'clip-1', fadeOutSec: 1.5 },
+    });
+
+    expect(
+      buildBackendRoutePayload('add_marker', {
+        sequenceId: 'seq-1',
+        time: 2,
+        label: 'Beat',
+        color: 'blue',
+      }),
+    ).toEqual({
+      commandType: 'addMarker',
+      params: { sequenceId: 'seq-1', time: 2, label: 'Beat', color: { r: 0, g: 0, b: 1 } },
+    });
   });
 });
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -14,6 +14,7 @@ import {
   createBackendToolExecutor,
   registerCompoundExpander,
   unregisterCompoundExpander,
+  MAX_PLAN_STEPS,
 } from './BackendToolExecutor';
 import type {
   IToolExecutor,
@@ -175,6 +176,12 @@ const TOOL_DEFS: TestToolDef[] = [
     name: 'add_transition',
     description: 'Add a transition',
     category: 'transition',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'add_text_clip',
+    description: 'Add an on-video text clip',
+    category: 'text',
     parameters: { type: 'object', properties: {} },
   },
   {
@@ -515,17 +522,64 @@ describe('BackendToolExecutor', () => {
       expect(extendedFrontend.execute).not.toHaveBeenCalled();
     });
 
-    it('should fall back to frontend execution for mutating transition tools that are not backend-safe', async () => {
+    it('should route add_transition to backend IPC as an effect command', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'plan-transition',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [
+          { stepId: 'step-1', success: true, data: { createdIds: ['effect-1'] }, durationMs: 5 },
+        ],
+        operationIds: ['op-1'],
+        executionTimeMs: 5,
+      });
+
       const result = await backend.execute(
         'add_transition',
-        { sequenceId: 'seq-1', trackId: 'track-1', clipId: 'clip-1', transitionType: 'dissolve' },
+        {
+          sequenceId: 'seq-1',
+          trackId: 'track-1',
+          clipId: 'clip-1',
+          transitionType: 'dissolve',
+          duration: 1.5,
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(true);
+      // Callers address the new transition by the effect id the command created.
+      expect(result.data).toMatchObject({ transitionId: 'effect-1' });
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          steps: [
+            expect.objectContaining({
+              toolName: 'addEffect',
+              params: {
+                sequenceId: 'seq-1',
+                trackId: 'track-1',
+                clipId: 'clip-1',
+                effectType: 'cross_dissolve',
+                params: { duration: 1.5 },
+              },
+            }),
+          ],
+        }),
+      });
+      expect(frontend.execute).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to frontend execution for mutating tools that are not backend-safe', async () => {
+      const result = await backend.execute(
+        'add_text_clip',
+        { sequenceId: 'seq-1', text: 'Hello', startTime: 0 },
         CONTEXT,
       );
 
       expect(result.success).toBe(true);
       expect(frontend.execute).toHaveBeenCalledWith(
-        'add_transition',
-        { sequenceId: 'seq-1', trackId: 'track-1', clipId: 'clip-1', transitionType: 'dissolve' },
+        'add_text_clip',
+        { sequenceId: 'seq-1', text: 'Hello', startTime: 0 },
         CONTEXT,
       );
       expect(mockInvoke).not.toHaveBeenCalled();
@@ -836,7 +890,7 @@ describe('BackendToolExecutor', () => {
       });
       expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
         plan: expect.objectContaining({
-          goal: expect.stringContaining('legacy execute_plan'),
+          goal: expect.stringContaining('2-step plan atomically'),
           sessionId: 'session-1',
           steps: [
             expect.objectContaining({
@@ -868,9 +922,9 @@ describe('BackendToolExecutor', () => {
               params: { clipId: 'clip-1', splitTime: 5 },
             },
             {
-              id: 'transition-step',
-              toolName: 'add_transition',
-              params: { clipId: 'clip-1b', transitionType: 'dissolve' },
+              id: 'text-step',
+              toolName: 'add_text_clip',
+              params: { text: 'Hello', startTime: 0 },
             },
           ],
         },
@@ -878,7 +932,10 @@ describe('BackendToolExecutor', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('not approved for backend-safe agent execution');
+      // The rejection must name the step that blocked it and list what is supported.
+      expect(result.error).toContain("Step 'text-step'");
+      expect(result.error).toContain('add_text_clip');
+      expect(result.error).toContain('split_clip');
       expect(frontend.execute).not.toHaveBeenCalled();
       expect(mockInvoke).not.toHaveBeenCalled();
     });
@@ -908,7 +965,8 @@ describe('BackendToolExecutor', () => {
         const result = await extendedBackend.execute('execute_plan', args, CONTEXT);
 
         expect(result.success).toBe(false);
-        expect(result.error).toContain('not approved for backend-safe agent execution');
+        expect(result.error).toContain("Step 'ripple-step'");
+        expect(result.error).toContain('Invalid ripple request');
         expect(extendedFrontend.execute).not.toHaveBeenCalled();
         expect(mockInvoke).not.toHaveBeenCalled();
       } finally {
@@ -975,7 +1033,7 @@ describe('BackendToolExecutor', () => {
       });
       expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
         plan: expect.objectContaining({
-          goal: expect.stringContaining('Promote legacy execute_plan'),
+          goal: expect.stringContaining('2-step plan atomically'),
           steps: [
             expect.objectContaining({ id: 'step-a', toolName: 'splitClip' }),
             expect.objectContaining({ id: 'step-b', toolName: 'moveClip' }),
@@ -1050,13 +1108,8 @@ describe('BackendToolExecutor', () => {
           { id: 'step-a', toolName: 'split_clip', params: { clipId: 'clip-1', atTimelineSec: 5 } },
           {
             id: 'step-b',
-            toolName: 'add_transition',
-            params: {
-              sequenceId: 'seq-1',
-              trackId: 'track-1',
-              clipId: 'clip-1',
-              transitionType: 'dissolve',
-            },
+            toolName: 'add_text_clip',
+            params: { sequenceId: 'seq-1', text: 'Hello', startTime: 0 },
           },
         ],
       };
@@ -1064,8 +1117,41 @@ describe('BackendToolExecutor', () => {
       const result = await extendedBackend.execute('execute_plan', args, CONTEXT);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('not approved for backend-safe agent execution');
+      expect(result.error).toContain("Step 'step-b'");
+      expect(result.error).toContain('add_text_clip');
       expect(extendedFrontend.execute).not.toHaveBeenCalled();
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should reject a plan larger than the shared step cap before invoking the backend', async () => {
+      const steps = Array.from({ length: MAX_PLAN_STEPS + 1 }, (_value, index) => ({
+        id: `step-${index}`,
+        toolName: 'split_clip',
+        params: { clipId: 'clip-1', splitTime: index },
+      }));
+
+      const result = await backend.execute('execute_plan', { steps }, CONTEXT);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(String(MAX_PLAN_STEPS));
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should reject a plan that alone exceeds the remaining per-run step budget', async () => {
+      const result = await backend.execute(
+        'execute_plan',
+        {
+          steps: [
+            { id: 'step-a', toolName: 'split_clip', params: { clipId: 'clip-1', splitTime: 1 } },
+            { id: 'step-b', toolName: 'split_clip', params: { clipId: 'clip-1', splitTime: 2 } },
+            { id: 'step-c', toolName: 'split_clip', params: { clipId: 'clip-1', splitTime: 3 } },
+          ],
+        },
+        { ...CONTEXT, remainingStepBudget: 2 },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('step budget');
       expect(mockInvoke).not.toHaveBeenCalled();
     });
   });
@@ -1138,13 +1224,8 @@ describe('BackendToolExecutor', () => {
           tools: [
             { name: 'split_clip', args: { clipId: 'c1', atTimelineSec: 5 } },
             {
-              name: 'add_transition',
-              args: {
-                sequenceId: 'seq-1',
-                trackId: 'track-1',
-                clipId: 'clip-1',
-                transitionType: 'dissolve',
-              },
+              name: 'add_text_clip',
+              args: { sequenceId: 'seq-1', text: 'Hello', startTime: 0 },
             },
           ],
           mode: 'sequential',
@@ -1156,15 +1237,10 @@ describe('BackendToolExecutor', () => {
       expect(result.success).toBe(true);
       expect(result.successCount).toBe(2);
       expect(result.failureCount).toBe(0);
-      expect(result.results.map((entry) => entry.tool)).toEqual(['split_clip', 'add_transition']);
+      expect(result.results.map((entry) => entry.tool)).toEqual(['split_clip', 'add_text_clip']);
       expect(frontend.execute).toHaveBeenCalledWith(
-        'add_transition',
-        {
-          sequenceId: 'seq-1',
-          trackId: 'track-1',
-          clipId: 'clip-1',
-          transitionType: 'dissolve',
-        },
+        'add_text_clip',
+        { sequenceId: 'seq-1', text: 'Hello', startTime: 0 },
         CONTEXT,
       );
     });

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -1166,6 +1166,102 @@ describe('BackendToolExecutor', () => {
       expect(result.error).toContain('step budget');
       expect(mockInvoke).not.toHaveBeenCalled();
     });
+
+    it('should charge applied steps so a later batch in the same run sees the smaller budget', async () => {
+      // A checked-but-never-charged budget bounds one call, not the run: two
+      // batches of 3 would both pass a 4-step remainder.
+      const maxStepsPerRun = 4;
+      const spent = { steps: 0 };
+      const budgetedContext: ExecutionContext = {
+        ...CONTEXT,
+        get remainingStepBudget(): number {
+          return Math.max(0, maxStepsPerRun - spent.steps);
+        },
+        chargeStepBudget: (steps: number): void => {
+          spent.steps += steps;
+        },
+      };
+      const buildSteps = (prefix: string) =>
+        [1, 2, 3].map((index) => ({
+          id: `${prefix}-${index}`,
+          toolName: 'split_clip',
+          params: { clipId: 'clip-1', splitTime: index },
+        }));
+
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'batch-1',
+        success: true,
+        totalSteps: 3,
+        stepsCompleted: 3,
+        stepResults: buildSteps('first').map((step) => ({
+          stepId: step.id,
+          success: true,
+          data: {},
+          durationMs: 1,
+        })),
+        operationIds: ['op-1'],
+        executionTimeMs: 3,
+      });
+
+      const first = await backend.execute(
+        'execute_plan',
+        { steps: buildSteps('first') },
+        budgetedContext,
+      );
+      const second = await backend.execute(
+        'execute_plan',
+        { steps: buildSteps('second') },
+        budgetedContext,
+      );
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(false);
+      expect(second.error).toContain('step budget');
+      expect(second.error).toContain('needs 3 steps but only 1');
+      expect(
+        mockInvoke.mock.calls.filter(([command]) => command === 'execute_agent_plan'),
+      ).toHaveLength(1);
+    });
+
+    it('should not charge a batch the backend rolled back', async () => {
+      const maxStepsPerRun = 4;
+      const spent = { steps: 0 };
+      const budgetedContext: ExecutionContext = {
+        ...CONTEXT,
+        get remainingStepBudget(): number {
+          return Math.max(0, maxStepsPerRun - spent.steps);
+        },
+        chargeStepBudget: (steps: number): void => {
+          spent.steps += steps;
+        },
+      };
+
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'batch-rolled-back',
+        success: false,
+        totalSteps: 3,
+        stepsCompleted: 1,
+        stepResults: [{ stepId: 'roll-1', success: false, error: 'boom', durationMs: 1 }],
+        operationIds: [],
+        errorMessage: 'Step failed',
+        executionTimeMs: 2,
+      });
+
+      const result = await backend.execute(
+        'execute_plan',
+        {
+          steps: [1, 2, 3].map((index) => ({
+            id: `roll-${index}`,
+            toolName: 'split_clip',
+            params: { clipId: 'clip-1', splitTime: index },
+          })),
+        },
+        budgetedContext,
+      );
+
+      expect(result.success).toBe(false);
+      expect(spent.steps).toBe(0);
+    });
   });
 
   // ===========================================================================

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -1877,6 +1877,92 @@ describe('BackendToolExecutor', () => {
       unregisterCompoundExpander('ripple_edit');
     });
 
+    it('should reject a batch whose compound step follows an edit to the same clip', async () => {
+      // Expanders read the timeline at plan-build time and emit absolute
+      // coordinates, so a stale expansion applies cleanly and silently leaves a
+      // gap. Refuse rather than produce one.
+      registerCompoundExpander('ripple_edit', (args) => [
+        { toolName: 'trimClip', params: { clipId: args.clipId, newSourceOut: args.trimEnd } },
+      ]);
+
+      const extendedFrontend = createMockFrontendExecutor([
+        ...TOOL_DEFS,
+        { name: 'ripple_edit', description: 'Ripple edit', category: 'clip', parameters: {} },
+      ]);
+      const extendedBackend = createBackendToolExecutor(extendedFrontend);
+
+      const result = await extendedBackend.execute(
+        'execute_plan',
+        {
+          steps: [
+            {
+              id: 'move-step',
+              toolName: 'move_clip',
+              params: { trackId: 'track-1', clipId: 'clip-1', newTimelineIn: 4 },
+            },
+            {
+              id: 'ripple-step',
+              toolName: 'ripple_edit',
+              params: { trackId: 'track-1', clipId: 'clip-1', trimEnd: 8 },
+            },
+          ],
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Step 'ripple-step'");
+      expect(result.error).toContain('clip-1');
+      expect(result.error).toContain('stale');
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should promote a batch whose compound step comes first', async () => {
+      registerCompoundExpander('ripple_edit', (args) => [
+        { toolName: 'trimClip', params: { clipId: args.clipId, newSourceOut: args.trimEnd } },
+      ]);
+
+      const extendedFrontend = createMockFrontendExecutor([
+        ...TOOL_DEFS,
+        { name: 'ripple_edit', description: 'Ripple edit', category: 'clip', parameters: {} },
+      ]);
+      const extendedBackend = createBackendToolExecutor(extendedFrontend);
+
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'plan-ordered',
+        success: true,
+        totalSteps: 2,
+        stepsCompleted: 2,
+        stepResults: [
+          { stepId: 'ripple-step__1', success: true, data: {}, durationMs: 2 },
+          { stepId: 'move-step', success: true, data: {}, durationMs: 2 },
+        ],
+        operationIds: ['op-1', 'op-2'],
+        executionTimeMs: 4,
+      });
+
+      const result = await extendedBackend.execute(
+        'execute_plan',
+        {
+          steps: [
+            {
+              id: 'ripple-step',
+              toolName: 'ripple_edit',
+              params: { trackId: 'track-1', clipId: 'clip-1', trimEnd: 8 },
+            },
+            {
+              id: 'move-step',
+              toolName: 'move_clip',
+              params: { trackId: 'track-1', clipId: 'clip-1', newTimelineIn: 4 },
+            },
+          ],
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
     it('should expand compound tool into multiple sub-steps for single execute', async () => {
       // Register compound expander for ripple_edit
       registerCompoundExpander('ripple_edit', (args) => [

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.test.ts
@@ -179,6 +179,18 @@ const TOOL_DEFS: TestToolDef[] = [
     parameters: { type: 'object', properties: {} },
   },
   {
+    name: 'set_transition_duration',
+    description: 'Change a transition duration',
+    category: 'transition',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'mute_clip',
+    description: 'Mute a clip',
+    category: 'audio',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
     name: 'add_text_clip',
     description: 'Add an on-video text clip',
     category: 'text',
@@ -1153,6 +1165,127 @@ describe('BackendToolExecutor', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('step budget');
       expect(mockInvoke).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // Mutation preflight sees the tool's own name and args
+  // ===========================================================================
+
+  describe('mutation preflight input fidelity', () => {
+    // The preflight is keyed on the tool name and on argument names. Routes
+    // that rename the command or rewrite the params must not be able to hide a
+    // bad id or a bad number from it, on either the single-call or batch path.
+
+    it('should preflight a renamed route under its own tool name', async () => {
+      const result = await backend.execute(
+        'mute_clip',
+        { sequenceId: 'seq-1', trackId: 'track-missing', clipId: 'clip-1', muted: true },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('PRECONDITION_FAILED');
+      expect(result.error).toContain('track-missing');
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should preflight a renamed route inside a batch under its own tool name', async () => {
+      const result = await backend.execute(
+        'execute_plan',
+        {
+          steps: [
+            {
+              id: 'mute-step',
+              toolName: 'mute_clip',
+              params: { sequenceId: 'seq-1', trackId: 'track-missing', clipId: 'clip-1' },
+            },
+          ],
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('PRECONDITION_FAILED');
+      expect(result.error).toContain('track-missing');
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should preflight a mapParams route against the args the caller sent', async () => {
+      const result = await backend.execute(
+        'set_transition_duration',
+        {
+          sequenceId: 'seq-1',
+          trackId: 'track-missing',
+          transitionId: 'effect-1',
+          duration: -2,
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('PRECONDITION_FAILED');
+      expect(result.error).toContain('track-missing');
+      expect(result.error).toContain('duration must be >= 0');
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should preflight a mapParams route inside a batch against the args the caller sent', async () => {
+      const result = await backend.execute(
+        'execute_plan',
+        {
+          steps: [
+            {
+              id: 'transition-step',
+              toolName: 'set_transition_duration',
+              params: {
+                sequenceId: 'seq-1',
+                trackId: 'track-1',
+                transitionId: 'effect-1',
+                duration: -2,
+              },
+            },
+          ],
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('duration must be >= 0');
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should still promote a batch whose first step passes preflight', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        planId: 'mute-plan',
+        success: true,
+        totalSteps: 1,
+        stepsCompleted: 1,
+        stepResults: [{ stepId: 'mute-step', success: true, data: {}, durationMs: 3 }],
+        operationIds: ['op-1'],
+        executionTimeMs: 3,
+      });
+
+      const result = await backend.execute(
+        'execute_plan',
+        {
+          steps: [
+            {
+              id: 'mute-step',
+              toolName: 'mute_clip',
+              params: { sequenceId: 'seq-1', trackId: 'track-1', clipId: 'clip-1', muted: true },
+            },
+          ],
+        },
+        CONTEXT,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockInvoke).toHaveBeenCalledWith('execute_agent_plan', {
+        plan: expect.objectContaining({
+          steps: [expect.objectContaining({ toolName: 'setClipMute' })],
+        }),
+      });
     });
   });
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -123,9 +123,6 @@ const BACKEND_DIRECT_ROUTES: ReadonlyMap<string, BackendDirectRoute> = new Map<
   ['rename_workspace_entry', { commandType: 'renameFile' }],
   ['move_workspace_entry', { commandType: 'moveFile' }],
   ['delete_workspace_entry', { commandType: 'deleteFile' }],
-  // `InsertClipPayload` has no `audioOnly` field and denies unknown fields;
-  // `InsertMedia` is the composite command the frontend handler already calls.
-  ['insert_clip', { commandType: 'insertMedia' }],
 
   // --- Deterministic arg remaps ---------------------------------------------
   [
@@ -387,7 +384,15 @@ function dedupeDependencies(dependsOn: string[]): string[] {
   return Array.from(new Set(dependsOn.filter((value) => value.length > 0)));
 }
 
-function normalizeBackendSingleStepData(
+/**
+ * Reshape one backend step result into the tool's advertised output shape.
+ *
+ * The backend `CommandResult` only carries `operationId`/`createdIds`/
+ * `deletedIds`, so a route may only exist for a tool whose output contract this
+ * function can satisfy. The route-fidelity guard in
+ * `BackendToolExecutor.backendSafety.test.ts` calls it for exactly that reason.
+ */
+export function normalizeBackendSingleStepData(
   toolName: string,
   params: Record<string, unknown>,
   data: unknown,
@@ -410,13 +415,6 @@ function normalizeBackendSingleStepData(
             ? params.clipId
             : undefined,
       newClipId: typeof data.newClipId === 'string' ? data.newClipId : (createdIds[0] ?? null),
-    };
-  }
-
-  if (toolName === 'insert_clip') {
-    return {
-      ...data,
-      clipId: typeof data.clipId === 'string' ? data.clipId : (createdIds[0] ?? null),
     };
   }
 

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -296,6 +296,17 @@ interface LegacyExecutePlanRoute {
     legacyStepId: string;
     backendStepIds: string[];
   }>;
+  /**
+   * Steps to run the mutation preflight on, under their ORIGINAL tool name and
+   * args.
+   *
+   * The plan's own steps carry backend command names and mapped params by then,
+   * and neither round-trips back to a registered tool, so preflighting those
+   * would silently resolve no category and skip every snapshot check. Only
+   * steps that nothing in the plan precedes are listed: a later step's inputs
+   * may not exist until an earlier step creates them.
+   */
+  preflightSteps: Array<{ toolName: string; params: Record<string, unknown> }>;
 }
 
 /**
@@ -310,6 +321,14 @@ interface BackendExecutionTarget {
   requestedToolName: string;
   effectiveToolName: string;
   params: Record<string, unknown>;
+  /**
+   * The tool's own args, before `mapParams` rewrote them for the payload.
+   *
+   * The mutation preflight is keyed on argument names — `sequenceId`,
+   * `trackId`, `clipId`, `duration` — and several routes rename or drop exactly
+   * those, so it has to see the args the model actually sent.
+   */
+  sourceParams: Record<string, unknown>;
   metaAction?: string;
 }
 
@@ -527,6 +546,7 @@ export class BackendToolExecutor implements IToolExecutor {
         requestedToolName: toolName,
         effectiveToolName: action,
         params: normalizeBackendParamsForBackend(action, metaToolArgs),
+        sourceParams: metaToolArgs,
         metaAction: action,
       };
     }
@@ -539,6 +559,7 @@ export class BackendToolExecutor implements IToolExecutor {
       requestedToolName: toolName,
       effectiveToolName: toolName,
       params: normalizeBackendParamsForBackend(toolName, args),
+      sourceParams: args,
     };
   }
 
@@ -568,6 +589,7 @@ export class BackendToolExecutor implements IToolExecutor {
     const lastBackendStepIdByLegacyId = new Map<string, string>();
     const backendSteps: AgentPlan['steps'] = [];
     const stepMappings: LegacyExecutePlanRoute['stepMappings'] = [];
+    const preflightSteps: LegacyExecutePlanRoute['preflightSteps'] = [];
     let previousLegacyFinalStepId: string | null = null;
 
     for (const step of steps) {
@@ -607,6 +629,10 @@ export class BackendToolExecutor implements IToolExecutor {
 
       const inheritedDependsOn = previousLegacyFinalStepId ? [previousLegacyFinalStepId] : [];
       const firstStepDependsOn = dedupeDependencies([...inheritedDependsOn, ...explicitDependsOn]);
+
+      if (firstStepDependsOn.length === 0) {
+        preflightSteps.push({ toolName: step.toolName, params: step.params });
+      }
 
       const expander = compoundExpanders.get(step.toolName);
       if (expander) {
@@ -692,6 +718,7 @@ export class BackendToolExecutor implements IToolExecutor {
           sessionId: context.sessionId,
         },
         stepMappings,
+        preflightSteps,
       },
     };
   }
@@ -777,13 +804,10 @@ export class BackendToolExecutor implements IToolExecutor {
 
       {
         const planRoute = planOutcome.route;
-        for (const step of planRoute.plan.steps) {
-          if ((step.dependsOn?.length ?? 0) > 0) {
-            continue;
-          }
+        for (const step of planRoute.preflightSteps) {
           const preflightFailure = this.getMutationPreflightFailure(
-            step.toolName.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`),
-            step.params as Record<string, unknown>,
+            step.toolName,
+            step.params,
             context,
           );
           if (preflightFailure) {
@@ -894,7 +918,7 @@ export class BackendToolExecutor implements IToolExecutor {
 
     const preflightFailure = this.getMutationPreflightFailure(
       executionTarget.effectiveToolName,
-      executionTarget.params,
+      executionTarget.sourceParams,
       context,
     );
     if (preflightFailure) {
@@ -1082,7 +1106,7 @@ export class BackendToolExecutor implements IToolExecutor {
         if (shouldPreflightNow) {
           const preflightFailure = this.getMutationPreflightFailure(
             executionTarget.effectiveToolName,
-            executionTarget.params,
+            executionTarget.sourceParams,
             context,
           );
           if (preflightFailure) {

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -48,30 +48,158 @@ const AGENT_PLAN_MUTATION_TIMEOUT_MS = 5 * 60 * 1000;
 // =============================================================================
 
 /**
- * Tools that can be sent directly to backend `CommandPayload::parse` after
- * snake_case -> camelCase normalization.
+ * Upper bound on the steps one `execute_plan` call may carry.
  *
- * Keep this list conservative: only include tools whose public args are already
- * command-shaped and do not rely on extra frontend orchestration.
+ * Pinned to the backstop every other plan surface enforces — see
+ * `MAX_PLAN_STEPS` in `src-tauri/src/core/ai/plan_executor.rs`, which the CLI
+ * (`crates/openreelio-cli/src/commands/plan.rs`) and MCP re-export. A batch
+ * tool is the one place an agent can smuggle unbounded work past the engine's
+ * per-run step budget, so the cap is checked here before the plan is built.
  */
-const BACKEND_DIRECT_TOOLS = new Set([
-  'add_effect',
-  'add_marker',
-  'move_clip',
-  'trim_clip',
-  'split_clip',
-  'delete_clip',
-  'change_clip_speed',
-  'add_track',
-  'remove_track',
-  'rename_track',
-  'remove_effect',
-  'remove_marker',
+export const MAX_PLAN_STEPS = 1000;
+
+/**
+ * A tool that maps onto exactly one backend `CommandPayload`.
+ *
+ * `commandType` is the name `CommandPayload::parse` accepts (its serde alias),
+ * and `mapParams` is the deterministic, state-free transform from the tool's
+ * public args to that payload's fields. A tool belongs here only when the
+ * backend command does everything its frontend handler does; anything that
+ * reads the timeline snapshot, resolves a name, or issues more than one command
+ * is a compound expander or stays on the frontend.
+ */
+interface BackendDirectRoute {
+  readonly commandType: string;
+  readonly mapParams?: (params: Record<string, unknown>) => Record<string, unknown>;
+}
+
+function withoutKeys(
+  params: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  const next = { ...params };
+  for (const key of keys) {
+    delete next[key];
+  }
+  return next;
+}
+
+/** `dissolve` is the tool's spelling of the `cross_dissolve` effect type. */
+function mapTransitionTypeToEffectType(value: unknown): unknown {
+  return value === 'dissolve' ? 'cross_dissolve' : value;
+}
+
+/**
+ * Tools that can be sent directly to backend `CommandPayload::parse`.
+ *
+ * Every entry is an audited 1:1 mapping; the guard test in
+ * `BackendToolExecutor.backendSafety.test.ts` fails when a registered mutating
+ * tool has no decision recorded here or in `BACKEND_FRONTEND_ONLY_TOOLS`.
+ */
+const BACKEND_DIRECT_ROUTES: ReadonlyMap<string, BackendDirectRoute> = new Map<
+  string,
+  BackendDirectRoute
+>([
+  // --- Args are already payload-shaped (name normalizes, fields match) -------
+  ['add_effect', { commandType: 'addEffect' }],
+  ['add_marker', { commandType: 'addMarker' }],
+  ['move_clip', { commandType: 'moveClip' }],
+  ['trim_clip', { commandType: 'trimClip' }],
+  ['split_clip', { commandType: 'splitClip' }],
+  ['delete_clip', { commandType: 'deleteClip' }],
+  ['change_clip_speed', { commandType: 'changeClipSpeed' }],
+  ['add_track', { commandType: 'addTrack' }],
+  ['remove_track', { commandType: 'removeTrack' }],
+  ['rename_track', { commandType: 'renameTrack' }],
+  ['remove_effect', { commandType: 'removeEffect' }],
+  ['remove_marker', { commandType: 'removeMarker' }],
+  ['add_mask', { commandType: 'addMask' }],
+  ['update_mask', { commandType: 'updateMask' }],
+  ['remove_mask', { commandType: 'removeMask' }],
+
+  // --- Fields match; only the command name differs --------------------------
+  ['mute_clip', { commandType: 'setClipMute' }],
+  ['create_workspace_folder', { commandType: 'createFolder' }],
+  ['rename_workspace_entry', { commandType: 'renameFile' }],
+  ['move_workspace_entry', { commandType: 'moveFile' }],
+  ['delete_workspace_entry', { commandType: 'deleteFile' }],
+  // `InsertClipPayload` has no `audioOnly` field and denies unknown fields;
+  // `InsertMedia` is the composite command the frontend handler already calls.
+  ['insert_clip', { commandType: 'insertMedia' }],
+
+  // --- Deterministic arg remaps ---------------------------------------------
+  [
+    'add_transition',
+    {
+      commandType: 'addEffect',
+      mapParams: (params) => ({
+        ...withoutKeys(params, ['transitionType', 'duration']),
+        effectType: mapTransitionTypeToEffectType(params.transitionType),
+        params: { duration: params.duration },
+      }),
+    },
+  ],
+  [
+    'set_transition_duration',
+    {
+      commandType: 'updateEffect',
+      // UpdateEffectPayload denies unknown fields: the locating ids must go.
+      mapParams: (params) => ({
+        effectId: params.transitionId,
+        params: { duration: params.duration },
+      }),
+    },
+  ],
+  [
+    'adjust_effect_param',
+    {
+      commandType: 'updateEffect',
+      mapParams: (params) => ({
+        effectId: params.effectId,
+        params: { [String(params.paramName)]: params.paramValue },
+      }),
+    },
+  ],
+  [
+    'add_fade_in',
+    {
+      commandType: 'setClipAudio',
+      mapParams: (params) => ({
+        ...withoutKeys(params, ['duration']),
+        fadeInSec: params.duration,
+      }),
+    },
+  ],
+  [
+    'add_fade_out',
+    {
+      commandType: 'setClipAudio',
+      mapParams: (params) => ({
+        ...withoutKeys(params, ['duration']),
+        fadeOutSec: params.duration,
+      }),
+    },
+  ],
 ]);
 
+/**
+ * Names of the tools that route straight to a backend command.
+ *
+ * Exported for the backend-safety guard test; execution reads
+ * `BACKEND_DIRECT_ROUTES` directly.
+ */
+export function getBackendDirectToolNames(): readonly string[] {
+  return [...BACKEND_DIRECT_ROUTES.keys()];
+}
+
 function normalizeToolNameForBackend(toolName: string): string {
-  // Backend CommandPayload parsing uses camelCase aliases. Agent tool names are
-  // snake_case, so normalize before sending to execute_agent_plan.
+  const route = BACKEND_DIRECT_ROUTES.get(toolName);
+  if (route) {
+    return route.commandType;
+  }
+
+  // Compound sub-steps and pass-through names: backend CommandPayload parsing
+  // uses camelCase aliases, agent tool names are snake_case.
   return toolName.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
 }
 
@@ -79,12 +207,14 @@ function normalizeBackendParamsForBackend(
   toolName: string,
   params: Record<string, unknown>,
 ): Record<string, unknown> {
+  const routed = BACKEND_DIRECT_ROUTES.get(toolName)?.mapParams?.(params) ?? params;
+
   const isAddMarker = toolName === 'add_marker' || toolName === 'addMarker';
-  if (!isAddMarker || !Object.prototype.hasOwnProperty.call(params, 'color')) {
-    return params;
+  if (!isAddMarker || !Object.prototype.hasOwnProperty.call(routed, 'color')) {
+    return routed;
   }
 
-  const nextParams = { ...params };
+  const nextParams = { ...routed };
   const color = normalizeMarkerColor(nextParams.color);
   if (color) {
     nextParams.color = color;
@@ -171,6 +301,14 @@ interface LegacyExecutePlanRoute {
   }>;
 }
 
+/**
+ * Either a plan promoted to the atomic backend path, or the reason it could
+ * not be — naming the step that blocked it, never a blanket refusal.
+ */
+type LegacyExecutePlanOutcome =
+  | { ok: true; route: LegacyExecutePlanRoute }
+  | { ok: false; error: string };
+
 interface BackendExecutionTarget {
   requestedToolName: string;
   effectiveToolName: string;
@@ -184,16 +322,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function parseLegacyExecutePlanSteps(
   args: Record<string, unknown>,
-): LegacyExecutePlanStep[] | null {
+): { ok: true; steps: LegacyExecutePlanStep[] } | { ok: false; error: string } {
   const rawSteps = args.steps;
-  if (!Array.isArray(rawSteps) || rawSteps.length === 0) {
-    return null;
+  if (!Array.isArray(rawSteps)) {
+    return { ok: false, error: 'execute_plan requires a `steps` array.' };
+  }
+  if (rawSteps.length === 0) {
+    return { ok: false, error: 'execute_plan requires at least one step.' };
+  }
+  if (rawSteps.length > MAX_PLAN_STEPS) {
+    return {
+      ok: false,
+      error:
+        `execute_plan received ${rawSteps.length} steps, which exceeds the maximum of ` +
+        `${MAX_PLAN_STEPS}. Split the work into several plans.`,
+    };
   }
 
   const steps: LegacyExecutePlanStep[] = [];
-  for (const rawStep of rawSteps) {
+  for (const [index, rawStep] of rawSteps.entries()) {
     if (!isRecord(rawStep)) {
-      return null;
+      return { ok: false, error: `Step at index ${index} must be an object.` };
     }
 
     const id = typeof rawStep.id === 'string' ? rawStep.id.trim() : '';
@@ -204,7 +353,15 @@ function parseLegacyExecutePlanSteps(
       : undefined;
 
     if (!id || !toolName || !params) {
-      return null;
+      const missing = [
+        id ? null : 'id',
+        toolName ? null : 'toolName',
+        params ? null : 'params',
+      ].filter((field): field is string => field !== null);
+      return {
+        ok: false,
+        error: `Step at index ${index} is missing required field(s): ${missing.join(', ')}.`,
+      };
     }
 
     steps.push({
@@ -215,7 +372,15 @@ function parseLegacyExecutePlanSteps(
     });
   }
 
-  return steps;
+  return { ok: true, steps };
+}
+
+/**
+ * The tools an `execute_plan` step may use, for rejection messages.
+ * Compound tools are included because they expand into backend steps.
+ */
+function describeSupportedPlanTools(): string {
+  return [...BACKEND_DIRECT_ROUTES.keys(), ...compoundExpanders.keys()].sort().join(', ');
 }
 
 function dedupeDependencies(dependsOn: string[]): string[] {
@@ -255,6 +420,15 @@ function normalizeBackendSingleStepData(
     };
   }
 
+  if (toolName === 'add_transition') {
+    // Callers address a transition by the effect id the command created.
+    return {
+      ...data,
+      transitionId:
+        typeof data.transitionId === 'string' ? data.transitionId : (createdIds[0] ?? null),
+    };
+  }
+
   return data;
 }
 
@@ -287,7 +461,7 @@ export class BackendToolExecutor implements IToolExecutor {
       return true;
     }
 
-    return BACKEND_DIRECT_TOOLS.has(toolName);
+    return BACKEND_DIRECT_ROUTES.has(toolName);
   }
 
   private isUnsafeMutatingFallback(toolName: string, args: Record<string, unknown>): boolean {
@@ -297,13 +471,6 @@ export class BackendToolExecutor implements IToolExecutor {
     }
 
     return requiresProjectMutationPreflight(toolName, toolDefinition.category, args);
-  }
-
-  private buildUnsupportedMutationFailure(toolName: string): ToolExecutionResult {
-    return createFailureResult(
-      `Mutating tool '${toolName}' is not approved for backend-safe agent execution.`,
-      0,
-    );
   }
 
   private getMutationPreflightFailure(
@@ -380,10 +547,23 @@ export class BackendToolExecutor implements IToolExecutor {
   private tryBuildLegacyExecutePlanRoute(
     args: Record<string, unknown>,
     context: ExecutionContext,
-  ): LegacyExecutePlanRoute | null {
-    const steps = parseLegacyExecutePlanSteps(args);
-    if (!steps) {
-      return null;
+  ): LegacyExecutePlanOutcome {
+    const parsed = parseLegacyExecutePlanSteps(args);
+    if (!parsed.ok) {
+      return { ok: false, error: parsed.error };
+    }
+    const steps = parsed.steps;
+
+    // A batch tool call is one tool call but many edit steps, so it must be
+    // charged against the run's step budget like any planned step would be.
+    const remainingStepBudget = context.remainingStepBudget;
+    if (typeof remainingStepBudget === 'number' && steps.length > remainingStepBudget) {
+      return {
+        ok: false,
+        error:
+          `This plan needs ${steps.length} steps but only ${remainingStepBudget} remain in this ` +
+          `run's step budget. Run a smaller plan, or finish the run and start another.`,
+      };
     }
 
     const seenLegacyIds = new Set<string>();
@@ -393,13 +573,23 @@ export class BackendToolExecutor implements IToolExecutor {
     let previousLegacyFinalStepId: string | null = null;
 
     for (const step of steps) {
-      if (seenLegacyIds.has(step.id) || step.toolName === 'execute_plan') {
-        return null;
+      if (seenLegacyIds.has(step.id)) {
+        return { ok: false, error: `Duplicate step id '${step.id}'.` };
+      }
+      if (step.toolName === 'execute_plan') {
+        return { ok: false, error: `Step '${step.id}': execute_plan cannot call itself.` };
       }
       seenLegacyIds.add(step.id);
 
       if (!this.isBackendToolName(step.toolName)) {
-        return null;
+        return {
+          ok: false,
+          error:
+            `Step '${step.id}' uses '${step.toolName}', which has no atomic backend route, ` +
+            `so the whole plan was rejected rather than applied halfway. ` +
+            `Call '${step.toolName}' on its own and keep execute_plan for these tools: ` +
+            `${describeSupportedPlanTools()}.`,
+        };
       }
 
       let explicitDependsOn: string[];
@@ -407,12 +597,14 @@ export class BackendToolExecutor implements IToolExecutor {
         explicitDependsOn = (step.dependsOn ?? []).map((dep) => {
           const mapped = lastBackendStepIdByLegacyId.get(dep);
           if (!mapped) {
-            throw new Error(`Legacy dependency '${dep}' cannot be resolved`);
+            throw new Error(
+              `Step '${step.id}' depends on '${dep}', which is not an earlier step in this plan`,
+            );
           }
           return mapped;
         });
-      } catch {
-        return null;
+      } catch (err) {
+        return { ok: false, error: `${getErrorMessage(err)}.` };
       }
 
       const inheritedDependsOn = previousLegacyFinalStepId ? [previousLegacyFinalStepId] : [];
@@ -423,11 +615,17 @@ export class BackendToolExecutor implements IToolExecutor {
         let expanded: ReturnType<CompoundExpander>;
         try {
           expanded = expander(step.params);
-        } catch {
-          return null;
+        } catch (err) {
+          return {
+            ok: false,
+            error: `Step '${step.id}' (${step.toolName}) could not be expanded: ${getErrorMessage(err)}`,
+          };
         }
         if (expanded.length === 0) {
-          return null;
+          return {
+            ok: false,
+            error: `Step '${step.id}' (${step.toolName}) expanded into no backend commands.`,
+          };
         }
 
         const generatedIds: string[] = [];
@@ -453,7 +651,10 @@ export class BackendToolExecutor implements IToolExecutor {
 
         const finalBackendStepId = generatedIds[generatedIds.length - 1];
         if (!finalBackendStepId) {
-          return null;
+          return {
+            ok: false,
+            error: `Step '${step.id}' (${step.toolName}) produced no executable backend step.`,
+          };
         }
         previousLegacyFinalStepId = finalBackendStepId;
         lastBackendStepIdByLegacyId.set(step.id, finalBackendStepId);
@@ -483,14 +684,17 @@ export class BackendToolExecutor implements IToolExecutor {
     }
 
     return {
-      plan: {
-        id: `legacy-plan-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        goal: `Promote legacy execute_plan to backend atomic execution (${steps.length} steps)`,
-        steps: backendSteps,
-        approvalGranted: true,
-        sessionId: context.sessionId,
+      ok: true,
+      route: {
+        plan: {
+          id: `plan-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          goal: `Execute a ${steps.length}-step plan atomically`,
+          steps: backendSteps,
+          approvalGranted: true,
+          sessionId: context.sessionId,
+        },
+        stepMappings,
       },
-      stepMappings,
     };
   }
 
@@ -562,15 +766,20 @@ export class BackendToolExecutor implements IToolExecutor {
     context: ExecutionContext,
   ): Promise<ToolExecutionResult> {
     if (toolName === 'execute_plan') {
-      let legacyRoute: LegacyExecutePlanRoute | null;
+      let planOutcome: LegacyExecutePlanOutcome;
       try {
-        legacyRoute = this.tryBuildLegacyExecutePlanRoute(args, context);
+        planOutcome = this.tryBuildLegacyExecutePlanRoute(args, context);
       } catch (err) {
         return createFailureResult(`execute_plan validation failed: ${getErrorMessage(err)}`, 0);
       }
 
-      if (legacyRoute) {
-        for (const step of legacyRoute.plan.steps) {
+      if (!planOutcome.ok) {
+        return createFailureResult(`execute_plan rejected: ${planOutcome.error}`, 0);
+      }
+
+      {
+        const planRoute = planOutcome.route;
+        for (const step of planRoute.plan.steps) {
           if ((step.dependsOn?.length ?? 0) > 0) {
             continue;
           }
@@ -583,9 +792,9 @@ export class BackendToolExecutor implements IToolExecutor {
             return createFailureResult(preflightFailure, 0);
           }
         }
-        const execution = await this.invokeBackendPlan(legacyRoute.plan, {
+        const execution = await this.invokeBackendPlan(planRoute.plan, {
           toolName,
-          legacy: true,
+          stepCount: planRoute.plan.steps.length,
         });
 
         if (!execution.ok) {
@@ -604,7 +813,7 @@ export class BackendToolExecutor implements IToolExecutor {
         const stepResultById = new Map(
           execution.result.stepResults.map((stepResult) => [stepResult.stepId, stepResult]),
         );
-        const stepResults = legacyRoute.stepMappings.map((mapping) => {
+        const stepResults = planRoute.stepMappings.map((mapping) => {
           const slice = mapping.backendStepIds
             .map((stepId) => stepResultById.get(stepId))
             .filter((stepResult): stepResult is NonNullable<typeof stepResult> =>
@@ -638,7 +847,7 @@ export class BackendToolExecutor implements IToolExecutor {
             error:
               execution.result.errorMessage ??
               execution.result.rollbackReport?.rollbackErrors?.join('; ') ??
-              'Legacy execute_plan backend promotion failed',
+              'execute_plan failed and was rolled back',
             data: {
               stepResults,
               rollbackReport: execution.result.rollbackReport ?? null,
@@ -663,8 +872,6 @@ export class BackendToolExecutor implements IToolExecutor {
           },
         };
       }
-
-      return this.buildUnsupportedMutationFailure(toolName);
     }
 
     let executionTarget: BackendExecutionTarget | null;

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -590,6 +590,7 @@ export class BackendToolExecutor implements IToolExecutor {
     const backendSteps: AgentPlan['steps'] = [];
     const stepMappings: LegacyExecutePlanRoute['stepMappings'] = [];
     const preflightSteps: LegacyExecutePlanRoute['preflightSteps'] = [];
+    const clipIdsMutatedEarlier = new Set<string>();
     let previousLegacyFinalStepId: string | null = null;
 
     for (const step of steps) {
@@ -635,6 +636,28 @@ export class BackendToolExecutor implements IToolExecutor {
       }
 
       const expander = compoundExpanders.get(step.toolName);
+      const stepClipId = typeof step.params.clipId === 'string' ? step.params.clipId : null;
+
+      if (expander && stepClipId && clipIdsMutatedEarlier.has(stepClipId)) {
+        // Expanders measure the timeline as it is when the plan is BUILT and
+        // emit absolute coordinates, so an earlier step in the same batch that
+        // moved or retimed the clip they measure makes the expansion stale.
+        // The stale commands still apply cleanly, leaving a silent gap or
+        // overlap that the atomic rollback never sees, so refuse up front.
+        return {
+          ok: false,
+          error:
+            `Step '${step.id}' (${step.toolName}) is expanded from the timeline as it is now, ` +
+            `but an earlier step in this plan already edits clip '${stepClipId}', so the ` +
+            `expansion would be stale. Run the steps up to and including that edit as one plan, ` +
+            `then send '${step.toolName}' in the next one.`,
+        };
+      }
+
+      if (stepClipId) {
+        clipIdsMutatedEarlier.add(stepClipId);
+      }
+
       if (expander) {
         let expanded: ReturnType<CompoundExpander>;
         try {

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -878,6 +878,10 @@ export class BackendToolExecutor implements IToolExecutor {
           };
         }
 
+        // The steps really applied, charged in the same unit the budget check
+        // above used. A rolled-back plan applied nothing and is not charged.
+        context.chargeStepBudget?.(planRoute.stepMappings.length);
+
         return {
           success: true,
           data: {

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.ts
@@ -189,6 +189,29 @@ export function getBackendDirectToolNames(): readonly string[] {
   return [...BACKEND_DIRECT_ROUTES.keys()];
 }
 
+/**
+ * The backend command a route emits for a given tool call.
+ *
+ * Exported for the backend-safety guard, which pins both halves: a renamed
+ * command or a quietly changed param mapping is only caught at runtime by a
+ * `deny_unknown_fields` parse error mid-plan, after earlier steps applied.
+ * Returns null for a tool with no route.
+ */
+export function buildBackendRoutePayload(
+  toolName: string,
+  params: Record<string, unknown>,
+): { commandType: string; params: Record<string, unknown> } | null {
+  const route = BACKEND_DIRECT_ROUTES.get(toolName);
+  if (!route) {
+    return null;
+  }
+
+  return {
+    commandType: route.commandType,
+    params: normalizeBackendParamsForBackend(toolName, params),
+  };
+}
+
 function normalizeToolNameForBackend(toolName: string): string {
   const route = BACKEND_DIRECT_ROUTES.get(toolName);
   if (route) {

--- a/src/agents/engine/adapters/tools/BackendToolExecutor.visibility.test.ts
+++ b/src/agents/engine/adapters/tools/BackendToolExecutor.visibility.test.ts
@@ -83,11 +83,18 @@ function createFrontendExecutor(tools: ToolInfo[]): IToolExecutor {
 describe('BackendToolExecutor visibility', () => {
   beforeEach(() => {
     mockIsMetaToolsEnabled.mockReturnValue(true);
-    mockGetVisibleMetaToolNames.mockReturnValue(['query', 'edit', 'audio', 'effects', 'text']);
+    mockGetVisibleMetaToolNames.mockReturnValue([
+      'query',
+      'edit',
+      'audio',
+      'effects',
+      'text',
+      'execute_plan',
+    ]);
     mockGetWorkspaceToolNames.mockReturnValue(['list_workspace_documents']);
   });
 
-  it('hides execute_plan from the default meta-tool surface', () => {
+  it('shows execute_plan and hides individual tools on the default meta-tool surface', () => {
     const frontend = createFrontendExecutor([
       createToolInfo('query', 'analysis'),
       createToolInfo('edit', 'timeline'),
@@ -99,7 +106,7 @@ describe('BackendToolExecutor visibility', () => {
     const backend = new BackendToolExecutor(frontend);
     const visibleNames = backend.getAvailableTools().map((tool) => tool.name);
 
-    expect(visibleNames).toEqual(['query', 'edit', 'list_workspace_documents']);
+    expect(visibleNames).toEqual(['query', 'edit', 'execute_plan', 'list_workspace_documents']);
   });
 
   it('keeps category-specific tool reads unfiltered', () => {

--- a/src/agents/engine/adapters/tools/ToolRegistryAdapter.metaVisibility.test.ts
+++ b/src/agents/engine/adapters/tools/ToolRegistryAdapter.metaVisibility.test.ts
@@ -39,11 +39,18 @@ function createTool(name: string, category: ToolCategory, description = name): T
 describe('ToolRegistryAdapter meta-tool visibility', () => {
   beforeEach(() => {
     mockIsMetaToolsEnabled.mockReturnValue(true);
-    mockGetVisibleMetaToolNames.mockReturnValue(['query', 'edit', 'audio', 'effects', 'text']);
+    mockGetVisibleMetaToolNames.mockReturnValue([
+      'query',
+      'edit',
+      'audio',
+      'effects',
+      'text',
+      'execute_plan',
+    ]);
     mockGetWorkspaceToolNames.mockReturnValue(['list_workspace_documents']);
   });
 
-  it('hides execute_plan and individual tools from the default tool surface', () => {
+  it('shows execute_plan and hides individual tools on the default tool surface', () => {
     const registry = new ToolRegistry();
     registry.register(createTool('query', 'analysis'));
     registry.register(createTool('edit', 'timeline'));
@@ -54,7 +61,7 @@ describe('ToolRegistryAdapter meta-tool visibility', () => {
     const adapter = createToolRegistryAdapter(registry);
     const visibleNames = adapter.getAvailableTools().map((tool) => tool.name);
 
-    expect(visibleNames).toEqual(['query', 'edit', 'list_workspace_documents']);
+    expect(visibleNames).toEqual(['query', 'edit', 'execute_plan', 'list_workspace_documents']);
   });
 
   it('keeps category-specific reads unfiltered for non-LLM callers', () => {

--- a/src/agents/engine/core/permissionSubject.ts
+++ b/src/agents/engine/core/permissionSubject.ts
@@ -5,6 +5,8 @@
  * preserving compatibility with legacy tool-name wildcard rules.
  */
 
+import { getActionDispatchingMetaToolNames } from '@/agents/tools/metaTools';
+
 export type PermissionSubjectType =
   | 'capability'
   | 'resource'
@@ -26,7 +28,17 @@ export interface PermissionSubject {
   aliases: string[];
 }
 
-const META_TOOL_NAMES = new Set(['query', 'edit', 'audio', 'effects', 'text', 'generate']);
+/**
+ * Meta-tool names, derived from the registry that defines them.
+ *
+ * A meta-tool call carries the real tool in its `action` argument, so the
+ * permission subject must be compiled from that action, not from the wrapper.
+ * Deriving the set means a new meta-tool cannot silently be permissioned as
+ * itself.
+ */
+const META_TOOL_NAMES: ReadonlySet<string> = new Set(
+  getActionDispatchingMetaToolNames().map((name) => name.toLowerCase()),
+);
 
 const EXACT_SUBJECTS: Record<string, { subjectType: PermissionSubjectType; subject: string }> = {
   analyze_asset: {

--- a/src/agents/engine/ports/IToolExecutor.ts
+++ b/src/agents/engine/ports/IToolExecutor.ts
@@ -26,6 +26,14 @@ export interface ExecutionContext {
   traceId?: string;
   /** Expected project state version for optimistic consistency checks */
   expectedStateVersion?: number;
+  /**
+   * Plan steps the run may still spend, from the engine's per-run step budget.
+   *
+   * A batch tool applies many edit steps behind a single tool call, so without
+   * this it could smuggle an unbounded amount of work past the budget the
+   * planner is held to. Undefined means the caller imposes no step budget.
+   */
+  remainingStepBudget?: number;
   /** Whether this is a dry run */
   dryRun?: boolean;
 }

--- a/src/agents/engine/ports/IToolExecutor.ts
+++ b/src/agents/engine/ports/IToolExecutor.ts
@@ -31,9 +31,20 @@ export interface ExecutionContext {
    *
    * A batch tool applies many edit steps behind a single tool call, so without
    * this it could smuggle an unbounded amount of work past the budget the
-   * planner is held to. Undefined means the caller imposes no step budget.
+   * planner is held to. Read it at call time: the engine keeps it live, so it
+   * already reflects everything charged earlier in the run. Undefined means the
+   * caller imposes no step budget.
    */
   remainingStepBudget?: number;
+  /**
+   * Charge steps a batch tool actually applied against the run's step budget.
+   *
+   * A checked-but-never-charged budget bounds one call, not the run: N batch
+   * calls would each be offered the full remainder. Call this once per batch
+   * that really executed, with the same step count `remainingStepBudget` was
+   * checked against. Undefined means the caller does no step accounting.
+   */
+  chargeStepBudget?: (steps: number) => void;
   /** Whether this is a dry run */
   dryRun?: boolean;
 }

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -168,7 +168,8 @@ const BATCH_EXECUTION = `## Batch Execution (meta-tool: execute_plan)
 - Prefer execute_plan for any edit of 3+ mutating steps: it applies them as one atomic backend plan (all-or-nothing rollback) in a single round trip, instead of N separate calls that can leave a half-finished timeline.
 - steps: [{ id, toolName, params, dependsOn? }] — toolName is the individual tool (split_clip, add_effect, ...), params are that tool's args. Steps run in order; dependsOn may only name earlier step ids.
 - The plan is rejected as a whole if any step names a tool with no atomic backend route; the error names the step and lists the tools that are supported. Run those steps as individual calls.
-- Use single tool calls when a later step's params depend on an earlier result you have not seen yet.`;
+- Use single tool calls when a later step's params depend on an earlier result you have not seen yet.
+- Compound steps (ripple_edit, roll_edit, slip_edit, slide_edit) are expanded against the timeline as it is when the plan is submitted, not as each step leaves it. Do not put one after a step that shifts the clips it measures — finish that plan first and send the compound step in the next one.`;
 
 const WORKSPACE_READ_TOOLS = `## Workspace Document Tools (read-only)
 - list_workspace_documents / read_workspace_document`;

--- a/src/agents/engine/prompts/toolReference.ts
+++ b/src/agents/engine/prompts/toolReference.ts
@@ -164,6 +164,12 @@ const GENERATE_ACTIONS = `## Generate Actions (meta-tool: generate)
 - import_asset_candidate(candidate, licenseAck=true) → import an approved stock candidate with license snapshot; rejects blocked policy candidates
 - generate_video/check_generation_status/estimate_generation_cost/cancel_generation → provider job primitives used by orchestration when video generation is enabled`;
 
+const BATCH_EXECUTION = `## Batch Execution (meta-tool: execute_plan)
+- Prefer execute_plan for any edit of 3+ mutating steps: it applies them as one atomic backend plan (all-or-nothing rollback) in a single round trip, instead of N separate calls that can leave a half-finished timeline.
+- steps: [{ id, toolName, params, dependsOn? }] — toolName is the individual tool (split_clip, add_effect, ...), params are that tool's args. Steps run in order; dependsOn may only name earlier step ids.
+- The plan is rejected as a whole if any step names a tool with no atomic backend route; the error names the step and lists the tools that are supported. Run those steps as individual calls.
+- Use single tool calls when a later step's params depend on an earlier result you have not seen yet.`;
+
 const WORKSPACE_READ_TOOLS = `## Workspace Document Tools (read-only)
 - list_workspace_documents / read_workspace_document`;
 
@@ -245,6 +251,7 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
         EFFECTS_ACTIONS,
         TEXT_ACTIONS,
         GENERATE_ACTIONS,
+        BATCH_EXECUTION,
         WORKSPACE_TOOLS,
         EDITING_CONCEPTS,
         COMMON_WORKFLOWS,
@@ -259,6 +266,7 @@ function getSectionsForRole(role: ToolReferenceRole): string[] {
         EFFECTS_ACTIONS,
         TEXT_ACTIONS,
         GENERATE_ACTIONS,
+        BATCH_EXECUTION,
         WORKSPACE_READ_TOOLS,
         EDITING_CONCEPTS,
         COMMON_WORKFLOWS,

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -76,9 +76,27 @@ function matchesTimelineInfoPath(path: string): boolean {
   );
 }
 
-function matchesInsertClipPath(path: string): boolean {
+/**
+ * Fields every backend `CommandResult` carries, whatever the command.
+ *
+ * A tool routed straight to the backend can promise these and nothing else —
+ * anything richer has to be reconstructed on the frontend from the refreshed
+ * snapshot, which a backend-routed tool never does.
+ */
+function matchesBackendCommandResultPath(path: string): boolean {
   return (
     path === 'data' ||
+    path === 'data.operationId' ||
+    path === 'data.createdIds' ||
+    /^data\.createdIds\[\d+\]$/.test(path) ||
+    path === 'data.deletedIds' ||
+    /^data\.deletedIds\[\d+\]$/.test(path)
+  );
+}
+
+function matchesInsertClipPath(path: string): boolean {
+  return (
+    matchesBackendCommandResultPath(path) ||
     path === 'data.clipId' ||
     path === 'data.linkedAudio' ||
     path === 'data.linkedAudio.trackId' ||
@@ -86,20 +104,15 @@ function matchesInsertClipPath(path: string): boolean {
     path === 'data.linkedAudio.createdTrack' ||
     path === 'data.sourceIn' ||
     path === 'data.sourceOut' ||
-    path === 'data.durationSec' ||
-    path === 'data.operationId' ||
-    path === 'data.createdIds' ||
-    /^data\.createdIds\[\d+\]$/.test(path)
+    path === 'data.durationSec'
   );
 }
 
 function matchesSplitClipPath(path: string): boolean {
   return (
-    matchesInsertClipPath(path) ||
+    matchesBackendCommandResultPath(path) ||
     path === 'data.newClipId' ||
-    path === 'data.sourceClipId' ||
-    path === 'data.deletedIds' ||
-    /^data\.deletedIds\[\d+\]$/.test(path)
+    path === 'data.sourceClipId'
   );
 }
 

--- a/src/agents/tools/batchToolSteps.ts
+++ b/src/agents/tools/batchToolSteps.ts
@@ -1,0 +1,92 @@
+/**
+ * Batch tool step extraction.
+ *
+ * A batch tool is one tool call that carries a list of other tool calls in its
+ * args. Anything that reasons about "what does this call actually do" —
+ * permission subjects, approval prompts — has to look inside, because the
+ * wrapper name says nothing about the steps.
+ */
+
+/** Tools whose real work is a list of other tool calls, and the arg holding it. */
+const BATCH_TOOL_STEP_KEYS: Readonly<Record<string, string>> = {
+  execute_plan: 'steps',
+};
+
+/** One tool call carried inside a batch tool's args. */
+export interface BatchStepCall {
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Whether a tool carries other tool calls in its args. */
+export function isBatchToolName(toolName: string): boolean {
+  return toolName.trim().toLowerCase() in BATCH_TOOL_STEP_KEYS;
+}
+
+/**
+ * The tool calls a batch tool carries, in order.
+ *
+ * Malformed steps are skipped rather than rejected: this runs on the permission
+ * path, where the job is to see every step that could execute, not to validate
+ * the plan — the executor does that and refuses the whole batch.
+ */
+export function extractBatchStepCalls(
+  toolName: string,
+  args: Record<string, unknown> = {},
+): BatchStepCall[] {
+  const stepsKey = BATCH_TOOL_STEP_KEYS[toolName.trim().toLowerCase()];
+  if (!stepsKey) {
+    return [];
+  }
+
+  const rawSteps = args[stepsKey];
+  if (!Array.isArray(rawSteps)) {
+    return [];
+  }
+
+  const calls: BatchStepCall[] = [];
+  for (const rawStep of rawSteps) {
+    if (!isRecord(rawStep)) {
+      continue;
+    }
+
+    const stepToolName = typeof rawStep.toolName === 'string' ? rawStep.toolName.trim() : '';
+    if (!stepToolName) {
+      continue;
+    }
+
+    calls.push({
+      toolName: stepToolName,
+      args: isRecord(rawStep.params) ? rawStep.params : {},
+    });
+  }
+
+  return calls;
+}
+
+/**
+ * Human-readable rundown of what a batch would run, e.g. `delete_clip x10,
+ * add_marker`. Returns null when the call is not a batch or carries no steps.
+ */
+export function summarizeBatchStepCalls(
+  toolName: string,
+  args: Record<string, unknown> = {},
+): string | null {
+  const calls = extractBatchStepCalls(toolName, args);
+  if (calls.length === 0) {
+    return null;
+  }
+
+  const countByToolName = new Map<string, number>();
+  for (const call of calls) {
+    countByToolName.set(call.toolName, (countByToolName.get(call.toolName) ?? 0) + 1);
+  }
+
+  return [...countByToolName.entries()]
+    .map(([name, count]) => (count > 1 ? `${name} x${count}` : name))
+    .join(', ');
+}

--- a/src/agents/tools/metaTools.test.ts
+++ b/src/agents/tools/metaTools.test.ts
@@ -223,9 +223,8 @@ describe('metaTools', () => {
 
     const visible = getVisibleMetaToolNames();
 
-    expect(visible).toEqual(['query', 'edit', 'audio', 'effects', 'text']);
+    expect(visible).toEqual(['query', 'edit', 'audio', 'effects', 'text', 'execute_plan']);
     expect(visible).not.toContain('generate');
-    expect(visible).not.toContain('execute_plan');
   });
 
   it('exposes the generate meta-tool when video generation is enabled', () => {
@@ -235,11 +234,31 @@ describe('metaTools', () => {
       const visible = getVisibleMetaToolNames();
 
       expect(visible).toContain('generate');
-      // Legacy compatibility tools stay hidden regardless of the flag.
-      expect(visible).not.toContain('execute_plan');
+      expect(visible).toContain('execute_plan');
     } finally {
       resetFeatureFlags();
     }
+  });
+
+  it('offers execute_plan as a batch surface the LLM can see', () => {
+    resetFeatureFlags();
+
+    expect(getVisibleMetaToolNames()).toContain('execute_plan');
+  });
+
+  it('refuses to run a plan without the atomic backend path', async () => {
+    const executePlan = globalToolRegistry.get('execute_plan');
+    expect(executePlan).toBeDefined();
+
+    const result = await executePlan!.handler(
+      {
+        steps: [{ id: 'step-1', toolName: 'split_clip', params: { clipId: 'clip-1' } }],
+      },
+      {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('USE_BACKEND_TOOLS');
   });
 
   it('forwards execution context from generate meta-tool to the underlying action', async () => {

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -879,82 +879,18 @@ const META_TOOLS: ToolDefinition[] = [
       },
       required: ['steps'],
     },
-    handler: async (args) => {
-      const steps = args.steps as Array<{
-        id: string;
-        toolName: string;
-        params: Record<string, unknown>;
-        dependsOn?: string[];
-      }>;
-
-      if (!Array.isArray(steps) || steps.length === 0) {
-        return { success: false, error: 'steps must be a non-empty array' };
-      }
-
-      const results: Array<{ stepId: string; success: boolean; result?: unknown; error?: string }> =
-        [];
-      const completed = new Set<string>();
-
-      for (const step of steps) {
-        // Check dependencies
-        if (step.dependsOn) {
-          for (const dep of step.dependsOn) {
-            if (!completed.has(dep)) {
-              return {
-                success: false,
-                error: `Step '${step.id}' depends on '${dep}' which has not completed`,
-                result: { completedSteps: results },
-              };
-            }
-          }
-        }
-
-        if (step.toolName === 'execute_plan') {
-          return {
-            success: false,
-            error: `Step '${step.id}': execute_plan cannot call itself`,
-            result: { completedSteps: results },
-          };
-        }
-
-        const toolDef = globalToolRegistry.get(step.toolName);
-        if (!toolDef) {
-          return {
-            success: false,
-            error: `Step '${step.id}': unknown tool '${step.toolName}'`,
-            result: { completedSteps: results },
-          };
-        }
-
-        try {
-          const stepResult = await globalToolRegistry.execute(step.toolName, step.params, {});
-          results.push({ stepId: step.id, ...stepResult });
-          if (!stepResult.success) {
-            return {
-              success: false,
-              error: `Step '${step.id}' (${step.toolName}) failed: ${stepResult.error}`,
-              result: { completedSteps: results },
-            };
-          }
-          completed.add(step.id);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return {
-            success: false,
-            error: `Step '${step.id}' (${step.toolName}) threw: ${msg}`,
-            result: { completedSteps: results },
-          };
-        }
-      }
-
-      return {
-        success: true,
-        result: {
-          stepsExecuted: results.length,
-          stepResults: results,
-        },
-      };
-    },
+    // The real implementation is the BackendToolExecutor intercept, which
+    // promotes the steps into a single atomic backend plan. This handler is
+    // only reached when that intercept is not in the chain, and a sequential
+    // best-effort loop here would silently apply half a plan with no rollback —
+    // the exact failure execute_plan exists to prevent. So it refuses.
+    handler: async () => ({
+      success: false,
+      error:
+        'execute_plan requires the backend tool path for atomic execution with rollback. ' +
+        'Enable the USE_BACKEND_TOOLS feature flag, or issue the steps as individual tool calls ' +
+        'knowing they are not atomic.',
+    }),
   },
 ];
 
@@ -983,7 +919,6 @@ export function unregisterMetaTools(): void {
 
 /** Pre-computed meta-tool names (static after module load). */
 const META_TOOL_NAMES: readonly string[] = META_TOOLS.map((t) => t.name);
-const LEGACY_META_TOOL_NAMES = new Set(['execute_plan']);
 
 /**
  * Meta-tools gated behind feature flags. These remain registered for direct
@@ -991,8 +926,19 @@ const LEGACY_META_TOOL_NAMES = new Set(['execute_plan']);
  */
 const FLAG_GATED_META_TOOL_NAMES = new Set(['generate']);
 const VISIBLE_META_TOOL_NAMES: readonly string[] = META_TOOL_NAMES.filter(
-  (name) => !LEGACY_META_TOOL_NAMES.has(name) && !FLAG_GATED_META_TOOL_NAMES.has(name),
+  (name) => !FLAG_GATED_META_TOOL_NAMES.has(name),
 );
+
+/**
+ * Meta-tools that dispatch through an `action` argument.
+ *
+ * `execute_plan` is a meta-tool but is not action-dispatching: it carries
+ * `steps`, so callers that resolve a meta-call to the tool it really runs must
+ * skip it rather than read a nonexistent action.
+ */
+const ACTION_DISPATCHING_META_TOOL_NAMES: readonly string[] = META_TOOLS.filter((tool) =>
+  Object.prototype.hasOwnProperty.call(tool.parameters.properties ?? {}, 'action'),
+).map((tool) => tool.name);
 
 /**
  * Get the names of all meta-tools.
@@ -1002,20 +948,23 @@ export function getMetaToolNames(): readonly string[] {
 }
 
 /**
+ * Get the meta-tools whose real target is named by their `action` argument.
+ */
+export function getActionDispatchingMetaToolNames(): readonly string[] {
+  return ACTION_DISPATCHING_META_TOOL_NAMES;
+}
+
+/**
  * Get the meta-tools that should be visible to the default runtime prompt
- * surface. Legacy compatibility tools remain registered but hidden. Speculative
- * meta-tools (e.g. `generate`) are only advertised when their feature flag is on
- * so the LLM does not see capabilities that are pinned off for release.
+ * surface. Speculative meta-tools (e.g. `generate`) are only advertised when
+ * their feature flag is on so the LLM does not see capabilities that are pinned
+ * off for release.
  */
 export function getVisibleMetaToolNames(): readonly string[] {
   if (isVideoGenerationEnabled()) {
     // `generate` is the only video-generation-gated meta-tool today; re-add it
-    // in flag-declaration order so the visible surface stays stable.
-    return META_TOOL_NAMES.filter((name) => !LEGACY_META_TOOL_NAMES.has(name));
+    // in declaration order so the visible surface stays stable.
+    return META_TOOL_NAMES;
   }
   return VISIBLE_META_TOOL_NAMES;
-}
-
-export function isLegacyMetaToolName(name: string): boolean {
-  return LEGACY_META_TOOL_NAMES.has(name);
 }

--- a/src/agents/tools/metaTools.ts
+++ b/src/agents/tools/metaTools.ts
@@ -850,7 +850,9 @@ const META_TOOLS: ToolDefinition[] = [
     name: 'execute_plan',
     description:
       'Execute a batch of editing operations sequentially. Backend-safe steps run atomically with rollback on failure; unsupported mutating steps are rejected. ' +
-      'Each step specifies a tool name and its parameters. Use this for complex multi-step edits.',
+      'Each step specifies a tool name and its parameters. Use this for complex multi-step edits. ' +
+      'Limitation: compound steps (ripple_edit, roll_edit, slip_edit, slide_edit) are expanded against the timeline as it is when the plan is submitted, ' +
+      'so do not place one after a step that shifts the clips it measures — send those in a later plan.',
     category: 'timeline',
     parameters: {
       type: 'object',

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2635,11 +2635,12 @@ async readAgentTrace(traceId: string) : Promise<Result<string, string>> {
  * respecting step dependencies via topological sort and resolving
  * `$fromStep`/`$path` references between steps.
  * 
- * On failure, rolls back completed steps in reverse order and marks their
- * persisted operation IDs as discarded so the append-only ops log cannot
- * resurrect partial plan work on reopen or history sync. Emits Tauri events
- * for each step's lifecycle (`agent:plan_step_start`,
- * `agent:plan_step_complete`, `agent:plan_step_failed`).
+ * This is the Tauri shell around [`execute_prepared_plan`]: it checks
+ * approval, validates the plan *before* consuming the approval proof, locks
+ * the project, and forwards step lifecycle progress to the frontend as
+ * `agent:plan_step_start` / `agent:plan_step_complete` /
+ * `agent:plan_step_failed`. Execution, rollback and persisted-op discarding
+ * live in the Tauri-free runner.
  */
 async executeAgentPlan(plan: AgentPlan) : Promise<Result<AgentPlanResult, string>> {
     try {

--- a/src/components/features/agent/parts/ToolApprovalPartRenderer.test.tsx
+++ b/src/components/features/agent/parts/ToolApprovalPartRenderer.test.tsx
@@ -59,4 +59,32 @@ describe('ToolApprovalPartRenderer', () => {
     expect(screen.queryByTestId('tool-approval-allow-btn')).not.toBeInTheDocument();
     expect(screen.queryByTestId('tool-approval-deny-btn')).not.toBeInTheDocument();
   });
+
+  it('names the steps a batch approval would run', () => {
+    render(
+      <ToolApprovalPartRenderer
+        part={{
+          ...pendingPart,
+          tool: 'execute_plan',
+          args: {
+            steps: [
+              { id: 's1', toolName: 'delete_clip', params: {} },
+              { id: 's2', toolName: 'delete_clip', params: {} },
+              { id: 's3', toolName: 'add_marker', params: {} },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('tool-approval-batch-steps')).toHaveTextContent(
+      'delete_clip x2, add_marker',
+    );
+  });
+
+  it('shows no batch summary for an ordinary tool call', () => {
+    render(<ToolApprovalPartRenderer part={pendingPart} />);
+
+    expect(screen.queryByTestId('tool-approval-batch-steps')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/features/agent/parts/ToolApprovalPartRenderer.tsx
+++ b/src/components/features/agent/parts/ToolApprovalPartRenderer.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { ChevronRight, Shield, ShieldAlert, ShieldCheck } from 'lucide-react';
 import type { ToolApprovalPart } from '@/agents/engine/core/conversation';
 import type { RiskLevel } from '@/agents/engine/core/types';
+import { summarizeBatchStepCalls } from '@/agents/tools/batchToolSteps';
 
 // =============================================================================
 // Types
@@ -97,6 +98,9 @@ export function ToolApprovalPartRenderer({
   const RiskIcon = risk.icon;
   const canAct = part.status === 'pending';
   const hasArgs = Object.keys(part.args).length > 0;
+  // A batch tool's own name says nothing about what it would run, so the
+  // prompt has to name the steps the approval actually covers.
+  const batchSteps = summarizeBatchStepCalls(part.tool, part.args);
 
   return (
     <div
@@ -131,6 +135,14 @@ export function ToolApprovalPartRenderer({
           </div>
           {part.description && (
             <p className="mt-0.5 break-words text-xs text-text-tertiary">{part.description}</p>
+          )}
+          {batchSteps && (
+            <p
+              className="mt-0.5 break-words text-xs text-text-tertiary"
+              data-testid="tool-approval-batch-steps"
+            >
+              Runs: {batchSteps}
+            </p>
           )}
         </div>
       </div>

--- a/src/stores/permissionStore.test.ts
+++ b/src/stores/permissionStore.test.ts
@@ -383,3 +383,85 @@ describe('permissionStore', () => {
     );
   });
 });
+
+describe('permissionStore batch calls', () => {
+  // A batch is one tool call but many edits, so allowing it must mean allowing
+  // every edit it carries — otherwise batching is a way around the per-tool
+  // rules the same calls would hit one at a time.
+
+  function batchArgs(...toolNames: string[]): Record<string, unknown> {
+    return {
+      steps: toolNames.map((toolName, index) => ({
+        id: `s${index + 1}`,
+        toolName,
+        params: { sequenceId: 'seq-1', trackId: 'track-1' },
+      })),
+    };
+  }
+
+  it('should ask for a permissive-preset batch that carries a destructive step', () => {
+    usePermissionStore.getState().setPreset('permissive');
+    const store = usePermissionStore.getState();
+
+    expect(store.resolvePermission('execute_plan', batchArgs('split_clip', 'move_clip'))).toBe(
+      'allow',
+    );
+    expect(
+      store.resolvePermission(
+        'execute_plan',
+        batchArgs('split_clip', 'delete_workspace_entry', 'delete_clip'),
+      ),
+    ).toBe('ask');
+  });
+
+  it('should deny a whole batch when one step is explicitly denied', () => {
+    usePermissionStore.getState().setPreset('permissive');
+    usePermissionStore.getState().addRule('timeline.clip.delete', 'deny', 'global');
+
+    const resolution = usePermissionStore
+      .getState()
+      .resolvePermissionDetails('execute_plan', batchArgs('split_clip', 'delete_clip'));
+
+    expect(resolution.permission).toBe('deny');
+    expect(resolution.matchedPattern).toBe('timeline.clip.delete');
+    expect(resolution.subject).toBe('approval.plan.execute');
+  });
+
+  it('should name the steps that escalated the batch', () => {
+    usePermissionStore.getState().setPreset('permissive');
+    const store = usePermissionStore.getState();
+
+    const resolution = store.resolvePermissionDetails(
+      'execute_plan',
+      batchArgs('split_clip', 'delete_clip', 'delete_clip', 'remove_track'),
+    );
+
+    expect(resolution.escalatingSteps.map((step) => step.toolName)).toEqual([
+      'delete_clip',
+      'remove_track',
+    ]);
+    expect(resolution.escalatingSteps.every((step) => step.permission === 'ask')).toBe(true);
+  });
+
+  it('should not escalate a batch whose steps are all allowed', () => {
+    usePermissionStore.getState().setPreset('permissive');
+    const store = usePermissionStore.getState();
+
+    const resolution = store.resolvePermissionDetails(
+      'execute_plan',
+      batchArgs('split_clip', 'move_clip', 'trim_clip'),
+    );
+
+    expect(resolution.permission).toBe('allow');
+    expect(resolution.escalatingSteps).toEqual([]);
+  });
+
+  it('should stop an allow_always batch grant from covering destructive steps later', () => {
+    usePermissionStore.getState().setPreset('permissive');
+    usePermissionStore.getState().allowAlways('execute_plan', batchArgs('split_clip'));
+
+    const store = usePermissionStore.getState();
+    expect(store.resolvePermission('execute_plan', batchArgs('split_clip'))).toBe('allow');
+    expect(store.resolvePermission('execute_plan', batchArgs('delete_clip'))).toBe('ask');
+  });
+});

--- a/src/stores/permissionStore.ts
+++ b/src/stores/permissionStore.ts
@@ -25,6 +25,7 @@ import type {
   PermissionDecision,
   PermissionDecisionSource,
 } from '@/agents/engine/core/agentSession';
+import { extractBatchStepCalls, type BatchStepCall } from '@/agents/tools/batchToolSteps';
 
 // =============================================================================
 // Types
@@ -50,6 +51,14 @@ interface MatchablePermissionRule {
 
 export type PermissionPreset = 'restrictive' | 'balanced' | 'permissive';
 
+/** A step inside a batch call that its own rules resolved more restrictively. */
+export interface PermissionStepEscalation {
+  toolName: string;
+  subject: string;
+  permission: ToolPermission;
+  matchedPattern: string | null;
+}
+
 export interface PermissionResolution {
   subjectType: PermissionSubjectType;
   subject: string;
@@ -59,6 +68,11 @@ export interface PermissionResolution {
   matchedPattern: string | null;
   matchedScope: PermissionRule['scope'] | null;
   source: PermissionDecisionSource;
+  /**
+   * Steps inside a batch call whose own subjects resolved more restrictively
+   * than the batch subject did. Empty for every non-batch call.
+   */
+  escalatingSteps: PermissionStepEscalation[];
 }
 
 export interface PermissionStoreState {
@@ -189,6 +203,70 @@ function toResolution(
     matchedPattern: match?.rule.pattern ?? null,
     matchedScope: match && match.rule.scope !== 'builtin' ? match.rule.scope : null,
     source,
+    escalatingSteps: [],
+  };
+}
+
+/**
+ * Fold a batch call's own resolution together with its steps', most restrictive
+ * wins: any deny denies the batch, otherwise any ask asks it.
+ *
+ * A batch is one tool call but many edits, so allowing it has to mean allowing
+ * every edit it carries. Resolving only the wrapper subject
+ * (`approval.plan.execute`) let a permissive `*` rule authorize deletes that a
+ * `delete_*` rule exists to stop, and skipped an explicit deny outright — the
+ * same calls issued one at a time were all checked.
+ *
+ * The reported rule is the one that decided, so the audit trail names the rule
+ * the user actually configured rather than the wrapper's.
+ */
+function resolveBatchPermission(
+  batchResolution: PermissionResolution,
+  stepCalls: BatchStepCall[],
+  globalRules: PermissionRule[],
+  sessionRules: PermissionRule[],
+): PermissionResolution {
+  let decided = batchResolution;
+  const escalatingSteps: PermissionStepEscalation[] = [];
+  const reportedToolNames = new Set<string>();
+
+  for (const stepCall of stepCalls) {
+    const stepSubject = buildPermissionSubject(stepCall.toolName, stepCall.args);
+    const stepResolution = toResolution(
+      stepSubject,
+      resolveMatchingRule(globalRules, sessionRules, stepSubject),
+    );
+
+    if (
+      PERMISSION_PRIORITY[stepResolution.permission] <=
+      PERMISSION_PRIORITY[batchResolution.permission]
+    ) {
+      continue;
+    }
+
+    if (!reportedToolNames.has(stepSubject.normalizedToolName)) {
+      reportedToolNames.add(stepSubject.normalizedToolName);
+      escalatingSteps.push({
+        toolName: stepSubject.normalizedToolName,
+        subject: stepResolution.subject,
+        permission: stepResolution.permission,
+        matchedPattern: stepResolution.matchedPattern,
+      });
+    }
+
+    if (PERMISSION_PRIORITY[stepResolution.permission] > PERMISSION_PRIORITY[decided.permission]) {
+      decided = stepResolution;
+    }
+  }
+
+  return {
+    ...batchResolution,
+    permission: decided.permission,
+    matchedRuleId: decided.matchedRuleId,
+    matchedPattern: decided.matchedPattern,
+    matchedScope: decided.matchedScope,
+    source: decided.source,
+    escalatingSteps,
   };
 }
 
@@ -328,7 +406,14 @@ export const usePermissionStore = create<PermissionStoreState>()(
         const { globalRules, sessionRules } = get();
         const subject = buildPermissionSubject(toolName, args);
         const bestMatch = resolveMatchingRule(globalRules, sessionRules, subject);
-        return toResolution(subject, bestMatch);
+        const resolution = toResolution(subject, bestMatch);
+
+        const stepCalls = extractBatchStepCalls(toolName, args);
+        if (stepCalls.length === 0) {
+          return resolution;
+        }
+
+        return resolveBatchPermission(resolution, stepCalls, globalRules, sessionRules);
       },
 
       hasHydratedSessionRules: (sessionId: string): boolean => {


### PR DESCRIPTION
### **User description**
## Description

PR 5 of the edit-quality roadmap (`docs/QUALITY_ROADMAP_PLAN.md`): the in-app `execute_plan` meta-tool becomes a first-class atomic batch surface. Research showed batching is where coding-agent-style editing gets its context economy — and the in-app model literally could not see the tool (hidden as "legacy"), while the only reachable fallback handler was a sequential loop with **no rollback** and an empty context.

- **Visible again**: `execute_plan` leaves the legacy set; the visible meta-tool surface is now `query, edit, audio, effects, text, execute_plan` (+ flag-gated `generate`). Prompts gained a short "prefer batching for ≥3-step mutations" section.
- **The naive handler is gone**: a non-atomic silent batch can never run. Without `USE_BACKend_TOOLS` the tool returns a structured refusal; the real path is the backend intercept with full rollback.
- **Backend-direct coverage 12 → 26 tools**, as an auditable `Map` (`{commandType, mapParams?}`) instead of a name set: isomorphic tools added (masks), renames routed (`mute_clip`, `insert_clip`, workspace verbs), deterministic remaps added (`add_transition`, `set_transition_duration`, `adjust_effect_param`, `add_fade_in/out`). The other 29 mutating tools carry a per-tool documented reason (snapshot fan-outs, id resolution, no CommandPayload). A registry-walking guard test fails any future mutating tool that ships without a backend-safety decision, and rejection errors now name the offending steps and the supported set.
- **The caps execute_plan used to bypass are closed**: `MAX_PLAN_STEPS = 1000` shared across Rust and TS (cross-language pin test), plans checked against the engine's remaining per-run step budget.
- **Backend plan path hardened** (closes the tracked follow-up from #791): `PlanExecutor::validate_and_prepare` now enforces the step cap (the constant lives in core; the CLI re-exports it), and `execute_agent_plan` sizes the undo history to the plan before the first step. The step loop + rollback moved into a Tauri-free `core/ai/plan_runner.rs` behind a `PlanStepReporter` port (wire events identical), which made a real 150-step rollback test possible — it fails with `left: 100, right: 150` when the capacity call is removed.

## Related Issue

Part of the edit-quality roadmap (no standalone issue).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — no-rollback fallback handler removed; >100-step backend rollback now complete
- [x] Test update

## Changes Made

- `metaTools.ts`: legacy set deleted; handler replaced by structured refusal; visibility tests updated.
- `BackendToolExecutor.ts`: `BACKEND_DIRECT_ROUTES` map, param remaps, step-cap + budget checks, actionable rejection errors; new `backendSafety` guard test.
- `permissionSubject.ts`: duplicated meta-tool list now derived from tool schemas (action-dispatching tools only).
- `core/ai/plan_runner.rs` (new, Tauri-free) + thin `execute_agent_plan` shell preserving approval → validate → lock → consume-proof ordering; `ensure_history_capacity` before the first step; shared `MAX_PLAN_STEPS` in `plan_executor.rs`, CLI re-export.

## Screenshots / Videos

N/A.

## Testing

### Test Environment

- OS: Windows 11 Pro
- Node.js version: project toolchain
- Rust version: workspace toolchain

### Tests Performed

- [x] Unit tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [x] Manual testing performed
- [x] New tests added for changes

TS: full `vitest run` 8283 passed / 0 failed (457 files); `tsc --noEmit` + eslint clean. Rust: lib 3732 passed, CLI 134 passed; clippy `-D warnings` + fmt clean; bundler feature-set check clean. Key contracts: registry-walking backend-safety guard (verified non-vacuous), cross-language step-cap pin, over-cap plan rejected before any step, 150-step failure rolls back completely (undo count + discarded op ids).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- `openspec/` is untracked/git-ignored in this repo, so the two stale spec statements about the meta-tool surface could not be updated from this branch — flagged for a local-docs pass.
- An adversarial review workflow is running against this branch in parallel with CI (same discipline as #791–#794); confirmed findings will be fixed here before merge.


___

### **PR Type**
Enhancement, Refactor, Tests


___

### **Description**
- Promotes `execute_plan` to a first-class atomic batch tool for agents.

- Expands backend-safe tool coverage from 12 to 26 tools with deterministic mapping.

- Enforces a shared 1000-step plan cap across Rust and TypeScript.

- Hardens backend plan execution with a Tauri-free runner and improved rollback.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph AgentEngine["Agentic Engine (TS)"]
    AE["execute_plan tool"] -- "Promote to Batch" --> BTE["BackendToolExecutor"]
  end
  subgraph Core["Core Registry & Runner (Rust)"]
    BTE -- "IPC: execute_agent_plan" --> PR["plan_runner.rs"]
    PR -- "Validate" --> PE["plan_executor.rs"]
    PR -- "Atomic Exec / Rollback" --> CE["CommandExecutor"]
  end
  PE -- "Shared Cap" --> BTE
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>BackendToolExecutor.ts</strong><dd><code>Implement batch promotion logic and expanded tool routing</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-a3aff75bdd811b11db7655a08b69d97087140aed6185e0824612b7f32326f54a">+275/-68</a></td>

</tr>

<tr>
  <td><strong>plan_runner.rs</strong><dd><code>New Tauri-free runner for atomic plan execution and rollback</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-e243020984dada1e6340496e3a7b0de83e04be617c7df25e9499917b191bada0">+621/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>plan_executor.rs</strong><dd><code>Define shared step limits and pre-execution validation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-c83bd3b95b4657bf1811a45d2ce44aaf065a8f5512b9fdc5b3f53b41aaaab04f">+73/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgenticEngine.ts</strong><dd><code>Track remaining step budget during plan execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-011b0b20aad60192a33ef841f0b1bf7d1d84d5b0ec950fc02f6d93c899a35246">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IToolExecutor.ts</strong><dd><code>Add remainingStepBudget to ExecutionContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-f663051ff7342dd222589aab3be4e94478f5a8d8363be63a24e4d3d832ec61d1">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BackendToolExecutor.backendSafety.test.ts</strong><dd><code>Add audit guards for backend-safe tool decisions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-1a830f276231e341e93a7ca19f7b20ea188f58a9ff9fb86feeec5f7f2cb780a1">+174/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactor</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>metaTools.ts</strong><dd><code>Expose execute_plan to LLM and remove naive fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-842f7132c091ca5476d87b73a280cb7192ba997487dfea06a0bd4e097e1a19b7">+36/-87</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agent.rs</strong><dd><code>Refactor Tauri command to delegate to the new plan runner</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-30882d103b0149635edaf6cba2976e67eab832be8d4ab6f2562944ae6868ba79">+35/-349</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>toolReference.ts</strong><dd><code>Update agent prompts to encourage batching via execute_plan</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-519afc20dfcf4453ee2fbf517f46e063a5894cec7cd8c72355ebf205e21d3567">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>plan.rs</strong><dd><code>Import shared MAX_PLAN_STEPS from core</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-f785809d35119699191fc261c8b8eee110c5be15fcf0bb5cadb1da8c4bcd1792">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-667b484d76a8f50c9eb23ff9e39ba16e959f8e092ee056b4f183d49d13133c87">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BackendToolExecutor.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-8e592e61f08c2f6dd01675f9d5577677dfe5ee2cb85c6da9fb3a916b9bb413a0">+110/-34</a></td>

</tr>

<tr>
  <td><strong>BackendToolExecutor.visibility.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-d4dbcadf7af2dfd67f0efc0e16ed5685b8edfc068cc816b1bb932f5cc83f6585">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToolRegistryAdapter.metaVisibility.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-52dac0c4f77fcbcb4a59e33bcaf23faa3df8889e7b137add4b653f614bbda901">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>permissionSubject.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-6c9e740e8475349cb8abd4b19f6826ef03e278906e8fd9e98ff331e7666eb595">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metaTools.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/795/files#diff-fba7abc9f4898abb5634a8c17070efef12feabcf68d91924e06c08e62de4e01e">+23/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added atomic multi-step plan execution with dependency ordering, progress reporting, and rollback on failure.
  - Made `execute_plan` available as a standard tool with clearer validation and execution errors.
  - Expanded backend support for direct and compound editing actions.
  - Added batch-step summaries in approval prompts and more precise permission handling.

- **Bug Fixes**
  - Improved transition result handling and rollback behavior.
  - Enforced remaining execution budgets across resumed and recovered plans.
  - Added safeguards for invalid plans, unsupported actions, and the 1,000-step limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->