### PR TITLE
fix(security): unify filtergraph escaping and validate path-derived ids

### DIFF
--- a/src-tauri/src/core/analysis/esd.rs
+++ b/src-tauri/src/core/analysis/esd.rs
@@ -436,13 +436,14 @@ fn esd_path(project_dir: &Path, id: &str) -> std::path::PathBuf {
 }
 
 /// Validates an ESD ID to prevent path traversal
+///
+/// Delegates to the canonical validator rather than re-deriving the rules. The previous
+/// hand-rolled check missed `:` and control characters, and on Windows `Path::join` with
+/// a disk-prefixed component discards the base path entirely — an `esdId` of `C:secret`
+/// escaped `.openreelio/esds/` without containing a separator or `..`, and `delete_esd`
+/// takes the id straight from IPC and calls `remove_file` on the result.
 fn validate_esd_id(id: &str) -> CoreResult<()> {
-    if id.is_empty() || id.contains('/') || id.contains('\\') || id.contains("..") {
-        return Err(CoreError::ValidationError(
-            "Invalid ESD ID: must not be empty or contain path separators".to_string(),
-        ));
-    }
-    Ok(())
+    crate::core::fs::validate_path_id_component(id, "esdId").map_err(CoreError::ValidationError)
 }
 
 /// Saves an ESD to disk at `{project}/.openreelio/esds/{id}.json`.

--- a/src-tauri/src/core/annotations/store.rs
+++ b/src-tauri/src/core/annotations/store.rs
@@ -64,13 +64,22 @@ impl AnnotationStore {
     }
 
     /// Returns the file path for an asset's annotation
-    pub fn annotation_path(&self, asset_id: &str) -> PathBuf {
-        self.annotations_dir.join(format!("{}.json", asset_id))
+    ///
+    /// # Security
+    /// `asset_id` arrives here straight from IPC arguments and from project state, and
+    /// no caller looks it up in `project.state.assets` first — `delete_annotation` in
+    /// particular takes a bare string and reaches `fs::remove_file`. Because every read,
+    /// write and delete in this store derives its path from this one method, validating
+    /// here confines all of them to the annotations directory.
+    pub fn annotation_path(&self, asset_id: &str) -> CoreResult<PathBuf> {
+        crate::core::fs::validate_path_id_component(asset_id, "assetId")
+            .map_err(CoreError::ValidationError)?;
+        Ok(self.annotations_dir.join(format!("{}.json", asset_id)))
     }
 
     /// Loads annotation for an asset
     pub fn load(&self, asset_id: &str) -> CoreResult<Option<AssetAnnotation>> {
-        let path = self.annotation_path(asset_id);
+        let path = self.annotation_path(asset_id)?;
 
         if !path.exists() {
             return Ok(None);
@@ -97,9 +106,12 @@ impl AnnotationStore {
 
     /// Saves annotation for an asset (atomic write via temp file + rename)
     pub fn save(&self, annotation: &AssetAnnotation) -> CoreResult<()> {
+        // Resolve (and thereby validate) the destination before creating anything: the
+        // temp file below interpolates the same id into a second file name.
+        let path = self.annotation_path(&annotation.asset_id)?;
+
         self.ensure_dir()?;
 
-        let path = self.annotation_path(&annotation.asset_id);
         let temp_path = self.annotations_dir.join(format!(
             ".{}.json.tmp.{}",
             annotation.asset_id,
@@ -136,7 +148,7 @@ impl AnnotationStore {
 
     /// Deletes annotation for an asset
     pub fn delete(&self, asset_id: &str) -> CoreResult<()> {
-        let path = self.annotation_path(asset_id);
+        let path = self.annotation_path(asset_id)?;
 
         if path.exists() {
             fs::remove_file(&path).map_err(|e| {
@@ -153,7 +165,8 @@ impl AnnotationStore {
 
     /// Checks if annotation exists for an asset
     pub fn exists(&self, asset_id: &str) -> bool {
-        self.annotation_path(asset_id).exists()
+        self.annotation_path(asset_id)
+            .is_ok_and(|path| path.exists())
     }
 
     /// Checks if annotation is stale (asset hash changed)
@@ -392,8 +405,39 @@ mod tests {
     #[test]
     fn test_annotation_path() {
         let (_temp_dir, store) = create_test_store();
-        let path = store.annotation_path("asset_001");
+        let path = store.annotation_path("asset_001").unwrap();
         assert!(path.ends_with("asset_001.json"));
+    }
+
+    #[test]
+    fn should_reject_traversing_asset_id_without_removing_anything() {
+        // Given a file that sits one level above the annotations directory, which a
+        // traversing asset id would resolve to
+        let (_temp_dir, store) = create_test_store();
+        store.ensure_dir().unwrap();
+        let outside = store
+            .annotations_dir()
+            .parent()
+            .unwrap()
+            .join("secret.json");
+        std::fs::write(&outside, b"{}").unwrap();
+
+        // When any store operation is asked for that id
+        for asset_id in ["../secret", "..\\secret", "sub/secret", "C:secret"] {
+            assert!(
+                store.annotation_path(asset_id).is_err(),
+                "annotation_path accepted {asset_id:?}"
+            );
+            assert!(
+                store.delete(asset_id).is_err(),
+                "delete accepted {asset_id:?}"
+            );
+            assert!(store.load(asset_id).is_err(), "load accepted {asset_id:?}");
+            assert!(!store.exists(asset_id), "exists accepted {asset_id:?}");
+        }
+
+        // Then the file outside the annotations directory is untouched
+        assert!(outside.exists());
     }
 
     #[test]

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -133,6 +133,11 @@ fn luma_sat_factor_expr(points: &[CurvePoint], luma_expr: &str) -> String {
 /// This is the single canonical filtergraph quoting rule for the whole crate; any
 /// other escaping of a value that ends up inside `option='<value>'` must delegate
 /// here rather than re-deriving the rules (see the rationale in the body).
+///
+/// For a **filesystem path**, prefer [`escape_ffmpeg_filter_path`]: the `\` -> `\\`
+/// rule below is not sufficient for a native Windows path, because several filters
+/// unescape the option value a second time and consume the doubled backslash. See
+/// that function for the details.
 pub(crate) fn escape_ffmpeg_filter_value(raw: &str) -> String {
     // FFmpeg filtergraphs treat `:` and `,` as separators and `\` as an escape character.
     // Windows paths also contain `\` and `:` (drive letter), so we must escape them to
@@ -155,12 +160,17 @@ pub(crate) fn escape_ffmpeg_filter_value(raw: &str) -> String {
 /// Escapes a filesystem path for embedding inside a single-quoted FFmpeg filter argument.
 ///
 /// Windows separators are normalized to `/` before the canonical quoting rule is
-/// applied. This is deliberate and load-bearing: a filtergraph option value is
-/// unescaped twice (once by the filtergraph parser, once by the option parser), so
-/// the single `\` -> `\\` doubling in [`escape_ffmpeg_filter_value`] is consumed
-/// entirely and a native Windows path loses all of its separators. Normalizing
-/// first removes every backslash, leaving only the `:`/`,`/`'` rules to apply —
-/// and FFmpeg accepts `/` as a separator on Windows.
+/// applied. This is deliberate and load-bearing, not cosmetic: several filters
+/// unescape their path option a second time, so the `\` -> `\\` doubling in
+/// [`escape_ffmpeg_filter_value`] is consumed and the path loses every separator.
+/// Verified against ffmpeg: `vidstabdetect=result='D\:\\dir\\a.trf'` silently
+/// writes a file literally named `Ddira.trf` in the working directory, and
+/// `subtitles=filename='D\:\\dir\\a.ass'` fails with `Unable to open D:dira.ass`.
+/// Normalizing first removes every backslash, leaving only the `:`/`,`/`'` rules to
+/// apply — and FFmpeg accepts `/` as a separator on Windows.
+///
+/// The drive colon must still be escaped: a raw `:` is read as an option separator
+/// even inside a single-quoted region.
 pub(crate) fn escape_ffmpeg_filter_path(raw: &str) -> String {
     escape_ffmpeg_filter_value(&raw.replace('\\', "/"))
 }

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -152,6 +152,33 @@ pub(crate) fn escape_ffmpeg_filter_value(raw: &str) -> String {
         .replace('\'', r"'\''")
 }
 
+/// Escapes a filesystem path for embedding inside a single-quoted FFmpeg filter argument.
+///
+/// Windows separators are normalized to `/` before the canonical quoting rule is
+/// applied. This is deliberate and load-bearing: a filtergraph option value is
+/// unescaped twice (once by the filtergraph parser, once by the option parser), so
+/// the single `\` -> `\\` doubling in [`escape_ffmpeg_filter_value`] is consumed
+/// entirely and a native Windows path loses all of its separators. Normalizing
+/// first removes every backslash, leaving only the `:`/`,`/`'` rules to apply —
+/// and FFmpeg accepts `/` as a separator on Windows.
+pub(crate) fn escape_ffmpeg_filter_path(raw: &str) -> String {
+    escape_ffmpeg_filter_value(&raw.replace('\\', "/"))
+}
+
+/// Builds the `vidstabdetect` analysis filter that writes motion transforms to `transforms_path`.
+///
+/// This is the analysis half of stabilization; [`FilterBuilder::build_stabilize_filter`]
+/// consumes the resulting `.trf` file in the apply pass. The path is emitted inside a
+/// single-quoted filter argument and therefore goes through [`escape_ffmpeg_filter_path`]:
+/// the transforms file is named after a clip id that originates in the project file, which
+/// is untrusted input.
+pub(crate) fn build_vidstabdetect_filter(transforms_path: &std::path::Path) -> String {
+    format!(
+        "vidstabdetect=shakiness=10:accuracy=15:result='{}'",
+        escape_ffmpeg_filter_path(&transforms_path.to_string_lossy())
+    )
+}
+
 fn escape_drawtext_value(raw: &str) -> String {
     // drawtext expands `%{...}` expressions; treat user-provided text as literal.
     let normalized = raw
@@ -1099,7 +1126,12 @@ impl Effect {
                     // Fallback to anlmdn if no model path provided
                     self.build_anlmdn_filter(strength)
                 } else {
-                    let escaped = model_path.replace('\\', "/").replace('\'', "'\\''");
+                    // Shared path rule: normalize separators, then apply the
+                    // canonical filtergraph quoting. This also escapes `:`, which
+                    // the previous ad-hoc escaping omitted — a raw `:` inside the
+                    // quoted region is still read as an option separator, so a
+                    // Windows drive-letter model path failed to parse.
+                    let escaped = escape_ffmpeg_filter_path(&model_path);
                     format!("arnndn=m='{}'", escaped)
                 }
             }
@@ -1424,11 +1456,8 @@ impl Effect {
 
         // Emitted inside a single-quoted region (`input='<path>'`); a literal `'`
         // must be closed-escaped-reopened as `'\''` so it cannot terminate the
-        // quote and inject additional filter nodes. See escape_ffmpeg_filter_value.
-        let escaped_path = analysis_path
-            .replace('\\', "/")
-            .replace(':', "\\:")
-            .replace('\'', "'\\''");
+        // quote and inject additional filter nodes. See escape_ffmpeg_filter_path.
+        let escaped_path = escape_ffmpeg_filter_path(&analysis_path);
 
         format!(
             "vidstabtransform=input='{}':smoothing={}:crop={}:optzoom={}:zoom={:.1}:interpol=bilinear",
@@ -5247,6 +5276,63 @@ mod tests {
         // Default analysis_path is empty → should return null
         let filter = effect.to_filter_body();
         assert_eq!(filter, "null");
+    }
+
+    #[test]
+    fn test_vidstabdetect_single_quote_cannot_break_out_of_filter() {
+        // The transforms file is named `<clipId>.trf`, and clip ids come from the
+        // project file. The id gate rejects separators and `..` but not `'`, so the
+        // quoting rule is what stops a crafted id from closing `result='...'` and
+        // having the remainder parsed as filtergraph syntax (`;[in]movie=...` gives
+        // arbitrary file read/write).
+        let filter = build_vidstabdetect_filter(std::path::Path::new(
+            "/proj/.openreelio/stabilize/x';[in]movie=filename=/etc/passwd[out];[out].trf",
+        ));
+
+        assert!(
+            !filter.contains("x';"),
+            "Single quote must not terminate the quoted region: {filter}"
+        );
+        assert!(
+            filter.contains(
+                "result='/proj/.openreelio/stabilize/x'\\'';[in]movie=filename=/etc/passwd[out];[out].trf'"
+            ),
+            "Expected close-escape-reopen quoting of the injected value, got: {filter}"
+        );
+    }
+
+    #[test]
+    fn test_vidstabdetect_normalizes_windows_separators_and_escapes_the_drive_colon() {
+        // A filtergraph option value is unescaped twice, so a doubled backslash is
+        // consumed entirely and a native Windows path would lose its separators.
+        // Normalizing to `/` avoids that; the drive colon still has to be escaped
+        // or it is read as an option separator even inside the quoted region.
+        let filter = build_vidstabdetect_filter(std::path::Path::new(
+            r"D:\proj\.openreelio\stabilize\clip1.trf",
+        ));
+
+        assert_eq!(
+            filter,
+            "vidstabdetect=shakiness=10:accuracy=15:result='D\\:/proj/.openreelio/stabilize/clip1.trf'"
+        );
+    }
+
+    #[test]
+    fn test_arnndn_model_path_escapes_the_drive_colon() {
+        // A raw `:` is still read as an option separator inside a quoted region, so
+        // a Windows drive-letter model path has to be escaped like any other path.
+        let mut effect = Effect::new(EffectType::NoiseReduction);
+        effect.set_param("algorithm", ParamValue::String("arnndn".to_string()));
+        effect.set_param(
+            "model_path",
+            ParamValue::String(r"D:\models\rnnoise.onnx".to_string()),
+        );
+
+        let filter = effect.to_filter_string("0:a", "aout");
+        assert!(
+            filter.contains("m='D\\:/models/rnnoise.onnx'"),
+            "Expected normalized and escaped model path, got: {filter}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -128,7 +128,12 @@ fn luma_sat_factor_expr(points: &[CurvePoint], luma_expr: &str) -> String {
 // FFmpeg Utility Functions
 // =============================================================================
 
-fn escape_ffmpeg_filter_value(raw: &str) -> String {
+/// Escapes a value for embedding inside a single-quoted FFmpeg filtergraph argument.
+///
+/// This is the single canonical filtergraph quoting rule for the whole crate; any
+/// other escaping of a value that ends up inside `option='<value>'` must delegate
+/// here rather than re-deriving the rules (see the rationale in the body).
+pub(crate) fn escape_ffmpeg_filter_value(raw: &str) -> String {
     // FFmpeg filtergraphs treat `:` and `,` as separators and `\` as an escape character.
     // Windows paths also contain `\` and `:` (drive letter), so we must escape them to
     // keep filter strings replayable and safe against filtergraph injection.

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -134,10 +134,10 @@ fn luma_sat_factor_expr(points: &[CurvePoint], luma_expr: &str) -> String {
 /// other escaping of a value that ends up inside `option='<value>'` must delegate
 /// here rather than re-deriving the rules (see the rationale in the body).
 ///
-/// For a **filesystem path**, prefer [`escape_ffmpeg_filter_path`]: the `\` -> `\\`
-/// rule below is not sufficient for a native Windows path, because several filters
-/// unescape the option value a second time and consume the doubled backslash. See
-/// that function for the details.
+/// For a **filesystem path**, prefer [`escape_ffmpeg_filter_path`], which normalizes
+/// separators before applying this rule so that a path is spelled identically in every
+/// filter. Both functions provide the same security property; see that function for why
+/// the normalization is worth doing anyway.
 pub(crate) fn escape_ffmpeg_filter_value(raw: &str) -> String {
     // FFmpeg filtergraphs treat `:` and `,` as separators and `\` as an escape character.
     // Windows paths also contain `\` and `:` (drive letter), so we must escape them to
@@ -160,17 +160,25 @@ pub(crate) fn escape_ffmpeg_filter_value(raw: &str) -> String {
 /// Escapes a filesystem path for embedding inside a single-quoted FFmpeg filter argument.
 ///
 /// Windows separators are normalized to `/` before the canonical quoting rule is
-/// applied. This is deliberate and load-bearing, not cosmetic: several filters
-/// unescape their path option a second time, so the `\` -> `\\` doubling in
-/// [`escape_ffmpeg_filter_value`] is consumed and the path loses every separator.
-/// Verified against ffmpeg: `vidstabdetect=result='D\:\\dir\\a.trf'` silently
-/// writes a file literally named `Ddira.trf` in the working directory, and
-/// `subtitles=filename='D\:\\dir\\a.ass'` fails with `Unable to open D:dira.ass`.
-/// Normalizing first removes every backslash, leaving only the `:`/`,`/`'` rules to
-/// apply — and FFmpeg accepts `/` as a separator on Windows.
+/// applied. This is a consistency measure, not the security boundary. FFmpeg accepts
+/// `/` as a path separator on Windows, and normalizing first means the emitted path is
+/// spelled the same way no matter how many unescaping passes a particular filter's
+/// option parser happens to apply to its value — so a path that works in one filter
+/// works in all of them.
+///
+/// The security property — that no input can terminate the quoted region and open a new
+/// filter node — comes entirely from the single-quote wrapping applied by
+/// [`escape_ffmpeg_filter_value`], which this function delegates to. Normalizing
+/// separators neither adds to nor subtracts from that.
 ///
 /// The drive colon must still be escaped: a raw `:` is read as an option separator
 /// even inside a single-quoted region.
+///
+/// Known limitation: a path containing a literal `'` cannot be represented faithfully.
+/// The `'\''` idiom keeps the parse inside the quoted region (so the security property
+/// holds) but the quote is dropped from the resulting value, yielding a path that does
+/// not exist. Callers that generate their own paths must reject apostrophes up front —
+/// see `core::fs::validate_filter_safe_path`.
 pub(crate) fn escape_ffmpeg_filter_path(raw: &str) -> String {
     escape_ffmpeg_filter_value(&raw.replace('\\', "/"))
 }
@@ -182,6 +190,9 @@ pub(crate) fn escape_ffmpeg_filter_path(raw: &str) -> String {
 /// single-quoted filter argument and therefore goes through [`escape_ffmpeg_filter_path`]:
 /// the transforms file is named after a clip id that originates in the project file, which
 /// is untrusted input.
+// The only production caller is the `stabilize_clip` IPC command, which is compiled
+// out without the `gui` feature; the tests below still exercise it in every config.
+#[cfg_attr(not(feature = "gui"), allow(dead_code))]
 pub(crate) fn build_vidstabdetect_filter(transforms_path: &std::path::Path) -> String {
     format!(
         "vidstabdetect=shakiness=10:accuracy=15:result='{}'",
@@ -5313,10 +5324,10 @@ mod tests {
 
     #[test]
     fn test_vidstabdetect_normalizes_windows_separators_and_escapes_the_drive_colon() {
-        // A filtergraph option value is unescaped twice, so a doubled backslash is
-        // consumed entirely and a native Windows path would lose its separators.
-        // Normalizing to `/` avoids that; the drive colon still has to be escaped
-        // or it is read as an option separator even inside the quoted region.
+        // Separators are normalized so a path is spelled the same way regardless of
+        // how many unescaping passes a given filter's option parser applies. The
+        // drive colon still has to be escaped or it is read as an option separator
+        // even inside the quoted region.
         let filter = build_vidstabdetect_filter(std::path::Path::new(
             r"D:\proj\.openreelio\stabilize\clip1.trf",
         ));
@@ -5757,5 +5768,162 @@ mod tests {
         );
         assert!(result.contains("null"), "Should produce null filter");
         assert!(!result.contains("eq="), "Should NOT apply effect globally");
+    }
+
+    // =========================================================================
+    // Empirical filtergraph injection tests
+    //
+    // The string assertions above encode a *belief* about how FFmpeg's filtergraph
+    // parser reads a quoted option value. These tests encode the security property
+    // itself: they hand the real parser a hostile path and count how many filter
+    // nodes it built. Exactly one means the payload never left the quoted region.
+    //
+    // Ignored by default because they need an `ffmpeg` binary. Run with:
+    //   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored injection
+    // =========================================================================
+
+    /// Resolves an ffmpeg binary for the empirical tests.
+    fn ffmpeg_binary_for_tests() -> std::path::PathBuf {
+        std::env::var_os("OPENREELIO_FFMPEG_PATH")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"))
+    }
+
+    /// Parses a filtergraph with the real FFmpeg and returns the node names it built.
+    ///
+    /// The graph is passed via `-/filter_complex <file>` so that nothing in the payload
+    /// has to survive an extra round of shell or argv quoting — what FFmpeg's parser
+    /// sees is byte-for-byte what the escaper produced. `-v debug` makes the parser name
+    /// every node it creates as `Parsed_<filter>_<index>`.
+    ///
+    /// The input is a generated file rather than `-f lavfi`, because a lavfi input is
+    /// itself a filtergraph and contributes its own `Parsed_*` node to the log — which
+    /// would be counted as if the payload had produced it.
+    ///
+    /// Returns `None` when ffmpeg could not be launched at all.
+    fn parsed_filter_node_names(filtergraph: &str) -> Option<Vec<String>> {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let graph_file = dir.path().join("graph.txt");
+        std::fs::write(&graph_file, filtergraph).expect("write filtergraph");
+
+        let input_file = dir.path().join("input.mp4");
+        let fixture = std::process::Command::new(ffmpeg_binary_for_tests())
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:s=64x64:r=5:d=0.4",
+                "-pix_fmt",
+                "yuv420p",
+                "-frames:v",
+                "2",
+            ])
+            .arg(&input_file)
+            .output()
+            .ok()?;
+        if !fixture.status.success() || !input_file.exists() {
+            return None;
+        }
+
+        let output = std::process::Command::new(ffmpeg_binary_for_tests())
+            .args(["-hide_banner", "-v", "debug", "-nostdin", "-i"])
+            .arg(&input_file)
+            .arg("-/filter_complex")
+            .arg(&graph_file)
+            .args(["-map", "[out]", "-frames:v", "1", "-f", "null", "-"])
+            .output()
+            .ok()?;
+
+        // Collect distinct `Parsed_*` identifiers. The exit status is deliberately
+        // ignored: a node that fails to *initialize* (a missing subtitle file, say)
+        // still tells us how many nodes the parser *created*, which is the property
+        // under test.
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        let mut names: Vec<String> = Vec::new();
+        for (index, _) in stderr.match_indices("Parsed_") {
+            let name: String = stderr[index..]
+                .chars()
+                .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+                .collect();
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+        Some(names)
+    }
+
+    /// Whether the local ffmpeg advertises `filter_name`.
+    fn ffmpeg_has_filter(filter_name: &str) -> bool {
+        std::process::Command::new(ffmpeg_binary_for_tests())
+            .args(["-hide_banner", "-filters"])
+            .output()
+            .is_ok_and(|output| {
+                String::from_utf8_lossy(&output.stdout).contains(&format!(" {filter_name} "))
+            })
+    }
+
+    /// A path carrying a filtergraph-injection payload, as a crafted project file
+    /// could produce by naming a clip or a subtitle asset.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1, `-/filter_complex` + `-v debug`): escaping
+    /// the quote naively as `\'` instead of `'\''` makes this exact payload parse as a
+    /// *second* filter node — `Parsed_anullsrc_1` — for both `subtitles=filename=` and
+    /// `vidstabdetect=result=`. So the `== 1` assertions below genuinely discriminate;
+    /// they are not satisfied by every possible input.
+    const INJECTION_PAYLOAD: &str = "/proj/x';anullsrc=r=48000";
+
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn subtitles_path_injection_creates_exactly_one_filter_node() {
+        // Built exactly as `append_ass_text_overlay` builds it.
+        let escaped = escape_ffmpeg_filter_value(&format!("{INJECTION_PAYLOAD}.ass"));
+        let graph = format!("[0:v]subtitles=filename='{escaped}'[out]");
+
+        let Some(nodes) = parsed_filter_node_names(&graph) else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+
+        assert_eq!(
+            nodes.len(),
+            1,
+            "The payload escaped the quoted region and built extra filter nodes: {nodes:?}"
+        );
+        assert!(
+            nodes[0].starts_with("Parsed_subtitles_"),
+            "Expected the single node to be the subtitles filter, got {nodes:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an ffmpeg binary built with libvidstab; run with --ignored"]
+    fn vidstabdetect_path_injection_creates_exactly_one_filter_node() {
+        if !ffmpeg_has_filter("vidstabdetect") {
+            eprintln!("Skipping: this ffmpeg has no vidstabdetect filter");
+            return;
+        }
+
+        let detect =
+            build_vidstabdetect_filter(std::path::Path::new(&format!("{INJECTION_PAYLOAD}.trf")));
+        let graph = format!("[0:v]{detect}[out]");
+
+        let Some(nodes) = parsed_filter_node_names(&graph) else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+
+        assert_eq!(
+            nodes.len(),
+            1,
+            "The payload escaped the quoted region and built extra filter nodes: {nodes:?}"
+        );
+        assert!(
+            nodes[0].starts_with("Parsed_vidstabdetect_"),
+            "Expected the single node to be the vidstabdetect filter, got {nodes:?}"
+        );
     }
 }

--- a/src-tauri/src/core/effects/mod.rs
+++ b/src-tauri/src/core/effects/mod.rs
@@ -15,6 +15,9 @@ pub use capabilities::{
     all_effect_capabilities, effect_capability, effect_capability_dto, effect_type_label,
     effect_type_supports_export, EffectCapability, EffectCapabilityDto, EffectRuntimeSupport,
 };
+/// Canonical filtergraph escaper, shared with the render pipeline and the IPC
+/// commands that build filter strings outside of the effect builders.
+pub(crate) use filter_builder::escape_ffmpeg_filter_value;
 pub use filter_builder::{FilterGraph, IntoFFmpegFilter};
 pub use gpu_filters::{GpuFilterBackend, GpuFilterContext};
 pub use mask_filters::{

--- a/src-tauri/src/core/effects/mod.rs
+++ b/src-tauri/src/core/effects/mod.rs
@@ -15,9 +15,15 @@ pub use capabilities::{
     all_effect_capabilities, effect_capability, effect_capability_dto, effect_type_label,
     effect_type_supports_export, EffectCapability, EffectCapabilityDto, EffectRuntimeSupport,
 };
-/// Canonical filtergraph escaper, shared with the render pipeline and the IPC
+/// Canonical filtergraph escapers, shared with the render pipeline and the IPC
 /// commands that build filter strings outside of the effect builders.
-pub(crate) use filter_builder::escape_ffmpeg_filter_value;
+// Some consumers live in `ipc::commands`, which is compiled with
+// `cfg(all(not(test), feature = "gui"))`, so these re-exports have no user in a
+// test build even though the underlying functions are exercised by unit tests.
+#[allow(unused_imports)]
+pub(crate) use filter_builder::{
+    build_vidstabdetect_filter, escape_ffmpeg_filter_path, escape_ffmpeg_filter_value,
+};
 pub use filter_builder::{FilterGraph, IntoFFmpegFilter};
 pub use gpu_filters::{GpuFilterBackend, GpuFilterContext};
 pub use mask_filters::{

--- a/src-tauri/src/core/effects/presets.rs
+++ b/src-tauri/src/core/effects/presets.rs
@@ -76,20 +76,15 @@ pub fn get_presets_dir(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("presets").join("effects")
 }
 
-/// Validates that a preset ID contains only safe characters (alphanumeric, hyphens, underscores).
-/// Prevents path traversal attacks via crafted IDs.
+/// Validates that a preset ID is safe to use as a file name component.
+///
+/// Delegates to the canonical validator rather than re-deriving the rules. The previous
+/// hand-rolled check missed `:`, and on Windows `Path::join` with a disk-prefixed
+/// component discards the base path entirely — a `presetId` of `C:secret` escaped the
+/// presets directory without containing a separator or `..`, and `delete_effect_preset`
+/// takes the id straight from IPC and calls `remove_file` on the result.
 fn validate_preset_id(preset_id: &str) -> Result<(), String> {
-    if preset_id.is_empty() {
-        return Err("Preset ID is empty".to_string());
-    }
-    if preset_id.contains('/')
-        || preset_id.contains('\\')
-        || preset_id.contains("..")
-        || preset_id.contains('\0')
-    {
-        return Err(format!("Invalid preset ID: {}", preset_id));
-    }
-    Ok(())
+    crate::core::fs::validate_path_id_component(preset_id, "presetId")
 }
 
 /// Returns the file path for a specific preset
@@ -446,15 +441,35 @@ mod tests {
         // Given a fresh directory
         let tmp = setup();
 
-        // When loading with a path traversal ID
-        let result = load_effect_preset(tmp.path(), "../../etc/passwd");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid preset ID"));
+        // Given a file a hostile preset id would resolve to. `C:secret` matters on
+        // Windows specifically: `Path::join` drops the base path for a disk-prefixed
+        // component, so the id escapes the presets directory without a separator or
+        // `..` anywhere in it.
+        let victim = tmp.path().join("secrets.json");
+        std::fs::write(&victim, b"{}").unwrap();
 
-        // And deleting with a path traversal ID
-        let result = delete_effect_preset(tmp.path(), "../secrets");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid preset ID"));
+        // When loading or deleting with any of these ids
+        for preset_id in [
+            "../../etc/passwd",
+            "..\\..\\secrets",
+            "../secrets",
+            "C:secrets",
+            "pre\0set",
+            "pre\nset",
+            "",
+        ] {
+            assert!(
+                load_effect_preset(tmp.path(), preset_id).is_err(),
+                "load accepted {preset_id:?}"
+            );
+            assert!(
+                delete_effect_preset(tmp.path(), preset_id).is_err(),
+                "delete accepted {preset_id:?}"
+            );
+        }
+
+        // Then nothing outside the presets directory was removed
+        assert!(victim.exists());
     }
 
     #[test]

--- a/src-tauri/src/core/fs/mod.rs
+++ b/src-tauri/src/core/fs/mod.rs
@@ -200,6 +200,33 @@ pub fn validate_local_input_path(path: &str, label: &str) -> Result<PathBuf, Str
     }
 }
 
+/// Validates a caller-supplied input path and confines the read to `allowed_roots`.
+///
+/// [`validate_local_input_path`] only proves that a path is local, non-traversing and an
+/// existing regular file — it accepts *any* absolute location on disk. An IPC command
+/// that reads a file named by the renderer must additionally confine the read, otherwise
+/// a compromised webview can use the command's success/failure and result counts as an
+/// oracle for files anywhere on the machine.
+///
+/// Callers are expected to map the error to a generic message so the rejected path is not
+/// reflected back to the caller.
+pub fn validate_scoped_input_path(
+    path: &str,
+    label: &str,
+    allowed_roots: &[&Path],
+) -> Result<PathBuf, String> {
+    // `validate_local_input_path` canonicalizes (best-effort), so compare against
+    // canonicalized roots to avoid symlink and case-normalization surprises.
+    let validated = validate_local_input_path(path, label)?;
+    let allowed_root_canon = canonical_allowed_roots(allowed_roots, label)?;
+
+    if !is_within_any_scope(&validated, &allowed_root_canon) {
+        return Err(format!("{label} must be within an allowed directory"));
+    }
+
+    Ok(validated)
+}
+
 /// Validates and canonicalizes a project directory path.
 ///
 /// This is used by IPC entry points that open projects to ensure:
@@ -1192,6 +1219,52 @@ mod tests {
         let path_str = file_path.to_string_lossy().to_string();
         let result = validate_output_path(&path_str, "outputPath");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_scoped_input_path_allows_within_root() {
+        let root = TempDir::new().unwrap();
+        let nested_dir = root.path().join("exports");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        let input = nested_dir.join("diarization.json");
+        std::fs::write(&input, "{}").unwrap();
+
+        let result = validate_scoped_input_path(
+            &input.to_string_lossy(),
+            "diarization inputPath",
+            &[root.path()],
+        );
+
+        assert!(
+            result.is_ok(),
+            "in-scope input must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_scoped_input_path_rejects_outside_root() {
+        // An absolute path to an existing regular file passes
+        // `validate_local_input_path` on its own; only the scope check stops the
+        // command from being used as a read oracle for the rest of the disk.
+        let allowed_root = TempDir::new().unwrap();
+        let outside_root = TempDir::new().unwrap();
+        let input = outside_root.path().join("secret.json");
+        std::fs::write(&input, "{}").unwrap();
+
+        assert!(
+            validate_local_input_path(&input.to_string_lossy(), "diarization inputPath").is_ok()
+        );
+
+        let result = validate_scoped_input_path(
+            &input.to_string_lossy(),
+            "diarization inputPath",
+            &[allowed_root.path()],
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("must be within an allowed directory"));
     }
 
     #[test]

--- a/src-tauri/src/core/fs/mod.rs
+++ b/src-tauri/src/core/fs/mod.rs
@@ -38,22 +38,60 @@ use crate::core::{CoreError, CoreResult};
 /// that will be used as part of a file path MUST be validated through this function.
 pub fn validate_path_id_component(id: &str, label: &str) -> Result<(), String> {
     // Check for empty or whitespace-only identifiers
-    let trimmed = id.trim();
-    if trimmed.is_empty() {
+    if id.trim().is_empty() {
         return Err(format!("{label} is empty or contains only whitespace"));
     }
-    if trimmed.contains("..")
-        || trimmed.contains('/')
-        || trimmed.contains('\\')
-        || trimmed.contains(':')
-    {
+    // Reject surrounding whitespace instead of silently trimming it. Callers validate
+    // one string and then interpolate that same string into a path, so validating a
+    // trimmed copy would leave the untrimmed original unchecked. No well-formed
+    // identifier (ULID, UUID, slug) carries padding, so a padded id is already malformed.
+    if id != id.trim() {
+        return Err(format!(
+            "Invalid {label}: contains leading or trailing whitespace"
+        ));
+    }
+    if id.contains("..") || id.contains('/') || id.contains('\\') || id.contains(':') {
         return Err(format!(
             "Invalid {label}: contains path traversal characters"
         ));
     }
     // Additional validation: reject control characters and null bytes
-    if trimmed.chars().any(|c| c.is_control()) {
+    if id.chars().any(|c| c.is_control()) {
         return Err(format!("Invalid {label}: contains control characters"));
+    }
+    Ok(())
+}
+
+/// Validates that a path can be embedded faithfully in an FFmpeg filtergraph option.
+///
+/// FFmpeg's filtergraph parser has no representation for a literal `'` inside an
+/// option value. The canonical `'\''` idiom (close quote, escaped quote, reopen quote)
+/// is what keeps a hostile value from breaking out of the quoted region and injecting
+/// new filter nodes, and that property holds for every input — but the quote itself is
+/// consumed by the parser rather than delivered, so the filter receives a path with the
+/// apostrophe missing. The filter then silently reads or writes the wrong file, or
+/// produces an empty result with no error.
+///
+/// Escaping cannot fix this; it is a limit of the option-value grammar. So any path the
+/// application *generates* for a quoted filter option — a temporary `.ass` subtitle
+/// file, a stabilization `.trf` directory, a `fontsdir` — must be rejected up front with
+/// an actionable message rather than silently producing a broken render. Such paths are
+/// derived from the project directory or the system temp directory, either of which can
+/// legitimately sit under a profile like `C:\Users\Ben's PC\`.
+///
+/// This is a fidelity guard, not a security boundary: the security boundary is the
+/// quoting itself, in `core::effects::escape_ffmpeg_filter_value`.
+///
+/// # Arguments
+/// * `path` - The generated path that will be interpolated into a filter option
+/// * `label` - A descriptive label for error messages (e.g., "subtitle overlay path")
+pub fn validate_filter_safe_path(path: &Path, label: &str) -> Result<(), String> {
+    if path.to_string_lossy().contains('\'') {
+        return Err(format!(
+            "{label} contains an apostrophe, which FFmpeg's filter parser cannot \
+             represent in an option value. Move the project to a path without an \
+             apostrophe (') and retry."
+        ));
     }
     Ok(())
 }
@@ -1057,6 +1095,51 @@ mod tests {
         // Newline
         let result = validate_path_id_component("foo\nbar", "assetId");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_reject_ids_that_differ_from_their_trimmed_form() {
+        // Given ids that only differ from a valid id by surrounding whitespace.
+        // The validator used to check a trimmed copy while callers went on to
+        // interpolate the original, so the padding was never actually checked.
+        for id in [
+            " asset_001",
+            "asset_001 ",
+            "\tasset_001",
+            "asset_001\n",
+            "asset_001\r\n",
+            " asset_001 ",
+        ] {
+            let result = validate_path_id_component(id, "assetId");
+            assert!(result.is_err(), "accepted padded id {id:?}");
+        }
+
+        // And the unpadded form still passes
+        assert!(validate_path_id_component("asset_001", "assetId").is_ok());
+    }
+
+    #[test]
+    fn should_reject_generated_filter_paths_containing_an_apostrophe() {
+        // Given a project directory under a profile name with an apostrophe.
+        // FFmpeg's `'\''` idiom keeps the parse inside the quoted region, so nothing
+        // can inject a filter node, but the quote itself never reaches the filter —
+        // the path silently becomes one that does not exist.
+        let hostile = Path::new(r"C:\Users\Ben's PC\project\.openreelio\overlay.ass");
+        let result = validate_filter_safe_path(hostile, "Text overlay path");
+        assert!(result.is_err());
+        let message = result.unwrap_err();
+        assert!(message.contains("apostrophe"));
+        assert!(message.contains("Text overlay path"));
+
+        // And an ordinary path is accepted
+        assert!(validate_filter_safe_path(
+            Path::new(r"C:\Users\Ben\project\.openreelio\overlay.ass"),
+            "Text overlay path"
+        )
+        .is_ok());
+        assert!(
+            validate_filter_safe_path(Path::new("/home/ben/project/overlay.ass"), "path").is_ok()
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/generative/video_input_validation.rs
+++ b/src-tauri/src/core/generative/video_input_validation.rs
@@ -47,6 +47,14 @@ pub fn quality_to_wire_value(quality: VideoQuality) -> &'static str {
 /// - Requires http/https
 /// - Trims whitespace
 /// - Removes trailing slash
+///
+/// Unlike the AI gateway's `validate_base_url`, this deliberately does *not* deny
+/// internal/loopback hosts. The gateway URL is dialed with user credentials attached,
+/// so pointing it at an internal address is an SSRF and key-exfiltration risk; this
+/// value only feeds a local `is_available()` check and is never persisted or used to
+/// issue a request, and a locally hosted provider on `localhost` is a supported setup.
+/// If this URL ever becomes the target of an actual request, adopt the gateway's
+/// internal-host denial here as well.
 #[cfg(feature = "ai-providers")]
 pub fn validate_base_url(url: &str) -> Result<String, String> {
     let trimmed = url.trim();

--- a/src-tauri/src/core/render/cache.rs
+++ b/src-tauri/src/core/render/cache.rs
@@ -21,6 +21,7 @@ use specta::Type;
 
 use crate::core::assets::Asset;
 use crate::core::effects::Effect;
+use crate::core::fs::validate_path_id_component;
 use crate::core::render::{build_render_plan, ExportSettings, RenderGraph};
 use crate::core::timeline::{Clip, Sequence, Track};
 use crate::core::types::SequenceId;
@@ -309,7 +310,8 @@ pub fn refresh_manifest_plan_fingerprints(
     let mut changed = false;
 
     for segment in &mut manifest.segments {
-        let segment_output = segment_cache_file(project_path, &manifest.sequence_id, segment.index);
+        let segment_output =
+            segment_cache_file(project_path, &manifest.sequence_id, segment.index)?;
         let settings = ExportSettings::preview(
             segment_output,
             Some(segment.start_sec),
@@ -837,19 +839,83 @@ pub fn render_cache_dir(project_dir: &Path) -> PathBuf {
         .join("renders")
 }
 
-/// Returns the cache directory for a specific sequence
-pub fn sequence_cache_dir(project_dir: &Path, sequence_id: &str) -> PathBuf {
-    render_cache_dir(project_dir).join(sequence_id)
+/// Returns the cache directory for a specific sequence.
+///
+/// # Security
+/// `sequence_id` reaches this function from the project file and from IPC arguments,
+/// neither of which is trusted, and the directory it names is passed to
+/// `remove_dir_all` by [`clear_sequence_cache`] without the id ever being looked up in
+/// `project.state.sequences`. Validation lives here, at the single choke point every
+/// cache path helper funnels through, so no caller can construct an unvalidated one.
+pub fn sequence_cache_dir(project_dir: &Path, sequence_id: &str) -> Result<PathBuf, String> {
+    validate_path_id_component(sequence_id, "sequenceId")?;
+    Ok(render_cache_dir(project_dir).join(sequence_id))
 }
 
 /// Returns the manifest file path for a sequence
-pub fn manifest_path(project_dir: &Path, sequence_id: &str) -> PathBuf {
-    sequence_cache_dir(project_dir, sequence_id).join(CACHE_MANIFEST_FILENAME)
+pub fn manifest_path(project_dir: &Path, sequence_id: &str) -> Result<PathBuf, String> {
+    Ok(sequence_cache_dir(project_dir, sequence_id)?.join(CACHE_MANIFEST_FILENAME))
 }
 
 /// Returns the cache file path for a segment
-pub fn segment_cache_file(project_dir: &Path, sequence_id: &str, index: u32) -> PathBuf {
-    sequence_cache_dir(project_dir, sequence_id).join(format!("segment_{index:04}.mp4"))
+pub fn segment_cache_file(
+    project_dir: &Path,
+    sequence_id: &str,
+    index: u32,
+) -> Result<PathBuf, String> {
+    Ok(sequence_cache_dir(project_dir, sequence_id)?.join(segment_cache_file_name(index)))
+}
+
+/// Builds the on-disk name for a cached segment.
+///
+/// This is the sole writer of the naming scheme; [`is_cached_segment_name`] mirrors it.
+fn segment_cache_file_name(index: u32) -> String {
+    format!("segment_{index:04}.mp4")
+}
+
+/// Reports whether `name` is a file name this module could have produced.
+///
+/// # Security
+/// `RenderCacheSegment::cached_file` is deserialized from `manifest.json` inside the
+/// project directory, so it is attacker-controlled whenever the project is. It is then
+/// joined onto the sequence cache directory and handed to `remove_file` or `fs::copy`.
+/// A value such as `../../../snapshot.json` would escape the cache directory entirely.
+/// Rather than blocklisting traversal, this allowlists exactly what
+/// [`segment_cache_file_name`] emits: a name that does not round-trip through the
+/// writer's own formatting was not written by us and is never touched.
+pub fn is_cached_segment_name(name: &str) -> bool {
+    let Some(digits) = name
+        .strip_prefix("segment_")
+        .and_then(|rest| rest.strip_suffix(".mp4"))
+    else {
+        return false;
+    };
+    if !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    digits
+        .parse::<u32>()
+        .is_ok_and(|index| segment_cache_file_name(index) == name)
+}
+
+/// Resolves a manifest-recorded segment file name to a path inside `seq_cache_dir`.
+///
+/// Returns `None` when the recorded name is not one this module writes; see
+/// [`is_cached_segment_name`]. Every consumer of `cached_file` must go through here
+/// before touching the filesystem.
+pub fn resolve_cached_segment_path(seq_cache_dir: &Path, cached_file: &str) -> Option<PathBuf> {
+    if !is_cached_segment_name(cached_file) {
+        tracing::warn!(
+            "Ignoring render cache entry with an unrecognized file name: {cached_file:?}"
+        );
+        return None;
+    }
+    Some(seq_cache_dir.join(cached_file))
+}
+
+/// Wraps a path-validation failure as an `io::Error` for the `io::Result` helpers.
+fn invalid_input(message: String) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, message)
 }
 
 // =============================================================================
@@ -858,7 +924,7 @@ pub fn segment_cache_file(project_dir: &Path, sequence_id: &str, index: u32) -> 
 
 /// Saves a cache manifest to disk (JSON)
 pub fn save_manifest(project_dir: &Path, manifest: &RenderCacheManifest) -> std::io::Result<()> {
-    let dir = sequence_cache_dir(project_dir, &manifest.sequence_id);
+    let dir = sequence_cache_dir(project_dir, &manifest.sequence_id).map_err(invalid_input)?;
     std::fs::create_dir_all(&dir)?;
 
     let path = dir.join(CACHE_MANIFEST_FILENAME);
@@ -878,7 +944,7 @@ pub fn load_manifest(
     project_dir: &Path,
     sequence_id: &str,
 ) -> std::io::Result<Option<RenderCacheManifest>> {
-    let path = manifest_path(project_dir, sequence_id);
+    let path = manifest_path(project_dir, sequence_id).map_err(invalid_input)?;
     if !path.exists() {
         return Ok(None);
     }
@@ -898,12 +964,28 @@ pub fn load_manifest(
 /// Returns the total bytes freed.
 pub fn cleanup_stale_files(project_dir: &Path, manifest: &mut RenderCacheManifest) -> u64 {
     let mut freed = 0u64;
-    let seq_dir = sequence_cache_dir(project_dir, &manifest.sequence_id);
+    // Fail closed: an unusable sequence id means no file here can be identified, so
+    // remove nothing rather than guessing at a path.
+    let seq_dir = match sequence_cache_dir(project_dir, &manifest.sequence_id) {
+        Ok(dir) => dir,
+        Err(error) => {
+            tracing::warn!("Skipping render cache cleanup: {error}");
+            return 0;
+        }
+    };
 
     for segment in &mut manifest.segments {
         if segment.state == CacheSegmentState::Stale {
             if let Some(ref file) = segment.cached_file {
-                let full_path = seq_dir.join(file);
+                let resolved = resolve_cached_segment_path(&seq_dir, file);
+                let Some(full_path) = resolved else {
+                    // The manifest names a file we never wrote. Drop the entry instead
+                    // of deleting whatever it points at.
+                    segment.cached_file = None;
+                    segment.file_size_bytes = 0;
+                    segment.state = CacheSegmentState::Empty;
+                    continue;
+                };
                 if full_path.exists() {
                     match std::fs::remove_file(&full_path) {
                         Ok(()) => {
@@ -942,7 +1024,7 @@ pub fn cleanup_stale_files(project_dir: &Path, manifest: &mut RenderCacheManifes
 
 /// Removes the entire cache directory for a sequence.
 pub fn clear_sequence_cache(project_dir: &Path, sequence_id: &str) -> std::io::Result<()> {
-    let dir = sequence_cache_dir(project_dir, sequence_id);
+    let dir = sequence_cache_dir(project_dir, sequence_id).map_err(invalid_input)?;
     if dir.exists() {
         std::fs::remove_dir_all(&dir)?;
     }
@@ -960,7 +1042,14 @@ pub fn enforce_cache_limit(
         return 0;
     }
 
-    let seq_dir = sequence_cache_dir(project_dir, &manifest.sequence_id);
+    // Fail closed, as in `cleanup_stale_files`.
+    let seq_dir = match sequence_cache_dir(project_dir, &manifest.sequence_id) {
+        Ok(dir) => dir,
+        Err(error) => {
+            tracing::warn!("Skipping render cache eviction: {error}");
+            return 0;
+        }
+    };
     let mut evicted = 0;
 
     // Evict from the end (highest index) first — user is more likely to play from the start
@@ -980,12 +1069,19 @@ pub fn enforce_cache_limit(
         if let Some(segment) = manifest.segments.iter_mut().find(|s| s.index == idx) {
             let mut file_removed = false;
             if let Some(ref file) = segment.cached_file {
-                let full_path = seq_dir.join(file);
-                match std::fs::remove_file(&full_path) {
-                    Ok(()) => file_removed = true,
-                    Err(e) => {
-                        tracing::warn!("Failed to evict cache file {}: {e}", full_path.display());
-                    }
+                match resolve_cached_segment_path(&seq_dir, file) {
+                    Some(full_path) => match std::fs::remove_file(&full_path) {
+                        Ok(()) => file_removed = true,
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to evict cache file {}: {e}",
+                                full_path.display()
+                            );
+                        }
+                    },
+                    // Unrecognized name: nothing of ours to remove, so drop the entry
+                    // and let the accounting below reclaim its recorded size.
+                    None => file_removed = true,
                 }
             } else {
                 file_removed = true; // No file to remove
@@ -1483,9 +1579,9 @@ mod tests {
 
         // When getting cache paths
         let cache_dir = render_cache_dir(project_dir);
-        let seq_dir = sequence_cache_dir(project_dir, "seq-001");
-        let manifest = manifest_path(project_dir, "seq-001");
-        let seg_file = segment_cache_file(project_dir, "seq-001", 3);
+        let seq_dir = sequence_cache_dir(project_dir, "seq-001").unwrap();
+        let manifest = manifest_path(project_dir, "seq-001").unwrap();
+        let seg_file = segment_cache_file(project_dir, "seq-001", 3).unwrap();
 
         // Then paths should follow the convention
         assert_eq!(
@@ -1616,7 +1712,7 @@ mod tests {
         manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 1024);
 
         // Create the actual file on disk
-        let seg_dir = sequence_cache_dir(tmp.path(), "seq1");
+        let seg_dir = sequence_cache_dir(tmp.path(), "seq1").unwrap();
         std::fs::create_dir_all(&seg_dir).unwrap();
         std::fs::write(seg_dir.join("segment_0000.mp4"), vec![0u8; 1024]).unwrap();
 
@@ -1637,7 +1733,7 @@ mod tests {
     fn should_clear_entire_sequence_cache() {
         // Given a sequence cache directory with files
         let tmp = tempfile::tempdir().unwrap();
-        let dir = sequence_cache_dir(tmp.path(), "seq1");
+        let dir = sequence_cache_dir(tmp.path(), "seq1").unwrap();
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("segment_0000.mp4"), b"test").unwrap();
         std::fs::write(dir.join("manifest.json"), b"{}").unwrap();
@@ -1650,6 +1746,134 @@ mod tests {
     }
 
     #[test]
+    fn should_reject_traversing_sequence_id_before_removing_anything() {
+        // Given a directory that a traversing sequence id would resolve to. The render
+        // cache lives at `<project>/.openreelio/cache/renders/<sequenceId>`, and
+        // `clear_sequence_cache` calls `remove_dir_all` on it without ever looking the
+        // id up in `project.state.sequences`.
+        let tmp = tempfile::tempdir().unwrap();
+        let victim = tmp.path().join("victim");
+        std::fs::create_dir_all(&victim).unwrap();
+        std::fs::write(victim.join("keep.txt"), b"keep").unwrap();
+
+        // When a hostile id reaches any cache path helper
+        for sequence_id in [
+            "../../../../victim",
+            "..\\..\\..\\..\\victim",
+            "seq/../../victim",
+            "C:",
+            "",
+            " seq1 ",
+        ] {
+            assert!(
+                sequence_cache_dir(tmp.path(), sequence_id).is_err(),
+                "sequence_cache_dir accepted {sequence_id:?}"
+            );
+            assert!(
+                manifest_path(tmp.path(), sequence_id).is_err(),
+                "manifest_path accepted {sequence_id:?}"
+            );
+            assert!(
+                segment_cache_file(tmp.path(), sequence_id, 0).is_err(),
+                "segment_cache_file accepted {sequence_id:?}"
+            );
+            assert!(
+                clear_sequence_cache(tmp.path(), sequence_id).is_err(),
+                "clear_sequence_cache accepted {sequence_id:?}"
+            );
+            assert!(
+                load_manifest(tmp.path(), sequence_id).is_err(),
+                "load_manifest accepted {sequence_id:?}"
+            );
+        }
+
+        // Then nothing outside the cache directory was removed
+        assert!(victim.join("keep.txt").exists());
+    }
+
+    #[test]
+    fn should_only_accept_segment_names_the_writer_produces() {
+        // Given the exact names `segment_cache_file` emits
+        for index in [0u32, 1, 42, 9999, 10_000, u32::MAX] {
+            let name = segment_cache_file_name(index);
+            assert!(
+                is_cached_segment_name(&name),
+                "rejected own output {name:?}"
+            );
+        }
+
+        // Then everything else is rejected — most importantly anything that escapes the
+        // sequence cache directory, since `cached_file` comes from the on-disk manifest
+        // and is handed to `remove_file` and `fs::copy`.
+        for name in [
+            "../../../../snapshot.json",
+            "..\\..\\snapshot.json",
+            "segment_0000.mp4/../../evil.mp4",
+            "segment_0.mp4",     // width below the writer's `{:04}`
+            "segment_00000.mp4", // padded past what `{:04}` emits for 0
+            "segment_0000.mkv",
+            "segment_00a0.mp4",
+            "s0.mp4",
+            "manifest.json",
+            "",
+        ] {
+            assert!(!is_cached_segment_name(name), "accepted {name:?}");
+        }
+    }
+
+    #[test]
+    fn should_not_remove_a_manifest_named_file_outside_the_cache_dir() {
+        // Given a manifest whose `cached_file` traverses out of the cache directory
+        let clip = make_test_clip("c1", "a1", 0.0, 10.0);
+        let track = make_test_track("t1", TrackKind::Video, vec![clip]);
+        let seq = make_test_sequence("seq1", vec![track]);
+        let effects = HashMap::new();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let seq_dir = sequence_cache_dir(tmp.path(), "seq1").unwrap();
+        std::fs::create_dir_all(&seq_dir).unwrap();
+        let victim = seq_dir.join("..").join("victim.mp4");
+        std::fs::write(&victim, vec![0u8; 1024]).unwrap();
+
+        let mut manifest = RenderCacheManifest::new("seq1", 10.0, 5.0, &seq, &effects);
+        manifest.mark_segment_cached(0, "../victim.mp4".to_string(), 1024);
+        manifest.segments[0].state = CacheSegmentState::Stale;
+
+        // When the stale-file sweep runs
+        let freed = cleanup_stale_files(tmp.path(), &mut manifest);
+
+        // Then nothing was deleted and the poisoned entry was dropped
+        assert_eq!(freed, 0);
+        assert!(victim.exists());
+        assert!(manifest.segments[0].cached_file.is_none());
+        assert_eq!(manifest.segments[0].state, CacheSegmentState::Empty);
+    }
+
+    #[test]
+    fn should_not_evict_a_manifest_named_file_outside_the_cache_dir() {
+        // Given an over-limit manifest whose `cached_file` traverses out of the cache dir
+        let clip = make_test_clip("c1", "a1", 0.0, 10.0);
+        let track = make_test_track("t1", TrackKind::Video, vec![clip]);
+        let seq = make_test_sequence("seq1", vec![track]);
+        let effects = HashMap::new();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let seq_dir = sequence_cache_dir(tmp.path(), "seq1").unwrap();
+        std::fs::create_dir_all(&seq_dir).unwrap();
+        let victim = seq_dir.join("..").join("victim.mp4");
+        std::fs::write(&victim, vec![0u8; 4096]).unwrap();
+
+        let mut manifest = RenderCacheManifest::new("seq1", 10.0, 5.0, &seq, &effects);
+        manifest.mark_segment_cached(0, "../victim.mp4".to_string(), 4096);
+
+        // When the size limit forces an eviction
+        enforce_cache_limit(tmp.path(), &mut manifest, 0);
+
+        // Then the file outside the cache directory survives
+        assert!(victim.exists());
+    }
+
+    #[test]
     fn should_evict_segments_when_cache_exceeds_limit() {
         // Given a manifest where total size exceeds the limit
         let clip = make_test_clip("c1", "a1", 0.0, 20.0);
@@ -1658,7 +1882,7 @@ mod tests {
         let effects = HashMap::new();
 
         let tmp = tempfile::tempdir().unwrap();
-        let seg_dir = sequence_cache_dir(tmp.path(), "seq1");
+        let seg_dir = sequence_cache_dir(tmp.path(), "seq1").unwrap();
         std::fs::create_dir_all(&seg_dir).unwrap();
 
         let mut manifest = RenderCacheManifest::new("seq1", 20.0, 5.0, &seq, &effects);
@@ -1694,7 +1918,7 @@ mod tests {
 
         let tmp = tempfile::tempdir().unwrap();
         let mut manifest = RenderCacheManifest::new("seq1", 10.0, 5.0, &seq, &effects);
-        manifest.mark_segment_cached(0, "s0.mp4".to_string(), 100);
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
 
         // When enforcing a large limit
         let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 10_000);

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -4589,13 +4589,6 @@ fn ass_escape_text(raw: &str) -> String {
     escaped
 }
 
-fn escape_filtergraph_value(raw: &str) -> String {
-    raw.replace('\\', r"\\")
-        .replace(':', r"\:")
-        .replace(',', r"\,")
-        .replace('\'', r"\'")
-}
-
 /// Reads the horizontal alignment an effect stores, normalized.
 fn caption_effect_alignment(effect: &Effect) -> String {
     effect
@@ -5134,9 +5127,16 @@ pub(super) fn append_ass_text_overlay(
     base_video_label: &str,
     ass_path: &Path,
 ) -> String {
+    use crate::core::effects::escape_ffmpeg_filter_value;
+
     let output_label = "[txtass0]";
     let path_text = ass_path.to_string_lossy();
-    let escaped_path = escape_filtergraph_value(path_text.as_ref());
+    // Both values land inside a single-quoted filter argument, so they must go
+    // through the canonical filtergraph escaper: a literal `'` has to be emitted
+    // as `'\''`, otherwise it terminates the quoted region and the rest of the
+    // value is parsed as filtergraph syntax (`;`/`[`/`]` + `movie=` would give
+    // arbitrary file read/write).
+    let escaped_path = escape_ffmpeg_filter_value(path_text.as_ref());
     // The filter takes a single directory, and libass reads it in addition to
     // the host's own font provider. Taking whichever path happened to sort
     // first meant a per-user font folder could shadow the system one; naming
@@ -5146,7 +5146,7 @@ pub(super) fn append_ass_text_overlay(
             let directory_text = directory.to_string_lossy();
             format!(
                 ":fontsdir='{}'",
-                escape_filtergraph_value(directory_text.as_ref())
+                escape_ffmpeg_filter_value(directory_text.as_ref())
             )
         })
         .unwrap_or_default();
@@ -7724,6 +7724,34 @@ mod tests {
             "got: {filter_complex}"
         );
         assert!(filter_complex.contains("subtitles=filename='/tmp/vertical.ass'"));
+    }
+
+    #[test]
+    fn test_ass_subtitles_path_single_quote_cannot_break_out_of_filter() {
+        // The ASS file lives under a project-derived directory, so a crafted
+        // project path can carry a single quote. An unescaped `'` would close the
+        // quoted filename and turn the rest of the value into filtergraph syntax
+        // (`;[in]movie=...` = arbitrary file read/write). The canonical escaper
+        // rewrites every literal quote to `'\''`, keeping the payload inside the
+        // quoted region.
+        let mut filter_complex = String::from("[0:v]null[outv]");
+        let label = append_ass_text_overlay(
+            &mut filter_complex,
+            "[outv]",
+            &PathBuf::from("/tmp/x';[in]movie=filename=/etc/passwd[out];[out].ass"),
+        );
+
+        assert_eq!(label, "[txtass0]");
+        assert!(
+            !filter_complex.contains("x';"),
+            "Single quote must not terminate the quoted region: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains(
+                "subtitles=filename='/tmp/x'\\'';[in]movie=filename=/etc/passwd[out];[out].ass'"
+            ),
+            "Expected close-escape-reopen quoting of the injected value, got: {filter_complex}"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -5142,6 +5142,20 @@ pub(super) fn append_ass_text_overlay(
     // first meant a per-user font folder could shadow the system one; naming
     // the platform's primary folder makes the choice deterministic.
     let fonts_dir_option = crate::core::text::fonts::primary_system_font_directory()
+        .filter(|directory| {
+            // Same apostrophe limit as the `.ass` path: FFmpeg cannot carry a literal
+            // `'` into an option value. Unlike the script path, this option is purely
+            // additive — libass still consults the host font provider without it — and
+            // the user cannot relocate the system font directory. So drop the option
+            // instead of failing the export.
+            match crate::core::fs::validate_filter_safe_path(directory, "System font directory") {
+                Ok(()) => true,
+                Err(message) => {
+                    tracing::warn!("{message} Continuing without the fontsdir option.");
+                    false
+                }
+            }
+        })
         .map(|directory| {
             let directory_text = directory.to_string_lossy();
             format!(
@@ -5689,6 +5703,14 @@ impl ExportEngine {
                     .tempdir()
                     .map_err(ExportError::IoError)?;
                 let ass_path = temp_dir.path().join("text-overlays.ass");
+                // The `subtitles` filter takes this path as a quoted option value, and
+                // FFmpeg's filtergraph grammar cannot carry a literal `'` through to the
+                // filter. The temp directory inherits the system temp root, which on
+                // Windows sits under the user profile (`C:\Users\Ben's PC\...`), so this
+                // is reachable without anything malformed. Fail loudly with a fixable
+                // instruction rather than rendering a video with every caption missing.
+                crate::core::fs::validate_filter_safe_path(&ass_path, "Text overlay path")
+                    .map_err(ExportError::InvalidSettings)?;
                 tokio::fs::write(&ass_path, ass_script)
                     .await
                     .map_err(ExportError::IoError)?;

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -45,10 +45,11 @@ pub use plan::{
 // Render cache re-exports
 pub use cache::{
     cleanup_stale_files, clear_sequence_cache, compute_plan_segment_fingerprint,
-    compute_segment_fingerprint, enforce_cache_limit, load_manifest, manifest_path,
-    refresh_manifest_plan_fingerprints, render_cache_dir, save_manifest, segment_cache_file,
-    sequence_cache_dir, CacheSegmentState, CacheSegmentStatusDto, RenderCacheConfig,
-    RenderCacheManifest, RenderCacheSegment, RenderCacheStatus, SegmentFingerprint,
+    compute_segment_fingerprint, enforce_cache_limit, is_cached_segment_name, load_manifest,
+    manifest_path, refresh_manifest_plan_fingerprints, render_cache_dir,
+    resolve_cached_segment_path, save_manifest, segment_cache_file, sequence_cache_dir,
+    CacheSegmentState, CacheSegmentStatusDto, RenderCacheConfig, RenderCacheManifest,
+    RenderCacheSegment, RenderCacheStatus, SegmentFingerprint,
 };
 
 // Smart render re-exports

--- a/src-tauri/src/core/render/smart.rs
+++ b/src-tauri/src/core/render/smart.rs
@@ -129,22 +129,18 @@ pub fn plan_smart_render(
 
     if !config.smart_render_enabled || manifest.segments.is_empty() {
         // Smart render disabled — re-encode everything
-        return SmartRenderPlan {
-            segments: manifest
-                .segments
-                .iter()
-                .map(|s| SmartRenderSegment {
-                    index: s.index,
-                    start_sec: s.start_sec,
-                    end_sec: s.end_sec,
-                    action: SegmentAction::ReEncode,
-                })
-                .collect(),
-            total_duration_sec: total_duration,
-        };
+        return reencode_every_segment(manifest, total_duration);
     }
 
-    let seq_dir = super::cache::sequence_cache_dir(project_dir, &manifest.sequence_id);
+    // Fail closed: without a usable cache directory there is nothing to copy from, so
+    // re-encode rather than resolving segment paths against an unvalidated id.
+    let seq_dir = match super::cache::sequence_cache_dir(project_dir, &manifest.sequence_id) {
+        Ok(dir) => dir,
+        Err(error) => {
+            tracing::warn!("Smart render falling back to a full re-encode: {error}");
+            return reencode_every_segment(manifest, total_duration);
+        }
+    };
 
     let segments = manifest
         .segments
@@ -166,6 +162,26 @@ pub fn plan_smart_render(
     }
 }
 
+/// Builds a plan that re-encodes every segment, ignoring the cache entirely.
+fn reencode_every_segment(
+    manifest: &RenderCacheManifest,
+    total_duration_sec: f64,
+) -> SmartRenderPlan {
+    SmartRenderPlan {
+        segments: manifest
+            .segments
+            .iter()
+            .map(|s| SmartRenderSegment {
+                index: s.index,
+                start_sec: s.start_sec,
+                end_sec: s.end_sec,
+                action: SegmentAction::ReEncode,
+            })
+            .collect(),
+        total_duration_sec,
+    }
+}
+
 /// Decides the action for a single segment based on its cache state.
 fn decide_segment_action(segment: &RenderCacheSegment, seq_cache_dir: &Path) -> SegmentAction {
     if segment.state != CacheSegmentState::Cached {
@@ -176,7 +192,13 @@ fn decide_segment_action(segment: &RenderCacheSegment, seq_cache_dir: &Path) -> 
         return SegmentAction::ReEncode;
     };
 
-    let cache_path = seq_cache_dir.join(file_name);
+    // `cached_file` comes out of the on-disk manifest, and the resulting path becomes a
+    // `fs::copy` source. Only names this crate writes are honoured; anything else is
+    // treated as a cache miss.
+    let Some(cache_path) = super::cache::resolve_cached_segment_path(seq_cache_dir, file_name)
+    else {
+        return SegmentAction::ReEncode;
+    };
 
     // Verify the file actually exists on disk
     if !cache_path.exists() {
@@ -308,13 +330,13 @@ mod tests {
         let mut manifest = RenderCacheManifest::new("seq1", 15.0, 5.0, &seq, &effects);
 
         // Create actual cache files on disk
-        let seg_dir = super::super::cache::sequence_cache_dir(tmp.path(), "seq1");
+        let seg_dir = super::super::cache::sequence_cache_dir(tmp.path(), "seq1").unwrap();
         std::fs::create_dir_all(&seg_dir).unwrap();
-        std::fs::write(seg_dir.join("s0.mp4"), b"cached0").unwrap();
-        std::fs::write(seg_dir.join("s1.mp4"), b"cached1").unwrap();
+        std::fs::write(seg_dir.join("segment_0000.mp4"), b"cached0").unwrap();
+        std::fs::write(seg_dir.join("segment_0001.mp4"), b"cached1").unwrap();
 
-        manifest.mark_segment_cached(0, "s0.mp4".to_string(), 100);
-        manifest.mark_segment_cached(1, "s1.mp4".to_string(), 100);
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
+        manifest.mark_segment_cached(1, "segment_0001.mp4".to_string(), 100);
 
         // When planning smart render
         let plan = plan_smart_render(&mut manifest, &seq, &effects, &config, tmp.path());
@@ -340,7 +362,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         let mut manifest = RenderCacheManifest::new("seq1", 10.0, 5.0, &seq, &effects);
-        manifest.mark_segment_cached(0, "s0.mp4".to_string(), 100);
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
 
         // When planning
         let plan = plan_smart_render(&mut manifest, &seq, &effects, &config, tmp.path());
@@ -359,7 +381,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         let mut manifest = RenderCacheManifest::new("seq1", 5.0, 5.0, &seq, &effects);
-        manifest.mark_segment_cached(0, "missing.mp4".to_string(), 100);
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
         // File NOT created on disk
 
         // When planning
@@ -378,12 +400,12 @@ mod tests {
         let config = RenderCacheConfig::default();
         let tmp = tempfile::tempdir().unwrap();
 
-        let seg_dir = super::super::cache::sequence_cache_dir(tmp.path(), "seq1");
+        let seg_dir = super::super::cache::sequence_cache_dir(tmp.path(), "seq1").unwrap();
         std::fs::create_dir_all(&seg_dir).unwrap();
-        std::fs::write(seg_dir.join("s0.mp4"), b"data").unwrap();
+        std::fs::write(seg_dir.join("segment_0000.mp4"), b"data").unwrap();
 
         let mut manifest = RenderCacheManifest::new("seq1", 10.0, 5.0, &seq, &effects);
-        manifest.mark_segment_cached(0, "s0.mp4".to_string(), 100);
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
 
         // When the sequence changes (different clip)
         let mut modified_seq = make_sequence(10.0);
@@ -404,16 +426,16 @@ mod tests {
         let config = RenderCacheConfig::default();
         let tmp = tempfile::tempdir().unwrap();
 
-        let seg_dir = super::super::cache::sequence_cache_dir(tmp.path(), "seq1");
+        let seg_dir = super::super::cache::sequence_cache_dir(tmp.path(), "seq1").unwrap();
         std::fs::create_dir_all(&seg_dir).unwrap();
         for i in 0..3 {
-            let name = format!("s{i}.mp4");
+            let name = format!("segment_{i:04}.mp4");
             std::fs::write(seg_dir.join(&name), b"data").unwrap();
         }
 
         let mut manifest = RenderCacheManifest::new("seq1", 20.0, 5.0, &seq, &effects);
         for i in 0..3 {
-            manifest.mark_segment_cached(i, format!("s{i}.mp4"), 100);
+            manifest.mark_segment_cached(i, format!("segment_{i:04}.mp4"), 100);
         }
 
         let plan = plan_smart_render(&mut manifest, &seq, &effects, &config, tmp.path());

--- a/src-tauri/src/ipc/commands/agent.rs
+++ b/src-tauri/src/ipc/commands/agent.rs
@@ -316,10 +316,11 @@ pub async fn read_agent_trace(
         project.path.clone()
     };
 
-    // Sanitize trace_id to prevent path traversal
-    if trace_id.contains('/') || trace_id.contains('\\') || trace_id.contains("..") {
-        return Err("Invalid trace_id: contains path separators or '..'".to_string());
-    }
+    // Use the same allowlist the write path applies. The inline check this replaces
+    // missed `:`, so a `trace_id` of `C:secret` escaped the traces directory on Windows
+    // (`Path::join` drops the base path for a disk-prefixed component) and returned the
+    // file's contents to the renderer.
+    validate_trace_id(&trace_id)?;
 
     let file_path = project_path
         .join(".openreelio")

--- a/src-tauri/src/ipc/commands/analysis.rs
+++ b/src-tauri/src/ipc/commands/analysis.rs
@@ -57,6 +57,7 @@ use crate::core::commands::AddEffectCommand;
 use crate::core::credentials::{CredentialType, CredentialVault};
 use crate::core::effects::{curve_points_to_json, CurvePoint, EffectType, ParamValue};
 use crate::core::ffmpeg::{FFmpegRunner, MediaInfo, SharedFFmpegState};
+use crate::core::fs::export_allowed_roots;
 use crate::core::jobs::{Job, JobStatus, JobType, Priority};
 use crate::core::project::ProjectState;
 #[cfg(feature = "ai-providers")]
@@ -903,12 +904,19 @@ pub async fn import_diarization_json(
 
     // Security: `input_path` is caller-supplied and reaches the filesystem directly.
     // Validate it (rejects `..` traversal, URL/protocol strings, and non-regular
-    // files) so a compromised renderer cannot coerce reads of arbitrary locations,
-    // and map IO/parse failures to generic messages so the target file's contents
+    // files) *and* confine it to the project directory plus the session-approved
+    // export directories, so a compromised renderer cannot point the import at an
+    // arbitrary file and read back its speaker/segment counts as an oracle. IO and
+    // parse failures are mapped to generic messages so the target file's contents
     // are never reflected back to the caller via error strings.
-    let validated_input_path = crate::core::fs::validate_local_input_path(
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let allowed_roots = export_allowed_roots(&project_path, &approved_dirs);
+    let allowed_root_refs: Vec<&std::path::Path> =
+        allowed_roots.iter().map(|p| p.as_path()).collect();
+    let validated_input_path = crate::core::fs::validate_scoped_input_path(
         &resolved_input_path.to_string_lossy(),
         "diarization inputPath",
+        &allowed_root_refs,
     )
     .map_err(|_| "Invalid diarization input path".to_string())?;
 

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -1683,6 +1683,13 @@ pub async fn stabilize_clip(
 
     let transforms_path = stab_dir.join(format!("{}.trf", clip_id));
 
+    // `vidstabdetect=result='<path>'` and the `vidstabtransform` apply pass both carry
+    // this path as a quoted filter option, and FFmpeg's filtergraph grammar cannot
+    // represent a literal `'` in one. The path derives from the project directory, which
+    // can legitimately sit under a profile like `C:\Users\Ben's PC\`. Without this guard
+    // pass 1 writes its transforms somewhere else and pass 2 stabilizes against nothing.
+    crate::core::fs::validate_filter_safe_path(&transforms_path, "Stabilization data path")?;
+
     // Emit initial progress
     let _ = app_handle.emit(
         "stabilize-progress",
@@ -2381,9 +2388,20 @@ fn cleanup_orphaned_cache_files(
         return;
     }
 
-    let seq_dir = crate::core::render::sequence_cache_dir(project_path, sequence_id);
+    // `sequence_id` and every entry in `files` originate in the on-disk manifest, so
+    // both are validated before this reaches `remove_file`.
+    let seq_dir = match crate::core::render::sequence_cache_dir(project_path, sequence_id) {
+        Ok(dir) => dir,
+        Err(error) => {
+            tracing::warn!("Skipping orphaned render cache cleanup: {error}");
+            return;
+        }
+    };
     for file in files {
-        let file_path = seq_dir.join(file);
+        let Some(file_path) = crate::core::render::resolve_cached_segment_path(&seq_dir, file)
+        else {
+            continue;
+        };
         if let Err(error) = std::fs::remove_file(&file_path) {
             if error.kind() != std::io::ErrorKind::NotFound {
                 tracing::warn!(
@@ -2804,7 +2822,13 @@ pub async fn render_preview_cache(
 
             // Build segment export settings
             let seg_output =
-                crate::core::render::segment_cache_file(&project_path, &job_seq_id, *idx);
+                match crate::core::render::segment_cache_file(&project_path, &job_seq_id, *idx) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        tracing::warn!("Skipping cache segment {idx}: {error}");
+                        continue;
+                    }
+                };
 
             if let Some(parent) = seg_output.parent() {
                 if let Err(e) = std::fs::create_dir_all(parent) {

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -7,7 +7,10 @@ use specta::Type;
 use tauri::State;
 
 use crate::core::{
-    fs::{export_allowed_roots, validate_local_input_path, validate_scoped_output_path},
+    fs::{
+        export_allowed_roots, validate_local_input_path, validate_path_id_component,
+        validate_scoped_output_path,
+    },
     render::{
         cancel_render_job, register_render_job, unregister_render_job, AudioExportFormat,
         ExportError, ExportPreset, ImageFormat, VideoExportRequest,
@@ -1608,6 +1611,12 @@ pub async fn stabilize_clip(
         zoom: _,
     } = args;
 
+    // Security: `clip_id` is used as a file name component below
+    // (`.openreelio/stabilize/<clipId>.trf`). Clip ids come from the project file,
+    // which is untrusted input, so reject separators and `..` before they can
+    // escape the stabilization directory.
+    validate_path_id_component(&clip_id, "clipId")?;
+
     // Validate crop_mode
     let valid_modes = ["none", "crop", "dynamic"];
     if !valid_modes.contains(&crop_mode.as_str()) {
@@ -1651,10 +1660,10 @@ pub async fn stabilize_clip(
         (asset.uri.clone(), project.path.clone())
     };
 
-    // Security: the asset URI can be set via UpdateAsset without validation, so
-    // re-validate before handing it to ffmpeg. This rejects `..`/URL/protocol
-    // strings and non-existent files, preventing path traversal, ffmpeg-protocol
-    // SSRF, and argument injection at the input arg.
+    // Security: asset URIs from a loaded project file have not passed the
+    // command-layer validation, so re-validate before handing it to ffmpeg. This
+    // rejects `..`/URL/protocol strings and non-existent files, preventing path
+    // traversal, ffmpeg-protocol SSRF, and argument injection at the input arg.
     let source_path = validate_local_input_path(&source_path, "stabilize source")
         .map_err(|e| format!("Invalid source media path: {}", e))?
         .to_string_lossy()
@@ -1688,17 +1697,7 @@ pub async fn stabilize_clip(
     let mut cmd = tokio::process::Command::new(&ffmpeg.info().ffmpeg_path);
     crate::core::process::configure_tokio_command(&mut cmd);
 
-    // FFmpeg filter escaping: backslashes to forward slashes, then escape
-    // special characters (\, :, ') per FFmpeg's libavfilter quoting rules.
-    let escaped_path = transforms_path
-        .to_string_lossy()
-        .replace('\\', "/")
-        .replace(':', "\\:")
-        .replace('\'', "\\'");
-    let detect_filter = format!(
-        "vidstabdetect=shakiness=10:accuracy=15:result='{}'",
-        escaped_path
-    );
+    let detect_filter = crate::core::effects::build_vidstabdetect_filter(&transforms_path);
 
     let output = cmd
         .args([
@@ -1898,12 +1897,12 @@ pub async fn smart_reframe(
         asset.uri.clone()
     };
 
-    // Security: the asset URI can be set via UpdateAsset without validation, so
-    // re-validate before handing it to ffprobe/ffmpeg. This rejects `..`/URL/
-    // protocol strings and non-existent files, preventing path traversal,
-    // ffmpeg-protocol SSRF, and ffprobe argument injection (the URI is passed as a
-    // bare positional arg below, so a leading `-` would otherwise be parsed as an
-    // option; an absolute validated path cannot).
+    // Security: asset URIs from a loaded project file have not passed the
+    // command-layer validation, so re-validate before handing it to ffprobe/ffmpeg.
+    // This rejects `..`/URL/protocol strings and non-existent files, preventing path
+    // traversal, ffmpeg-protocol SSRF, and ffprobe argument injection (the URI is
+    // passed as a bare positional arg below, so a leading `-` would otherwise be
+    // parsed as an option; an absolute validated path cannot).
     let source_path = validate_local_input_path(&source_path, "reframe source")
         .map_err(|e| format!("Invalid source media path: {}", e))?
         .to_string_lossy()

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -470,10 +470,11 @@ pub async fn transcribe_asset(
             .get(&asset_id)
             .ok_or_else(|| format!("Asset not found: {}", asset_id))?;
 
-        // Security: the asset URI can be set via UpdateAsset without validation, and
-        // this synchronous path feeds it straight to ffmpeg. Re-validate to reject
-        // `..`/URL/protocol strings and non-existent files, preventing path traversal
-        // and ffmpeg-protocol handling of a caller-controlled input.
+        // Security: asset URIs from a loaded project file have not passed the
+        // command-layer validation, and this synchronous path feeds them straight to
+        // ffmpeg. Re-validate to reject `..`/URL/protocol strings and non-existent
+        // files, preventing path traversal and ffmpeg-protocol handling of a
+        // caller-controlled input.
         let validated =
             crate::core::fs::validate_local_input_path(&asset.uri, "transcription source")
                 .map_err(|e| format!("Invalid source media path: {}", e))?;

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -514,6 +514,11 @@ pub async fn transcribe_asset(
     tokio::fs::create_dir_all(&temp_dir)
         .await
         .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+    // The asset id names a file in the shared temp directory and is later removed by
+    // the guard below. Membership in `project.state.assets` is not a path check — a
+    // crafted project can key an asset as `../../evil` and satisfy the lookup — so
+    // validate it here, as the other command handlers in this file already do.
+    validate_path_id_component(&asset_id, "Asset ID")?;
     let audio_path = temp_dir.join(format!("{}.wav", asset_id));
 
     // RAII guard for temp file cleanup (ensures cleanup on both success and error)
@@ -651,6 +656,9 @@ pub async fn transcribe_sequence(
     tokio::fs::create_dir_all(&temp_dir)
         .await
         .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+    // Same reasoning as the per-asset path above: a `HashMap` hit does not make the key
+    // safe as a path component, and this file is removed by the guard below.
+    validate_path_id_component(&resolved_sequence_id, "Sequence ID")?;
     let audio_path = temp_dir.join(format!("sequence-{}.wav", resolved_sequence_id));
 
     struct TempFileGuard(std::path::PathBuf);


### PR DESCRIPTION
### **User description**
## Summary

Security hardening: unifies filtergraph value escaping on the one audited-safe implementation, and closes a family of path-injection holes reachable from a crafted `project.json` (which this codebase already treats as untrusted input) — filtergraph command injection and filesystem delete/overwrite/read primitives from unvalidated ids.

### Filtergraph escaping (F1/F2)

- Three divergent escapers collapsed onto the hardened `escape_ffmpeg_filter_value` (single-quote → `'\''`); deleted the duplicate that used the `\'` pattern the canonical one documents as a breakout vector, and folded two ad-hoc inline escapers (this incidentally fixed an `arnndn` model-path bug where a `:` in a Windows path failed to parse).
- **`stabilize_clip` command injection + path traversal (the one live-reachable vuln): closed.** `clip_id` from an untrusted project now passes `validate_path_id_component` (traversal) and its filter value goes through the shared escaper (injection). Verified empirically against ffmpeg 9: the pre-fix `\'` escaping instantiates an injected `movie=`/`anullsrc` filter node; the fixed `'\''` keeps the whole payload inside one quoted value (exactly one `Parsed_*` node).

### Path-id validation, same threat model (High)

Ids deserialized from `project.json` / manifests reached filesystem operations with no validation. On Windows a `C:<name>` component silently discards the base path (no separator or `..` needed), so these were real escape primitives:

- Render cache `sequence_id` → `remove_dir_all` (and `clear_render_cache` didn't even look the sequence up) — validated at the `sequence_cache_dir` choke point, all callers covered.
- Manifest `cached_file` → `remove_file`/copy — allowlisted to names the writer actually produces (`segment_NNNN.mp4`); poisoned entries dropped.
- `delete_annotation` `asset_id` → arbitrary `.json` delete — validated at the store boundary.
- Transcription temp `asset_id`/`sequence_id` → temp `.wav` removed by an RAII guard — validated (matching the same file's other sites).
- Audit found three more delete/read primitives with the same `:`-missing hand-rolled validators: `delete_effect_preset`, `delete_esd`, `read_agent_trace` — all fixed.

### Also

- `import_diarization_json` reads confined to project + session-approved dirs (`validate_scoped_input_path`, canonicalize-before-compare — symlink/junction escape verified closed).
- Corrected a doc comment from the first pass that asserted an ffmpeg failure mode that does not reproduce; the escaper's rationale is now honest (security comes from the quote wrapping, not separator normalization).
- App-generated paths containing an apostrophe (unrepresentable in ffmpeg 9's filter parser — the quote is deleted, not a security issue but a silent-corruption one) now fail with an actionable message ("move the project to a path without an apostrophe") instead of silently producing a broken/empty render; `fontsdir` degrades with a warning instead.

### Already-fixed audit items (verified, not re-done)

`UpdateAsset.uri` validation and the AI `base_url` SSRF/internal-host denial were already remediated at HEAD (the AI provider path is live — embeddings/search consume the gateway — so it was not removed); only stale "without validation" comments were corrected.

## Test plan

- src-tauri lib: 3924 passed (+13); CLI: 375 passed; clippy (default + dev-full) / fmt / bundler feature check / bindings all clean
- New: escaper breakout string-assertions plus two `#[ignore]`d ffmpeg-9 integration tests that assert exactly one `Parsed_*` node (negative control measured: naive `\'` yields a second node) — the tests encode the security property, not a belief about the parser
- Path-id rejection tests for every closed primitive (`../`, `/`, `C:`, whitespace ids)

## Follow-ups (reported, not in scope)

- Validating `asset.uri` at project-load time for the ~16 consumers that hand it to ffmpeg/ffprobe without re-validating (needs two-tier handling to preserve offline-media relink).
- Two MEDIUM read-oracle helpers in the CLI analysis path (`confine_to_project` missing, the MCP sibling does it right), and unreachable manifest-path joins in two plugin providers.
- `ipc/commands/*` test modules never compile (cfg-gated out) — a separate chip.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Unifies FFmpeg filtergraph escaping on a single hardened implementation.

- Fixes command injection and path traversal vulnerabilities in stabilization.

- Validates all path-derived IDs from untrusted project files.

- Restricts diarization imports to approved export directories.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Untrusted Project/IPC Input"] -- "validate_path_id_component" --> B["Safe ID Component"]
  B -- "Interpolate" --> C["Filesystem Path"]
  C -- "escape_ffmpeg_filter_path" --> D["FFmpeg Filter Argument"]
  D -- "Execute" --> E["Hardened FFmpeg Process"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>filter_builder.rs</strong><dd><code>Centralize FFmpeg filtergraph escaping and path normalization</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-86aaa5bbc7d4304dce89d4a4bb017d4044971db7e1ef672b58072d452c2ab8de">+276/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>presets.rs</strong><dd><code>Delegate preset ID validation to canonical validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-a394463456c5efd73260c78931edb0fcbaf9012a40fe56d99a929025cd98452b">+36/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>smart.rs</strong><dd><code>Add fail-closed logic for smart render path resolution</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-14a497d6f472b7901109ae33a0c5ef9b8c24c2d8e14a825962b42b95c5b18cec">+50/-28</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Security</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Add scoped input validation and FFmpeg-safe path checks</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-ee66fa1da6146df4d95e808d678b6225815dbfaa120f3407e29f92d40676a71b">+164/-8</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>store.rs</strong><dd><code>Validate asset IDs in annotation storage operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-8a83b02d6c24cfe960582d44afd559de5e5e2fd99c5a58d301e8cffd31edd278">+51/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong><dd><code>Validate clip IDs and paths in stabilization command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+48/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>analysis.rs</strong><dd><code>Confine diarization imports to approved directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-27ee8d77b931eb5265b4548b8b912173ea914870e28c0a6e0ecba9a971e37f5f">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.rs</strong><dd><code>Validate IDs used for temporary transcription files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-8f3bc0f34153988c4c381f436da7aaa711daad3d84418067f3505cfb3055b5cc">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>cache.rs</strong><dd><code>Harden render cache path resolution and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-630fc011e9e6377be668e04305949567349f26fefcf086384602a27b4aaec044">+251/-27</a></td>

</tr>

<tr>
  <td><strong>export.rs</strong><dd><code>Use unified escaping for ASS subtitle overlays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+59/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>esd.rs</strong><dd><code>Update ESD ID validation to prevent traversal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-79cc8f3826c25a7a19ccbe05e74255bfd29618e0db7256f45d9051a49adb3d3e">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.rs</strong><dd><code>Fix path traversal in agent trace reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-30882d103b0149635edaf6cba2976e67eab832be8d4ab6f2562944ae6868ba79">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-54d6258715ab80f17fa5820d371e99b74bd7aef022f4d2cd88289d18793f46e1">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>video_input_validation.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-28f2643651ce83198908f674d19157eb2199f35509777b203ad653a67a7fbefa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/823/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Strengthened validation for asset, sequence, preset, trace, annotation, and stabilization identifiers.
  - Blocked path traversal, unsafe Windows paths, control characters, and other path-like values.
  - Restricted imported files to approved project and export locations.
  - Hardened render caches and cleanup against unsafe paths and filenames.
  - Improved FFmpeg path and filter escaping to prevent injection.

- **Bug Fixes**
  - Smart rendering now safely falls back to full re-encoding when cache data is invalid or unavailable.
  - Unsafe font and subtitle paths are rejected during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->