### PR TITLE
feat(render): render per-clip transform and opacity in final export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,15 +392,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Ensure healthy apt mirror
-        # playwright --with-deps drives apt; a dead Azure mirror hangs it for
-        # the full 6h job timeout, so swap to archive.ubuntu.com up front.
+      - name: Use archive.ubuntu.com apt mirror
+        # playwright --with-deps drives apt with no retry of its own, and the
+        # Azure mirror can answer metadata probes while hanging on package
+        # fetches — so swap unconditionally rather than health-checking.
         run: |
-          if ! timeout 20 curl -fsI http://azure.archive.ubuntu.com/ubuntu/dists/noble/InRelease >/dev/null; then
-            echo "azure mirror unhealthy; switching to archive.ubuntu.com"
-            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt 2>/dev/null || true
-            sudo find /etc/apt -name '*.list' -o -name '*.sources' | xargs -r sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g'
-          fi
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt 2>/dev/null || true
+          sudo find /etc/apt -name '*.list' -o -name '*.sources' | xargs -r sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g'
 
       - name: Install Playwright browsers
         timeout-minutes: 20

--- a/crates/openreelio-cli/src/commands/frame.rs
+++ b/crates/openreelio-cli/src/commands/frame.rs
@@ -18,9 +18,10 @@ use openreelio_core::assets::Asset;
 use openreelio_core::effects::{Effect, EffectType, IntoFFmpegFilter, ParamValue};
 use openreelio_core::ffmpeg::{FFmpegRunner, FrameExtractOptions};
 use openreelio_core::render::{
-    build_render_graph, build_render_plan, clip_source_time_at, probed_image_dimensions,
-    scaled_frame_dimensions, validate_export_settings, ExportEngine, ExportSettings,
-    FrameExportSettings, ImageFormat,
+    build_render_graph, build_render_plan, clip_needs_transform_composition, clip_source_time_at,
+    probed_image_dimensions, scaled_frame_dimensions, source_dimensions_from_audio_info,
+    validate_export_settings_with_dimensions, ExportEngine, ExportSettings, FrameExportSettings,
+    ImageFormat, SourceDimensionMap,
 };
 use openreelio_core::timeline::Sequence;
 use openreelio_core::ActiveProject;
@@ -1018,7 +1019,7 @@ async fn run_timeline_mode(
 ) -> anyhow::Result<serde_json::Value> {
     let (sequence_id, sequence) = resolve_sequence(project, args.sequence.clone())?;
     ensure_times_inside_sequence(sequence, times)?;
-    let context = TimelineFrameContext {
+    let mut context = TimelineFrameContext {
         engine: ExportEngine::new(runner.clone()),
         runner,
         project,
@@ -1027,7 +1028,10 @@ async fn run_timeline_mode(
         format: format.clone(),
         max_width: args.max_width.unwrap_or(DEFAULT_MAX_WIDTH),
         mode,
+        source_dimensions: SourceDimensionMap::new(),
+        validated: false,
     };
+    context.measure_sources().await;
 
     if batch {
         std::fs::create_dir_all(&args.out).map_err(|error| {
@@ -1071,7 +1075,7 @@ async fn run_grid_mode(
     let (sequence_id, sequence) = resolve_sequence(project, args.sequence.clone())?;
     ensure_times_inside_sequence(sequence, times)?;
     let cell = resolve_cell_size(args);
-    let context = TimelineFrameContext {
+    let mut context = TimelineFrameContext {
         engine: ExportEngine::new(runner.clone()),
         runner,
         project,
@@ -1082,7 +1086,10 @@ async fn run_grid_mode(
         format: ImageFormat::Jpeg,
         max_width: grid_cell_extract_width(args, cell),
         mode,
+        source_dimensions: SourceDimensionMap::new(),
+        validated: false,
     };
+    context.measure_sources().await;
 
     let staging = CellStaging::new(cell, args.label_cells)?;
 
@@ -1307,6 +1314,18 @@ struct TimelineFrameContext<'a> {
     format: ImageFormat,
     max_width: u32,
     mode: TimelineMode,
+    /// Source sizes measured once for the whole invocation.
+    ///
+    /// Export validation measures every transformed clip's source with FFprobe.
+    /// The composite path validates the render it is about to run, so without a
+    /// shared measurement a 4x4 contact sheet over five assets meant 160 FFprobe
+    /// spawns instead of five.
+    source_dimensions: SourceDimensionMap,
+    /// Whether the composite path has already validated this invocation.
+    ///
+    /// Nothing validation inspects changes between frames of the same sequence,
+    /// so it runs on the first composited frame and is trusted afterwards.
+    validated: bool,
 }
 
 impl TimelineFrameContext<'_> {
@@ -1318,19 +1337,35 @@ impl TimelineFrameContext<'_> {
         &self.project.state.effects
     }
 
+    /// Measures every asset once so per-frame validation spawns no probes.
+    async fn measure_sources(&mut self) {
+        let audio_info = self
+            .engine
+            .probe_assets_for_audio(self.sequence, self.assets())
+            .await;
+        self.source_dimensions = source_dimensions_from_audio_info(&audio_info);
+    }
+
     /// Extracts one timeline still, falling back to a composited render when
-    /// fast mode cannot serve the requested time (title cards, gaps).
+    /// fast mode cannot serve the requested time (title cards, gaps) or cannot
+    /// show what the timeline actually says (transformed clips).
     async fn extract(
-        &self,
+        &mut self,
         index: usize,
         time_sec: f64,
         output_path: &Path,
     ) -> anyhow::Result<FrameEntry> {
         if self.mode == TimelineMode::Fast {
-            if let Some((clip, _)) =
-                self.engine
-                    .find_topmost_clip_at_time(self.sequence, self.assets(), time_sec)
-            {
+            // Fast mode reads the topmost clip's source file directly, so a clip
+            // that is moved, scaled, rotated or faded would come back looking
+            // untouched — an agent checking its own transform edit would see no
+            // change. Compositing is the only way to show it.
+            let fast_clip = self
+                .engine
+                .find_topmost_clip_at_time(self.sequence, self.assets(), time_sec)
+                .filter(|(clip, _)| !clip_needs_transform_composition(clip));
+
+            if let Some((clip, _)) = fast_clip {
                 let settings = FrameExportSettings {
                     time_sec,
                     format: self.format.clone(),
@@ -1380,7 +1415,7 @@ impl TimelineFrameContext<'_> {
     /// Range renders decode from timeline zero, so the cost grows with
     /// `time_sec` — this is the accurate but slow path.
     async fn render_composite(
-        &self,
+        &mut self,
         time_sec: f64,
         output_path: &Path,
     ) -> anyhow::Result<(u32, u32)> {
@@ -1405,13 +1440,21 @@ impl TimelineFrameContext<'_> {
         settings.width = Some(width);
         settings.height = Some(height);
 
-        let validation =
-            validate_export_settings(self.sequence, self.assets(), self.effects(), &settings);
-        if !validation.is_valid {
-            return Err(anyhow::anyhow!(
-                "Composite render validation failed: {}",
-                validation.errors.join("; ")
-            ));
+        if !self.validated {
+            let validation = validate_export_settings_with_dimensions(
+                self.sequence,
+                self.assets(),
+                self.effects(),
+                &settings,
+                Some(&self.source_dimensions),
+            );
+            if !validation.is_valid {
+                return Err(anyhow::anyhow!(
+                    "Composite render validation failed: {}",
+                    validation.errors.join("; ")
+                ));
+            }
+            self.validated = true;
         }
 
         let graph = build_render_graph(&self.project.state, self.sequence_id)

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -1673,7 +1673,8 @@ fn build_command_schema() -> Value {
             },
             "SetClipTransform": {
                 "required": ["sequenceId", "trackId", "clipId", "transform"],
-                "transformShape": "transform includes position{x,y}, scale{x,y}, rotationDeg, and anchor{x,y}; text clips use this for preview drag/resize/rotate parity."
+                "transformShape": "transform includes position{x,y}, scale{x,y}, rotationDeg, and anchor{x,y}; text clips use this for preview drag/resize/rotate parity.",
+                "note": "Renders in the final export for every visual clip, not just in the preview: position, scale, rotationDeg and anchor are all composited onto the canvas. SetClipOpacity likewise renders. Motion keyframes (SetClipMotionKeyframes) still render static at the clip's base transform and the render reports a warning saying so."
             }
         },
         "mediaWorkflows": {
@@ -1691,7 +1692,7 @@ fn build_command_schema() -> Value {
                 "CreateTrack(kind=\"video\" or \"overlay\") when there is no unlocked non-overlapping text track above the media.",
                 "AddTextClip with a preset id, or with a complete TextClipData for content, typography, color, background, shadow, outline, position, rotation, and opacity when no preset fits.",
                 "Prefer preset plus a content override over hand-assembled typography; see presetCatalog under payloadHints.AddTextClip for what each id is for.",
-                "SetClipTransform for exact preview drag/resize/rotate parity using normalized position, scale, rotationDeg, and anchor."
+                "SetClipTransform for exact drag/resize/rotate placement using normalized position, scale, rotationDeg, and anchor; it renders in the final export as well as in the preview."
             ],
             "timedSubtitles": [
                 "Call openreelio.transcription.status first and explain missing model installation before attempting automatic subtitles.",

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -181,6 +181,10 @@ fn start_render(args: StartArgs) -> anyhow::Result<()> {
     let graph = build_render_graph(&project.state, &seq_id)
         .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
 
+    // Validation measures transformed clips with FFprobe, so the resolved
+    // binaries have to be registered before it runs — see `ffmpeg_env`.
+    let ffmpeg_info = ensure_ffmpeg()?;
+
     let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
     if !validation.is_valid {
         return Err(anyhow::anyhow!(
@@ -197,7 +201,6 @@ fn start_render(args: StartArgs) -> anyhow::Result<()> {
     }
     let plan_hash = render_plan.plan_hash.clone();
 
-    let ffmpeg_info = ensure_ffmpeg()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -1323,6 +1323,395 @@ fn test_render_start_exports_video_when_ffmpeg_is_available() {
     );
 }
 
+/// Generates a flat clip of one colour at an explicit frame size.
+///
+/// The size is a parameter because a transformed clip's placement depends on the
+/// source's aspect ratio: a 16:9 source in a 16:9 canvas needs no letterbox
+/// arithmetic, while a 4:3 one does, and only the second shape can tell a
+/// correctly measured source from a wrongly assumed one.
+fn create_solid_colour_video(
+    path: &std::path::Path,
+    colour: &str,
+    size: &str,
+    duration_secs: u32,
+) -> bool {
+    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+        return false;
+    };
+    let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
+        eprintln!("Skipping transform render test: ffmpeg lacks a supported video encoder");
+        return false;
+    };
+
+    let mut command = Command::new(ffmpeg_path);
+    command.args([
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        &format!("color=c={colour}:s={size}:r=25:d={duration_secs}"),
+        "-c:v",
+        video_encoder,
+    ]);
+    if video_encoder == "libx264" {
+        command.args(["-pix_fmt", "yuv420p"]);
+    }
+
+    let status = command
+        .arg(path)
+        .status()
+        .expect("Failed to generate solid colour fixture with ffmpeg");
+    if !status.success() {
+        eprintln!("Skipping transform render test: ffmpeg could not generate the fixture");
+    }
+    status.success()
+}
+
+/// Reads one RGB pixel out of a rendered file.
+///
+/// Returns `None` when ffmpeg is unavailable or produced no pixel, so callers
+/// can skip rather than fail on a machine without a usable ffmpeg.
+fn sample_rendered_pixel(
+    path: &std::path::Path,
+    at_sec: f64,
+    x: u32,
+    y: u32,
+) -> Option<(u8, u8, u8)> {
+    let ffmpeg_path = system_ffmpeg_path()?;
+    let output = Command::new(ffmpeg_path)
+        .args(["-v", "error", "-ss", &at_sec.to_string(), "-i"])
+        .arg(path)
+        .args([
+            // The conversion has to come first: cropping a single pixel out of a
+            // subsampled plane asks for a zero-width chroma plane and fails.
+            "-vf",
+            &format!("format=rgb24,crop=w=1:h=1:x={x}:y={y}"),
+            "-frames:v",
+            "1",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "-",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() || output.stdout.len() < 3 {
+        return None;
+    }
+    Some((output.stdout[0], output.stdout[1], output.stdout[2]))
+}
+
+/// Imports a fixture, places it on the first video track and trims it to the
+/// fixture's real length, returning `(sequence_id, track_id, clip_id)`.
+///
+/// `asset import` records no probed duration, so the timeline hands the clip its
+/// 10s default; trimming keeps the rendered length a statement about the edit
+/// rather than about a clip that outruns its source.
+fn place_trimmed_clip(path: &str, source_path: &std::path::Path, duration_sec: f64) -> String {
+    let import = run_cli_ok(&[
+        "asset",
+        "import",
+        "--path",
+        path,
+        "--file",
+        source_path.to_str().unwrap(),
+    ]);
+    let asset_id = import["createdIds"][0].as_str().unwrap().to_string();
+
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", path]);
+    let track_id = tracks["tracks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|track| track["kind"] == "Video")
+        .and_then(|track| track["id"].as_str())
+        .unwrap()
+        .to_string();
+
+    let inserted = run_cli_ok(&[
+        "timeline", "insert", "--path", path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+    let clip_id = inserted["createdIds"][0].as_str().unwrap().to_string();
+
+    run_cli_ok(&[
+        "timeline",
+        "trim",
+        "--path",
+        path,
+        "--track",
+        &track_id,
+        "--clip",
+        &clip_id,
+        "--source-in",
+        "0",
+        "--source-out",
+        &duration_sec.to_string(),
+    ]);
+
+    track_id + "|" + &clip_id
+}
+
+/// Feature: Transformed clips in the final render
+/// Scenario: a scaled, repositioned clip lands where the preview puts it
+///
+/// Half scale with the anchor pinned at a quarter of the canvas both ways puts
+/// the picture in the top-left quadrant exactly. Export used to refuse this
+/// clip outright, so the assertions here are about pixels, not exit codes:
+/// source colour inside the quadrant, black outside it, and a file exactly as
+/// long as the timeline.
+#[test]
+fn test_render_transform_places_a_scaled_clip_in_the_top_left_quadrant() {
+    if system_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("render_transform_place");
+    let path = project_path(&dir, "render_transform_place");
+
+    const FIXTURE_SEC: f64 = 2.0;
+    let source_path = dir.path().join("transform_source.mp4");
+    if !create_solid_colour_video(&source_path, "red", "640x360", FIXTURE_SEC as u32) {
+        return;
+    }
+
+    let ids = place_trimmed_clip(&path, &source_path, FIXTURE_SEC);
+    let (track_id, clip_id) = ids.split_once('|').unwrap();
+    let sequence_id = run_cli_ok(&["timeline", "info", "--path", &path])["sequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "SetClipTransform",
+        "--payload",
+        &serde_json::json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "transform": {
+                "position": { "x": 0.25, "y": 0.25 },
+                "scale": { "x": 0.5, "y": 0.5 },
+                "rotationDeg": 0.0,
+                "anchor": { "x": 0.5, "y": 0.5 },
+            },
+        })
+        .to_string(),
+    ]);
+
+    let output_path = dir.path().join("transform-render.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "a transformed clip must render.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let Some((width, height)) = ffprobe_image_size(&output_path) else {
+        return;
+    };
+    assert_eq!(
+        width * 9,
+        height * 16,
+        "the fixture and the canvas must share an aspect ratio for this placement to be exact"
+    );
+
+    let inside = sample_rendered_pixel(&output_path, 1.0, width / 4, height / 4)
+        .expect("a pixel inside the placed quadrant");
+    assert!(
+        inside.0 > 150 && inside.1 < 80 && inside.2 < 80,
+        "the placed quadrant must show the source colour, got {inside:?}"
+    );
+
+    let outside = sample_rendered_pixel(&output_path, 1.0, width * 3 / 4, height * 3 / 4)
+        .expect("a pixel outside the placed quadrant");
+    assert!(
+        outside.0 < 40 && outside.1 < 40 && outside.2 < 40,
+        "the canvas outside the placed clip must stay black, got {outside:?}"
+    );
+
+    if let Some(rendered_duration) = ffprobe_duration_secs(&output_path) {
+        assert!(
+            (rendered_duration - FIXTURE_SEC).abs() < 0.2,
+            "the composite must not change the timeline length: {rendered_duration} vs {FIXTURE_SEC}"
+        );
+    }
+}
+
+/// Feature: Transformed clips in the final render
+/// Scenario: a half-opacity clip renders at half brightness
+///
+/// White at 50% over the black canvas is mid grey. Anything else means the
+/// alpha stage was dropped or applied twice.
+#[test]
+fn test_render_transform_renders_clip_opacity_over_black() {
+    if system_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("render_transform_opacity");
+    let path = project_path(&dir, "render_transform_opacity");
+
+    const FIXTURE_SEC: f64 = 2.0;
+    let source_path = dir.path().join("opacity_source.mp4");
+    if !create_solid_colour_video(&source_path, "white", "640x360", FIXTURE_SEC as u32) {
+        return;
+    }
+
+    let ids = place_trimmed_clip(&path, &source_path, FIXTURE_SEC);
+    let (track_id, clip_id) = ids.split_once('|').unwrap();
+    let sequence_id = run_cli_ok(&["timeline", "info", "--path", &path])["sequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "SetClipOpacity",
+        "--payload",
+        &serde_json::json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "opacity": 0.5,
+        })
+        .to_string(),
+    ]);
+
+    let output_path = dir.path().join("opacity-render.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "a translucent clip must render.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let Some((width, height)) = ffprobe_image_size(&output_path) else {
+        return;
+    };
+    let centre = sample_rendered_pixel(&output_path, 1.0, width / 2, height / 2)
+        .expect("a pixel at the canvas centre");
+    for channel in [centre.0, centre.1, centre.2] {
+        assert!(
+            (95..=160).contains(&channel),
+            "white at half opacity over black must render mid grey, got {centre:?}"
+        );
+    }
+}
+
+/// Feature: Transformed clips in the final render
+/// Scenario: placement follows the source's measured shape, not its stored one
+///
+/// `asset import` files every video away as a placeholder 1920x1080, so a 4:3
+/// source that is only trusted rather than measured would be placed as if it
+/// were 16:9 — 960x540 spanning x 480..1440 instead of 720x540 spanning
+/// x 600..1320. The two sample points below sit inside exactly one of those.
+#[test]
+fn test_render_transform_places_a_clip_by_its_measured_aspect_ratio() {
+    if system_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("render_transform_aspect");
+    let path = project_path(&dir, "render_transform_aspect");
+
+    const FIXTURE_SEC: f64 = 2.0;
+    let source_path = dir.path().join("aspect_source.mp4");
+    if !create_solid_colour_video(&source_path, "green", "480x360", FIXTURE_SEC as u32) {
+        return;
+    }
+
+    let ids = place_trimmed_clip(&path, &source_path, FIXTURE_SEC);
+    let (track_id, clip_id) = ids.split_once('|').unwrap();
+    let sequence_id = run_cli_ok(&["timeline", "info", "--path", &path])["sequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "SetClipTransform",
+        "--payload",
+        &serde_json::json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "transform": {
+                "position": { "x": 0.5, "y": 0.5 },
+                "scale": { "x": 0.5, "y": 0.5 },
+                "rotationDeg": 0.0,
+                "anchor": { "x": 0.5, "y": 0.5 },
+            },
+        })
+        .to_string(),
+    ]);
+
+    let output_path = dir.path().join("aspect-render.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "a transformed 4:3 clip must render.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let Some((width, height)) = ffprobe_image_size(&output_path) else {
+        return;
+    };
+    if (width, height) != (1920, 1080) {
+        // The sample points below are hand-computed against a 1080p canvas.
+        return;
+    }
+
+    let centre =
+        sample_rendered_pixel(&output_path, 1.0, 960, 540).expect("a pixel at the canvas centre");
+    assert!(
+        centre.1 > 100 && centre.0 < 90,
+        "the clip must cover the canvas centre, got {centre:?}"
+    );
+
+    for (x, y) in [(520_u32, 540_u32), (1380, 540)] {
+        let pixel = sample_rendered_pixel(&output_path, 1.0, x, y)
+            .unwrap_or_else(|| panic!("a pixel at ({x}, {y})"));
+        assert!(
+            pixel.0 < 40 && pixel.1 < 40 && pixel.2 < 40,
+            "a 4:3 source scaled by half spans x 600..1320, so ({x}, {y}) must be black, \
+             got {pixel:?}"
+        );
+    }
+}
+
 #[test]
 fn test_render_start_rejects_proxy_combined_with_preset() {
     let dir = create_temp_project("render_proxy_conflict");

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -85,10 +85,30 @@ fn project_path(dir: &tempfile::TempDir, name: &str) -> String {
     dir.path().join(name).to_string_lossy().to_string()
 }
 
-fn system_ffmpeg_path() -> Option<PathBuf> {
-    openreelio_core::ffmpeg::detect_system_ffmpeg()
-        .ok()
-        .map(|info| info.ffmpeg_path)
+/// The FFmpeg the CLI under test would actually use.
+///
+/// Resolving PATH alone made every render test skip itself on any machine — CI
+/// included — where FFmpeg is bundled next to the binary or installed through
+/// the in-app manager rather than being on PATH. Those runs reported green
+/// while executing nothing. This mirrors `ffmpeg_env::resolve_options`: the
+/// executable's own directory is the only resource root, then the managed
+/// install, then dev-mode binaries, then PATH.
+fn available_ffmpeg_path() -> Option<PathBuf> {
+    let resource_roots = cli_bin()
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .into_iter()
+        .collect();
+
+    openreelio_core::ffmpeg::resolve_ffmpeg(&openreelio_core::ffmpeg::FFmpegResolveOptions {
+        resource_roots,
+        // The CLI is launched with the overrides cleared, so the tests resolve
+        // without them too.
+        use_env: false,
+        ..Default::default()
+    })
+    .ok()
+    .map(|info| info.ffmpeg_path)
 }
 
 /// Run a CLI command from `cwd` with extra environment variables applied.
@@ -215,7 +235,7 @@ fn create_sample_video(path: &std::path::Path) -> bool {
 }
 
 fn create_sample_video_with_duration(path: &std::path::Path, duration_secs: u32) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
 
@@ -270,7 +290,7 @@ fn preferred_video_encoder(ffmpeg_path: &std::path::Path) -> Option<&'static str
 /// Shot detection needs an unambiguous scene change; a single flat colour
 /// source produces none.
 fn create_sample_video_with_scene_change(path: &std::path::Path) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
     let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
@@ -315,7 +335,7 @@ fn create_sample_video_with_scene_change(path: &std::path::Path) -> bool {
 /// Silence detection and audio profiling need a real audio stream; the plain
 /// colour fixture is video-only.
 fn create_sample_video_with_audio(path: &std::path::Path) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
     let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
@@ -361,7 +381,7 @@ fn create_sample_video_with_audio(path: &std::path::Path) -> bool {
 /// Generates a 4-second audio-only WAV fixture, for tests that need a clip an
 /// audio track will accept.
 fn create_sample_audio(path: &std::path::Path) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
 
@@ -392,7 +412,7 @@ fn create_sample_audio(path: &std::path::Path) -> bool {
 /// rendered proxy stays well under the true-peak ceiling `verify` enforces;
 /// a full-scale sine would be a clipped, not a healthy, render.
 fn create_sample_video_with_scene_change_and_audio(path: &std::path::Path) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
     let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
@@ -444,16 +464,90 @@ fn create_sample_video_with_scene_change_and_audio(path: &std::path::Path) -> bo
     status.success()
 }
 
-fn system_ffprobe_path() -> Option<PathBuf> {
-    openreelio_core::ffmpeg::detect_system_ffmpeg()
-        .ok()
-        .map(|info| info.ffprobe_path)
+/// The FFprobe that ships with the FFmpeg the CLI under test would use.
+///
+/// Resolved the same way as [`available_ffmpeg_path`] so the measurement tools
+/// are available wherever the CLI itself can render.
+fn available_ffprobe_path() -> Option<PathBuf> {
+    let resource_roots = cli_bin()
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .into_iter()
+        .collect();
+
+    openreelio_core::ffmpeg::resolve_ffmpeg(&openreelio_core::ffmpeg::FFmpegResolveOptions {
+        resource_roots,
+        use_env: false,
+        ..Default::default()
+    })
+    .ok()
+    .map(|info| info.ffprobe_path)
+}
+
+/// Reads the nominal frame rate of a rendered file's video stream.
+fn ffprobe_video_fps(path: &std::path::Path) -> Option<f64> {
+    let ffprobe_path = available_ffprobe_path()?;
+    let output = Command::new(ffprobe_path)
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=r_frame_rate",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let text = text.trim();
+    match text.split_once('/') {
+        Some((numerator, denominator)) => {
+            let numerator: f64 = numerator.trim().parse().ok()?;
+            let denominator: f64 = denominator.trim().parse().ok()?;
+            (denominator > 0.0).then_some(numerator / denominator)
+        }
+        None => text.parse().ok(),
+    }
+}
+
+/// Counts the video frames a rendered file actually contains.
+///
+/// Decoded frame-by-frame rather than derived from the container duration: a
+/// composite that silently dropped its tail still reports a plausible duration,
+/// and only the frame count catches it.
+fn ffprobe_video_frame_count(path: &std::path::Path) -> Option<u64> {
+    let ffprobe_path = available_ffprobe_path()?;
+    let output = Command::new(ffprobe_path)
+        .args([
+            "-v",
+            "error",
+            "-count_frames",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=nb_read_frames",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
 /// Probe the total duration (in seconds) of a media file via ffprobe.
 /// Returns `None` if ffprobe is unavailable or the output cannot be parsed.
 fn ffprobe_duration_secs(path: &std::path::Path) -> Option<f64> {
-    let ffprobe_path = system_ffprobe_path()?;
+    let ffprobe_path = available_ffprobe_path()?;
     let output = Command::new(ffprobe_path)
         .args([
             "-v",
@@ -477,7 +571,7 @@ fn ffprobe_duration_secs(path: &std::path::Path) -> Option<f64> {
 /// This is deliberately not `format=duration`: the container duration is the
 /// maximum across all streams, so it says nothing about where the pictures stop.
 fn ffprobe_video_duration_secs(path: &std::path::Path) -> Option<f64> {
-    let ffprobe_path = system_ffprobe_path()?;
+    let ffprobe_path = available_ffprobe_path()?;
     let output = Command::new(ffprobe_path)
         .args([
             "-v",
@@ -501,7 +595,7 @@ fn ffprobe_video_duration_secs(path: &std::path::Path) -> Option<f64> {
 /// Probe the height (in pixels) of the first video stream via ffprobe.
 /// Returns `None` if ffprobe is unavailable or the output cannot be parsed.
 fn ffprobe_video_height(path: &std::path::Path) -> Option<u32> {
-    let ffprobe_path = system_ffprobe_path()?;
+    let ffprobe_path = available_ffprobe_path()?;
     let output = Command::new(ffprobe_path)
         .args([
             "-v",
@@ -528,7 +622,7 @@ fn ffprobe_video_height(path: &std::path::Path) -> Option<u32> {
 /// stream. Returns `None` if ffprobe is unavailable or the output cannot be
 /// parsed.
 fn ffprobe_image_size(path: &std::path::Path) -> Option<(u32, u32)> {
-    let ffprobe_path = system_ffprobe_path()?;
+    let ffprobe_path = available_ffprobe_path()?;
     let output = Command::new(ffprobe_path)
         .args([
             "-v",
@@ -1234,7 +1328,7 @@ fn test_render_start_invalid_preset() {
 
 #[test]
 fn test_ffmpeg_info_reports_resolved_binaries() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -1264,7 +1358,7 @@ fn test_ffmpeg_info_reports_resolved_binaries() {
 
 #[test]
 fn test_render_start_exports_video_when_ffmpeg_is_available() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -1335,7 +1429,7 @@ fn create_solid_colour_video(
     size: &str,
     duration_secs: u32,
 ) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
     let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
@@ -1377,7 +1471,7 @@ fn sample_rendered_pixel(
     x: u32,
     y: u32,
 ) -> Option<(u8, u8, u8)> {
-    let ffmpeg_path = system_ffmpeg_path()?;
+    let ffmpeg_path = available_ffmpeg_path()?;
     let output = Command::new(ffmpeg_path)
         .args(["-v", "error", "-ss", &at_sec.to_string(), "-i"])
         .arg(path)
@@ -1463,7 +1557,7 @@ fn place_trimmed_clip(path: &str, source_path: &std::path::Path, duration_sec: f
 /// long as the timeline.
 #[test]
 fn test_render_transform_places_a_scaled_clip_in_the_top_left_quadrant() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -1528,24 +1622,35 @@ fn test_render_transform_places_a_scaled_clip_in_the_top_left_quadrant() {
         "the fixture and the canvas must share an aspect ratio for this placement to be exact"
     );
 
-    let inside = sample_rendered_pixel(&output_path, 1.0, width / 4, height / 4)
+    // The clip spans the top-left quadrant, so the quadrant boundary runs
+    // through the canvas centre. Sampling at an eighth and seven-eighths keeps
+    // both probes three-quarters of a quadrant away from that edge, where a
+    // one-pixel placement error cannot flip the answer.
+    let inside = sample_rendered_pixel(&output_path, 1.0, width / 8, height / 8)
         .expect("a pixel inside the placed quadrant");
     assert!(
         inside.0 > 150 && inside.1 < 80 && inside.2 < 80,
         "the placed quadrant must show the source colour, got {inside:?}"
     );
 
-    let outside = sample_rendered_pixel(&output_path, 1.0, width * 3 / 4, height * 3 / 4)
+    let outside = sample_rendered_pixel(&output_path, 1.0, width * 7 / 8, height * 7 / 8)
         .expect("a pixel outside the placed quadrant");
     assert!(
         outside.0 < 40 && outside.1 < 40 && outside.2 < 40,
         "the canvas outside the placed clip must stay black, got {outside:?}"
     );
 
-    if let Some(rendered_duration) = ffprobe_duration_secs(&output_path) {
-        assert!(
-            (rendered_duration - FIXTURE_SEC).abs() < 0.2,
-            "the composite must not change the timeline length: {rendered_duration} vs {FIXTURE_SEC}"
+    // Frame count, not duration: the composite used to end at whichever input
+    // ran out first, which drops tail frames while leaving the container
+    // duration looking right.
+    if let (Some(frames), Some(fps)) = (
+        ffprobe_video_frame_count(&output_path),
+        ffprobe_video_fps(&output_path),
+    ) {
+        let expected = (FIXTURE_SEC * fps).round() as u64;
+        assert_eq!(
+            frames, expected,
+            "the composite must emit every frame of the clip's slot at {fps} fps"
         );
     }
 }
@@ -1557,7 +1662,7 @@ fn test_render_transform_places_a_scaled_clip_in_the_top_left_quadrant() {
 /// alpha stage was dropped or applied twice.
 #[test]
 fn test_render_transform_renders_clip_opacity_over_black() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -1615,8 +1720,8 @@ fn test_render_transform_renders_clip_opacity_over_black() {
         .expect("a pixel at the canvas centre");
     for channel in [centre.0, centre.1, centre.2] {
         assert!(
-            (95..=160).contains(&channel),
-            "white at half opacity over black must render mid grey, got {centre:?}"
+            (118..=138).contains(&channel),
+            "white at half opacity over black must render 128 +/- 10, got {centre:?}"
         );
     }
 }
@@ -1630,7 +1735,7 @@ fn test_render_transform_renders_clip_opacity_over_black() {
 /// x 600..1320. The two sample points below sit inside exactly one of those.
 #[test]
 fn test_render_transform_places_a_clip_by_its_measured_aspect_ratio() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -1712,6 +1817,306 @@ fn test_render_transform_places_a_clip_by_its_measured_aspect_ratio() {
     }
 }
 
+/// Creates a single-frame PNG still of one colour.
+///
+/// Stills are the shape that broke hardest: a one-frame overlay input ended the
+/// composite immediately, so a transformed still produced a file with no video
+/// stream at all.
+fn create_solid_colour_still(path: &std::path::Path, colour: &str, size: &str) -> bool {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
+        return false;
+    };
+
+    let status = Command::new(ffmpeg_path)
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            &format!("color=c={colour}:s={size}"),
+            "-frames:v",
+            "1",
+        ])
+        .arg(path)
+        .status()
+        .expect("Failed to generate still fixture with ffmpeg");
+    if !status.success() {
+        eprintln!("Skipping transform render test: ffmpeg could not generate the still fixture");
+    }
+    status.success()
+}
+
+/// Feature: Transformed clips in the final render
+/// Scenario: a one-frame source fills its whole slot
+///
+/// The composite used to end with whichever input ran out first. A still has
+/// exactly one frame, so a transformed still rendered a file with no video
+/// stream at all, and a 25 fps clip in a 30 fps canvas lost its tail frames.
+/// Holding the last frame for the length of the slot is what both cases need.
+#[test]
+fn test_render_transform_fills_the_slot_from_a_single_frame_source() {
+    if available_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("render_transform_still");
+    let path = project_path(&dir, "render_transform_still");
+
+    const SLOT_SEC: f64 = 2.0;
+    let source_path = dir.path().join("still_source.png");
+    if !create_solid_colour_still(&source_path, "blue", "640x360") {
+        return;
+    }
+
+    let ids = place_trimmed_clip(&path, &source_path, SLOT_SEC);
+    let (track_id, clip_id) = ids.split_once('|').unwrap();
+    let sequence_id = run_cli_ok(&["timeline", "info", "--path", &path])["sequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "SetClipTransform",
+        "--payload",
+        &serde_json::json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "transform": {
+                "position": { "x": 0.5, "y": 0.5 },
+                "scale": { "x": 0.5, "y": 0.5 },
+                "rotationDeg": 0.0,
+                "anchor": { "x": 0.5, "y": 0.5 },
+            },
+        })
+        .to_string(),
+    ]);
+
+    let output_path = dir.path().join("still-render.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "a transformed still must render.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let size = ffprobe_image_size(&output_path);
+    assert!(
+        size.is_some(),
+        "a transformed still must still produce a video stream"
+    );
+
+    let (Some(frames), Some(fps)) = (
+        ffprobe_video_frame_count(&output_path),
+        ffprobe_video_fps(&output_path),
+    ) else {
+        return;
+    };
+    let expected = (SLOT_SEC * fps).round() as u64;
+    assert_eq!(
+        frames, expected,
+        "a one-frame source must be held for its whole {SLOT_SEC}s slot at {fps} fps"
+    );
+
+    // And what it holds is the picture, not black.
+    if let Some((width, height)) = size {
+        let centre = sample_rendered_pixel(&output_path, SLOT_SEC * 0.75, width / 2, height / 2)
+            .expect("a pixel near the end of the slot");
+        assert!(
+            centre.2 > 120 && centre.0 < 90,
+            "the held frame must still show the source, got {centre:?}"
+        );
+    }
+}
+
+/// Feature: Truthful degradation
+/// Scenario: motion keyframes are reported as unrendered
+///
+/// Motion animates in the preview and does not animate in the export. Saying so
+/// is the difference between a known limitation and a silent one.
+#[test]
+fn test_render_reports_motion_keyframes_as_unrendered() {
+    if available_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("render_motion_warning");
+    let path = project_path(&dir, "render_motion_warning");
+
+    const FIXTURE_SEC: f64 = 2.0;
+    let source_path = dir.path().join("motion_source.mp4");
+    if !create_solid_colour_video(&source_path, "red", "640x360", FIXTURE_SEC as u32) {
+        return;
+    }
+
+    let ids = place_trimmed_clip(&path, &source_path, FIXTURE_SEC);
+    let (track_id, clip_id) = ids.split_once('|').unwrap();
+    let sequence_id = run_cli_ok(&["timeline", "info", "--path", &path])["sequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Two keyframes that actually move the clip. A lone keyframe equal to the
+    // base transform describes exactly the picture the export already produces
+    // and must not warn.
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "SetClipMotionKeyframes",
+        "--payload",
+        &serde_json::json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "keyframes": [
+                {
+                    "timeOffset": 0.0,
+                    "transform": {
+                        "position": { "x": 0.25, "y": 0.5 },
+                        "scale": { "x": 1.0, "y": 1.0 },
+                        "rotationDeg": 0.0,
+                        "anchor": { "x": 0.5, "y": 0.5 },
+                    },
+                },
+                {
+                    "timeOffset": 1.0,
+                    "transform": {
+                        "position": { "x": 0.75, "y": 0.5 },
+                        "scale": { "x": 1.0, "y": 1.0 },
+                        "rotationDeg": 0.0,
+                        "anchor": { "x": 0.5, "y": 0.5 },
+                    },
+                },
+            ],
+        })
+        .to_string(),
+    ]);
+
+    let output_path = dir.path().join("motion-render.mp4");
+    let (stdout, stderr, success) = run_cli(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+    assert!(
+        success,
+        "a clip with motion keyframes must still render.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let rendered: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let warnings: Vec<&str> = rendered["warnings"]
+        .as_array()
+        .expect("warnings")
+        .iter()
+        .filter_map(|warning| warning.as_str())
+        .collect();
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("Motion keyframes")
+                && warning.contains("not yet rendered")),
+        "unrendered motion must be reported: {warnings:?}"
+    );
+}
+
+/// Feature: Perception matches the render
+/// Scenario: fast frame extraction composites a transformed clip
+///
+/// Fast mode reads the topmost clip's source file straight off disk. For a
+/// transformed clip that shows the untransformed picture, so an agent checking
+/// its own transform edit would see no change at all.
+#[test]
+fn test_frame_extract_fast_falls_back_to_composite_for_a_transformed_clip() {
+    if available_ffmpeg_path().is_none() {
+        return;
+    }
+
+    let dir = create_temp_project("frame_fast_transform");
+    let path = project_path(&dir, "frame_fast_transform");
+
+    const FIXTURE_SEC: f64 = 2.0;
+    let source_path = dir.path().join("fast_transform_source.mp4");
+    if !create_solid_colour_video(&source_path, "red", "640x360", FIXTURE_SEC as u32) {
+        return;
+    }
+
+    let ids = place_trimmed_clip(&path, &source_path, FIXTURE_SEC);
+    let (track_id, clip_id) = ids.split_once('|').unwrap();
+    let sequence_id = run_cli_ok(&["timeline", "info", "--path", &path])["sequenceId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        &path,
+        "--type",
+        "SetClipTransform",
+        "--payload",
+        &serde_json::json!({
+            "sequenceId": sequence_id,
+            "trackId": track_id,
+            "clipId": clip_id,
+            "transform": {
+                "position": { "x": 0.25, "y": 0.25 },
+                "scale": { "x": 0.5, "y": 0.5 },
+                "rotationDeg": 0.0,
+                "anchor": { "x": 0.5, "y": 0.5 },
+            },
+        })
+        .to_string(),
+    ]);
+
+    let still_path = dir.path().join("fast-frame.png");
+    let extracted = run_cli_ok(&[
+        "frame",
+        "extract",
+        "--path",
+        &path,
+        "--time",
+        "1.0",
+        "--mode",
+        "fast",
+        "--out",
+        still_path.to_str().unwrap(),
+    ]);
+
+    let frame = &extracted["frames"][0];
+    assert_eq!(
+        frame["fellBackToComposite"], true,
+        "fast mode must report that it composited instead: {extracted}"
+    );
+
+    let Some((width, height)) = ffprobe_image_size(&still_path) else {
+        return;
+    };
+    let outside = sample_rendered_pixel(&still_path, 0.0, width * 7 / 8, height * 7 / 8)
+        .expect("a pixel outside the placed quadrant");
+    assert!(
+        outside.0 < 40 && outside.1 < 40 && outside.2 < 40,
+        "the extracted still must show the transform, not the raw source, got {outside:?}"
+    );
+}
+
 #[test]
 fn test_render_start_rejects_proxy_combined_with_preset() {
     let dir = create_temp_project("render_proxy_conflict");
@@ -1750,7 +2155,7 @@ fn test_render_start_rejects_inverted_range() {
 
 #[test]
 fn test_render_start_proxy_renders_480p_range_with_progress() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -1858,7 +2263,7 @@ fn create_project_with_timeline_clip(
     name: &str,
     duration_secs: u32,
 ) -> Option<(tempfile::TempDir, String, String)> {
-    system_ffmpeg_path()?;
+    available_ffmpeg_path()?;
 
     let dir = create_temp_project(name);
     let path = project_path(&dir, name);
@@ -2553,7 +2958,7 @@ fn create_video_with_longer_audio(
     video_secs: u32,
     audio_secs: u32,
 ) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         return false;
     };
     let Some(video_encoder) = preferred_video_encoder(&ffmpeg_path) else {
@@ -2751,7 +3156,7 @@ fn test_frame_extract_rejects_contact_sheet_flags_without_a_grid() {
 fn test_frame_extract_rejects_a_file_without_a_video_stream() {
     let dir = create_temp_project("frame_file_no_video_test");
     let path = project_path(&dir, "frame_file_no_video_test");
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -3951,7 +4356,7 @@ fn test_plan_from_profile_rejects_an_asset_that_is_not_in_the_project() {
 /// against. Silent fixtures cannot see either failure, so this one has sound.
 #[test]
 fn test_render_with_a_transition_effect_matches_the_timeline_length_and_warns() {
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         return;
     }
 
@@ -5007,7 +5412,7 @@ fn test_version_flag() {
 #[test]
 fn test_core_flow_create_import_edit_caption_render_end_to_end() {
     // Skip cleanly if FFmpeg is genuinely unavailable in this environment.
-    if system_ffmpeg_path().is_none() {
+    if available_ffmpeg_path().is_none() {
         eprintln!("Skipping core-flow E2E test: ffmpeg not found");
         return;
     }
@@ -5135,7 +5540,7 @@ fn create_project_with_media(
     file_name: &str,
     build_media: impl Fn(&std::path::Path) -> bool,
 ) -> Option<(tempfile::TempDir, String, String)> {
-    system_ffmpeg_path()?;
+    available_ffmpeg_path()?;
 
     let dir = create_temp_project(name);
     let path = project_path(&dir, name);
@@ -6150,7 +6555,7 @@ const BROKEN_RENDER_SECONDS: u32 = 10;
 /// Returning rather than failing keeps these guards skippable on a machine
 /// without a media toolchain, exactly like the render tests above.
 fn synthesize_media(path: &std::path::Path, args: &[&str], encode_video: bool) -> bool {
-    let Some(ffmpeg_path) = system_ffmpeg_path() else {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
         eprintln!("Skipping broken-render test: ffmpeg unavailable");
         return false;
     };

--- a/distribution/skills/skills/openreelio/editing/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/editing/REFERENCE.md
@@ -50,6 +50,36 @@ Payloads are camelCase JSON objects matching the IPC payload format. Use
 `command validate` runs the same strict parser without touching the project —
 check before you execute.
 
+## Framing a clip: transform and opacity
+
+`SetClipTransform` places a clip on the canvas with normalized coordinates, and
+`SetClipOpacity` fades it. Both render in the final export, not just the preview:
+
+```bash
+openreelio-cli command execute --path ./demo --type SetClipTransform \
+  --payload '{"sequenceId":"…","trackId":"…","clipId":"…","transform":{
+    "position":{"x":0.25,"y":0.25},"scale":{"x":0.5,"y":0.5},
+    "rotationDeg":0,"anchor":{"x":0.5,"y":0.5}}}'
+
+openreelio-cli command execute --path ./demo --type SetClipOpacity \
+  --payload '{"sequenceId":"…","trackId":"…","clipId":"…","opacity":0.5}'
+```
+
+- `position` is where the **anchor** lands on the canvas, as a fraction of it —
+  `{0.5, 0.5}` is the centre. `anchor` is the point of the picture that gets
+  pinned there, also normalized, and rotation turns about it.
+- `scale` multiplies the letterbox fit, so `{1, 1}` is "fitted to the canvas"
+  and `{0.5, 0.5}` is a quarter of its area.
+- The placement is measured against the source's real pixel size, so a 4:3 clip
+  in a 16:9 sequence keeps its shape.
+
+Two limits still apply. **Motion keyframes**
+(`SetClipMotionKeyframes`) animate in the preview but render static at the
+clip's base transform, and `render start` reports a warning saying so.
+**Simultaneous layered clips** — two visible video clips overlapping in time,
+which is what picture-in-picture needs — and **blend modes** are still rejected
+by export validation. A transform is for framing one clip at a time.
+
 ## Transitions
 
 Transitions are effects — there is no `AddTransition` command. `AddEffect`

--- a/distribution/skills/skills/openreelio/perception/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/perception/REFERENCE.md
@@ -69,8 +69,12 @@ openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30 --out sheet
   directory.
 - `--mode fast` (default) renders the topmost file-backed clip only — no
   effects, text, or compositing. Cheap, and right for "what footage is here". It
-  auto-falls back to composite when there is no such clip (a title card, say) and
-  reports `fellBackToComposite: true`.
+  auto-falls back to composite, reporting `fellBackToComposite: true`, whenever
+  fast mode cannot answer honestly: when there is no file-backed clip at that
+  time (a title card, say), and when the topmost clip carries a transform or a
+  non-default opacity, whose whole point is that the picture is no longer the
+  source file. So a still used to check your own `SetClipTransform` edit shows
+  the transform, at composite cost.
 - `--mode composite` renders a minimal window through the full stack, so effects
   and overlays appear. Range renders decode from zero, so it costs more. It works
   anywhere inside the timeline, including over a gap — a gap has no picture, so a

--- a/distribution/skills/skills/openreelio/render/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/render/REFERENCE.md
@@ -55,6 +55,25 @@ The result on stdout:
  "planHash":"c2b33fc72122ba67","warnings":[]}
 ```
 
+## What the render puts on screen
+
+Per-clip framing renders. `SetClipTransform` (position, scale, rotation, anchor)
+and `SetClipOpacity` are composited onto the canvas in the final export, exactly
+where the preview draws them.
+
+Three things still do not, and the render says so rather than pretending:
+
+| Feature | In `render start` |
+| ------- | ----------------- |
+| Clip transform and opacity | **Yes.** Composited at the clip's base values. |
+| Motion keyframes (`SetClipMotionKeyframes`) | **No.** The clip renders static at its base transform; the result carries a `warnings` entry naming the clip. |
+| Simultaneous layered video clips (picture-in-picture) | **No.** Validation refuses the render. |
+| Blend modes | **No.** Validation refuses the render. |
+
+`frame extract --mode fast` shows the *composited* picture for a transformed
+clip — it detects the transform and falls back to composite mode rather than
+handing back the untouched source file. See the perception reference.
+
 ## Inspect without encoding
 
 ```bash

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -206,6 +206,35 @@ alongside the picture. Until that exists the render degrades loudly rather than
 shipping a file that disagrees with its own timeline. For a soft-looking cut
 today, put `fade-out` on the outgoing clip and `fade-in` on the incoming one.
 
+### Framing a clip: transform and opacity
+
+`SetClipTransform` places a clip on the canvas and `SetClipOpacity` fades it.
+Both render in the final export, not just in the preview:
+
+```bash
+openreelio-cli command execute --path ./demo --type SetClipTransform   --payload '{"sequenceId":"…","trackId":"…","clipId":"…","transform":{
+    "position":{"x":0.25,"y":0.25},"scale":{"x":0.5,"y":0.5},
+    "rotationDeg":0,"anchor":{"x":0.5,"y":0.5}}}'
+```
+
+`position` is where the *anchor* lands on the canvas as a fraction of it;
+`anchor` is the point of the picture pinned there, and rotation turns about it.
+`scale` multiplies the letterbox fit, so `{1, 1}` means "fitted to the canvas".
+Placement is measured against the source's real pixel size, so a 4:3 clip in a
+16:9 sequence keeps its shape.
+
+Three limits remain, and the export is explicit about each:
+
+| Feature | Rendered by `render start` |
+|---------|----------------------------|
+| Clip transform and opacity | **Yes** — composited at the clip's base values |
+| Motion keyframes (`SetClipMotionKeyframes`) | **Not yet** — the clip renders static at its base transform and the result carries a `warnings` entry naming it |
+| Simultaneous layered video clips (picture-in-picture), blend modes | **Not yet** — validation refuses the render rather than dropping a layer |
+
+Motion is stored, round-trips through the project and animates in the preview;
+only the render is static. A clip whose keyframes all match its base transform
+is not warned about, because that is exactly the picture the export produces.
+
 ### Atomic batches: `plan execute`
 
 An edit plan is `{"id": "...", "steps": [{"id","commandType","payload","dependsOn"}]}`.
@@ -387,8 +416,12 @@ openreelio-cli frame extract --path ./demo --grid 3x2 --between 0 30 --out sheet
 
 - `--mode fast` (default) renders the topmost file-backed clip only: no
   effects, text or compositing. Cheap, and right for "what footage is here". It
-  auto-falls back to composite when there is no such clip (a title card, for
-  example) and reports `fellBackToComposite: true`.
+  auto-falls back to composite, reporting `fellBackToComposite: true`, whenever
+  fast mode cannot answer honestly: when there is no file-backed clip at that
+  time (a title card, for example), and when the topmost clip carries a
+  transform or a non-default opacity — the whole point of which is that the
+  picture is no longer the source file. Checking your own `SetClipTransform`
+  edit therefore shows the transform, at composite cost.
 - `--mode composite` renders a minimal window through the full stack, so
   effects and overlays appear. Range renders decode from zero, so it costs more.
   It works anywhere inside the timeline, including over a gap — a gap has no

--- a/src-tauri/src/core/assets/metadata.rs
+++ b/src-tauri/src/core/assets/metadata.rs
@@ -29,6 +29,13 @@ pub struct MediaMetadata {
     pub audio: Option<AudioInfo>,
     /// Format name (e.g., "mov,mp4,m4a,3gp,3g2,mj2")
     pub format: String,
+    /// Display-matrix rotation of the primary video stream, in degrees.
+    ///
+    /// `video.width`/`video.height` stay the *coded* size; FFmpeg auto-rotates on
+    /// decode, so a quarter turn here means the frames it produces are
+    /// `height x width`. See [`crate::core::ffmpeg::display_dimensions`].
+    #[serde(default)]
+    pub rotation_deg: f64,
 }
 
 impl Default for MediaMetadata {
@@ -39,6 +46,7 @@ impl Default for MediaMetadata {
             video: None,
             audio: None,
             format: String::new(),
+            rotation_deg: 0.0,
         }
     }
 }
@@ -70,6 +78,10 @@ struct FFprobeStream {
     color_primaries: Option<String>,
     #[allow(dead_code)]
     pix_fmt: Option<String>,
+    /// Per-stream side data; carries the display matrix on rotated recordings.
+    side_data_list: Option<Vec<serde_json::Value>>,
+    /// Stream tags; older remuxes only leave `rotate` behind.
+    tags: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -150,6 +162,7 @@ impl MetadataExtractor {
             for stream in streams {
                 match stream.codec_type.as_str() {
                     "video" if metadata.video.is_none() => {
+                        metadata.rotation_deg = Self::parse_display_rotation(&stream);
                         metadata.video = Some(Self::parse_video_stream(&stream));
                     }
                     "audio" if metadata.audio.is_none() => {
@@ -193,6 +206,28 @@ impl MetadataExtractor {
             is_hdr,
             color_transfer: stream.color_transfer.clone(),
         }
+    }
+
+    /// Read the display-matrix rotation a video stream advertises.
+    ///
+    /// The two shapes FFprobe emits are reassembled into the JSON object the
+    /// shared parser reads, so the sync and async probe paths cannot disagree
+    /// about what a rotated recording means.
+    fn parse_display_rotation(stream: &FFprobeStream) -> f64 {
+        let mut probe_shape = serde_json::Map::new();
+        if let Some(side_data_list) = stream.side_data_list.clone() {
+            probe_shape.insert(
+                "side_data_list".to_string(),
+                serde_json::Value::Array(side_data_list),
+            );
+        }
+        if let Some(tags) = stream.tags.clone() {
+            probe_shape.insert("tags".to_string(), tags);
+        }
+
+        crate::core::ffmpeg::rotation::rotation_from_probe_stream(&serde_json::Value::Object(
+            probe_shape,
+        ))
     }
 
     /// Parse audio stream info
@@ -257,6 +292,75 @@ mod tests {
     fn test_ffprobe_availability_check() {
         // This just tests that the function runs without panicking
         let _is_available = MetadataExtractor::is_available();
+    }
+
+    // -------------------------------------------------------------------------
+    // Display Rotation Tests
+    // -------------------------------------------------------------------------
+
+    /// Feature: Portrait phone footage
+    /// Scenario: a display matrix is read alongside the coded dimensions
+    ///
+    /// A phone records portrait as a landscape-coded stream plus a quarter-turn
+    /// display matrix. FFmpeg auto-rotates on decode, so anything sizing a
+    /// picture off the coded width and height alone stretches the clip.
+    #[test]
+    fn should_parse_the_display_matrix_rotation_of_a_portrait_recording() {
+        let json = r#"{
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "r_frame_rate": "30/1",
+                    "side_data_list": [
+                        {
+                            "side_data_type": "Display Matrix",
+                            "displaymatrix": "00000000: 0 65536 0",
+                            "rotation": -90
+                        }
+                    ]
+                }
+            ],
+            "format": { "duration": "4.0", "size": "1000", "format_name": "mov,mp4" }
+        }"#;
+
+        let metadata = MetadataExtractor::parse_ffprobe_output(json).expect("parse");
+
+        let video = metadata.video.expect("video stream");
+        assert_eq!((video.width, video.height), (1920, 1080));
+        assert_eq!(metadata.rotation_deg, -90.0);
+        assert_eq!(
+            crate::core::ffmpeg::display_dimensions(
+                video.width,
+                video.height,
+                metadata.rotation_deg
+            ),
+            (1080, 1920)
+        );
+    }
+
+    /// Feature: Portrait phone footage
+    /// Scenario: an unrotated recording reports no turn
+    #[test]
+    fn should_report_no_rotation_for_an_ordinary_recording() {
+        let json = r#"{
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1280,
+                    "height": 720,
+                    "r_frame_rate": "30/1"
+                }
+            ],
+            "format": { "duration": "4.0", "size": "1000", "format_name": "mov,mp4" }
+        }"#;
+
+        let metadata = MetadataExtractor::parse_ffprobe_output(json).expect("parse");
+
+        assert_eq!(metadata.rotation_deg, 0.0);
     }
 
     // -------------------------------------------------------------------------

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -1868,6 +1868,15 @@ impl FilterGraph {
         self.effects.iter().any(|e| e.is_audio())
     }
 
+    /// The video effects this graph emits, in the order they are applied.
+    ///
+    /// Callers that need to know what the picture looks like *after* the effect
+    /// chain — its size, for instance — have to walk the same list, in the same
+    /// order, that [`FilterGraph::to_video_filter_complex`] emits.
+    pub fn video_effects(&self) -> impl Iterator<Item = &Effect> {
+        self.effects.iter().filter(|effect| effect.is_video())
+    }
+
     /// Generates the FFmpeg filter_complex string for video effects
     ///
     /// # Arguments

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -23,6 +23,7 @@ mod commands;
 mod detection;
 pub mod installer;
 mod resolver;
+pub mod rotation;
 mod runner;
 mod state;
 
@@ -36,6 +37,7 @@ pub use resolver::{
     resolve_and_register, resolve_ffmpeg, resolved_ffmpeg_path, resolved_ffprobe_path,
     set_resolved_paths, FFmpegResolveOptions, ResolvedFFmpeg, FFMPEG_PATH_ENV, FFPROBE_PATH_ENV,
 };
+pub use rotation::{display_dimensions, normalize_rotation_deg, rotation_swaps_dimensions};
 pub use runner::{
     capture_filter_stderr, AudioStreamInfo, FFmpegProgress, FFmpegRunner, FilterCapture,
     FilterMode, FrameExtractOptions, MediaInfo, RenderSettings, VideoStreamInfo, WaveformData,

--- a/src-tauri/src/core/ffmpeg/rotation.rs
+++ b/src-tauri/src/core/ffmpeg/rotation.rs
@@ -1,0 +1,160 @@
+//! Display-matrix rotation carried by a container's video stream.
+//!
+//! A phone shooting in portrait usually records a landscape-coded stream plus a
+//! display matrix telling players to turn it. FFmpeg honours that matrix when it
+//! decodes (auto-rotation is on unless `-noautorotate` is passed), so the frames
+//! a filtergraph sees are already turned: a stream coded 1920x1080 with a quarter
+//! turn decodes to 1080x1920.
+//!
+//! Anything that reasons about "how big is this picture" therefore has to read
+//! the matrix too, or it will letterbox and stretch every portrait phone clip.
+
+/// A quarter turn, in degrees.
+const QUARTER_TURN_DEG: f64 = 90.0;
+
+/// A half turn, in degrees.
+const HALF_TURN_DEG: f64 = 180.0;
+
+/// Slack for comparing a rotation against an exact right angle.
+const ROTATION_MATCH_EPSILON_DEG: f64 = 1.0;
+
+/// Folds a raw rotation into `(-180, 180]`.
+///
+/// Containers report the same turn as `90`, `-270` or `450` depending on who
+/// wrote them, and `NaN` shows up in files that were remuxed badly.
+pub fn normalize_rotation_deg(raw: f64) -> f64 {
+    if !raw.is_finite() {
+        return 0.0;
+    }
+
+    let mut normalized = raw % (2.0 * HALF_TURN_DEG);
+    if normalized > HALF_TURN_DEG {
+        normalized -= 2.0 * HALF_TURN_DEG;
+    } else if normalized <= -HALF_TURN_DEG {
+        normalized += 2.0 * HALF_TURN_DEG;
+    }
+    normalized
+}
+
+/// Whether a rotation turns the picture onto its side.
+///
+/// Only quarter turns swap the extents; a half turn leaves them alone.
+pub fn rotation_swaps_dimensions(rotation_deg: f64) -> bool {
+    let normalized = normalize_rotation_deg(rotation_deg).abs();
+    (normalized - QUARTER_TURN_DEG).abs() < ROTATION_MATCH_EPSILON_DEG
+}
+
+/// The size the decoder actually hands downstream for a coded size plus rotation.
+pub fn display_dimensions(width: u32, height: u32, rotation_deg: f64) -> (u32, u32) {
+    if rotation_swaps_dimensions(rotation_deg) {
+        (height, width)
+    } else {
+        (width, height)
+    }
+}
+
+/// Reads the display-matrix rotation off an FFprobe stream object.
+///
+/// Modern FFprobe reports it as `side_data_list[].rotation`; older builds (and
+/// some remuxers) only leave a `tags.rotate` string behind, so both are read.
+/// Returns `0.0` when the stream carries neither.
+pub fn rotation_from_probe_stream(stream: &serde_json::Value) -> f64 {
+    let from_side_data = stream
+        .get("side_data_list")
+        .and_then(|list| list.as_array())
+        .and_then(|entries| {
+            entries
+                .iter()
+                .find_map(|entry| entry.get("rotation").and_then(json_number))
+        });
+
+    let raw = from_side_data.or_else(|| {
+        stream
+            .get("tags")
+            .and_then(|tags| tags.get("rotate"))
+            .and_then(json_number)
+    });
+
+    raw.map(normalize_rotation_deg).unwrap_or(0.0)
+}
+
+/// FFprobe writes rotation as a JSON number, but `tags.rotate` is a string.
+fn json_number(value: &serde_json::Value) -> Option<f64> {
+    value.as_f64().or_else(|| {
+        value
+            .as_str()
+            .and_then(|raw| raw.trim().parse::<f64>().ok())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feature: Display-matrix rotation
+    /// Scenario: equivalent spellings of the same turn normalize together
+    #[test]
+    fn should_normalize_equivalent_rotations() {
+        assert_eq!(normalize_rotation_deg(90.0), 90.0);
+        assert_eq!(normalize_rotation_deg(-270.0), 90.0);
+        assert_eq!(normalize_rotation_deg(450.0), 90.0);
+        assert_eq!(normalize_rotation_deg(-90.0), -90.0);
+        assert_eq!(normalize_rotation_deg(270.0), -90.0);
+        assert_eq!(normalize_rotation_deg(180.0), 180.0);
+        assert_eq!(normalize_rotation_deg(-180.0), 180.0);
+        assert_eq!(normalize_rotation_deg(0.0), 0.0);
+        assert_eq!(normalize_rotation_deg(f64::NAN), 0.0);
+    }
+
+    /// Feature: Display-matrix rotation
+    /// Scenario: only quarter turns put the picture on its side
+    #[test]
+    fn should_swap_dimensions_only_for_quarter_turns() {
+        assert!(rotation_swaps_dimensions(90.0));
+        assert!(rotation_swaps_dimensions(-90.0));
+        assert!(rotation_swaps_dimensions(270.0));
+        assert!(!rotation_swaps_dimensions(0.0));
+        assert!(!rotation_swaps_dimensions(180.0));
+
+        assert_eq!(display_dimensions(1920, 1080, 90.0), (1080, 1920));
+        assert_eq!(display_dimensions(1920, 1080, 180.0), (1920, 1080));
+        assert_eq!(display_dimensions(1920, 1080, 0.0), (1920, 1080));
+    }
+
+    /// Feature: Display-matrix rotation
+    /// Scenario: a portrait phone clip reports its turn through side_data_list
+    #[test]
+    fn should_read_rotation_from_side_data_list() {
+        let stream = serde_json::json!({
+            "codec_type": "video",
+            "width": 1920,
+            "height": 1080,
+            "side_data_list": [
+                { "side_data_type": "Display Matrix", "displaymatrix": "...", "rotation": -90 }
+            ]
+        });
+
+        assert_eq!(rotation_from_probe_stream(&stream), -90.0);
+    }
+
+    /// Feature: Display-matrix rotation
+    /// Scenario: an older remux only leaves a rotate tag behind
+    #[test]
+    fn should_read_rotation_from_the_rotate_tag() {
+        let stream = serde_json::json!({
+            "codec_type": "video",
+            "tags": { "rotate": "270" }
+        });
+
+        assert_eq!(rotation_from_probe_stream(&stream), -90.0);
+    }
+
+    /// Feature: Display-matrix rotation
+    /// Scenario: a stream with no matrix is not rotated
+    #[test]
+    fn should_report_no_rotation_when_the_stream_carries_none() {
+        let stream = serde_json::json!({ "codec_type": "video", "width": 640, "height": 480 });
+
+        assert_eq!(rotation_from_probe_stream(&stream), 0.0);
+    }
+}

--- a/src-tauri/src/core/ffmpeg/runner.rs
+++ b/src-tauri/src/core/ffmpeg/runner.rs
@@ -225,6 +225,13 @@ pub struct VideoStreamInfo {
     /// FFprobe color transfer string (e.g. `smpte2084`, `arib-std-b67`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color_transfer: Option<String>,
+    /// Display-matrix rotation in degrees, folded into `(-180, 180]`.
+    ///
+    /// `width` and `height` are the *coded* size. FFmpeg auto-rotates on decode,
+    /// so a quarter turn here means the frames downstream are `height x width`;
+    /// [`crate::core::ffmpeg::display_dimensions`] applies the swap.
+    #[serde(default)]
+    pub rotation_deg: f64,
 }
 
 /// Audio stream information.
@@ -2097,6 +2104,8 @@ fn parse_video_stream(stream: &serde_json::Value) -> FFmpegResult<VideoStreamInf
         Some("smpte2084") | Some("arib-std-b67") | Some("hlg") | Some("pq")
     );
 
+    let rotation_deg = crate::core::ffmpeg::rotation::rotation_from_probe_stream(stream);
+
     Ok(VideoStreamInfo {
         width,
         height,
@@ -2106,6 +2115,7 @@ fn parse_video_stream(stream: &serde_json::Value) -> FFmpegResult<VideoStreamInf
         bitrate,
         is_hdr,
         color_transfer,
+        rotation_deg,
     })
 }
 

--- a/src-tauri/src/core/qc/rules.rs
+++ b/src-tauri/src/core/qc/rules.rs
@@ -2060,13 +2060,15 @@ impl QCRule for LicenseRule {
 
 /// Rule that checks if all clips match the sequence aspect ratio
 ///
-/// Reports the mismatch and stops there. The export pipeline already fits every
-/// source into the canvas with `force_original_aspect_ratio=decrease` plus a
-/// pad, so a mismatch shows as bars rather than as broken output — and the only
-/// command that could override that framing, `SetClipTransform`, puts the clip
-/// on a non-identity transform, which the final export path rejects outright.
-/// Suggesting it would turn a cosmetic warning into a render that will not
-/// start, so this rule deliberately carries no fix.
+/// Reports the mismatch and stops there. The export pipeline fits every source
+/// into the canvas with `force_original_aspect_ratio=decrease` plus a pad, so a
+/// mismatch shows as bars rather than as broken output.
+///
+/// A reframe fix is possible in principle — the export now composites
+/// `SetClipTransform`, so a scale-and-crop suggestion would render — but
+/// choosing *which* part of a mismatched frame to keep is a judgement about the
+/// picture, not arithmetic this rule can do. No such fix is implemented yet, so
+/// the rule reports and leaves the framing decision to the caller.
 #[derive(Debug, Default)]
 pub struct AspectRatioRule;
 
@@ -2937,7 +2939,7 @@ mod tests {
         assert_eq!(rule.default_severity(), Severity::Warning);
         assert!(
             !rule.supports_auto_fix(),
-            "no single command reframes a clip without breaking export"
+            "reframing is a judgement about the picture; no auto-fix is implemented yet"
         );
     }
 
@@ -2965,7 +2967,7 @@ mod tests {
         assert_eq!(violations[0].severity, Severity::Warning);
         assert!(
             !violations[0].auto_fixable,
-            "SetClipTransform puts the clip on a transform the export path rejects"
+            "reframing is a judgement about the picture; no auto-fix is implemented yet"
         );
         assert!(violations[0].suggested_fix.is_none());
         assert_eq!(violations[0].metrics["trackId"], sequence.tracks[0].id);

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2747,6 +2747,7 @@ pub(super) fn append_video_transform_composition(
 ) {
     let staged_label = format!("{}_tx", output_label);
     let canvas_label = format!("{}_bg", output_label);
+    let (alpha_format, overlay_format) = transform_composition_formats(pixel_format);
 
     filter_complex.push_str(&format!(
         "[{}]scale={}:{},setsar=1",
@@ -2757,7 +2758,7 @@ pub(super) fn append_video_transform_composition(
     // a translucent one needs an alpha channel to attenuate. Either way the pixel
     // format has to carry alpha before the filter that uses it.
     if layout.is_rotated() || layout.is_translucent() {
-        filter_complex.push_str(",format=rgba");
+        filter_complex.push_str(&format!(",format={}", alpha_format));
     }
 
     if layout.is_rotated() {
@@ -2778,10 +2779,17 @@ pub(super) fn append_video_transform_composition(
 
     filter_complex.push_str(&format!("[{}];", staged_label));
 
+    // `shortest=1` ends the composite with whichever input runs out first, so the
+    // canvas has to last at least one frame or the segment renders empty.
+    let minimum_duration_sec = if fps.is_finite() && fps > 0.0 {
+        1.0 / fps
+    } else {
+        TIMELINE_EPSILON_SEC
+    };
     append_black_video_gap(
         filter_complex,
         &canvas_label,
-        duration_sec,
+        duration_sec.max(minimum_duration_sec),
         width,
         height,
         fps,
@@ -2789,15 +2797,29 @@ pub(super) fn append_video_transform_composition(
     );
 
     filter_complex.push_str(&format!(
-        "[{}][{}]overlay=x={}:y={}:shortest=1,setsar=1,fps={},format={}[{}];",
+        "[{}][{}]overlay=x={}:y={}:shortest=1:format={},setsar=1,fps={},format={}[{}];",
         canvas_label,
         staged_label,
         layout.overlay_x,
         layout.overlay_y,
+        overlay_format,
         format_speed_number(fps),
         pixel_format,
         output_label
     ));
+}
+
+/// The working format and `overlay` mode that keep a composite at the output's
+/// bit depth.
+///
+/// `overlay` defaults to 8-bit `yuv420`, so a 10-bit export whose clip happened
+/// to be transformed would quietly lose two bits per channel on the way through.
+fn transform_composition_formats(pixel_format: &str) -> (&'static str, &'static str) {
+    match pixel_format {
+        "yuv422p10le" => ("yuva422p10le", "yuv422p10"),
+        "yuv420p10le" => ("yuva420p10le", "yuv420p10"),
+        _ => ("yuva420p", "yuv420"),
+    }
 }
 
 pub(super) fn append_black_video_gap(
@@ -9272,6 +9294,38 @@ mod tests {
     }
 
     /// Feature: Transformed clips in the final render
+    /// Scenario: a 10-bit export composites at 10 bits
+    ///
+    /// `overlay` defaults to 8-bit `yuv420`. Leaving it there would mean a clip
+    /// quietly lost two bits per channel for no reason other than having been
+    /// moved, which is the kind of loss nobody would think to look for.
+    #[test]
+    fn test_build_filter_keeps_a_ten_bit_export_at_ten_bits() {
+        let (sequence, assets) = sequence_with_one_transformed_clip(Transform::default(), 0.5);
+        let args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ExportSettings {
+                bit_depth: Some(10),
+                ..ExportSettings::default()
+            },
+        )
+        .expect("a ten-bit transformed clip should build a filtergraph");
+        let filter_complex = filter_complex_of(&args);
+
+        assert!(
+            filter_complex.contains("format=yuva420p10le,colorchannelmixer=aa=0.5"),
+            "the alpha stage must keep the output's bit depth. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("shortest=1:format=yuv420p10,"),
+            "the composite must not downconvert the canvas. Got: {filter_complex}"
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
     /// Scenario: a scaled, repositioned clip is composited onto the canvas
     ///
     /// 1280x720 fits a 1920x1080 canvas at 1.5x, halved by the clip scale to
@@ -9301,7 +9355,7 @@ mod tests {
         );
         assert!(
             filter_complex.contains(
-                "[vnorm0_bg][vnorm0_tx]overlay=x=96:y=540:shortest=1,setsar=1,fps=30,format=yuv420p[vnorm0];"
+                "[vnorm0_bg][vnorm0_tx]overlay=x=96:y=540:shortest=1:format=yuv420,setsar=1,fps=30,format=yuv420p[vnorm0];"
             ),
             "the clip must be placed at the transformed corner. Got: {filter_complex}"
         );
@@ -9319,7 +9373,7 @@ mod tests {
 
         assert!(
             filter_complex.contains(
-                "scale=1920:1080,setsar=1,format=rgba,colorchannelmixer=aa=0.5[vnorm0_tx];"
+                "scale=1920:1080,setsar=1,format=yuva420p,colorchannelmixer=aa=0.5[vnorm0_tx];"
             ),
             "a faded clip must be attenuated before compositing. Got: {filter_complex}"
         );
@@ -9350,7 +9404,7 @@ mod tests {
 
         assert!(
             filter_complex.contains(
-                "scale=960:540,setsar=1,format=rgba,rotate=1.570796:ow=540:oh=960:c=black@0[vnorm0_tx];"
+                "scale=960:540,setsar=1,format=yuva420p,rotate=1.570796:ow=540:oh=960:c=black@0[vnorm0_tx];"
             ),
             "the rotation must be given a box that fits the turned frame. Got: {filter_complex}"
         );

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -22,6 +22,7 @@ use crate::core::{
     ffmpeg::FFmpegRunner,
     fs::validate_local_input_path,
     render::hdr::{build_tonemap_filter, HdrMetadata, TonemapMode, TonemapParams},
+    render::transform_layout::ClipTransformLayout,
     render::{
         build_ffmpeg_invocation_for_render_plan, build_ffmpeg_invocation_from_args,
         execute_ffmpeg_invocation, execute_ffmpeg_output, RenderPlan,
@@ -155,22 +156,6 @@ pub(super) fn clip_audio_is_suppressed_by_companion(
     track.kind != TrackKind::Audio
         && asset.kind == AssetKind::Video
         && audio_companion_keys.contains(&create_audio_companion_key(clip))
-}
-
-fn clip_has_identity_transform(clip: &Clip) -> bool {
-    (clip.transform.position.x - 0.5).abs() < 0.0001
-        && (clip.transform.position.y - 0.5).abs() < 0.0001
-        && (clip.transform.scale.x - 1.0).abs() < 0.0001
-        && (clip.transform.scale.y - 1.0).abs() < 0.0001
-        && clip.transform.rotation_deg.abs() < 0.0001
-        && (clip.transform.anchor.x - 0.5).abs() < 0.0001
-        && (clip.transform.anchor.y - 0.5).abs() < 0.0001
-}
-
-fn clip_uses_unsupported_visual_composition(clip: &Clip) -> bool {
-    !is_text_clip(clip)
-        && !clip.is_adjustment_layer()
-        && (!clip_has_identity_transform(clip) || (clip.opacity - 1.0).abs() > 0.0001)
 }
 
 fn has_layered_visual_overlap(sequence: &Sequence) -> bool {
@@ -2670,6 +2655,151 @@ pub(super) fn append_video_stream_normalization(
     ));
 }
 
+/// Whether a clip is placed on the canvas untouched.
+///
+/// An identity clip is letterboxed into the canvas and nothing else, which is
+/// exactly what [`append_video_stream_normalization`] already does, so it keeps
+/// the cheaper graph and needs no source dimensions.
+pub(super) fn clip_has_identity_transform(clip: &Clip) -> bool {
+    (clip.transform.position.x - 0.5).abs() < TRANSFORM_EPSILON
+        && (clip.transform.position.y - 0.5).abs() < TRANSFORM_EPSILON
+        && (clip.transform.scale.x - 1.0).abs() < TRANSFORM_EPSILON
+        && (clip.transform.scale.y - 1.0).abs() < TRANSFORM_EPSILON
+        && clip.transform.rotation_deg.abs() < TRANSFORM_EPSILON
+        && (clip.transform.anchor.x - 0.5).abs() < TRANSFORM_EPSILON
+        && (clip.transform.anchor.y - 0.5).abs() < TRANSFORM_EPSILON
+}
+
+/// Whether a clip has to be composited onto the canvas rather than simply fitted.
+///
+/// Text clips and adjustment layers carry a transform too, but they are drawn by
+/// the ASS/drawtext overlay path and the grading path respectively, so neither
+/// takes part in this composite.
+pub(super) fn clip_needs_transform_composition(clip: &Clip) -> bool {
+    !is_text_clip(clip)
+        && !clip.is_adjustment_layer()
+        && (!clip_has_identity_transform(clip)
+            || (f64::from(clip.opacity) - 1.0).abs() > TRANSFORM_EPSILON)
+}
+
+/// Tolerance for treating a transform component as untouched.
+const TRANSFORM_EPSILON: f64 = 0.0001;
+
+/// Pixel dimensions of the media a clip decodes, cached for one export run.
+///
+/// Keyed by asset id. A `None` entry records that the asset was already looked at
+/// and could not be measured, so a broken file is probed once rather than once
+/// per clip that uses it.
+pub(super) type SourceDimensionCache = HashMap<String, Option<(u32, u32)>>;
+
+/// Measures the media an asset points at.
+///
+/// FFprobe comes first because it reports what will actually be decoded. The
+/// stored `Asset::video` metadata is only a fallback: `ImportAssetCommand::new`
+/// files every video away as a placeholder `VideoInfo::default()` (1920x1080)
+/// unless the caller enriched it, so trusting it first would silently letterbox
+/// or stretch anything imported headlessly.
+///
+/// Returns `None` when neither source can name the dimensions.
+pub(super) fn resolve_asset_source_dimensions(
+    asset: &Asset,
+    cache: &mut SourceDimensionCache,
+) -> Option<(u32, u32)> {
+    if let Some(cached) = cache.get(&asset.id) {
+        return *cached;
+    }
+
+    let probed = crate::core::assets::MetadataExtractor::extract(&asset.uri)
+        .ok()
+        .and_then(|metadata| metadata.video)
+        .map(|video| (video.width, video.height));
+
+    let resolved = probed
+        .or_else(|| {
+            asset
+                .video
+                .as_ref()
+                .map(|video| (video.width, video.height))
+        })
+        .filter(|(width, height)| *width > 0 && *height > 0);
+
+    cache.insert(asset.id.clone(), resolved);
+    resolved
+}
+
+/// Emits the filter chain that places one transformed clip on the output canvas.
+///
+/// The chain is `scale` -> optional `rotate` -> optional alpha -> `overlay` onto
+/// a black canvas of the clip's own timeline duration. It ends in the same shape
+/// [`append_video_stream_normalization`] produces — `setsar=1,fps=,format=` on a
+/// full-canvas frame — so the downstream concat cannot tell the two apart.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn append_video_transform_composition(
+    filter_complex: &mut String,
+    input_label: &str,
+    output_label: &str,
+    layout: &ClipTransformLayout,
+    duration_sec: f64,
+    width: u32,
+    height: u32,
+    fps: f64,
+    pixel_format: &str,
+) {
+    let staged_label = format!("{}_tx", output_label);
+    let canvas_label = format!("{}_bg", output_label);
+
+    filter_complex.push_str(&format!(
+        "[{}]scale={}:{},setsar=1",
+        input_label, layout.scaled_width, layout.scaled_height
+    ));
+
+    // A rotated frame needs somewhere transparent for its corners to land in, and
+    // a translucent one needs an alpha channel to attenuate. Either way the pixel
+    // format has to carry alpha before the filter that uses it.
+    if layout.is_rotated() || layout.is_translucent() {
+        filter_complex.push_str(",format=rgba");
+    }
+
+    if layout.is_rotated() {
+        filter_complex.push_str(&format!(
+            ",rotate={}:ow={}:oh={}:c=black@0",
+            format_speed_number(layout.rotation_rad),
+            layout.bounding_width,
+            layout.bounding_height
+        ));
+    }
+
+    if layout.is_translucent() {
+        filter_complex.push_str(&format!(
+            ",colorchannelmixer=aa={}",
+            format_speed_number(layout.opacity)
+        ));
+    }
+
+    filter_complex.push_str(&format!("[{}];", staged_label));
+
+    append_black_video_gap(
+        filter_complex,
+        &canvas_label,
+        duration_sec,
+        width,
+        height,
+        fps,
+        pixel_format,
+    );
+
+    filter_complex.push_str(&format!(
+        "[{}][{}]overlay=x={}:y={}:shortest=1,setsar=1,fps={},format={}[{}];",
+        canvas_label,
+        staged_label,
+        layout.overlay_x,
+        layout.overlay_y,
+        format_speed_number(fps),
+        pixel_format,
+        output_label
+    ));
+}
+
 pub(super) fn append_black_video_gap(
     filter_complex: &mut String,
     output_label: &str,
@@ -5128,6 +5258,9 @@ pub fn validate_export_settings(
 ) -> ExportValidation {
     let mut validation = ExportValidation::valid();
     let timeline_clock = TimelineClock::new(sequence.format.fps.clone());
+    // Shared with the filtergraph builder's resolution so validation and the
+    // render cannot disagree about how big a source is.
+    let mut source_dimensions = SourceDimensionCache::new();
 
     for error in validate_export_settings_options(settings) {
         validation.add_error(error);
@@ -5213,10 +5346,18 @@ pub fn validate_export_settings(
                 ));
             }
 
-            if track.kind == TrackKind::Video && clip_uses_unsupported_visual_composition(clip) {
-                validation.add_error(format!(
-                    "Clip '{}' uses transform or opacity settings that final render export does not support yet",
-                    clip.id
+            // Motion is stored, round-trips through the project, and animates in
+            // the preview; what it is not is rendered. The export composites the
+            // clip once, at its base transform, so the caller is told what the
+            // file will actually show rather than left to discover it.
+            if track.kind == TrackKind::Video
+                && !clip.motion_keyframes.is_empty()
+                && !clip.is_adjustment_layer()
+                && !is_text_clip(clip)
+            {
+                validation.add_warning(format!(
+                    "Motion keyframes on clip '{}' on track '{}' are not yet rendered; the clip renders with its base transform",
+                    clip.id, track.name
                 ));
             }
 
@@ -5255,6 +5396,19 @@ pub fn validate_export_settings(
                 validation.add_error(format!(
                     "Invalid asset path for asset '{}': {}",
                     asset.id, err
+                ));
+            }
+
+            // Placing a transformed clip needs the source's real pixel size. An
+            // identity clip is only fitted to the canvas, so it never pays for
+            // this and never fails on it.
+            if track.kind == TrackKind::Video
+                && clip_needs_transform_composition(clip)
+                && resolve_asset_source_dimensions(asset, &mut source_dimensions).is_none()
+            {
+                validation.add_error(format!(
+                    "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
+                    asset.id, clip.id
                 ));
             }
 
@@ -5390,6 +5544,7 @@ pub fn detect_timeline_gaps(sequence: &Sequence) -> Vec<TimelineGap> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::timeline::Transform;
 
     fn create_temp_media_file(filename: &str) -> String {
         let dir = std::env::temp_dir().join("openreelio-test-media");
@@ -6474,8 +6629,14 @@ mod tests {
             .any(|error| error.to_lowercase().contains("blend mode export")));
     }
 
+    /// Feature: Transformed clips in the final render
+    /// Scenario: a moved, translucent clip exports instead of being refused
+    ///
+    /// The preview has always let a clip be moved and faded. Export used to
+    /// reject exactly those clips, so a project that looked finished could not
+    /// be rendered at all. The composite path renders them now.
     #[test]
-    fn test_validation_rejects_clip_transform_or_opacity_that_export_cannot_render() {
+    fn test_validation_accepts_a_clip_the_export_now_composites() {
         use crate::core::assets::VideoInfo;
         use crate::core::timeline::{Clip, SequenceFormat, Track};
         use crate::core::Point2D;
@@ -6511,12 +6672,87 @@ mod tests {
         );
 
         assert!(
-            validation
-                .errors
-                .iter()
-                .any(|error| error.to_lowercase().contains("transform or opacity")),
-            "Expected unsupported transform/opacity validation error. Got: {:?}",
+            validation.is_valid,
+            "a transformed, translucent clip must export. Got: {:?}",
             validation.errors
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: keyframed motion renders static, and says so
+    ///
+    /// The preview animates `motion_keyframes`; the export composites the clip
+    /// once. Silently rendering the base transform would hand back a file that
+    /// disagrees with what the editor just watched.
+    #[test]
+    fn test_validation_warns_that_motion_keyframes_render_static() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track, TransformKeyframe};
+        use crate::core::Point2D;
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("Video 1");
+
+        let mut clip = Clip::new("video_asset")
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        clip.id = "moving-clip".to_string();
+        clip.motion_keyframes = vec![
+            TransformKeyframe {
+                time_offset: 0.0,
+                transform: Transform::default(),
+                interpolation: Default::default(),
+            },
+            TransformKeyframe {
+                time_offset: 3.0,
+                transform: Transform {
+                    position: Point2D::new(0.75, 0.5),
+                    ..Transform::default()
+                },
+                interpolation: Default::default(),
+            },
+        ];
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let video_path = create_temp_media_file("validation_motion.mp4");
+        let mut assets = HashMap::new();
+        let mut video_asset =
+            Asset::new_video("validation_motion.mp4", &video_path, VideoInfo::default())
+                .with_duration(3.0)
+                .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+
+        assert!(
+            validation.is_valid,
+            "keyframed motion must not block the export: {:?}",
+            validation.errors
+        );
+        let warning = validation
+            .warnings
+            .iter()
+            .find(|warning| warning.contains("Motion keyframes"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "keyframed motion must be reported: {:?}",
+                    validation.warnings
+                )
+            });
+        assert!(
+            warning.contains("moving-clip"),
+            "the warning must name the clip: {warning}"
+        );
+        assert!(
+            warning.contains("base transform"),
+            "the warning must say what happens instead: {warning}"
         );
     }
 
@@ -8978,6 +9214,172 @@ mod tests {
         args.windows(2)
             .find_map(|window| (window[0] == "-filter_complex").then_some(window[1].as_str()))
             .expect("filter_complex argument")
+    }
+
+    /// A 1080p sequence holding one 720p clip for three seconds.
+    ///
+    /// The source is deliberately smaller than the canvas so the "fit the source
+    /// into the canvas first" half of the placement contract is exercised rather
+    /// than cancelling out at 1:1.
+    fn sequence_with_one_transformed_clip(
+        transform: Transform,
+        opacity: f32,
+    ) -> (Sequence, std::collections::HashMap<String, Asset>) {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat};
+
+        let mut sequence = Sequence::new("Transform", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("Video 1");
+        let mut clip = Clip::new("video_asset")
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        clip.transform = transform;
+        clip.opacity = opacity;
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let video_path = create_temp_media_file("transform_source.mp4");
+        let mut video_asset = Asset::new_video(
+            "transform_source.mp4",
+            &video_path,
+            VideoInfo {
+                width: 1280,
+                height: 720,
+                ..VideoInfo::default()
+            },
+        )
+        .with_duration(3.0)
+        .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+
+        let mut assets = std::collections::HashMap::new();
+        assets.insert(video_asset.id.clone(), video_asset);
+
+        (sequence, assets)
+    }
+
+    fn build_transform_filter_complex(transform: Transform, opacity: f32) -> String {
+        let (sequence, assets) = sequence_with_one_transformed_clip(transform, opacity);
+        let args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ExportSettings::default(),
+        )
+        .expect("a transformed clip should build a filtergraph");
+        filter_complex_of(&args).to_string()
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: a scaled, repositioned clip is composited onto the canvas
+    ///
+    /// 1280x720 fits a 1920x1080 canvas at 1.5x, halved by the clip scale to
+    /// 960x540. Its centre lands at (0.3 * 1920, 0.75 * 1080) = (576, 810), so
+    /// the frame's top-left corner is (96, 540).
+    #[test]
+    fn test_build_filter_composites_a_scaled_and_moved_clip() {
+        use crate::core::Point2D;
+
+        let filter_complex = build_transform_filter_complex(
+            Transform {
+                scale: Point2D::new(0.5, 0.5),
+                position: Point2D::new(0.3, 0.75),
+                ..Transform::default()
+            },
+            1.0,
+        );
+
+        assert!(
+            filter_complex.contains("scale=960:540,setsar=1[vnorm0_tx];"),
+            "the clip must be scaled to its transformed size. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex
+                .contains("color=c=black:s=1920x1080:r=30:d=3,format=yuv420p[vnorm0_bg];"),
+            "the composite needs a canvas as long as the clip. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains(
+                "[vnorm0_bg][vnorm0_tx]overlay=x=96:y=540:shortest=1,setsar=1,fps=30,format=yuv420p[vnorm0];"
+            ),
+            "the clip must be placed at the transformed corner. Got: {filter_complex}"
+        );
+        assert!(
+            !filter_complex.contains("colorchannelmixer"),
+            "a fully opaque clip must not pay for an alpha filter. Got: {filter_complex}"
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: a faded clip keeps its framing and gains an alpha stage
+    #[test]
+    fn test_build_filter_renders_clip_opacity() {
+        let filter_complex = build_transform_filter_complex(Transform::default(), 0.5);
+
+        assert!(
+            filter_complex.contains(
+                "scale=1920:1080,setsar=1,format=rgba,colorchannelmixer=aa=0.5[vnorm0_tx];"
+            ),
+            "a faded clip must be attenuated before compositing. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("overlay=x=0:y=0:shortest=1"),
+            "an untransformed faded clip still fills the canvas. Got: {filter_complex}"
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: a rotated clip gets a box big enough for its own corners
+    ///
+    /// A 960x540 frame turned a quarter turn sweeps a 540x960 box. Rotating
+    /// about the centre anchor leaves the picture centred, so the box's corner
+    /// is (960 - 270, 540 - 480).
+    #[test]
+    fn test_build_filter_rotates_a_clip_into_a_bounding_box() {
+        use crate::core::Point2D;
+
+        let filter_complex = build_transform_filter_complex(
+            Transform {
+                scale: Point2D::new(0.5, 0.5),
+                rotation_deg: 90.0,
+                ..Transform::default()
+            },
+            1.0,
+        );
+
+        assert!(
+            filter_complex.contains(
+                "scale=960:540,setsar=1,format=rgba,rotate=1.570796:ow=540:oh=960:c=black@0[vnorm0_tx];"
+            ),
+            "the rotation must be given a box that fits the turned frame. Got: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("overlay=x=690:y=60:shortest=1"),
+            "the rotated frame must stay centred on its anchor. Got: {filter_complex}"
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: an untouched clip keeps the cheaper letterbox graph
+    ///
+    /// The composite path costs an extra canvas source and an overlay per clip.
+    /// Nothing about an identity clip needs either, and the whole existing corpus
+    /// of graph-shape tests is written against the fit-and-pad chain.
+    #[test]
+    fn test_build_filter_leaves_an_identity_clip_on_the_normalization_path() {
+        let filter_complex = build_transform_filter_complex(Transform::default(), 1.0);
+
+        assert!(
+            filter_complex.contains(
+                "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=30,format=yuv420p[vnorm0];"
+            ),
+            "an identity clip must still be fitted and padded. Got: {filter_complex}"
+        );
+        assert!(
+            !filter_complex.contains("overlay="),
+            "an identity clip must not be composited. Got: {filter_complex}"
+        );
     }
 
     /// Feature: Render output length

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -28,7 +28,8 @@ use crate::core::{
         execute_ffmpeg_invocation, execute_ffmpeg_output, RenderPlan,
     },
     timeline::{
-        BlendMode, Canvas, Clip, Sequence, SlowMotionInterpolation, TimelineClock, Track, TrackKind,
+        BlendMode, Canvas, Clip, Sequence, SlowMotionInterpolation, TimelineClock, Track,
+        TrackKind, Transform,
     },
 };
 
@@ -2023,6 +2024,13 @@ pub enum ExportError {
 pub struct AssetAudioInfo {
     /// Whether the asset has an audio stream
     pub has_audio: bool,
+    /// Pixel dimensions of the asset's video stream as the decoder emits them.
+    ///
+    /// The same probe that answers "does this have audio" already measured the
+    /// picture, so carrying it here spares the filtergraph builder an FFprobe run
+    /// per transformed asset. `None` means the probe found no video stream, or
+    /// fell back to metadata that cannot vouch for a size.
+    pub source_dimensions: Option<(u32, u32)>,
 }
 
 impl AssetAudioInfo {
@@ -2030,6 +2038,17 @@ impl AssetAudioInfo {
     pub fn from_media_info(media_info: &crate::core::ffmpeg::MediaInfo) -> Self {
         Self {
             has_audio: media_info.audio.is_some(),
+            source_dimensions: media_info
+                .video
+                .as_ref()
+                .map(|video| {
+                    crate::core::ffmpeg::display_dimensions(
+                        video.width,
+                        video.height,
+                        video.rotation_deg,
+                    )
+                })
+                .filter(|(width, height)| *width > 0 && *height > 0),
         }
     }
 
@@ -2039,6 +2058,7 @@ impl AssetAudioInfo {
     pub fn from_asset(asset: &Asset) -> Self {
         Self {
             has_audio: asset.audio.is_some(),
+            source_dimensions: stored_asset_source_dimensions(asset),
         }
     }
 }
@@ -2655,12 +2675,15 @@ pub(super) fn append_video_stream_normalization(
     ));
 }
 
+/// Tolerance for treating a transform component as untouched.
+const TRANSFORM_EPSILON: f64 = 0.0001;
+
 /// Whether a clip is placed on the canvas untouched.
 ///
 /// An identity clip is letterboxed into the canvas and nothing else, which is
 /// exactly what [`append_video_stream_normalization`] already does, so it keeps
 /// the cheaper graph and needs no source dimensions.
-pub(super) fn clip_has_identity_transform(clip: &Clip) -> bool {
+fn clip_has_identity_transform(clip: &Clip) -> bool {
     (clip.transform.position.x - 0.5).abs() < TRANSFORM_EPSILON
         && (clip.transform.position.y - 0.5).abs() < TRANSFORM_EPSILON
         && (clip.transform.scale.x - 1.0).abs() < TRANSFORM_EPSILON
@@ -2675,15 +2698,12 @@ pub(super) fn clip_has_identity_transform(clip: &Clip) -> bool {
 /// Text clips and adjustment layers carry a transform too, but they are drawn by
 /// the ASS/drawtext overlay path and the grading path respectively, so neither
 /// takes part in this composite.
-pub(super) fn clip_needs_transform_composition(clip: &Clip) -> bool {
+pub fn clip_needs_transform_composition(clip: &Clip) -> bool {
     !is_text_clip(clip)
         && !clip.is_adjustment_layer()
         && (!clip_has_identity_transform(clip)
             || (f64::from(clip.opacity) - 1.0).abs() > TRANSFORM_EPSILON)
 }
-
-/// Tolerance for treating a transform component as untouched.
-const TRANSFORM_EPSILON: f64 = 0.0001;
 
 /// Pixel dimensions of the media a clip decodes, cached for one export run.
 ///
@@ -2691,6 +2711,82 @@ const TRANSFORM_EPSILON: f64 = 0.0001;
 /// and could not be measured, so a broken file is probed once rather than once
 /// per clip that uses it.
 pub(super) type SourceDimensionCache = HashMap<String, Option<(u32, u32)>>;
+
+/// Source dimensions an earlier probe already measured, keyed by asset id.
+///
+/// Passing one of these into [`validate_export_settings_with_dimensions`] is what
+/// keeps validation from spawning its own FFprobe per transformed asset.
+pub type SourceDimensionMap = HashMap<String, (u32, u32)>;
+
+/// Everything the export's asset probe learned about picture sizes.
+pub fn source_dimensions_from_audio_info(
+    audio_info: &HashMap<String, AssetAudioInfo>,
+) -> SourceDimensionMap {
+    audio_info
+        .iter()
+        .filter_map(|(asset_id, info)| {
+            info.source_dimensions
+                .map(|dimensions| (asset_id.clone(), dimensions))
+        })
+        .collect()
+}
+
+/// Turns an already-measured dimension map into a cache the resolver can read.
+///
+/// Only measured assets are seeded. An asset the probe could not size is left
+/// out entirely rather than seeded as `None`, so the resolver still gets its
+/// chance to measure it before the export gives up on the clip.
+pub(super) fn seed_source_dimension_cache(
+    audio_info: &HashMap<String, AssetAudioInfo>,
+) -> SourceDimensionCache {
+    audio_info
+        .iter()
+        .filter_map(|(asset_id, info)| {
+            info.source_dimensions
+                .map(|dimensions| (asset_id.clone(), Some(dimensions)))
+        })
+        .collect()
+}
+
+/// Whether a clip's motion keyframes would show anything the static render will not.
+///
+/// Motion is stored, round-trips through the project and animates in the
+/// preview, but the export composites the clip once at its base transform. That
+/// is only worth telling the caller about when the keyframes actually move the
+/// clip: a lone keyframe, or a run of identical ones, describes exactly the
+/// picture the export already produces, and warning about it trains callers to
+/// ignore the warning that matters.
+pub(super) fn clip_motion_differs_from_base_transform(clip: &Clip) -> bool {
+    let mut keyframes = clip.motion_keyframes.iter();
+    let Some(first) = keyframes.next() else {
+        return false;
+    };
+
+    if !transforms_match(&first.transform, &clip.transform) {
+        return true;
+    }
+
+    keyframes.any(|keyframe| !transforms_match(&keyframe.transform, &first.transform))
+}
+
+fn transforms_match(left: &Transform, right: &Transform) -> bool {
+    (left.position.x - right.position.x).abs() < TRANSFORM_EPSILON
+        && (left.position.y - right.position.y).abs() < TRANSFORM_EPSILON
+        && (left.scale.x - right.scale.x).abs() < TRANSFORM_EPSILON
+        && (left.scale.y - right.scale.y).abs() < TRANSFORM_EPSILON
+        && (left.rotation_deg - right.rotation_deg).abs() < TRANSFORM_EPSILON
+        && (left.anchor.x - right.anchor.x).abs() < TRANSFORM_EPSILON
+        && (left.anchor.y - right.anchor.y).abs() < TRANSFORM_EPSILON
+}
+
+/// The error text for a clip whose effect chain resizes unpredictably.
+pub(super) fn unmeasurable_effect_message(effect_label: &str, clip_id: &str) -> String {
+    format!(
+        "Effect '{}' on clip '{}' changes the picture size in a way the export cannot measure, \
+         so the clip's transform cannot be placed",
+        effect_label, clip_id
+    )
+}
 
 /// Measures the media an asset points at.
 ///
@@ -2709,22 +2805,255 @@ pub(super) fn resolve_asset_source_dimensions(
         return *cached;
     }
 
-    let probed = crate::core::assets::MetadataExtractor::extract(&asset.uri)
-        .ok()
-        .and_then(|metadata| metadata.video)
-        .map(|video| (video.width, video.height));
+    let probed = match crate::core::assets::MetadataExtractor::extract(&asset.uri) {
+        Ok(metadata) => metadata.video.as_ref().map(|video| {
+            crate::core::ffmpeg::display_dimensions(
+                video.width,
+                video.height,
+                metadata.rotation_deg,
+            )
+        }),
+        Err(error) => {
+            // Silently trusting the stored metadata here is what let a broken
+            // file render at the 1920x1080 placeholder size, so the failure has
+            // to be visible even when the fallback below rescues the export.
+            tracing::warn!(
+                asset_id = %asset.id,
+                error = %error,
+                "Could not probe asset for its source dimensions"
+            );
+            None
+        }
+    };
 
     let resolved = probed
-        .or_else(|| {
-            asset
-                .video
-                .as_ref()
-                .map(|video| (video.width, video.height))
-        })
+        .or_else(|| stored_asset_source_dimensions(asset))
         .filter(|(width, height)| *width > 0 && *height > 0);
 
     cache.insert(asset.id.clone(), resolved);
     resolved
+}
+
+/// The dimensions an asset's *stored* metadata can vouch for.
+///
+/// `ImportAssetCommand::new` files unenriched video away as a whole
+/// `VideoInfo::default()`, which is a non-zero 1920x1080 and therefore passes
+/// every "did we get a size" check while meaning "nobody looked". Recognising
+/// that exact placeholder shape is what turns a failed probe into the loud
+/// "Could not determine source dimensions" error instead of a stretched render.
+fn stored_asset_source_dimensions(asset: &Asset) -> Option<(u32, u32)> {
+    let video = asset.video.as_ref()?;
+    if *video == crate::core::assets::VideoInfo::default() {
+        return None;
+    }
+    Some((video.width, video.height))
+}
+
+/// The picture size the transform stage actually receives.
+///
+/// The transform emits an absolute `scale=W:H`, so it has to be sized against
+/// the frame that reaches it — not against the file on disk. A `Crop` earlier in
+/// the clip's chain hands the transform a smaller picture, and `Zoom` hands it a
+/// fixed 1280x720 (`zoompan`'s `s=hd720`); sizing off the probed dimensions in
+/// either case stretches the clip, even when the only transform is opacity.
+///
+/// Returns the label of the offending effect when its output size cannot be read
+/// off the filter it emits. Guessing there would render silently wrong, so the
+/// caller turns it into a validation error naming the clip.
+pub(super) fn effective_source_dimensions(
+    probed_dimensions: (u32, u32),
+    graph: &FilterGraph,
+) -> Result<(u32, u32), String> {
+    let mut dimensions = probed_dimensions;
+
+    for effect in graph.video_effects() {
+        // A masked effect is drawn back over the untouched frame by
+        // `apply_effect_through_mask_group`, so the group outputs the size it
+        // was handed no matter what the effect body does.
+        if effect.masks.has_enabled_masks() {
+            continue;
+        }
+
+        let body = effect.build_filter_params();
+        for segment in split_filter_chain(&body) {
+            match filter_segment_dimensions(segment) {
+                SegmentDimensions::Unchanged => {}
+                SegmentDimensions::Fixed(width, height) if width > 0 && height > 0 => {
+                    dimensions = (width, height);
+                }
+                _ => return Err(effect_type_label(&effect.effect_type)),
+            }
+        }
+    }
+
+    Ok(dimensions)
+}
+
+/// How one FFmpeg filter changes the frame size flowing through it.
+enum SegmentDimensions {
+    /// The filter leaves the frame size alone.
+    Unchanged,
+    /// The filter outputs this size.
+    Fixed(u32, u32),
+    /// The filter resizes, but not to a size this can read off the string.
+    Unknown,
+}
+
+/// Splits a filter chain body into its individual filters.
+///
+/// Commas separate filters, except inside the quoted expressions FFmpeg accepts
+/// as parameter values — `crop=608:1080:'if(lt(t,1),0,120)':0` is one filter, not
+/// three.
+fn split_filter_chain(body: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    let mut quoted = false;
+    let mut depth = 0_i32;
+
+    for (index, character) in body.char_indices() {
+        match character {
+            '\'' => quoted = !quoted,
+            '(' if !quoted => depth += 1,
+            ')' if !quoted => depth = depth.saturating_sub(1),
+            ',' if !quoted && depth == 0 => {
+                segments.push(body[start..index].trim());
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    segments.push(body[start..].trim());
+
+    segments
+        .into_iter()
+        .filter(|segment| !segment.is_empty())
+        .collect()
+}
+
+/// Splits one filter's arguments on `:`, respecting quoted expressions.
+fn split_filter_arguments(arguments: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut quoted = false;
+    let mut depth = 0_i32;
+
+    for (index, character) in arguments.char_indices() {
+        match character {
+            '\'' => quoted = !quoted,
+            '(' if !quoted => depth += 1,
+            ')' if !quoted => depth = depth.saturating_sub(1),
+            ':' if !quoted && depth == 0 => {
+                parts.push(arguments[start..index].trim());
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    parts.push(arguments[start..].trim());
+    parts
+}
+
+/// Reads the output size of a single filter.
+///
+/// Every arm here was checked against `Effect::build_filter_params`: of the
+/// filters that builder can emit, only `crop` (`Crop`, `AutoReframe`) and
+/// `zoompan` (`Zoom`) resize. `scale`/`pad`/`transpose` never come out of it
+/// today and are listed so a future effect that emits one is caught loudly by
+/// [`effective_source_dimensions`] rather than mis-sizing a transform.
+fn filter_segment_dimensions(segment: &str) -> SegmentDimensions {
+    let (name, arguments) = match segment.split_once('=') {
+        Some((name, arguments)) => (name.trim(), arguments),
+        None => (segment.trim(), ""),
+    };
+
+    let arguments = split_filter_arguments(arguments);
+
+    match name {
+        "crop" | "scale" | "pad" => {
+            match sized_arguments(&arguments, ("w", "width"), ("h", "height")) {
+                Some((width, height)) => SegmentDimensions::Fixed(width, height),
+                None => SegmentDimensions::Unknown,
+            }
+        }
+        "zoompan" => match named_argument(&arguments, "s") {
+            // `zoompan` defaults to `hd720` when no size is given, which is what
+            // the builder relies on when it does pass one.
+            None => SegmentDimensions::Fixed(1280, 720),
+            Some(size) => match parse_frame_size(size) {
+                Some((width, height)) => SegmentDimensions::Fixed(width, height),
+                None => SegmentDimensions::Unknown,
+            },
+        },
+        "rotate" => {
+            // `rotate` keeps the input size unless it is told otherwise.
+            let output_width = named_argument(&arguments, "ow");
+            let output_height = named_argument(&arguments, "oh");
+            match (output_width, output_height) {
+                (None, None) => SegmentDimensions::Unchanged,
+                (Some(width), Some(height)) => {
+                    match (width.parse::<u32>().ok(), height.parse::<u32>().ok()) {
+                        (Some(width), Some(height)) => SegmentDimensions::Fixed(width, height),
+                        _ => SegmentDimensions::Unknown,
+                    }
+                }
+                _ => SegmentDimensions::Unknown,
+            }
+        }
+        "scale2ref" | "tile" | "transpose" | "hstack" | "vstack" | "xstack" => {
+            SegmentDimensions::Unknown
+        }
+        _ => SegmentDimensions::Unchanged,
+    }
+}
+
+/// Reads a filter's width and height, whether they were given by name or position.
+fn sized_arguments(
+    arguments: &[&str],
+    width_names: (&str, &str),
+    height_names: (&str, &str),
+) -> Option<(u32, u32)> {
+    let width = named_argument(arguments, width_names.0)
+        .or_else(|| named_argument(arguments, width_names.1))
+        .or_else(|| positional_argument(arguments, 0));
+    let height = named_argument(arguments, height_names.0)
+        .or_else(|| named_argument(arguments, height_names.1))
+        .or_else(|| positional_argument(arguments, 1));
+
+    Some((width?.parse().ok()?, height?.parse().ok()?))
+}
+
+fn named_argument<'a>(arguments: &[&'a str], name: &str) -> Option<&'a str> {
+    arguments.iter().find_map(|argument| {
+        argument
+            .split_once('=')
+            .filter(|(key, _)| key.trim() == name)
+            .map(|(_, value)| value.trim())
+    })
+}
+
+fn positional_argument<'a>(arguments: &[&'a str], index: usize) -> Option<&'a str> {
+    let argument = arguments.get(index)?.trim();
+    if argument.contains('=') {
+        return None;
+    }
+    Some(argument)
+}
+
+/// Parses an FFmpeg frame size, either `WxH` or one of the standard abbreviations.
+fn parse_frame_size(size: &str) -> Option<(u32, u32)> {
+    let size = size.trim().trim_matches('\'');
+    if let Some((width, height)) = size.split_once('x') {
+        return Some((width.trim().parse().ok()?, height.trim().parse().ok()?));
+    }
+
+    match size {
+        "hd480" => Some((852, 480)),
+        "hd720" => Some((1280, 720)),
+        "hd1080" => Some((1920, 1080)),
+        "2k" => Some((2048, 1080)),
+        "4k" => Some((4096, 2160)),
+        _ => None,
+    }
 }
 
 /// Emits the filter chain that places one transformed clip on the output canvas.
@@ -2755,10 +3084,20 @@ pub(super) fn append_video_transform_composition(
     ));
 
     // A rotated frame needs somewhere transparent for its corners to land in, and
-    // a translucent one needs an alpha channel to attenuate. Either way the pixel
-    // format has to carry alpha before the filter that uses it.
-    if layout.is_rotated() || layout.is_translucent() {
-        filter_complex.push_str(&format!(",format={}", alpha_format));
+    // a translucent one needs an alpha channel to attenuate. Rotation has to fill
+    // with a YUV-alpha format because `rotate` writes its `c=black@0` corners in
+    // the working format; plain opacity is cheaper in RGBA, which is the format
+    // `colorchannelmixer` works in natively — asking for `yuva` there makes
+    // FFmpeg insert a yuva -> argb -> yuva round trip on every frame.
+    let staged_alpha_format = if layout.is_rotated() {
+        Some(alpha_format)
+    } else if layout.is_translucent() {
+        Some(opacity_only_alpha_format(alpha_format))
+    } else {
+        None
+    };
+    if let Some(staged_alpha_format) = staged_alpha_format {
+        filter_complex.push_str(&format!(",format={}", staged_alpha_format));
     }
 
     if layout.is_rotated() {
@@ -2779,34 +3118,55 @@ pub(super) fn append_video_transform_composition(
 
     filter_complex.push_str(&format!("[{}];", staged_label));
 
-    // `shortest=1` ends the composite with whichever input runs out first, so the
-    // canvas has to last at least one frame or the segment renders empty.
+    // The canvas has to last at least one frame or the segment renders empty.
     let minimum_duration_sec = if fps.is_finite() && fps > 0.0 {
         1.0 / fps
     } else {
         TIMELINE_EPSILON_SEC
     };
+    let slot_duration_sec = duration_sec.max(minimum_duration_sec);
     append_black_video_gap(
         filter_complex,
         &canvas_label,
-        duration_sec.max(minimum_duration_sec),
+        slot_duration_sec,
         width,
         height,
         fps,
         pixel_format,
     );
 
+    // No `shortest=1`: it ends the composite at whichever input runs out first,
+    // which is the *overlay* whenever the clip's stream is shorter than its slot.
+    // A 25 fps source in a 30 fps canvas loses the tail frames that way, and a
+    // one-frame still produces no video stream at all. The canvas is the main
+    // input and already carries the slot's length, `eof_action` defaults to
+    // `repeat` so a short overlay holds its last frame, and the explicit `trim`
+    // afterwards pins the segment to exactly the slot for long streams too.
     filter_complex.push_str(&format!(
-        "[{}][{}]overlay=x={}:y={}:shortest=1:format={},setsar=1,fps={},format={}[{}];",
+        "[{}][{}]overlay=x={}:y={}:format={},setsar=1,fps={},trim=duration={},setpts=PTS-STARTPTS,format={}[{}];",
         canvas_label,
         staged_label,
         layout.overlay_x,
         layout.overlay_y,
         overlay_format,
         format_speed_number(fps),
+        format_speed_number(slot_duration_sec),
         pixel_format,
         output_label
     ));
+}
+
+/// The alpha-carrying format to stage an opacity-only clip in.
+///
+/// `colorchannelmixer` works in RGB, so an 8-bit clip is cheaper to attenuate in
+/// `rgba` than in `yuva420p` — the latter makes FFmpeg auto-insert a conversion
+/// to `argb` and back. A 10-bit export has no 8-bit-free RGBA equivalent in the
+/// graph's working depth, so it keeps its planar YUV-alpha format.
+fn opacity_only_alpha_format(alpha_format: &'static str) -> &'static str {
+    match alpha_format {
+        "yuva420p" => "rgba",
+        other => other,
+    }
 }
 
 /// The working format and `overlay` mode that keep a composite at the output's
@@ -4165,6 +4525,22 @@ impl ExportEngine {
         width: Option<u32>,
         height: Option<u32>,
     ) -> FilterGraph {
+        build_clip_filter_graph(clip, effects, width, height)
+    }
+}
+
+/// Builds the effect chain for one clip.
+///
+/// Free-standing because validation has to walk the same chain the render will
+/// emit — to work out what size the picture is by the time the transform stage
+/// sees it — and validation has no `ExportEngine` to hand.
+pub(super) fn build_clip_filter_graph(
+    clip: &Clip,
+    effects: &std::collections::HashMap<String, Effect>,
+    width: Option<u32>,
+    height: Option<u32>,
+) -> FilterGraph {
+    {
         use crate::core::effects::EffectType;
 
         let mut graph = FilterGraph::new();
@@ -4213,7 +4589,9 @@ impl ExportEngine {
 
         graph
     }
+}
 
+impl ExportEngine {
     /// Build FFmpeg complex filter with audio stream awareness
     ///
     /// This method properly handles clips without audio streams by:
@@ -5271,18 +5649,46 @@ fn validate_caption_track_qc(
     }
 }
 
-/// Validate export settings before starting export
+/// Validate export settings before starting export.
+///
+/// This can spawn FFprobe (see [`validate_export_settings_with_dimensions`]), so
+/// callers on an async runtime must run it on a blocking thread.
 pub fn validate_export_settings(
     sequence: &Sequence,
     assets: &std::collections::HashMap<String, Asset>,
     effects: &std::collections::HashMap<String, Effect>,
     settings: &ExportSettings,
 ) -> ExportValidation {
+    validate_export_settings_with_dimensions(sequence, assets, effects, settings, None)
+}
+
+/// Validate export settings, reusing source dimensions someone already measured.
+///
+/// Placing a transformed clip needs the source's real pixel size. Without
+/// `known_source_dimensions` this measures the sources itself, which spawns a
+/// synchronous FFprobe per transformed asset — pass
+/// [`source_dimensions_from_audio_info`] when the export has already probed.
+pub fn validate_export_settings_with_dimensions(
+    sequence: &Sequence,
+    assets: &std::collections::HashMap<String, Asset>,
+    effects: &std::collections::HashMap<String, Effect>,
+    settings: &ExportSettings,
+    known_source_dimensions: Option<&SourceDimensionMap>,
+) -> ExportValidation {
     let mut validation = ExportValidation::valid();
     let timeline_clock = TimelineClock::new(sequence.format.fps.clone());
-    // Shared with the filtergraph builder's resolution so validation and the
-    // render cannot disagree about how big a source is.
-    let mut source_dimensions = SourceDimensionCache::new();
+    let (canvas_width, canvas_height) = output_video_dimensions(sequence, settings);
+    // Seeded from whatever the caller already measured, then filled in by the
+    // same resolver the filtergraph builder uses, so validation and the render
+    // cannot disagree about how big a source is.
+    let mut source_dimensions: SourceDimensionCache = known_source_dimensions
+        .map(|known| {
+            known
+                .iter()
+                .map(|(asset_id, dimensions)| (asset_id.clone(), Some(*dimensions)))
+                .collect()
+        })
+        .unwrap_or_default();
 
     for error in validate_export_settings_options(settings) {
         validation.add_error(error);
@@ -5373,7 +5779,7 @@ pub fn validate_export_settings(
             // clip once, at its base transform, so the caller is told what the
             // file will actually show rather than left to discover it.
             if track.kind == TrackKind::Video
-                && !clip.motion_keyframes.is_empty()
+                && clip_motion_differs_from_base_transform(clip)
                 && !clip.is_adjustment_layer()
                 && !is_text_clip(clip)
             {
@@ -5424,14 +5830,30 @@ pub fn validate_export_settings(
             // Placing a transformed clip needs the source's real pixel size. An
             // identity clip is only fitted to the canvas, so it never pays for
             // this and never fails on it.
-            if track.kind == TrackKind::Video
-                && clip_needs_transform_composition(clip)
-                && resolve_asset_source_dimensions(asset, &mut source_dimensions).is_none()
-            {
-                validation.add_error(format!(
-                    "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
-                    asset.id, clip.id
-                ));
+            if track.kind == TrackKind::Video && clip_needs_transform_composition(clip) {
+                match resolve_asset_source_dimensions(asset, &mut source_dimensions) {
+                    None => validation.add_error(format!(
+                        "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
+                        asset.id, clip.id
+                    )),
+                    Some(probed_dimensions) => {
+                        // The clip's own effects can resize the picture before
+                        // the transform sees it. Failing loudly beats scaling
+                        // against a size that is no longer true.
+                        let graph = build_clip_filter_graph(
+                            clip,
+                            effects,
+                            Some(canvas_width),
+                            Some(canvas_height),
+                        );
+                        if let Err(effect_label) =
+                            effective_source_dimensions(probed_dimensions, &graph)
+                        {
+                            validation
+                                .add_error(unmeasurable_effect_message(&effect_label, &clip.id));
+                        }
+                    }
+                }
             }
 
             validate_clip_asset_qc(&mut validation, clip, track, asset, sequence, settings);
@@ -5778,7 +6200,10 @@ mod tests {
         let mut audio_info = HashMap::new();
         audio_info.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
         let settings = ExportSettings::default();
         let engine = ExportEngine::new(FFmpegRunner::new(FFmpegInfo {
@@ -6679,7 +7104,11 @@ mod tests {
         let mut video_asset = Asset::new_video(
             "validation_transform.mp4",
             &video_path,
-            VideoInfo::default(),
+            VideoInfo {
+                width: 1280,
+                height: 720,
+                ..VideoInfo::default()
+            },
         )
         .with_duration(3.0)
         .with_file_size(3_000_000);
@@ -6696,6 +7125,109 @@ mod tests {
         assert!(
             validation.is_valid,
             "a transformed, translucent clip must export. Got: {:?}",
+            validation.errors
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: an unmeasurable source is refused instead of guessed at
+    ///
+    /// The import placeholder is a non-zero 1920x1080, so a transformed clip
+    /// whose file cannot be probed used to be placed as though it were exactly
+    /// 1080p — right-looking on 1080p footage, silently stretched on anything
+    /// else. Refusing is the only honest answer.
+    #[test]
+    fn test_validation_refuses_a_transformed_clip_with_no_measurable_source() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+        use crate::core::Point2D;
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("Video 1");
+
+        let mut clip = Clip::new("video_asset")
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        clip.transform.position = Point2D::new(0.25, 0.75);
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        // An empty file FFprobe cannot read, carrying the untouched import
+        // placeholder as its only stored metadata.
+        let video_path = create_temp_media_file("validation_unmeasurable.mp4");
+        let mut assets = HashMap::new();
+        let mut video_asset = Asset::new_video(
+            "validation_unmeasurable.mp4",
+            &video_path,
+            VideoInfo::default(),
+        )
+        .with_duration(3.0)
+        .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+
+        assert!(
+            validation
+                .errors
+                .iter()
+                .any(|error| error.contains("Could not determine source dimensions")),
+            "an unmeasurable transformed clip must be refused. Got: {:?}",
+            validation.errors
+        );
+    }
+
+    /// Feature: Transformed clips in the final render
+    /// Scenario: caller-supplied measurements spare validation its own probes
+    #[test]
+    fn test_validation_uses_pre_resolved_source_dimensions() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+        use crate::core::Point2D;
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("Video 1");
+
+        let mut clip = Clip::new("video_asset")
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        clip.transform.position = Point2D::new(0.25, 0.75);
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let video_path = create_temp_media_file("validation_preresolved.mp4");
+        let mut assets = HashMap::new();
+        let mut video_asset = Asset::new_video(
+            "validation_preresolved.mp4",
+            &video_path,
+            VideoInfo::default(),
+        )
+        .with_duration(3.0)
+        .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let known: SourceDimensionMap = [("video_asset".to_string(), (1080_u32, 1920_u32))]
+            .into_iter()
+            .collect();
+
+        let validation = validate_export_settings_with_dimensions(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+            Some(&known),
+        );
+
+        assert!(
+            validation.is_valid,
+            "an already-measured source needs no probe of its own. Got: {:?}",
             validation.errors
         );
     }
@@ -7679,7 +8211,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let proxy_args = build_complex_filter_args_with_audio_info(
@@ -7956,6 +8491,7 @@ mod tests {
                 bitrate: Some(8_000_000),
                 is_hdr: false,
                 color_transfer: None,
+                rotation_deg: 0.0,
             }),
             audio: Some(AudioStreamInfo {
                 sample_rate: 48000,
@@ -7986,6 +8522,7 @@ mod tests {
                 bitrate: Some(8_000_000),
                 is_hdr: false,
                 color_transfer: None,
+                rotation_deg: 0.0,
             }),
             audio: None, // No audio stream
             format: "mp4".to_string(),
@@ -8029,7 +8566,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "silent_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -8099,7 +8639,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "audio_asset".to_string(),
-            AssetAudioInfo { has_audio: true },
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -8150,7 +8693,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "audio_asset".to_string(),
-            AssetAudioInfo { has_audio: true },
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let engine = ExportEngine::new(FFmpegRunner::new(FFmpegInfo {
@@ -8236,9 +8782,18 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "broken_video".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
-        audio_info_map.insert("voiceover".to_string(), AssetAudioInfo { has_audio: true });
+        audio_info_map.insert(
+            "voiceover".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
 
         let engine = ExportEngine::new(FFmpegRunner::new(FFmpegInfo {
             ffmpeg_path: PathBuf::from("/usr/bin/ffmpeg"),
@@ -8326,10 +8881,19 @@ mod tests {
         assets.insert(silent_video.id.clone(), silent_video);
 
         let mut audio_info_map = std::collections::HashMap::new();
-        audio_info_map.insert("voiceover".to_string(), AssetAudioInfo { has_audio: true });
+        audio_info_map.insert(
+            "voiceover".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
         audio_info_map.insert(
             "silent_video".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let engine = ExportEngine::new(FFmpegRunner::new(FFmpegInfo {
@@ -8392,9 +8956,21 @@ mod tests {
 
         let mut assets = std::collections::HashMap::new();
         let mut audio_info_map = std::collections::HashMap::new();
-        audio_info_map.insert("voiceover".to_string(), AssetAudioInfo { has_audio: true });
+        audio_info_map.insert(
+            "voiceover".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
         if let Some(asset) = tail_asset {
-            audio_info_map.insert(asset.id.clone(), AssetAudioInfo { has_audio: true });
+            audio_info_map.insert(
+                asset.id.clone(),
+                AssetAudioInfo {
+                    has_audio: true,
+                    ..AssetAudioInfo::default()
+                },
+            );
             assets.insert(asset.id.clone(), asset);
         }
         assets.insert(voiceover.id.clone(), voiceover);
@@ -8596,11 +9172,17 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "visible_video".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
         audio_info_map.insert(
             "hidden_video".to_string(),
-            AssetAudioInfo { has_audio: true },
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let args = build_complex_filter_args_with_audio_info(
@@ -8657,7 +9239,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -8786,7 +9371,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -8876,7 +9464,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let mut text_effect = Effect::new(EffectType::TextOverlay);
@@ -8968,7 +9559,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let mut text_effect = Effect::new(EffectType::TextOverlay);
@@ -9035,7 +9629,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: true },
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let args = build_complex_filter_args_with_audio_info(
@@ -9097,8 +9694,20 @@ mod tests {
         assets.insert(asset2.id.clone(), asset2);
 
         let mut audio_info = HashMap::new();
-        audio_info.insert("asset1".to_string(), AssetAudioInfo { has_audio: true });
-        audio_info.insert("asset2".to_string(), AssetAudioInfo { has_audio: true });
+        audio_info.insert(
+            "asset1".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
+        audio_info.insert(
+            "asset2".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
 
         let args = build_complex_filter_args_with_audio_info(
             &sequence,
@@ -9320,7 +9929,7 @@ mod tests {
             "the alpha stage must keep the output's bit depth. Got: {filter_complex}"
         );
         assert!(
-            filter_complex.contains("shortest=1:format=yuv420p10,"),
+            filter_complex.contains("format=yuv420p10,setsar=1,fps=30,trim=duration=3,"),
             "the composite must not downconvert the canvas. Got: {filter_complex}"
         );
     }
@@ -9355,7 +9964,7 @@ mod tests {
         );
         assert!(
             filter_complex.contains(
-                "[vnorm0_bg][vnorm0_tx]overlay=x=96:y=540:shortest=1:format=yuv420,setsar=1,fps=30,format=yuv420p[vnorm0];"
+                "[vnorm0_bg][vnorm0_tx]overlay=x=96:y=540:format=yuv420,setsar=1,fps=30,trim=duration=3,setpts=PTS-STARTPTS,format=yuv420p[vnorm0];"
             ),
             "the clip must be placed at the transformed corner. Got: {filter_complex}"
         );
@@ -9373,12 +9982,12 @@ mod tests {
 
         assert!(
             filter_complex.contains(
-                "scale=1920:1080,setsar=1,format=yuva420p,colorchannelmixer=aa=0.5[vnorm0_tx];"
+                "scale=1920:1080,setsar=1,format=rgba,colorchannelmixer=aa=0.5[vnorm0_tx];"
             ),
             "a faded clip must be attenuated before compositing. Got: {filter_complex}"
         );
         assert!(
-            filter_complex.contains("overlay=x=0:y=0:shortest=1"),
+            filter_complex.contains("overlay=x=0:y=0:format=yuv420,"),
             "an untransformed faded clip still fills the canvas. Got: {filter_complex}"
         );
     }
@@ -9409,7 +10018,7 @@ mod tests {
             "the rotation must be given a box that fits the turned frame. Got: {filter_complex}"
         );
         assert!(
-            filter_complex.contains("overlay=x=690:y=60:shortest=1"),
+            filter_complex.contains("overlay=x=690:y=60:format=yuv420,"),
             "the rotated frame must stay centred on its anchor. Got: {filter_complex}"
         );
     }
@@ -9433,6 +10042,213 @@ mod tests {
         assert!(
             !filter_complex.contains("overlay="),
             "an identity clip must not be composited. Got: {filter_complex}"
+        );
+    }
+
+    /// Builds a one-effect graph the dimension walker can be pointed at.
+    fn graph_with_effect(effect: Effect) -> FilterGraph {
+        let mut graph = FilterGraph::new();
+        graph.add_effect(effect);
+        graph.sort_by_order();
+        graph
+    }
+
+    /// Feature: Effect-aware transform placement
+    /// Scenario: a crop resizes the picture the transform is measured against
+    ///
+    /// The transform emits an absolute `scale=W:H`. Measuring it against the
+    /// file on disk while the effect chain hands it a cropped frame stretches
+    /// the clip by exactly the crop ratio.
+    #[test]
+    fn test_effective_source_dimensions_follows_a_crop() {
+        let mut crop = Effect::new(EffectType::Crop);
+        crop.set_param("width", ParamValue::Float(640.0));
+        crop.set_param("height", ParamValue::Float(360.0));
+        crop.set_param("x", ParamValue::Float(0.0));
+        crop.set_param("y", ParamValue::Float(0.0));
+
+        let dimensions = effective_source_dimensions((1920, 1080), &graph_with_effect(crop))
+            .expect("a crop's output size is written into the filter");
+
+        assert_eq!(dimensions, (640, 360));
+    }
+
+    /// Feature: Effect-aware transform placement
+    /// Scenario: a zoom hands the transform a fixed 1280x720 frame
+    ///
+    /// `zoompan` is emitted with `s=hd720`, so the picture reaching the
+    /// transform is 720p no matter how big the source was — this bites even a
+    /// clip whose only "transform" is an opacity change.
+    #[test]
+    fn test_effective_source_dimensions_follows_a_zoom() {
+        let mut zoom = Effect::new(EffectType::Zoom);
+        zoom.set_param("zoom_type", ParamValue::String("in".to_string()));
+        zoom.set_param("duration", ParamValue::Float(2.0));
+        zoom.set_param("zoom_factor", ParamValue::Float(1.5));
+
+        let dimensions = effective_source_dimensions((3840, 2160), &graph_with_effect(zoom))
+            .expect("zoompan states its output size");
+
+        assert_eq!(dimensions, (1280, 720));
+    }
+
+    /// Feature: Effect-aware transform placement
+    /// Scenario: effects that do not resize leave the measurement alone
+    #[test]
+    fn test_effective_source_dimensions_ignores_non_resizing_effects() {
+        let mut brightness = Effect::new(EffectType::Brightness);
+        brightness.set_param("value", ParamValue::Float(0.2));
+
+        let dimensions =
+            effective_source_dimensions((1280, 720), &graph_with_effect(brightness)).unwrap();
+
+        assert_eq!(dimensions, (1280, 720));
+    }
+
+    /// Feature: Effect-aware transform placement
+    /// Scenario: a crop that cannot be measured is refused rather than guessed
+    ///
+    /// `AutoReframe` without analysis data emits `null`, but a crop whose size
+    /// is an expression would be unreadable. Placing the clip anyway would put
+    /// it silently in the wrong place and at the wrong size.
+    #[test]
+    fn test_effective_source_dimensions_refuses_an_unreadable_resize() {
+        let unreadable = "crop=iw/2:ih/2:0:0";
+
+        assert!(matches!(
+            filter_segment_dimensions(unreadable),
+            SegmentDimensions::Unknown
+        ));
+    }
+
+    /// Feature: Effect-aware transform placement
+    /// Scenario: a masked effect composites back at the original size
+    ///
+    /// `apply_effect_through_mask_group` overlays the corrected picture onto the
+    /// untouched one, so the group always outputs what it was handed.
+    #[test]
+    fn test_effective_source_dimensions_ignores_a_masked_crop() {
+        use crate::core::masks::{Mask, MaskShape, RectMask};
+
+        let mut crop = Effect::new(EffectType::Crop);
+        crop.set_param("width", ParamValue::Float(640.0));
+        crop.set_param("height", ParamValue::Float(360.0));
+        crop.masks
+            .masks
+            .push(Mask::new(MaskShape::Rectangle(RectMask::default())));
+
+        let dimensions =
+            effective_source_dimensions((1920, 1080), &graph_with_effect(crop)).unwrap();
+
+        assert_eq!(dimensions, (1920, 1080));
+    }
+
+    /// Feature: Source measurement
+    /// Scenario: an unprobeable asset with placeholder metadata is unresolvable
+    ///
+    /// `ImportAssetCommand::new` files unenriched video away as a whole
+    /// `VideoInfo::default()`, which is a non-zero 1920x1080. Trusting it would
+    /// turn "nobody measured this" into "it is exactly 1080p".
+    #[test]
+    fn test_resolve_source_dimensions_rejects_the_import_placeholder() {
+        use crate::core::assets::VideoInfo;
+
+        let missing_path = std::env::temp_dir().join("openreelio-does-not-exist.mp4");
+        let mut asset = Asset::new_video(
+            "placeholder.mp4",
+            missing_path.to_string_lossy().as_ref(),
+            VideoInfo::default(),
+        );
+        asset.id = "placeholder_asset".to_string();
+
+        let mut cache = SourceDimensionCache::new();
+        assert_eq!(resolve_asset_source_dimensions(&asset, &mut cache), None);
+    }
+
+    /// Feature: Source measurement
+    /// Scenario: enriched metadata still rescues an unprobeable asset
+    #[test]
+    fn test_resolve_source_dimensions_falls_back_to_measured_metadata() {
+        use crate::core::assets::VideoInfo;
+
+        let missing_path = std::env::temp_dir().join("openreelio-does-not-exist.mp4");
+        let mut asset = Asset::new_video(
+            "measured.mp4",
+            missing_path.to_string_lossy().as_ref(),
+            VideoInfo {
+                width: 1080,
+                height: 1920,
+                ..VideoInfo::default()
+            },
+        );
+        asset.id = "measured_asset".to_string();
+
+        let mut cache = SourceDimensionCache::new();
+        assert_eq!(
+            resolve_asset_source_dimensions(&asset, &mut cache),
+            Some((1080, 1920))
+        );
+    }
+
+    /// Feature: Truthful degradation
+    /// Scenario: motion that matches the base transform is not worth a warning
+    ///
+    /// The export composites the clip once at its base transform. Keyframes that
+    /// describe exactly that picture change nothing, and warning about them
+    /// teaches callers to ignore the warning that matters.
+    #[test]
+    fn test_motion_warning_only_fires_when_the_keyframes_move_the_clip() {
+        use crate::core::timeline::{Clip, KeyframeInterpolation, TransformKeyframe};
+        use crate::core::Point2D;
+
+        let base = Transform {
+            position: Point2D::new(0.25, 0.5),
+            ..Transform::default()
+        };
+        let keyframe_at = |time_offset: f64, transform: Transform| TransformKeyframe {
+            time_offset,
+            transform,
+            interpolation: KeyframeInterpolation::Linear,
+        };
+
+        let mut clip = Clip::new("asset").with_source_range(0.0, 2.0).place_at(0.0);
+        clip.transform = base.clone();
+        assert!(!clip_motion_differs_from_base_transform(&clip));
+
+        clip.motion_keyframes = vec![keyframe_at(0.0, base.clone())];
+        assert!(
+            !clip_motion_differs_from_base_transform(&clip),
+            "a lone keyframe equal to the base renders exactly as the export already does"
+        );
+
+        clip.motion_keyframes = vec![
+            keyframe_at(0.0, base.clone()),
+            keyframe_at(1.0, base.clone()),
+        ];
+        assert!(
+            !clip_motion_differs_from_base_transform(&clip),
+            "keyframes that never differ describe a static clip"
+        );
+
+        clip.motion_keyframes = vec![
+            keyframe_at(0.0, base.clone()),
+            keyframe_at(
+                1.0,
+                Transform {
+                    position: Point2D::new(0.75, 0.5),
+                    ..Transform::default()
+                },
+            ),
+        ];
+        assert!(
+            clip_motion_differs_from_base_transform(&clip),
+            "motion the export will not render must be reported"
+        );
+
+        clip.motion_keyframes = vec![keyframe_at(0.0, Transform::default())];
+        assert!(
+            clip_motion_differs_from_base_transform(&clip),
+            "a single keyframe that disagrees with the base is still a difference"
         );
     }
 
@@ -9501,7 +10317,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "hidden_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let args = build_complex_filter_args_with_audio_info(
@@ -9643,7 +10462,13 @@ mod tests {
         assets.insert(asset.id.clone(), asset);
 
         let mut audio_info = HashMap::new();
-        audio_info.insert("asset1".to_string(), AssetAudioInfo { has_audio: true });
+        audio_info.insert(
+            "asset1".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
 
         let args = build_complex_filter_args_with_audio_info(
             &sequence,
@@ -9704,7 +10529,10 @@ mod tests {
         let mut audio_info = HashMap::new();
         audio_info.insert(
             "shared_asset".to_string(),
-            AssetAudioInfo { has_audio: true },
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let args = build_complex_filter_args_with_audio_info(
@@ -9782,7 +10610,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "video_asset".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -9888,7 +10719,10 @@ mod tests {
         let mut audio_info_map = std::collections::HashMap::new();
         audio_info_map.insert(
             "normal_asset".to_string(),
-            AssetAudioInfo { has_audio: true },
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -9974,10 +10808,19 @@ mod tests {
 
         // Create audio info map
         let mut audio_info_map = std::collections::HashMap::new();
-        audio_info_map.insert("with_audio".to_string(), AssetAudioInfo { has_audio: true });
+        audio_info_map.insert(
+            "with_audio".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::default()
+            },
+        );
         audio_info_map.insert(
             "without_audio".to_string(),
-            AssetAudioInfo { has_audio: false },
+            AssetAudioInfo {
+                has_audio: false,
+                ..AssetAudioInfo::default()
+            },
         );
 
         let effects = std::collections::HashMap::new();
@@ -10069,6 +10912,7 @@ mod tests {
                 asset_id,
                 AssetAudioInfo {
                     has_audio: with_audio,
+                    ..AssetAudioInfo::default()
                 },
             );
 

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -23,11 +23,12 @@ use super::{
         build_audio_trim_filter, build_video_trim_filter, clip_audio_is_suppressed_by_companion,
         clip_needs_transform_composition, collect_audio_companion_keys,
         collect_caption_drawtext_filters, collect_enabled_clips_sorted,
-        collect_overlay_text_drawtext_filters, generated_text_visual_end_sec,
-        hdr_metadata_for_asset, is_text_clip, output_video_dimensions, output_video_fps,
-        output_video_pixel_format, resolve_asset_source_dimensions, AssetAudioInfo, ExportEngine,
-        ExportError, ExportSettings, SourceDimensionCache, VideoCodec, VideoTimelineSegment,
-        TIMELINE_EPSILON_SEC,
+        collect_overlay_text_drawtext_filters, effective_source_dimensions,
+        generated_text_visual_end_sec, hdr_metadata_for_asset, is_text_clip,
+        output_video_dimensions, output_video_fps, output_video_pixel_format,
+        resolve_asset_source_dimensions, seed_source_dimension_cache, unmeasurable_effect_message,
+        AssetAudioInfo, ExportEngine, ExportError, ExportSettings, VideoCodec,
+        VideoTimelineSegment, TIMELINE_EPSILON_SEC,
     },
     transform_layout::compute_clip_transform_layout,
     RenderPlan,
@@ -96,9 +97,11 @@ pub(super) fn build_sequence_ffmpeg_args(
     let output_fps = output_video_fps(ctx.sequence, ctx.settings);
     let output_pixel_format = output_video_pixel_format(ctx.settings);
 
-    // Measuring a source costs an FFprobe run, so only transformed clips pay for
-    // it and each asset pays at most once per export.
-    let mut source_dimensions = SourceDimensionCache::new();
+    // The export already probed every unique asset to find out whether it has
+    // audio, and that probe reports the picture size too. Seeding the cache with
+    // it means the builder spawns no FFprobe of its own; assets the probe could
+    // not measure are simply absent and fall through to the resolver.
+    let mut source_dimensions = seed_source_dimension_cache(ctx.audio_info);
 
     let mut adjustment_layer_effects = Vec::new();
     for (clip, _track) in &all_clips {
@@ -201,13 +204,25 @@ pub(super) fn build_sequence_ffmpeg_args(
                         // drawn onto the canvas rather than fitted to it. The
                         // placement follows the source's real pixel dimensions,
                         // which is also what the preview measures.
-                        let (source_width, source_height) =
+                        let probed_dimensions =
                             resolve_asset_source_dimensions(asset, &mut source_dimensions)
                                 .ok_or_else(|| {
                                     ExportError::InvalidSettings(format!(
                                     "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
                                     asset.id, clip.id
                                 ))
+                                })?;
+
+                        // The transform scales to an absolute size, so it has to
+                        // be measured against the frame the effect chain hands
+                        // it rather than against the file on disk.
+                        let (source_width, source_height) =
+                            effective_source_dimensions(probed_dimensions, &clip_filter_graph)
+                                .map_err(|effect_label| {
+                                    ExportError::InvalidSettings(unmeasurable_effect_message(
+                                        &effect_label,
+                                        &clip.id,
+                                    ))
                                 })?;
 
                         let layout = compute_clip_transform_layout(
@@ -224,7 +239,7 @@ pub(super) fn build_sequence_ffmpeg_args(
                             &video_out_label,
                             &normalized_video_label,
                             &layout,
-                            clip.place.timeline_out_sec() - clip.place.timeline_in_sec,
+                            clip.place.duration_sec,
                             output_width,
                             output_height,
                             output_fps,

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -18,15 +18,18 @@ use super::{
     export::{
         append_ass_text_overlay, append_black_video_gap, append_caption_overlays,
         append_master_audio_output, append_output_time_range_args, append_text_clip_overlays,
-        append_timeline_video_output, append_video_stream_normalization, apply_audio_mix_settings,
-        asset_has_playable_audio, build_audio_trim_filter, build_video_trim_filter,
-        clip_audio_is_suppressed_by_companion, collect_audio_companion_keys,
+        append_timeline_video_output, append_video_stream_normalization,
+        append_video_transform_composition, apply_audio_mix_settings, asset_has_playable_audio,
+        build_audio_trim_filter, build_video_trim_filter, clip_audio_is_suppressed_by_companion,
+        clip_needs_transform_composition, collect_audio_companion_keys,
         collect_caption_drawtext_filters, collect_enabled_clips_sorted,
         collect_overlay_text_drawtext_filters, generated_text_visual_end_sec,
         hdr_metadata_for_asset, is_text_clip, output_video_dimensions, output_video_fps,
-        output_video_pixel_format, AssetAudioInfo, ExportEngine, ExportError, ExportSettings,
-        VideoCodec, VideoTimelineSegment, TIMELINE_EPSILON_SEC,
+        output_video_pixel_format, resolve_asset_source_dimensions, AssetAudioInfo, ExportEngine,
+        ExportError, ExportSettings, SourceDimensionCache, VideoCodec, VideoTimelineSegment,
+        TIMELINE_EPSILON_SEC,
     },
+    transform_layout::compute_clip_transform_layout,
     RenderPlan,
 };
 
@@ -92,6 +95,10 @@ pub(super) fn build_sequence_ffmpeg_args(
     let (output_width, output_height) = output_video_dimensions(ctx.sequence, ctx.settings);
     let output_fps = output_video_fps(ctx.sequence, ctx.settings);
     let output_pixel_format = output_video_pixel_format(ctx.settings);
+
+    // Measuring a source costs an FFprobe run, so only transformed clips pay for
+    // it and each asset pays at most once per export.
+    let mut source_dimensions = SourceDimensionCache::new();
 
     let mut adjustment_layer_effects = Vec::new();
     for (clip, _track) in &all_clips {
@@ -189,15 +196,51 @@ pub(super) fn build_sequence_ffmpeg_args(
                         ));
                     }
 
-                    append_video_stream_normalization(
-                        &mut filter_complex,
-                        &video_out_label,
-                        &normalized_video_label,
-                        output_width,
-                        output_height,
-                        output_fps,
-                        output_pixel_format,
-                    );
+                    if clip_needs_transform_composition(clip) {
+                        // A moved, scaled, rotated or translucent clip has to be
+                        // drawn onto the canvas rather than fitted to it. The
+                        // placement follows the source's real pixel dimensions,
+                        // which is also what the preview measures.
+                        let (source_width, source_height) =
+                            resolve_asset_source_dimensions(asset, &mut source_dimensions)
+                                .ok_or_else(|| {
+                                    ExportError::InvalidSettings(format!(
+                                    "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
+                                    asset.id, clip.id
+                                ))
+                                })?;
+
+                        let layout = compute_clip_transform_layout(
+                            source_width,
+                            source_height,
+                            output_width,
+                            output_height,
+                            &clip.transform,
+                            clip.opacity,
+                        );
+
+                        append_video_transform_composition(
+                            &mut filter_complex,
+                            &video_out_label,
+                            &normalized_video_label,
+                            &layout,
+                            clip.place.timeline_out_sec() - clip.place.timeline_in_sec,
+                            output_width,
+                            output_height,
+                            output_fps,
+                            output_pixel_format,
+                        );
+                    } else {
+                        append_video_stream_normalization(
+                            &mut filter_complex,
+                            &video_out_label,
+                            &normalized_video_label,
+                            output_width,
+                            output_height,
+                            output_fps,
+                            output_pixel_format,
+                        );
+                    }
 
                     video_segments.push(VideoTimelineSegment::new(
                         format!("[{}]", normalized_video_label),

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -17,6 +17,7 @@ pub mod hardware;
 pub mod hdr;
 pub mod plan;
 pub mod smart;
+mod transform_layout;
 
 pub use executor::{
     execute_ffmpeg_invocation, execute_ffmpeg_output, FfmpegExecutionResult, FfmpegOutput,

--- a/src-tauri/src/core/render/transform_layout.rs
+++ b/src-tauri/src/core/render/transform_layout.rs
@@ -1,0 +1,530 @@
+//! Geometry for per-clip visual transforms in the final render.
+//!
+//! The preview draws a transformed clip onto a 2D canvas; the export draws the
+//! same clip with an FFmpeg `scale` -> `rotate` -> `overlay` chain. Both have to
+//! land the picture in the same place, so the placement arithmetic lives here,
+//! once, as pure functions with no FFmpeg strings and no timeline traversal.
+//!
+//! # The contract shared with the preview
+//!
+//! `TimelinePreviewPlayer.drawVisualWithClipTransform` fits the source into the
+//! canvas (`baseScale = min(canvasW / sourceW, canvasH / sourceH)`), multiplies
+//! by the clip's scale, translates to `position * canvas`, rotates, and draws the
+//! scaled image at `(-anchor.x * scaledW, -anchor.y * scaledH)`.
+//!
+//! Two consequences fall out of that draw call, and both are load-bearing here:
+//!
+//! 1. The **anchor**, not the picture's centre, is what `position` pins to the
+//!    canvas. `anchor = (0, 0)` puts the picture's top-left corner at `position`.
+//! 2. Rotation happens about that same anchor point, because the canvas rotates
+//!    the coordinate system before the image is drawn into it.
+//!
+//! FFmpeg has no notion of an anchor: `rotate` spins about the input's centre and
+//! `overlay` positions by top-left corner. Bridging the two is the whole job of
+//! [`compute_clip_transform_layout`] — it rotates the centre-relative-to-anchor
+//! offset by the same angle and folds the result into the overlay corner.
+//!
+//! # Coordinate conventions
+//!
+//! Canvas Y grows downward, and a positive angle is a clockwise turn on screen.
+//! Both `ctx.rotate` and FFmpeg's `rotate` filter agree on this, so the same
+//! matrix serves both:
+//!
+//! ```text
+//! R(t) * (x, y) = (x*cos(t) - y*sin(t), x*sin(t) + y*cos(t))
+//! ```
+
+use crate::core::timeline::Transform;
+
+/// Smallest scale factor a clip may render at.
+///
+/// Mirrors the clamp `SetClipTransformCommand::sanitize_transform` applies, so a
+/// transform that arrived through a command and one that arrived by editing
+/// project JSON by hand render identically.
+const MIN_SCALE: f64 = 0.01;
+
+/// Largest scale factor a clip may render at. Also mirrors the command clamp.
+const MAX_SCALE: f64 = 100.0;
+
+/// Video filters and encoders want even dimensions at every stage of the graph.
+const DIMENSION_ALIGNMENT: f64 = 2.0;
+
+/// Ceiling on any intermediate frame dimension.
+///
+/// A 100x scale on a 4K canvas would otherwise ask FFmpeg to allocate a frame
+/// hundreds of thousands of pixels wide. Anything beyond this is already far
+/// outside the canvas, so clamping costs no visible picture.
+const MAX_DIMENSION: f64 = 32_766.0;
+
+/// Below this the rotation is a no-op and the graph omits the `rotate` filter.
+const ROTATION_EPSILON_RAD: f64 = 1e-9;
+
+/// Below this the clip is fully opaque and the graph omits the alpha filter.
+const OPACITY_EPSILON: f64 = 1e-4;
+
+/// Trig results this close to zero are floating-point residue of a right angle.
+///
+/// `cos(PI / 2)` is 6.1e-17, not 0. Left alone that residue rounds a quarter
+/// turn's bounding box up by a whole pixel and drags the overlay corner with it,
+/// so a clip that should sit flush ends up a pixel off.
+const TRIG_SNAP_EPSILON: f64 = 1e-12;
+
+/// Slack allowed when rounding a bounding box up, in pixels.
+///
+/// Ceiling an exact dimension that arrived a whisker above itself would add two
+/// pixels of transparent margin. A micron of tolerance costs no coverage.
+const DIMENSION_CEIL_TOLERANCE: f64 = 1e-6;
+
+/// Where and how large a transformed clip renders on the output canvas.
+///
+/// Every field is already rounded to what FFmpeg will actually be told, so the
+/// overlay position is computed against the *rounded* frame sizes rather than
+/// against the ideal ones. That keeps the composite self-consistent even when
+/// even-alignment nudges a dimension by a pixel.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct ClipTransformLayout {
+    /// Width the source is scaled to before rotation (even, >= 2).
+    pub scaled_width: u32,
+    /// Height the source is scaled to before rotation (even, >= 2).
+    pub scaled_height: u32,
+    /// Clockwise rotation in radians. Zero when the clip is not rotated.
+    pub rotation_rad: f64,
+    /// Width of the axis-aligned box the rotated frame needs (even).
+    pub bounding_width: u32,
+    /// Height of the axis-aligned box the rotated frame needs (even).
+    pub bounding_height: u32,
+    /// X of the frame's top-left corner on the canvas. May be negative.
+    pub overlay_x: i32,
+    /// Y of the frame's top-left corner on the canvas. May be negative.
+    pub overlay_y: i32,
+    /// Alpha the frame composites with, clamped to `0.0..=1.0`.
+    pub opacity: f64,
+}
+
+impl ClipTransformLayout {
+    /// Whether the graph needs a `rotate` filter for this clip.
+    pub(super) fn is_rotated(&self) -> bool {
+        self.rotation_rad.abs() > ROTATION_EPSILON_RAD
+    }
+
+    /// Whether the graph needs an alpha filter for this clip.
+    pub(super) fn is_translucent(&self) -> bool {
+        self.opacity < 1.0 - OPACITY_EPSILON
+    }
+}
+
+/// Places a transformed clip on the output canvas.
+///
+/// `source_width`/`source_height` are the pixel dimensions of the decoded media,
+/// which is what the preview measures too. Non-finite or out-of-range transform
+/// components fall back to their identity values with a warning rather than
+/// poisoning the filtergraph with `NaN`.
+pub(super) fn compute_clip_transform_layout(
+    source_width: u32,
+    source_height: u32,
+    canvas_width: u32,
+    canvas_height: u32,
+    transform: &Transform,
+    opacity: f32,
+) -> ClipTransformLayout {
+    let source_width = f64::from(source_width.max(1));
+    let source_height = f64::from(source_height.max(1));
+    let canvas_width = f64::from(canvas_width.max(1));
+    let canvas_height = f64::from(canvas_height.max(1));
+
+    // The preview fits the source inside the canvas before applying the clip's
+    // own scale, so an identity transform is a letterboxed fit and nothing else.
+    let base_scale = (canvas_width / source_width).min(canvas_height / source_height);
+    let base_scale = if base_scale.is_finite() && base_scale > 0.0 {
+        base_scale
+    } else {
+        warn_fallback("base scale", base_scale);
+        1.0
+    };
+
+    let scale_x = sanitize_scale(transform.scale.x, "scale.x");
+    let scale_y = sanitize_scale(transform.scale.y, "scale.y");
+
+    let scaled_width = align_dimension(source_width * base_scale * scale_x);
+    let scaled_height = align_dimension(source_height * base_scale * scale_y);
+
+    let rotation_deg = sanitize_finite(transform.rotation_deg, 0.0, "rotation");
+    let rotation_rad = rotation_deg.to_radians();
+    let (sin, cos) = if rotation_rad.abs() > ROTATION_EPSILON_RAD {
+        let (sin, cos) = rotation_rad.sin_cos();
+        (snap_trig(sin), snap_trig(cos))
+    } else {
+        (0.0, 1.0)
+    };
+
+    // The axis-aligned box a rotated rectangle sweeps out. `rotate` is told these
+    // as `ow`/`oh`, so nothing gets clipped by its own rotation.
+    let width = f64::from(scaled_width);
+    let height = f64::from(scaled_height);
+    let bounding_width = align_dimension_up((width * cos).abs() + (height * sin).abs());
+    let bounding_height = align_dimension_up((width * sin).abs() + (height * cos).abs());
+
+    let anchor_x = sanitize_normalized(transform.anchor.x, "anchor.x");
+    let anchor_y = sanitize_normalized(transform.anchor.y, "anchor.y");
+    let position_x = sanitize_normalized(transform.position.x, "position.x");
+    let position_y = sanitize_normalized(transform.position.y, "position.y");
+
+    // Offset from the anchor to the picture's centre, in the clip's own
+    // (unrotated) frame. The canvas rotates around the anchor, so this offset
+    // rotates with the picture.
+    let centre_from_anchor_x = (0.5 - anchor_x) * width;
+    let centre_from_anchor_y = (0.5 - anchor_y) * height;
+    let rotated_x = centre_from_anchor_x * cos - centre_from_anchor_y * sin;
+    let rotated_y = centre_from_anchor_x * sin + centre_from_anchor_y * cos;
+
+    // `rotate` keeps the input centre at the output centre, and `overlay` places
+    // by top-left corner, so the corner is the picture centre less half the box.
+    let centre_x = position_x * canvas_width + rotated_x;
+    let centre_y = position_y * canvas_height + rotated_y;
+    let overlay_x = round_to_i32(centre_x - f64::from(bounding_width) / 2.0);
+    let overlay_y = round_to_i32(centre_y - f64::from(bounding_height) / 2.0);
+
+    ClipTransformLayout {
+        scaled_width,
+        scaled_height,
+        rotation_rad: if rotation_rad.abs() > ROTATION_EPSILON_RAD {
+            rotation_rad
+        } else {
+            0.0
+        },
+        bounding_width,
+        bounding_height,
+        overlay_x,
+        overlay_y,
+        opacity: sanitize_opacity(opacity),
+    }
+}
+
+fn sanitize_scale(value: f64, field: &str) -> f64 {
+    if !value.is_finite() {
+        warn_fallback(field, value);
+        return 1.0;
+    }
+    value.clamp(MIN_SCALE, MAX_SCALE)
+}
+
+fn sanitize_normalized(value: f64, field: &str) -> f64 {
+    if !value.is_finite() {
+        warn_fallback(field, value);
+        return 0.5;
+    }
+    value.clamp(0.0, 1.0)
+}
+
+fn sanitize_finite(value: f64, fallback: f64, field: &str) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        warn_fallback(field, value);
+        fallback
+    }
+}
+
+fn sanitize_opacity(opacity: f32) -> f64 {
+    let opacity = f64::from(opacity);
+    if !opacity.is_finite() {
+        warn_fallback("opacity", opacity);
+        return 1.0;
+    }
+    opacity.clamp(0.0, 1.0)
+}
+
+fn warn_fallback(field: &str, value: f64) {
+    tracing::warn!(
+        field,
+        value,
+        "Clip transform component is not finite; rendering with its identity value"
+    );
+}
+
+/// Rounds to the nearest even pixel count within the renderable range.
+fn align_dimension(value: f64) -> u32 {
+    align_with(value, f64::round)
+}
+
+/// Rounds up to the next even pixel count within the renderable range.
+fn align_dimension_up(value: f64) -> u32 {
+    align_with(value - DIMENSION_CEIL_TOLERANCE, f64::ceil)
+}
+
+fn snap_trig(value: f64) -> f64 {
+    if value.abs() < TRIG_SNAP_EPSILON {
+        0.0
+    } else {
+        value
+    }
+}
+
+fn align_with(value: f64, round: fn(f64) -> f64) -> u32 {
+    if !value.is_finite() {
+        warn_fallback("dimension", value);
+        return DIMENSION_ALIGNMENT as u32;
+    }
+    let aligned = round(value / DIMENSION_ALIGNMENT) * DIMENSION_ALIGNMENT;
+    aligned.clamp(DIMENSION_ALIGNMENT, MAX_DIMENSION) as u32
+}
+
+fn round_to_i32(value: f64) -> i32 {
+    if !value.is_finite() {
+        warn_fallback("overlay offset", value);
+        return 0;
+    }
+    value
+        .round()
+        .clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Point2D;
+
+    const CANVAS_W: u32 = 1920;
+    const CANVAS_H: u32 = 1080;
+
+    /// A 16:9 source fills a 16:9 canvas exactly, which keeps the hand-computed
+    /// expectations below free of letterbox arithmetic.
+    const SOURCE_W: u32 = 1280;
+    const SOURCE_H: u32 = 720;
+
+    fn layout(transform: Transform, opacity: f32) -> ClipTransformLayout {
+        compute_clip_transform_layout(SOURCE_W, SOURCE_H, CANVAS_W, CANVAS_H, &transform, opacity)
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: an untouched clip fills the canvas the way the old graph did
+    #[test]
+    fn should_fill_the_canvas_when_the_transform_is_identity() {
+        let result = layout(Transform::default(), 1.0);
+
+        // baseScale = min(1920/1280, 1080/720) = 1.5 -> 1920x1080 at the origin.
+        assert_eq!(result.scaled_width, 1920);
+        assert_eq!(result.scaled_height, 1080);
+        assert_eq!(result.bounding_width, 1920);
+        assert_eq!(result.bounding_height, 1080);
+        assert_eq!(result.overlay_x, 0);
+        assert_eq!(result.overlay_y, 0);
+        assert!(!result.is_rotated());
+        assert!(!result.is_translucent());
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a letterboxed source keeps its aspect ratio
+    #[test]
+    fn should_letterbox_a_source_narrower_than_the_canvas() {
+        // 4:3 into 16:9: baseScale = min(1920/640, 1080/480) = 2.25 -> 1440x1080,
+        // centred, so 240px of black either side.
+        let result =
+            compute_clip_transform_layout(640, 480, CANVAS_W, CANVAS_H, &Transform::default(), 1.0);
+
+        assert_eq!(result.scaled_width, 1440);
+        assert_eq!(result.scaled_height, 1080);
+        assert_eq!(result.overlay_x, 240);
+        assert_eq!(result.overlay_y, 0);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: moving a clip shifts it by the same fraction of the canvas
+    #[test]
+    fn should_translate_by_the_normalized_position_delta() {
+        let transform = Transform {
+            position: Point2D::new(0.25, 0.75),
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // Centre moves to (480, 810); the frame is still 1920x1080.
+        assert_eq!(result.scaled_width, 1920);
+        assert_eq!(result.scaled_height, 1080);
+        assert_eq!(result.overlay_x, 480 - 960);
+        assert_eq!(result.overlay_y, 810 - 540);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a half-scale clip stays centred on the canvas
+    #[test]
+    fn should_keep_a_half_scale_clip_centred() {
+        let transform = Transform {
+            scale: Point2D::new(0.5, 0.5),
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        assert_eq!(result.scaled_width, 960);
+        assert_eq!(result.scaled_height, 540);
+        assert_eq!(result.overlay_x, 960 - 480);
+        assert_eq!(result.overlay_y, 540 - 270);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a quarter-turn about the centre swaps the frame's extents
+    #[test]
+    fn should_swap_extents_for_a_quarter_turn_about_the_centre() {
+        let transform = Transform {
+            rotation_deg: 90.0,
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // The picture is still scaled to 1920x1080; its bounding box is 1080x1920.
+        assert_eq!(result.scaled_width, 1920);
+        assert_eq!(result.scaled_height, 1080);
+        assert_eq!(result.bounding_width, 1080);
+        assert_eq!(result.bounding_height, 1920);
+        // Rotating about the centre leaves the centre where it was.
+        assert_eq!(result.overlay_x, 960 - 540);
+        assert_eq!(result.overlay_y, 540 - 960);
+        assert!(result.is_rotated());
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: rotation pivots about the anchor, not about the picture centre
+    ///
+    /// With the anchor at the top-left corner and the position at the canvas
+    /// centre, that corner stays pinned at (960, 540) and the picture swings
+    /// clockwise below and to the left of it.
+    #[test]
+    fn should_pivot_about_a_corner_anchor() {
+        let transform = Transform {
+            anchor: Point2D::new(0.0, 0.0),
+            scale: Point2D::new(0.5, 0.5),
+            rotation_deg: 90.0,
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // Scaled frame is 960x540; its bounding box after a quarter turn is 540x960.
+        assert_eq!(result.scaled_width, 960);
+        assert_eq!(result.scaled_height, 540);
+        assert_eq!(result.bounding_width, 540);
+        assert_eq!(result.bounding_height, 960);
+
+        // Centre-from-anchor is (480, 270) unrotated. A clockwise quarter turn
+        // sends (x, y) to (-y, x), so it becomes (-270, 480): the picture centre
+        // lands at (960 - 270, 540 + 480) = (690, 1020).
+        assert_eq!(result.overlay_x, 690 - 270);
+        assert_eq!(result.overlay_y, 1020 - 480);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a 45 degree turn needs a bounding box wider than the picture
+    #[test]
+    fn should_size_the_bounding_box_for_a_diagonal_turn() {
+        let transform = Transform {
+            scale: Point2D::new(0.5, 0.5),
+            rotation_deg: 45.0,
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // 960x540 turned 45 degrees: (960 + 540) / sqrt(2) = 1060.66 both ways,
+        // rounded up to the next even pixel.
+        assert_eq!(result.scaled_width, 960);
+        assert_eq!(result.scaled_height, 540);
+        assert_eq!(result.bounding_width, 1062);
+        assert_eq!(result.bounding_height, 1062);
+        // Rotation about the centre anchor keeps the centre at the canvas centre.
+        assert_eq!(result.overlay_x, 960 - 531);
+        assert_eq!(result.overlay_y, 540 - 531);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: non-uniform scale and rotation compose without losing either
+    #[test]
+    fn should_compose_non_uniform_scale_with_rotation() {
+        let transform = Transform {
+            scale: Point2D::new(0.5, 0.25),
+            rotation_deg: 90.0,
+            position: Point2D::new(0.25, 0.5),
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // 1920*0.5 x 1080*0.25 = 960x270, quarter-turned to a 270x960 box.
+        assert_eq!(result.scaled_width, 960);
+        assert_eq!(result.scaled_height, 270);
+        assert_eq!(result.bounding_width, 270);
+        assert_eq!(result.bounding_height, 960);
+        // Centre anchor, so the picture centre sits at (0.25 * 1920, 540).
+        assert_eq!(result.overlay_x, 480 - 135);
+        assert_eq!(result.overlay_y, 540 - 480);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: opacity is carried through and clamped
+    #[test]
+    fn should_clamp_opacity_into_the_renderable_range() {
+        assert!((layout(Transform::default(), 0.5).opacity - 0.5).abs() < 1e-9);
+        assert!((layout(Transform::default(), 2.0).opacity - 1.0).abs() < 1e-9);
+        assert!((layout(Transform::default(), -1.0).opacity - 0.0).abs() < 1e-9);
+        assert!(layout(Transform::default(), 0.5).is_translucent());
+        assert!(!layout(Transform::default(), 1.0).is_translucent());
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a corrupt transform renders as identity instead of poisoning the graph
+    ///
+    /// Commands sanitize these, but a project file edited by hand does not go
+    /// through a command. `NaN` reaching the filtergraph would make FFmpeg fail
+    /// on a string it cannot parse.
+    #[test]
+    fn should_fall_back_to_identity_for_non_finite_components() {
+        let transform = Transform {
+            scale: Point2D::new(f64::NAN, f64::INFINITY),
+            rotation_deg: f64::NAN,
+            position: Point2D::new(f64::NAN, 0.5),
+            anchor: Point2D::new(0.5, f64::NEG_INFINITY),
+        };
+
+        let result = layout(transform, f32::NAN);
+
+        assert_eq!(result.scaled_width, 1920);
+        assert_eq!(result.scaled_height, 1080);
+        assert_eq!(result.overlay_x, 0);
+        assert_eq!(result.overlay_y, 0);
+        assert!(!result.is_rotated());
+        assert!(!result.is_translucent());
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: an absurd scale is clamped instead of allocating a huge frame
+    #[test]
+    fn should_clamp_dimensions_that_would_exceed_the_renderable_size() {
+        let transform = Transform {
+            scale: Point2D::new(1000.0, 1000.0),
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // Scale clamps to 100x, and 1920 * 100 clamps again at the frame ceiling.
+        assert_eq!(result.scaled_width, 32_766);
+        assert_eq!(result.scaled_height, 32_766);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a vanishingly small scale still produces an encodable frame
+    #[test]
+    fn should_keep_a_tiny_clip_at_a_minimum_even_size() {
+        let transform = Transform {
+            scale: Point2D::new(0.0, 0.0),
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        assert_eq!(result.scaled_width, 20); // 1920 * 0.01, the command's floor
+        assert_eq!(result.scaled_height, 10); // 1080 * 0.01 = 10.8 -> nearest even
+    }
+}

--- a/src-tauri/src/core/render/transform_layout.rs
+++ b/src-tauri/src/core/render/transform_layout.rs
@@ -49,12 +49,20 @@ const MAX_SCALE: f64 = 100.0;
 /// Video filters and encoders want even dimensions at every stage of the graph.
 const DIMENSION_ALIGNMENT: f64 = 2.0;
 
-/// Ceiling on any intermediate frame dimension.
+/// Hard ceiling on any intermediate frame dimension.
 ///
-/// A 100x scale on a 4K canvas would otherwise ask FFmpeg to allocate a frame
-/// hundreds of thousands of pixels wide. Anything beyond this is already far
-/// outside the canvas, so clamping costs no visible picture.
+/// This is FFmpeg's own limit; the canvas-relative cap below bites long before
+/// it does, so this only backstops arithmetic that went somewhere unexpected.
 const MAX_DIMENSION: f64 = 32_766.0;
+
+/// How much larger than the canvas diagonal a scaled frame is allowed to get.
+///
+/// Once a frame is this big, every extra pixel is off-canvas no matter where the
+/// anchor puts it: the canvas diagonal bounds the distance from any on-screen
+/// point to any canvas corner, so a frame twice that across already covers the
+/// canvas from any placement the layout can produce. Letting the scale run free
+/// instead costs real memory — `scale=17` on 1080p is already ~900 MB a frame.
+const MAX_CANVAS_DIAGONAL_MULTIPLE: f64 = 2.0;
 
 /// Below this the rotation is a no-op and the graph omits the `rotate` filter.
 const ROTATION_EPSILON_RAD: f64 = 1e-9;
@@ -145,8 +153,18 @@ pub(super) fn compute_clip_transform_layout(
     let scale_x = sanitize_scale(transform.scale.x, "scale.x");
     let scale_y = sanitize_scale(transform.scale.y, "scale.y");
 
-    let scaled_width = align_dimension(source_width * base_scale * scale_x);
-    let scaled_height = align_dimension(source_height * base_scale * scale_y);
+    // Both axes shrink by the same factor when the frame is too big to render,
+    // because clamping them independently would silently restretch the picture:
+    // a 100x scale on 16:9 would come out square.
+    let ideal_width = source_width * base_scale * scale_x;
+    let ideal_height = source_height * base_scale * scale_y;
+    let shrink = uniform_shrink(
+        ideal_width,
+        ideal_height,
+        frame_dimension_limit(canvas_width, canvas_height),
+    );
+    let scaled_width = align_dimension(ideal_width * shrink);
+    let scaled_height = align_dimension(ideal_height * shrink);
 
     let rotation_deg = sanitize_finite(transform.rotation_deg, 0.0, "rotation");
     let rotation_rad = rotation_deg.to_radians();
@@ -179,10 +197,16 @@ pub(super) fn compute_clip_transform_layout(
 
     // `rotate` keeps the input centre at the output centre, and `overlay` places
     // by top-left corner, so the corner is the picture centre less half the box.
+    //
+    // The corner is snapped to an even pixel because `overlay` in a chroma-
+    // subsampled format floors both offsets to the subsampling grid anyway
+    // (x=101 lands at 100, x=-51 at -52). Rounding here makes the number the
+    // graph carries the number FFmpeg acts on, so the placement error is a
+    // symmetric half-pixel instead of a one-sided whole one.
     let centre_x = position_x * canvas_width + rotated_x;
     let centre_y = position_y * canvas_height + rotated_y;
-    let overlay_x = round_to_i32(centre_x - f64::from(bounding_width) / 2.0);
-    let overlay_y = round_to_i32(centre_y - f64::from(bounding_height) / 2.0);
+    let overlay_x = round_to_even_i32(centre_x - f64::from(bounding_width) / 2.0);
+    let overlay_y = round_to_even_i32(centre_y - f64::from(bounding_height) / 2.0);
 
     ClipTransformLayout {
         scaled_width,
@@ -269,14 +293,37 @@ fn align_with(value: f64, round: fn(f64) -> f64) -> u32 {
     aligned.clamp(DIMENSION_ALIGNMENT, MAX_DIMENSION) as u32
 }
 
-fn round_to_i32(value: f64) -> i32 {
+/// The largest a scaled frame may get before the extra pixels are all off-canvas.
+fn frame_dimension_limit(canvas_width: f64, canvas_height: f64) -> f64 {
+    let diagonal = canvas_width.hypot(canvas_height);
+    if !diagonal.is_finite() || diagonal <= 0.0 {
+        return MAX_DIMENSION;
+    }
+    (diagonal * MAX_CANVAS_DIAGONAL_MULTIPLE).clamp(DIMENSION_ALIGNMENT, MAX_DIMENSION)
+}
+
+/// The single factor that brings both axes inside `limit` without reshaping them.
+fn uniform_shrink(width: f64, height: f64, limit: f64) -> f64 {
+    let mut factor = 1.0_f64;
+    for extent in [width, height] {
+        if extent.is_finite() && extent > limit {
+            factor = factor.min(limit / extent);
+        }
+    }
+    if factor.is_finite() && factor > 0.0 {
+        factor
+    } else {
+        1.0
+    }
+}
+
+fn round_to_even_i32(value: f64) -> i32 {
     if !value.is_finite() {
         warn_fallback("overlay offset", value);
         return 0;
     }
-    value
-        .round()
-        .clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32
+    let even = (value / DIMENSION_ALIGNMENT).round() * DIMENSION_ALIGNMENT;
+    even.clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32
 }
 
 #[cfg(test)]
@@ -434,8 +481,9 @@ mod tests {
         assert_eq!(result.bounding_width, 1062);
         assert_eq!(result.bounding_height, 1062);
         // Rotation about the centre anchor keeps the centre at the canvas centre.
-        assert_eq!(result.overlay_x, 960 - 531);
-        assert_eq!(result.overlay_y, 540 - 531);
+        // The ideal corner is (429, 9); both snap up to the next even pixel.
+        assert_eq!(result.overlay_x, 430);
+        assert_eq!(result.overlay_y, 10);
     }
 
     /// Feature: Transform layout
@@ -456,8 +504,9 @@ mod tests {
         assert_eq!(result.scaled_height, 270);
         assert_eq!(result.bounding_width, 270);
         assert_eq!(result.bounding_height, 960);
-        // Centre anchor, so the picture centre sits at (0.25 * 1920, 540).
-        assert_eq!(result.overlay_x, 480 - 135);
+        // Centre anchor, so the picture centre sits at (0.25 * 1920, 540). The
+        // ideal corner x is 345, which snaps up to the next even pixel.
+        assert_eq!(result.overlay_x, 346);
         assert_eq!(result.overlay_y, 540 - 480);
     }
 
@@ -498,9 +547,12 @@ mod tests {
     }
 
     /// Feature: Transform layout
-    /// Scenario: an absurd scale is clamped instead of allocating a huge frame
+    /// Scenario: an absurd scale is clamped without reshaping the picture
+    ///
+    /// Clamping each axis at its own ceiling used to turn a 16:9 source square,
+    /// so a 100x zoom rendered stretched as well as enormous.
     #[test]
-    fn should_clamp_dimensions_that_would_exceed_the_renderable_size() {
+    fn should_clamp_dimensions_uniformly_when_the_scale_is_absurd() {
         let transform = Transform {
             scale: Point2D::new(1000.0, 1000.0),
             ..Transform::default()
@@ -508,9 +560,79 @@ mod tests {
 
         let result = layout(transform, 1.0);
 
-        // Scale clamps to 100x, and 1920 * 100 clamps again at the frame ceiling.
-        assert_eq!(result.scaled_width, 32_766);
-        assert_eq!(result.scaled_height, 32_766);
+        // Scale clamps to 100x -> 192000x108000, then one shrink factor brings the
+        // long axis down to twice the canvas diagonal (2 * hypot(1920, 1080)).
+        assert_eq!(result.scaled_width, 4406);
+        assert_eq!(result.scaled_height, 2478);
+
+        let source_aspect = f64::from(SOURCE_W) / f64::from(SOURCE_H);
+        let clamped_aspect = f64::from(result.scaled_width) / f64::from(result.scaled_height);
+        assert!(
+            (clamped_aspect - source_aspect).abs() < 0.01,
+            "clamping must preserve the aspect ratio: {clamped_aspect} vs {source_aspect}"
+        );
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: a clamped frame is still placed where the anchor says it should be
+    ///
+    /// The overlay corner is derived from the post-clamp size, so the visible
+    /// region a viewer sees is the one the anchor and position asked for.
+    #[test]
+    fn should_place_a_clamped_frame_from_its_post_clamp_size() {
+        let transform = Transform {
+            scale: Point2D::new(1000.0, 1000.0),
+            anchor: Point2D::new(0.0, 0.0),
+            position: Point2D::new(0.5, 0.5),
+            ..Transform::default()
+        };
+
+        let result = layout(transform, 1.0);
+
+        // Anchor at the top-left corner, position at the canvas centre: the corner
+        // is pinned to (960, 540) and the rest of the frame runs down and right.
+        assert_eq!(result.scaled_width, 4406);
+        assert_eq!(result.scaled_height, 2478);
+        assert_eq!(result.overlay_x, 960);
+        assert_eq!(result.overlay_y, 540);
+    }
+
+    /// Feature: Transform layout
+    /// Scenario: overlay offsets land on the grid `overlay` actually snaps to
+    ///
+    /// `overlay` floors x and y to the chroma subsampling grid in yuv420, so an
+    /// odd number in the graph is a number FFmpeg silently changes.
+    #[test]
+    fn should_emit_even_overlay_offsets() {
+        for (position_x, position_y) in [
+            (0.0, 0.0),
+            (0.137, 0.911),
+            (0.5, 0.5),
+            (0.333, 0.666),
+            (1.0, 1.0),
+        ] {
+            let transform = Transform {
+                position: Point2D::new(position_x, position_y),
+                scale: Point2D::new(0.3137, 0.7123),
+                rotation_deg: 37.0,
+                ..Transform::default()
+            };
+
+            let result = layout(transform, 1.0);
+
+            assert_eq!(
+                result.overlay_x % 2,
+                0,
+                "overlay_x {} is odd at position {position_x}",
+                result.overlay_x
+            );
+            assert_eq!(
+                result.overlay_y % 2,
+                0,
+                "overlay_y {} is odd at position {position_y}",
+                result.overlay_y
+            );
+        }
     }
 
     /// Feature: Transform layout

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -16,6 +16,30 @@ use crate::core::{
 };
 use crate::AppState;
 
+/// Runs export validation without blocking the async runtime.
+///
+/// Validation measures every transformed clip's source with a synchronous
+/// FFprobe. Calling it inline would park a Tauri runtime worker on a child
+/// process for as long as the probe takes, which is exactly the blocking the
+/// worker-separation rule exists to prevent.
+async fn validate_export_settings_off_runtime(
+    sequence: &crate::core::timeline::Sequence,
+    assets: &std::collections::HashMap<String, crate::core::assets::Asset>,
+    effects: &std::collections::HashMap<String, crate::core::effects::Effect>,
+    settings: &crate::core::render::ExportSettings,
+) -> Result<crate::core::render::ExportValidation, String> {
+    let sequence = sequence.clone();
+    let assets = assets.clone();
+    let effects = effects.clone();
+    let settings = settings.clone();
+
+    tokio::task::spawn_blocking(move || {
+        crate::core::render::validate_export_settings(&sequence, &assets, &effects, &settings)
+    })
+    .await
+    .map_err(|error| format!("Export validation task failed: {}", error))
+}
+
 // =============================================================================
 // DTOs
 // =============================================================================
@@ -335,7 +359,7 @@ pub async fn start_render(
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
 ) -> Result<RenderStartResult, String> {
-    use crate::core::render::{validate_export_settings, ExportEngine, ExportProgress};
+    use crate::core::render::{ExportEngine, ExportProgress};
     use tauri::Emitter;
 
     // Get sequence/assets/effects + project path from project state
@@ -414,7 +438,8 @@ pub async fn start_render(
         .await?;
 
     // Validate export settings before starting
-    let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
+    let validation =
+        validate_export_settings_off_runtime(&sequence, &assets, &effects, &settings).await?;
     if !validation.is_valid {
         let error_msg = validation.errors.join("; ");
         return Err(format!("Export validation failed: {}", error_msg));
@@ -594,7 +619,7 @@ pub async fn render_range(
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
 ) -> Result<RenderStartResult, String> {
-    use crate::core::render::{validate_export_settings, ExportEngine, ExportProgress};
+    use crate::core::render::{ExportEngine, ExportProgress};
     use tauri::Emitter;
 
     // Validate range
@@ -669,12 +694,20 @@ pub async fn render_range(
     resolve_export_hardware_preferences(&app_handle, &ffmpeg.info().ffmpeg_path, &mut settings)
         .await?;
 
-    let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
+    let validation =
+        validate_export_settings_off_runtime(&sequence, &assets, &effects, &settings).await?;
     if !validation.is_valid {
         return Err(format!(
             "Export validation failed: {}",
             validation.errors.join("; ")
         ));
+    }
+
+    // Same warnings `start_render` logs: motion keyframes and the rest describe
+    // ways the file will differ from the preview, and a range export differs the
+    // same way.
+    for warning in &validation.warnings {
+        tracing::warn!("Range export warning: {}", warning);
     }
 
     let render_plan =
@@ -834,9 +867,7 @@ pub async fn batch_render(
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
 ) -> Result<BatchRenderStartResult, String> {
-    use crate::core::render::{
-        validate_export_settings, ExportEngine, ExportProgress, ExportSettings,
-    };
+    use crate::core::render::{ExportEngine, ExportProgress, ExportSettings};
     use tauri::Emitter;
 
     if items.is_empty() {
@@ -906,7 +937,8 @@ pub async fn batch_render(
             item.out_point,
         )?;
 
-        let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
+        let validation =
+            validate_export_settings_off_runtime(&sequence, &assets, &effects, &settings).await?;
         if !validation.is_valid {
             return Err(format!(
                 "Batch item {} validation failed: {}",
@@ -2787,12 +2819,21 @@ pub async fn render_preview_cache(
                 Some(*end_sec),
             );
 
-            let validation = crate::core::render::validate_export_settings(
+            let validation = match validate_export_settings_off_runtime(
                 &fresh_sequence,
                 &fresh_assets,
                 &fresh_effects,
                 &seg_settings,
-            );
+            )
+            .await
+            {
+                Ok(validation) => validation,
+                Err(error) => {
+                    tracing::warn!("Preview cache segment {} validation failed: {error}", idx);
+                    let _ = app_handle.emit("render-cache-error", error);
+                    break;
+                }
+            };
             if !validation.is_valid {
                 let error = format!(
                     "Preview cache segment {} validation failed: {}",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -9457,7 +9457,15 @@ isHdr?: boolean;
 /**
  * FFprobe color transfer string (e.g. `smpte2084`, `arib-std-b67`).
  */
-colorTransfer?: string | null }
+colorTransfer?: string | null; 
+/**
+ * Display-matrix rotation in degrees, folded into `(-180, 180]`.
+ * 
+ * `width` and `height` are the *coded* size. FFmpeg auto-rotates on decode,
+ * so a quarter turn here means the frames downstream are `height x width`;
+ * [`crate::core::ffmpeg::display_dimensions`] applies the swap.
+ */
+rotationDeg?: number }
 /**
  * A visual clip layer in compositor order.
  */


### PR DESCRIPTION
### **User description**
## Summary

Final render export now renders per-clip visual transforms — position, scale, rotation, anchor — and clip opacity. Previously the preview offered full transform editing on any clip while `validate_export_settings` hard-rejected the project at export time ("uses transform or opacity settings that final render export does not support yet"), making any transformed project unexportable.

### How it works

- New pure-math module `core/render/transform_layout.rs` computes the placement layout (fitted scale x transform scale, rotation bounding box, anchor-pinned overlay position) with the exact same semantics as the preview's canvas renderer (`drawVisualWithClipTransform`). Verified pixel-exact against real ffmpeg for axis-aligned, quarter-turn, and general-angle-about-a-corner cases.
- Per-clip filtergraph stage: `scale -> [alpha format] -> [rotate with transparent fill] -> [opacity] -> overlay onto a canvas-sized black base -> fps/trim/format`, bounded to the clip's exact timeline slot. Identity clips keep the previous normalization path byte-for-byte (pinned by test).
- Source dimensions are measured (ffprobe, display-matrix-rotation aware) via the existing async export probe and shared with validation and the graph builder — asset-import placeholder metadata (1920x1080) is explicitly rejected rather than trusted.
- 8-bit and 10-bit (HDR/ProRes) outputs keep their bit depth through the composite.

### Behavior changes

- The transform/opacity validation rejection is removed. Blend modes, simultaneous layered clips (PiP), and overlay tracks are still rejected with their existing errors.
- Motion keyframes: previously silently rendered static; now render static **with a render warning** naming the clip (only when the keyframes actually differ from the base transform).
- `frame extract --mode fast` now falls back to composite when the topmost clip carries a transform/opacity, so agents verifying their own edits see the transformed picture (`fellBackToComposite: true`).
- CLI `render start` resolves FFmpeg before validation (validation may now probe sources).
- Tauri IPC render commands run validation via `spawn_blocking` (validation can spawn ffprobe).
- Docs/skills updated: AGENT_GUIDE, editing/render/perception REFERENCE, MCP SetClipTransform description; stale QC rationale corrected.

### Review process

Implemented, then three adversarial review passes (geometry/ffmpeg semantics with empirical pixel sampling, integration blast radius, edge cases & test quality) produced 17 findings — all fixed, including: `shortest=1` frame truncation (25fps->30fps lost frames; 1-frame stills rendered zero frames), effect-changed dimensions (crop/zoom) breaking the absolute scale, phone-video display-matrix rotation ignored, independent axis clamping enabling OOM-sized frames, vacuous e2e skips, and probe storms in contact-sheet extraction.

## Test plan

- `cargo test` (src-tauri lib): 3801 passed / CLI: 150 passed
- New unit tests: transform layout golden placements (hand-derived), rotation side-data parsing, effective-source-dimension walking (crop/zoom/masked), placeholder rejection
- New real-ffmpeg e2e: placement pixel assertions (off-boundary sample points), opacity half-blend (tight tolerance), single-frame source fills its slot (frame-count assertion), fast-mode fallback visibility, motion-keyframe warning surface
- `cargo clippy --workspace -D warnings`, `cargo fmt --check`, bundler feature-set check, `export_bindings` diff committed

## Known limitations (unchanged, intentionally out of scope)

- Simultaneous layered video clips (picture-in-picture) still do not export — the overlap gate remains.
- Blend modes still do not export.
- Motion keyframes render static (warned).
- Non-square SAR sources keep the existing coded-dimension fit (preview and export agree; follow-up chip filed).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements per-clip visual transforms and opacity in final render exports.

- Adds `transform_layout` module for FFmpeg-compatible geometry calculations.

- Updates validation to support transformed clips and warn about motion keyframes.

- Enhances `frame extract` to support compositing for transformed clips.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Clip Transform Data"] -- "transform_layout.rs" --> B["FFmpeg Filtergraph"]
  B -- "scale/rotate/overlay" --> C["Final Render Output"]
  D["Asset Probe"] -- "Source Dimensions" --> A
  E["Validation"] -- "Check Support" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>transform_layout.rs</strong><dd><code>New module for calculating FFmpeg-compatible transform layouts</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-99d4e6cb34b516190bd48a31e7d102c53fbc516f4ab3c74be11f44ea00043801">+652/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>export.rs</strong><dd><code>Implement transform composition logic and updated validation</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+1374/-74</a></td>

</tr>

<tr>
  <td><strong>frame.rs</strong><dd><code>Update frame extraction to handle transformed clips via composition</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-c47708a90f60cf6fc8376a523d5213a7be6f80c06e26671b9e0f6820f783fda2">+62/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>runner.rs</strong><dd><code>Include display-matrix rotation in video stream metadata</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-cb27acc68d5699de8a7a989c8827bd2b409d52107a708a6f82094293251fccee">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rotation.rs</strong><dd><code>Helper for parsing rotation from FFprobe metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-1be0afd7053efebe8bae9bb9984f8dade37ba0e90b916dea9e296fa745ec3527">+160/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>integration.rs</strong><dd><code>Add integration tests for transform and opacity rendering</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+821/-27</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Expose rotation degrees in TypeScript bindings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>mcp.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-280e1b2f4fcfd0aff373db2f4103f98a471444033d18d9ad282608a80355019f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-cc3496de9305713d70667351fab7c5a60539b3fbb1dd4940b15419d868b1f1bb">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-09f1fbcec2ba7a75b725e8485fb6f7b13ba4ab79c79bb96279303767f681c4b2">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-40f74bdcd5d6950bc452545f551fa24eb3a4a375d6bb00eaaff5412a802d6d8f">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT_GUIDE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-609f4b6b6395bee5b56f2cb041c6803bc2afd043dbb10d33c31349b6e8c96a26">+35/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metadata.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-f92f01c44c85ff6773b02ad6ee5a319c6137723869c318812765f636253545b4">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>filter_builder.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-86aaa5bbc7d4304dce89d4a4bb017d4044971db7e1ef672b58072d452c2ab8de">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-9ae7a973de71a367eeff8df45197b3e3c27b6d1fc78c4f1b2629b32cf05ad346">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rules.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-c3e2f76cb1db6c209b3bc6dfe0bb6270435179d7bc9d79ea229e5077a4c151f8">+11/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ffmpeg_plan.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-7f93452cf29faaec41eb667dd7d07cf667603dace2d8f99aba49ae2e38c3e2df">+74/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/818/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+51/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exports now support clip positioning, scaling, rotation, and opacity.
  - Fast frame extraction uses composited rendering for transformed or translucent clips.
  - Video rotation metadata improves displayed dimensions and aspect-ratio accuracy.
  - Export validation accounts for transformed source dimensions and provides clearer errors.

- **Documentation**
  - Added guidance for transforms, opacity, framing, motion-keyframe limitations, and layered video behavior.

- **Bug Fixes**
  - Improved FFmpeg detection and validation across managed and bundled installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->