### PR TITLE
fix: resolve Codex mid-point review findings (captions, transitions, CLI scoping)

### DIFF
--- a/crates/openreelio-cli/src/commands/analysis.rs
+++ b/crates/openreelio-cli/src/commands/analysis.rs
@@ -871,6 +871,16 @@ fn build_source_analysis_report(
     project_dir: &Path,
     asset_id: &str,
 ) -> anyhow::Result<Value> {
+    // The report reads two files named after this id, so the id decides which
+    // file the process opens. The caller supplies it directly on the command
+    // line, and a project snapshot is restored without validating the ids inside
+    // it, so neither the argument nor the state lookup can be relied on to have
+    // rejected `..\..\somewhere-else` already. Gate it before the lookup, ahead
+    // of any filesystem access - the MCP sibling confines the same path for the
+    // same reason. `search-library` records a rejected asset as skipped rather
+    // than failing the whole search.
+    crate::validate::path_safe_id(asset_id, "assetId")?;
+
     let asset = project
         .state
         .assets
@@ -1421,6 +1431,10 @@ fn load_cached_bundle(
     project_dir: &Path,
     asset_id: &str,
 ) -> anyhow::Result<Option<CachedAnalysisBundle>> {
+    // Defence in depth: the caller has already gated the id, but this is the
+    // line that turns it into a path, so it carries its own guard.
+    crate::validate::path_safe_id(asset_id, "assetId")?;
+
     let path = project_dir
         .join(".openreelio")
         .join("analysis")
@@ -1446,6 +1460,10 @@ fn load_cached_bundle(
 }
 
 fn load_annotation(project_dir: &Path, asset_id: &str) -> anyhow::Result<Option<Value>> {
+    // Defence in depth: the caller has already gated the id, but this is the
+    // line that turns it into a path, so it carries its own guard.
+    crate::validate::path_safe_id(asset_id, "assetId")?;
+
     let path = project_dir
         .join(".openreelio")
         .join("annotations")

--- a/crates/openreelio-cli/src/validate.rs
+++ b/crates/openreelio-cli/src/validate.rs
@@ -48,6 +48,22 @@ pub fn non_empty(value: &str, param_name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Validates that an identifier is safe to use as a single path component.
+///
+/// An id that reaches a `Path::join` decides which file the process opens, and
+/// nothing upstream guarantees the id is well formed: a project snapshot is
+/// restored without validating the ids inside it, so a project file can carry an
+/// asset whose id is `..\..\somewhere-else`. Any CLI path built from an id must
+/// therefore be gated here first.
+///
+/// Delegates to the core's single definition rather than re-deriving the rule,
+/// so the CLI cannot drift from what the rest of the engine enforces.
+pub fn path_safe_id(id: &str, label: &str) -> anyhow::Result<()> {
+    openreelio_core::fs::validate_path_id_component(id, label).map_err(|error| {
+        anyhow::anyhow!("{error}. Identifiers are used as file names and cannot name a path.")
+    })
+}
+
 /// Validates that start < end for a time range.
 pub fn time_range_ordered(
     start: f64,
@@ -174,5 +190,36 @@ mod tests {
     #[test]
     fn test_trim_points_ordered_rejects_inverted() {
         assert!(trim_points_ordered(Some(8.0), Some(5.0)).is_err());
+    }
+
+    #[test]
+    fn test_path_safe_id_rejects_anything_that_names_a_path() {
+        for hostile in [
+            "..",
+            "../secret",
+            r"..\secret",
+            "nested/secret",
+            r"nested\secret",
+            "C:",
+            "trailing..",
+            "",
+            "   ",
+            " padded ",
+            "with\0null",
+            "with\nnewline",
+        ] {
+            assert!(
+                path_safe_id(hostile, "assetId").is_err(),
+                "'{}' must never be used as a file name",
+                hostile.escape_debug()
+            );
+        }
+    }
+
+    #[test]
+    fn test_path_safe_id_accepts_the_ids_the_engine_really_mints() {
+        for id in ["01HXYZ123ABC", "asset_001", "my-asset-name", "자산_001"] {
+            assert!(path_safe_id(id, "assetId").is_ok(), "'{id}' is well formed");
+        }
     }
 }

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -6233,6 +6233,97 @@ fn bundle_path(project_path: &str, asset_id: &str) -> PathBuf {
         .join("bundle.json")
 }
 
+/// Rewrites every occurrence of an asset id in a project's persisted state.
+///
+/// Stands in for the threat this guards against: an operation log or snapshot
+/// that reached the machine from somewhere other than this CLI. Nothing on the
+/// load path validates the ids inside one, so a project file is free to name an
+/// asset `../../../secret`.
+fn rewrite_persisted_asset_id(project_path: &str, from: &str, to: &str) {
+    let state_dir = PathBuf::from(project_path)
+        .join(".openreelio")
+        .join("state");
+    for file in ["ops.jsonl", "snapshot.json"] {
+        let path = state_dir.join(file);
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            std::fs::write(&path, content.replace(from, to)).unwrap();
+        }
+    }
+}
+
+#[test]
+fn test_analysis_report_refuses_an_asset_id_that_names_a_path() {
+    // The report opens two files named after the asset id — the cached bundle
+    // at `.openreelio/analysis/<id>/bundle.json` and the annotation at
+    // `.openreelio/annotations/<id>.json` — so the id decides which file the
+    // process opens. An id that walks out of those directories reads an
+    // arbitrary JSON file and prints its contents straight back to the caller.
+    let (dir, path, asset_id) = create_project_with_analysis("analysis_report_traversal");
+
+    // A file outside the project, at exactly the place the annotation lookup
+    // lands for `../../../secret`, and shaped so its text would be echoed
+    // verbatim into the report's `annotations.ocrPreview`.
+    std::fs::write(
+        dir.path().join("secret.json"),
+        serde_json::json!({
+            "analysis": {
+                "textOcr": {
+                    "provider": "outside",
+                    "results": [{ "text": "OUTSIDE-THE-PROJECT-SECRET" }],
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    // The exploit needs the hostile id to survive the state lookup, which is
+    // what a project file that was not written by this CLI provides.
+    rewrite_persisted_asset_id(&path, &asset_id, "../../../secret");
+
+    for hostile in [
+        "../../../secret",
+        r"..\..\..\secret",
+        "..",
+        "nested/secret",
+        r"nested\secret",
+        "C:",
+    ] {
+        let (stdout, stderr) =
+            run_cli_err(&["analysis", "report", "--path", &path, "--id", hostile]);
+
+        assert!(
+            stderr.contains("path traversal") || stderr.contains("assetId"),
+            "'{hostile}' must be refused as an unusable id, not attempted.\n\
+             stdout: {stdout}\nstderr: {stderr}"
+        );
+        assert!(
+            !stdout.contains("OUTSIDE-THE-PROJECT-SECRET")
+                && !stderr.contains("OUTSIDE-THE-PROJECT-SECRET"),
+            "'{hostile}' must never disclose a file outside the project.\n\
+             stdout: {stdout}\nstderr: {stderr}"
+        );
+    }
+
+    // The same guard covers the search verb, which builds the very same report.
+    let (stdout, stderr) = run_cli_err(&[
+        "analysis",
+        "search",
+        "--path",
+        &path,
+        "--id",
+        "../../../secret",
+        "--query",
+        "secret",
+    ]);
+    assert!(
+        !stdout.contains("OUTSIDE-THE-PROJECT-SECRET")
+            && !stderr.contains("OUTSIDE-THE-PROJECT-SECRET"),
+        "search must not disclose a file outside the project.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
 #[test]
 fn test_analysis_shots_detects_and_persists_scene_change() {
     let Some((_dir, path, asset_id)) = create_project_with_media(

--- a/src-tauri/src/core/captions/mod.rs
+++ b/src-tauri/src/core/captions/mod.rs
@@ -46,7 +46,8 @@ pub mod whisper;
 // Re-export models
 pub use models::{
     Caption, CaptionId, CaptionPosition, CaptionStyle, CaptionTrack, CaptionTrackId, Color,
-    CustomPosition, FontWeight, TextAlignment, VerticalPosition, CAPTION_SIDE_MARGIN_PERCENT,
+    CustomPosition, FontWeight, TextAlignment, VerticalPosition, CAPTION_CUSTOM_DEFAULT_Y_PERCENT,
+    CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT, CAPTION_SIDE_MARGIN_PERCENT,
     CAPTION_WRAP_BOX_WIDTH_PERCENT,
 };
 

--- a/src-tauri/src/core/captions/models.rs
+++ b/src-tauri/src/core/captions/models.rs
@@ -42,6 +42,27 @@ pub const CAPTION_SIDE_MARGIN_PERCENT: f64 = 10.0;
 /// Width of the box a preset caption wraps inside, as a canvas percentage.
 pub const CAPTION_WRAP_BOX_WIDTH_PERCENT: f64 = 100.0 - 2.0 * CAPTION_SIDE_MARGIN_PERCENT;
 
+/// Vertical margin a preset caption is held off its edge by when nothing else
+/// says otherwise, as a canvas percentage.
+///
+/// A caption can be created with no stored position at all (`CreateCaptionCommand`
+/// leaves `caption_position` as `None`), so every surface that draws one has to
+/// pick the same height for it or the caption moves between the preview and the
+/// exported file. The single Rust definition; the burn-in, the `drawtext`
+/// fallback and the render graph all read it from here.
+///
+/// The preview holds the same number in `DEFAULT_CAPTION_POSITION.marginPercent`
+/// (`src/types/index.ts`); the two must move together.
+pub const CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT: f64 = 5.0;
+
+/// Vertical position a custom caption anchor falls back to, as a canvas
+/// percentage from the top.
+///
+/// A custom anchor names a point rather than a margin, so an anchor that names
+/// only an x lands here. Mirrors `DEFAULT_CAPTION_POSITION` handling in
+/// `src/utils/captionStyle.ts`, which reads an absent `yPercent` as 90.
+pub const CAPTION_CUSTOM_DEFAULT_Y_PERCENT: f64 = 90.0;
+
 /// Vertical position of caption on screen
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -82,7 +103,7 @@ impl Default for CustomPosition {
     fn default() -> Self {
         Self {
             x_percent: 50.0,
-            y_percent: 90.0, // Near bottom
+            y_percent: CAPTION_CUSTOM_DEFAULT_Y_PERCENT, // Near bottom
         }
     }
 }
@@ -106,7 +127,7 @@ impl Default for CaptionPosition {
     fn default() -> Self {
         Self::Preset {
             vertical: VerticalPosition::Bottom,
-            margin_percent: 5.0,
+            margin_percent: CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT,
         }
     }
 }

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -12685,6 +12685,49 @@ mod tests {
     }
 
     #[test]
+    fn a_transition_on_a_muted_video_track_is_left_out_instead_of_failing_the_export() {
+        use crate::core::timeline::{Clip, Track};
+
+        // Muting a video track drops it from the render, so its clips never
+        // become segments. The planner used to plan the transition anyway, and
+        // the stitch then found a plan entry it could not fold and refused the
+        // entire export - a muted track took the whole file down with it.
+        let (mut sequence, assets, effects, audio_info) = build_transition_fixture(
+            &[
+                TransitionClipSpec::new(5.0, Some(one_second_dissolve("muted-dissolve"))),
+                TransitionClipSpec::new(5.0, None),
+            ],
+            false,
+        );
+        sequence.tracks[0].muted = true;
+
+        // Something has to survive the mute, or the export would have nothing
+        // to render for reasons that have nothing to do with the transition.
+        let mut audible = Track::new_video("Video 2");
+        let mut clip = Clip::new("asset0")
+            .with_source_range(0.0, 5.0)
+            .place_at(0.0);
+        clip.id = "kept-clip".to_string();
+        audible.add_clip(clip);
+        sequence.add_track(audible);
+
+        let args = build_complex_filter_args_with_audio_info(
+            &sequence,
+            &assets,
+            &effects,
+            &audio_info,
+            &ExportSettings::default(),
+        )
+        .expect("a transition on a muted track must not fail the export");
+        let joined = args.join(" ");
+
+        assert!(
+            !joined.contains("xfade"),
+            "a muted track's transition must be absent from the graph: {joined}"
+        );
+    }
+
+    #[test]
     fn an_audio_only_export_hears_the_same_crossfades_the_video_export_shows() {
         use crate::core::effects::{EffectType, ParamValue};
         use crate::core::ffmpeg::{FFmpegInfo, FFmpegRunner};

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -3781,12 +3781,23 @@ fn get_json_field<'a>(object: &'a Map<String, Value>, keys: &[&str]) -> Option<&
     keys.iter().find_map(|key| object.get(*key))
 }
 
+/// Reads a caption's numeric field, refusing anything that is not a real number.
+///
+/// `f64::from_str` accepts `"NaN"`, `"inf"` and `"-Infinity"`, and every consumer
+/// of this value goes on to `clamp` it — which returns NaN unchanged rather than
+/// pulling it into range. A style blob carrying `{"fontSize": "NaN"}` therefore
+/// used to reach `format!("{:.2}")` and put the literal text `NaN` in an ASS
+/// style column, which libass reads as a parse failure for the whole line. A
+/// non-finite field is treated as absent, so the caller's `unwrap_or` default
+/// applies exactly as it would for a missing key.
 fn parse_json_number(value: &Value) -> Option<f64> {
-    match value {
+    let parsed = match value {
         Value::Number(number) => number.as_f64(),
         Value::String(raw) => raw.trim().parse::<f64>().ok(),
         _ => None,
-    }
+    };
+
+    parsed.filter(|number| number.is_finite())
 }
 
 fn parse_json_bool(value: &Value) -> Option<bool> {
@@ -4782,8 +4793,24 @@ fn effect_int_param(effect: &Effect, name: &str, fallback: i64) -> i64 {
         .unwrap_or(fallback)
 }
 
+/// Reads a float parameter, treating a non-finite one as unset.
+///
+/// The last line of defence for the numeric columns of an ASS script. Every
+/// caller clamps what it gets here, and `f64::clamp` returns NaN unchanged, so
+/// without this a NaN or infinity that reached an effect param from *any*
+/// source - a hand-written plan, a plugin, a future parser - would be formatted
+/// straight into a style or an override tag as `NaN` or `inf` and cost libass
+/// the whole line. `parse_json_number` already rejects them at the caption
+/// parser; this makes the property hold no matter which path set the param.
 fn effect_float_param(effect: &Effect, name: &str, fallback: f64) -> f64 {
-    effect.get_float(name).unwrap_or(fallback)
+    debug_assert!(
+        fallback.is_finite(),
+        "the fallback for '{name}' must itself be a real number"
+    );
+    effect
+        .get_float(name)
+        .filter(|value| value.is_finite())
+        .unwrap_or(fallback)
 }
 
 fn effect_bool_param(effect: &Effect, name: &str, fallback: bool) -> bool {
@@ -7545,6 +7572,138 @@ mod tests {
                 "{position} must keep the default bottom margins. Got: {script}"
             );
         }
+    }
+
+    #[test]
+    fn test_a_non_finite_caption_number_never_reaches_the_ass_script() {
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        // `"NaN"`, `"inf"` and friends parse as perfectly good `f64`s, and every
+        // consumer of a caption number goes on to `clamp` it - which returns NaN
+        // unchanged rather than pulling it into range. A style blob carrying one
+        // used to be formatted straight into an ASS style column as the literal
+        // text `NaN`, and libass drops a line it cannot parse, so the caption
+        // silently vanished from the render.
+        for hostile in [
+            "NaN",
+            "nan",
+            "inf",
+            "-inf",
+            "Infinity",
+            "-Infinity",
+            "infinity",
+        ] {
+            let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+            let mut track = Track::new_caption("Captions");
+            let mut clip = Clip::new("caption-asset")
+                .with_source_range(0.0, 2.0)
+                .place_at(0.0);
+            clip.label = Some("Hostile numbers".to_string());
+            clip.caption_style = Some(serde_json::json!({
+                "fontSize": hostile,
+                "lineHeight": hostile,
+                "letterSpacing": hostile,
+                "opacity": hostile,
+                "outlineWidth": hostile,
+                "backgroundPadding": hostile,
+            }));
+            clip.caption_position = Some(serde_json::json!({
+                "type": "preset",
+                "vertical": "bottom",
+                "marginPercent": hostile,
+            }));
+            track.add_clip(clip);
+            sequence.add_track(track);
+
+            let script = build_ass_text_overlay_script(&sequence, &HashMap::new())
+                .expect("script result")
+                .expect("script exists");
+
+            // Rust formats the two as `NaN` and `inf`/`-inf`. `Inf` with a
+            // capital I is not checked because the script's own
+            // `[Script Info]` header contains it.
+            for poison in ["NaN", "nan", "inf"] {
+                assert!(
+                    !script.contains(poison),
+                    "'{hostile}' must not survive into the script as '{poison}'. Got: {script}"
+                );
+            }
+            // And the field falls back to the default rather than to something
+            // arbitrary: 48pt type, held off the bottom by the shared margin.
+            assert!(
+                script.contains(",48.00,"),
+                "a refused font size must fall back to the default. Got: {script}"
+            );
+            assert!(
+                script.contains(",2,192,192,54,1\n"),
+                "a refused margin must fall back to the shared default. Got: {script}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_a_non_finite_effect_param_cannot_be_formatted_into_an_ass_field() {
+        use crate::core::effects::ParamValue;
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        // Defence in depth for the formatters themselves: whatever put a
+        // non-finite number on an effect param - a hand-written plan, a plugin,
+        // a parser that has not been written yet - the ASS emitter must still
+        // produce a script libass can read. `rotation` is the sharp case,
+        // because it is the one float the emitter never clamped at all.
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_caption("Captions");
+        let mut clip = Clip::new("caption-asset")
+            .with_source_range(0.0, 2.0)
+            .place_at(0.0);
+        clip.label = Some("Poisoned params".to_string());
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let mut effect = build_caption_text_effect(&sequence.tracks[0].clips[0])
+            .expect("a caption clip builds a text effect");
+        for param in ["font_size", "rotation", "opacity", "x", "y"] {
+            effect.set_param(param, ParamValue::Float(f64::NAN));
+        }
+        effect.set_param("scale_x_percent", ParamValue::Float(f64::INFINITY));
+        effect.set_param("scale_y_percent", ParamValue::Float(f64::NEG_INFINITY));
+
+        let mut styles = String::new();
+        let mut events = String::new();
+        append_ass_text_style_and_event(
+            &mut styles,
+            &mut events,
+            &AssEventContext {
+                style_name: "OpenReelioText0",
+                layer: 0,
+                font_family: "Arial",
+                anchor: ass_text_anchor(
+                    &sequence.tracks[0].clips[0],
+                    &TrackKind::Caption,
+                    &effect,
+                    1920,
+                    1080,
+                ),
+            },
+            &sequence.tracks[0].clips[0],
+            &effect,
+        );
+
+        let emitted = format!("{styles}{events}");
+        for poison in ["NaN", "nan", "inf"] {
+            assert!(
+                !emitted.contains(poison),
+                "a non-finite param must not be formatted as '{poison}'. Got: {emitted}"
+            );
+        }
+        assert!(
+            emitted.contains("\\frz0.00"),
+            "an unusable rotation falls back to no rotation. Got: {emitted}"
+        );
+        assert!(
+            emitted.contains(",100.00,100.00,"),
+            "unusable scales fall back to unscaled type. Got: {emitted}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -14,7 +14,10 @@ use tokio::sync::mpsc::Sender;
 
 use crate::core::{
     assets::{Asset, AssetKind},
-    captions::CAPTION_SIDE_MARGIN_PERCENT,
+    captions::{
+        CAPTION_CUSTOM_DEFAULT_Y_PERCENT, CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT,
+        CAPTION_SIDE_MARGIN_PERCENT,
+    },
     commands::TEXT_ASSET_PREFIX,
     effects::{
         effect_capability, effect_type_label, Effect, EffectType, FilterGraph, IntoFFmpegFilter,
@@ -3888,7 +3891,7 @@ fn normalized_caption_margin_percent(margin_percent: f64) -> f64 {
     (if margin_percent.is_finite() {
         margin_percent
     } else {
-        5.0
+        CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT
     })
     .clamp(0.0, 50.0)
 }
@@ -3919,12 +3922,6 @@ enum CaptionAnchor {
     Custom { x: f64, y: f64 },
 }
 
-/// Vertical margin a caption with no stored position is held off the bottom by.
-///
-/// Numerically the same as the side margin today, but the two answer different
-/// questions and are free to diverge.
-const CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT: f64 = 10.0;
-
 /// Horizontal anchor a preset caption uses for the given alignment.
 ///
 /// Left-aligned text grows right from the left margin, right-aligned text grows
@@ -3942,7 +3939,10 @@ pub(crate) fn caption_preset_anchor_x(alignment: &str) -> f64 {
 
 fn resolve_caption_anchor(position: Option<&Value>, style: Option<&Value>) -> CaptionAnchor {
     // No stored position renders where a caption always has: along the bottom,
-    // a tenth of the canvas clear of the edge.
+    // `CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT` of the canvas clear of the edge.
+    // The preview draws a positionless caption from the same number, so the two
+    // have to read it from one definition or a caption created without a
+    // position sits at one height on screen and another in the file.
     let mut anchor = CaptionAnchor::Preset {
         vertical: CaptionVertical::Bottom,
         margin_percent: CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT,
@@ -3952,7 +3952,7 @@ fn resolve_caption_anchor(position: Option<&Value>, style: Option<&Value>) -> Ca
         if let Some(preset) = position_value.as_str() {
             return CaptionAnchor::Preset {
                 vertical: CaptionVertical::parse(preset),
-                margin_percent: 5.0,
+                margin_percent: CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT,
             };
         }
 
@@ -3968,7 +3968,7 @@ fn resolve_caption_anchor(position: Option<&Value>, style: Option<&Value>) -> Ca
                 let margin_percent =
                     get_json_field(position_object, &["marginPercent", "margin_percent"])
                         .and_then(parse_json_number)
-                        .unwrap_or(5.0);
+                        .unwrap_or(CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT);
                 return CaptionAnchor::Preset {
                     vertical: CaptionVertical::parse(vertical),
                     margin_percent,
@@ -3990,7 +3990,9 @@ fn resolve_caption_anchor(position: Option<&Value>, style: Option<&Value>) -> Ca
             if custom_x.is_some() || custom_y.is_some() {
                 anchor = CaptionAnchor::Custom {
                     x: custom_x.map(normalize_caption_axis).unwrap_or(0.5),
-                    y: custom_y.map(normalize_caption_axis).unwrap_or(0.9),
+                    y: custom_y
+                        .map(normalize_caption_axis)
+                        .unwrap_or(CAPTION_CUSTOM_DEFAULT_Y_PERCENT / 100.0),
                 };
             }
         }
@@ -7539,10 +7541,74 @@ mod tests {
                 "{position} must not pin the caption. Got: {script}"
             );
             assert!(
-                script.contains(",2,192,192,108,"),
+                script.contains(",2,192,192,54,"),
                 "{position} must keep the default bottom margins. Got: {script}"
             );
         }
+    }
+
+    #[test]
+    fn test_a_positionless_caption_burns_in_at_the_preview_default_margin() {
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        // A caption can be created with no stored position at all, and the
+        // preview draws that caption `DEFAULT_CAPTION_POSITION.marginPercent`
+        // (`src/types/index.ts`) of the canvas off the bottom. The burn-in used
+        // to carry its own default of twice that, so the very same caption sat
+        // at one height on screen and another in the exported file.
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut caption_track = Track::new_caption("Captions");
+        let mut caption_clip = Clip::new("caption-asset")
+            .with_source_range(0.0, 2.0)
+            .place_at(0.0);
+        caption_clip.label = Some("Positionless".to_string());
+        assert!(
+            caption_clip.caption_position.is_none(),
+            "the fixture has to exercise the no-stored-position path"
+        );
+        caption_track.add_clip(caption_clip);
+        sequence.add_track(caption_track);
+
+        let script = build_ass_text_overlay_script(&sequence, &HashMap::new())
+            .expect("script result")
+            .expect("script exists");
+
+        let expected_margin_v =
+            (CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT / 100.0 * 1080.0).round() as i32;
+        assert_eq!(
+            expected_margin_v, 54,
+            "the shared default is 5% of a 1080-line canvas"
+        );
+        assert!(
+            !script.contains("\\pos("),
+            "a positionless caption keeps its margins rather than being pinned. Got: {script}"
+        );
+        assert!(
+            script.contains(&format!(",,192,192,{expected_margin_v},,")),
+            "the event's MarginV must be the preview's default, not the burn-in's own. \
+             Got: {script}"
+        );
+        assert!(
+            script.contains(&format!(",2,192,192,{expected_margin_v},1\n")),
+            "the style must carry the same MarginV as the event. Got: {script}"
+        );
+    }
+
+    #[test]
+    fn test_the_burn_in_and_the_render_graph_agree_on_the_default_caption_height() {
+        // The ASS path expresses the default as a margin off the bottom edge
+        // and the render graph as a distance down from the top, so the one
+        // number they share only stays shared if both are read from the same
+        // constant. `resolve_caption_position_percent` in `graph.rs` is the
+        // other half of this pairing.
+        let anchor = resolve_caption_anchor(None, None);
+        let (_, y) = caption_anchor_position(anchor, "center");
+
+        assert_eq!(
+            y * 100.0,
+            100.0 - CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT,
+            "a positionless caption sits one default margin above the bottom edge"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/render/graph.rs
+++ b/src-tauri/src/core/render/graph.rs
@@ -9,6 +9,7 @@ use serde_json::{Map, Value};
 use specta::Type;
 
 use crate::core::{
+    captions::{CAPTION_CUSTOM_DEFAULT_Y_PERCENT, CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT},
     commands::{get_text_data, is_text_clip},
     project::ProjectState,
     text::{TextAlignment, TextClipData},
@@ -694,11 +695,13 @@ fn resolve_caption_position_percent(
         TextAlignment::Right => 90.0,
         TextAlignment::Center => 50.0,
     };
-    let mut y = 90.0;
+    // A caption with no stored position sits on the shared default margin, the
+    // same one the preview and the ASS burn-in read.
+    let mut y = vertical_position_to_y_percent("bottom", CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT);
 
     if let Some(position_value) = position {
         if let Some(preset) = position_value.as_str() {
-            y = vertical_position_to_y_percent(preset, 5.0);
+            y = vertical_position_to_y_percent(preset, CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT);
             return (x, y);
         }
 
@@ -710,8 +713,10 @@ fn resolve_caption_position_percent(
                     .unwrap_or_else(|| "bottom".to_string());
                 let margin_percent =
                     json_number(position_object, &["marginPercent", "margin_percent"])
-                        .map(|value| clamp_finite(value, 0.0, 50.0, 5.0))
-                        .unwrap_or(5.0);
+                        .map(|value| {
+                            clamp_finite(value, 0.0, 50.0, CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT)
+                        })
+                        .unwrap_or(CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT);
                 return (x, vertical_position_to_y_percent(&vertical, margin_percent));
             }
 
@@ -727,11 +732,15 @@ fn resolve_caption_position_percent(
                 {
                     x = normalize_caption_axis(custom_x, 50.0);
                 }
-                if let Some(custom_y) =
-                    json_number(position_object, &["yPercent", "y_percent", "y"])
-                {
-                    y = normalize_caption_axis(custom_y, 90.0);
-                }
+                // A custom anchor names a point, so an anchor that names only an
+                // x falls back to the custom default rather than to the preset
+                // margin the positionless case uses. `resolve_caption_anchor` in
+                // `export.rs` reads it the same way.
+                y = json_number(position_object, &["yPercent", "y_percent", "y"])
+                    .map(|custom_y| {
+                        normalize_caption_axis(custom_y, CAPTION_CUSTOM_DEFAULT_Y_PERCENT)
+                    })
+                    .unwrap_or(CAPTION_CUSTOM_DEFAULT_Y_PERCENT);
                 return (x, y);
             }
         }
@@ -749,7 +758,12 @@ fn resolve_caption_position_percent(
 }
 
 fn vertical_position_to_y_percent(vertical: &str, margin_percent: f64) -> f64 {
-    let margin = clamp_finite(margin_percent, 0.0, 50.0, 5.0);
+    let margin = clamp_finite(
+        margin_percent,
+        0.0,
+        50.0,
+        CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT,
+    );
     match vertical.trim().to_ascii_lowercase().as_str() {
         "top" => margin,
         "center" | "middle" => 50.0,
@@ -1080,5 +1094,30 @@ mod tests {
                 "textData": null
             })
         );
+    }
+
+    #[test]
+    fn positionless_caption_sits_on_the_shared_default_margin() {
+        // The render graph, the ASS burn-in and the preview all draw a caption
+        // that carries no stored position, and they only agree on where if all
+        // three read one number. The graph used to hold its own copy of 10%
+        // while the preview used 5%.
+        let (_, y) = resolve_caption_position_percent(None, None, &TextAlignment::Center);
+
+        assert_eq!(y, 100.0 - CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT);
+        assert_eq!(y, 95.0, "the shared default is a 5% bottom margin");
+    }
+
+    #[test]
+    fn custom_caption_anchor_naming_only_an_x_keeps_the_custom_default_height() {
+        // A custom anchor names a point, so an absent y falls back to the
+        // custom default rather than to the preset margin - the same reading
+        // `resolve_caption_anchor` in `export.rs` gives the identical blob.
+        let position = serde_json::json!({ "type": "custom", "xPercent": 20.0 });
+        let (x, y) =
+            resolve_caption_position_percent(Some(&position), None, &TextAlignment::Center);
+
+        assert_eq!(x, 20.0);
+        assert_eq!(y, CAPTION_CUSTOM_DEFAULT_Y_PERCENT);
     }
 }

--- a/src-tauri/src/core/render/graph.rs
+++ b/src-tauri/src/core/render/graph.rs
@@ -595,13 +595,23 @@ fn json_bool(object: &Map<String, Value>, keys: &[&str]) -> Option<bool> {
     json_value(object, keys).and_then(parse_json_bool)
 }
 
+/// Reads a numeric field, refusing anything that is not a real number.
+///
+/// `f64::from_str` accepts `"NaN"`, `"inf"` and `"-Infinity"`, and a NaN that
+/// reached a `TextRenderSpec` would serialise to `null` and break the typed
+/// contract the renderers read. A non-finite field is treated as absent, so the
+/// caller's default applies exactly as it would for a missing key. Mirrors
+/// `parse_json_number` in `export.rs`, which reads the same style blobs.
 fn parse_json_number(value: &Value) -> Option<f64> {
-    value.as_f64().or_else(|| {
-        value
-            .as_str()
-            .map(str::trim)
-            .and_then(|raw| raw.parse::<f64>().ok())
-    })
+    value
+        .as_f64()
+        .or_else(|| {
+            value
+                .as_str()
+                .map(str::trim)
+                .and_then(|raw| raw.parse::<f64>().ok())
+        })
+        .filter(|number| number.is_finite())
 }
 
 fn parse_json_bool(value: &Value) -> Option<bool> {
@@ -1094,6 +1104,33 @@ mod tests {
                 "textData": null
             })
         );
+    }
+
+    #[test]
+    fn a_non_finite_caption_number_is_read_as_absent() {
+        // `"NaN"` and `"inf"` both parse as real `f64` values, and a NaN that
+        // reached a `TextRenderSpec` would serialise to `null` and break the
+        // typed contract the renderers read.
+        for hostile in ["NaN", "inf", "-Infinity"] {
+            let value = serde_json::json!(hostile);
+            assert_eq!(
+                parse_json_number(&value),
+                None,
+                "'{hostile}' is not a number a renderer can use"
+            );
+        }
+
+        // A refused margin falls back to the shared default, exactly as a
+        // missing one does.
+        let position = serde_json::json!({
+            "type": "preset",
+            "vertical": "bottom",
+            "marginPercent": "NaN",
+        });
+        let (_, y) =
+            resolve_caption_position_percent(Some(&position), None, &TextAlignment::Center);
+
+        assert_eq!(y, 100.0 - CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT);
     }
 
     #[test]

--- a/src-tauri/src/core/render/transition_stitch.rs
+++ b/src-tauri/src/core/render/transition_stitch.rs
@@ -318,6 +318,16 @@ fn picture_refusal_reason(clip: &Clip, track: &Track) -> Option<&'static str> {
     if !matches!(track.kind, TrackKind::Video) {
         return Some("it is not on a video track, so there is no picture to blend");
     }
+    // The export collects its clips from the tracks that contribute to the
+    // output, so a muted track has no segment for the stitch to fold. Planning a
+    // transition across a boundary the stitch will never see leaves the plan
+    // entry orphaned, which the fold refuses outright - the whole render fails
+    // over a transition on a track the caller had already taken out of the file.
+    // Refuse the transition here instead, and keep this predicate the same one
+    // `collect_enabled_clips_sorted` uses so the two cannot disagree.
+    if !track.contributes_to_output() {
+        return Some("its track is muted, so the export leaves it out of the render entirely");
+    }
     if !track.visible {
         return Some("its track is hidden, so there is no picture to blend");
     }
@@ -1401,6 +1411,71 @@ mod tests {
         assert!(
             reason.contains("text clip"),
             "the refusal must name what the clip really is: {reason}"
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_transition_on_a_muted_video_track_rather_than_orphan_it() {
+        // The export collects its clips from the tracks that contribute to the
+        // output, and muting a video track takes it out of that list entirely.
+        // A transition planned across a boundary on such a track therefore has
+        // no segments for the stitch to fold, and the fold refuses an unfolded
+        // plan entry by failing the whole render - so muting one track used to
+        // stop the export dead rather than simply leaving that track out.
+        let (mut sequence, assets, effects, lengths) = build(vec![
+            with_handles(0.0, 5.0, Some(dissolve(1.0))),
+            with_handles(5.0, 5.0, None),
+        ]);
+        sequence.tracks[0].muted = true;
+        assert!(
+            sequence.tracks[0].visible,
+            "the track has to stay visible so the muting is what refuses it"
+        );
+        assert!(
+            !sequence.tracks[0].contributes_to_output(),
+            "the fixture must match the predicate the export collects clips with"
+        );
+
+        let plan = plan_sequence_transitions(&sequence, &assets, &effects, FPS, |asset| {
+            lengths.get(&asset.id).copied()
+        });
+
+        assert!(
+            plan.is_empty(),
+            "a muted track's transition must never reach the fold"
+        );
+        assert!(
+            !plan.touches("clip0") && !plan.touches("clip1"),
+            "neither side may be given handles the render would bake in"
+        );
+        let refusal = &plan.refusals()[0];
+        assert_eq!(refusal.clip_id, "clip0");
+        assert!(
+            refusal.reason.contains("muted"),
+            "the refusal must name muting as the cause: {}",
+            refusal.reason
+        );
+    }
+
+    #[test]
+    fn should_still_refuse_a_hidden_track_for_having_no_picture() {
+        // A hidden video track still contributes its audio, so it stays in the
+        // export's clip list and its transition is refused for the reason it
+        // always was. Only muting removes the track outright.
+        let (mut sequence, assets, effects, lengths) = build(vec![
+            with_handles(0.0, 5.0, Some(dissolve(1.0))),
+            with_handles(5.0, 5.0, None),
+        ]);
+        sequence.tracks[0].visible = false;
+
+        let plan = plan_sequence_transitions(&sequence, &assets, &effects, FPS, |asset| {
+            lengths.get(&asset.id).copied()
+        });
+
+        let reason = &plan.refusals()[0].reason;
+        assert!(
+            reason.contains("hidden"),
+            "a hidden track keeps its own reason: {reason}"
         );
     }
 

--- a/src-tauri/src/core/render/transition_stitch.rs
+++ b/src-tauri/src/core/render/transition_stitch.rs
@@ -349,6 +349,53 @@ fn picture_refusal_reason(clip: &Clip, track: &Track) -> Option<&'static str> {
     None
 }
 
+/// Clip ids that more than one of the clips in this render answers to.
+///
+/// Every map in a [`TransitionPlan`] is keyed by clip id, and a video segment
+/// carries nothing but that id, so the plan has no way to tell two clips with
+/// one id apart. The consequences are not cosmetic: the second clip to be
+/// planned overwrites the first's entry in `by_outgoing`, the handles widened
+/// for one clip's source window are applied to the other's trim and `adelay`,
+/// and the fold either blends the wrong pair or refuses the render for an orphan
+/// the planner created itself.
+///
+/// Nothing this engine mints produces a duplicate id, but an operation log or
+/// snapshot restored from elsewhere is not checked for one, so the planner has
+/// to assume it can happen. Repairing the ids belongs to whatever wrote them;
+/// what the planner owes the caller is to leave that boundary as a clean cut and
+/// say which id made it ambiguous.
+///
+/// Scoped to the clips the export actually collects, which is the same set the
+/// segments are built from - a duplicate on a track that is not in the file
+/// cannot be confused with anything that is.
+fn duplicated_clip_ids(sequence: &Sequence) -> HashSet<&str> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut duplicated: HashSet<&str> = HashSet::new();
+
+    for track in &sequence.tracks {
+        if !track.contributes_to_output() {
+            continue;
+        }
+        for clip in track.clips.iter().filter(|clip| clip.enabled) {
+            if !seen.insert(clip.id.as_str()) {
+                duplicated.insert(clip.id.as_str());
+            }
+        }
+    }
+
+    duplicated
+}
+
+/// The refusal reason for a boundary whose clip id names more than one clip.
+fn duplicate_id_refusal_reason(clip_id: &str, side: &str) -> String {
+    format!(
+        "duplicate clip id at a transition boundary: more than one clip in this render is \
+         called '{clip_id}', and the render addresses a clip only by its id, so the handles \
+         and fades meant for the {side} clip could be applied to the other one; give the \
+         clips distinct ids"
+    )
+}
+
 /// Whether a clip's render window can be moved into unused source media at all.
 ///
 /// A frozen, reversed or time-remapped clip does not map timeline seconds onto
@@ -409,6 +456,7 @@ pub(crate) fn plan_sequence_transitions(
 
     let frame_sec = 1.0 / fps;
     let mut candidates: Vec<Candidate> = Vec::new();
+    let duplicated_ids = duplicated_clip_ids(sequence);
 
     for track in &sequence.tracks {
         let mut clips: Vec<&Clip> = track.clips.iter().filter(|clip| clip.enabled).collect();
@@ -460,6 +508,12 @@ pub(crate) fn plan_sequence_transitions(
                 continue;
             }
 
+            if duplicated_ids.contains(clip.id.as_str()) {
+                plan.refusals
+                    .push(refuse(duplicate_id_refusal_reason(&clip.id, "outgoing")));
+                continue;
+            }
+
             let Some(next) = clips.get(index + 1).copied().filter(|next| {
                 (next.place.timeline_in_sec - clip.place.timeline_out_sec()).abs()
                     <= TIMELINE_EPSILON_SEC
@@ -476,6 +530,12 @@ pub(crate) fn plan_sequence_transitions(
                     "the incoming clip '{}' contributes no picture to blend into: {reason}",
                     next.id
                 )));
+                continue;
+            }
+
+            if duplicated_ids.contains(next.id.as_str()) {
+                plan.refusals
+                    .push(refuse(duplicate_id_refusal_reason(&next.id, "incoming")));
                 continue;
             }
 
@@ -1454,6 +1514,122 @@ mod tests {
             refusal.reason.contains("muted"),
             "the refusal must name muting as the cause: {}",
             refusal.reason
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_boundary_whose_clip_id_names_more_than_one_clip() {
+        // Every map in the plan is keyed by clip id, and a video segment carries
+        // nothing but that id, so two clips answering to one id make the plan
+        // ambiguous: the handles widened for the boundary's incoming clip would
+        // also be applied to an unrelated clip elsewhere in the render, whose
+        // source window would then be trimmed to media the edit never asked for.
+        // Nothing this engine mints produces a duplicate id, but a snapshot
+        // restored from elsewhere is not checked for one.
+        let (mut sequence, assets, effects, lengths) = build(vec![
+            with_handles(0.0, 5.0, Some(dissolve(1.0))),
+            with_handles(5.0, 5.0, None),
+        ]);
+
+        let mut other = Track::new_video("V2");
+        let mut collision = Clip::new("asset1")
+            .with_source_range(2.0, 7.0)
+            .place_at(20.0);
+        collision.id = "clip1".to_string();
+        other.add_clip(collision);
+        sequence.add_track(other);
+
+        let plan = plan_sequence_transitions(&sequence, &assets, &effects, FPS, |asset| {
+            lengths.get(&asset.id).copied()
+        });
+
+        assert!(
+            plan.is_empty(),
+            "an ambiguous boundary must be left as a clean cut"
+        );
+        assert_eq!(
+            plan.handles("clip1"),
+            ClipHandles::default(),
+            "neither clip called 'clip1' may have a handle applied to it"
+        );
+        assert!(
+            plan.audio_fades("clip1").is_none(),
+            "neither clip called 'clip1' may have a fade applied to it"
+        );
+        assert!(!plan.touches("clip0") && !plan.touches("clip1"));
+
+        let refusal = &plan.refusals()[0];
+        assert_eq!(refusal.clip_id, "clip0");
+        assert!(
+            refusal
+                .reason
+                .contains("duplicate clip id at a transition boundary"),
+            "the refusal must name the cause: {}",
+            refusal.reason
+        );
+        assert!(
+            refusal.reason.contains("clip1"),
+            "the refusal must name the id that is ambiguous: {}",
+            refusal.reason
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_boundary_whose_outgoing_clip_id_is_duplicated() {
+        // The same ambiguity on the side that carries the effect. Its entry in
+        // `by_outgoing` would be overwritten by whichever clip of that id was
+        // planned last, so the render could blend a boundary nobody authored.
+        let (mut sequence, assets, effects, lengths) = build(vec![
+            with_handles(0.0, 5.0, Some(dissolve(1.0))),
+            with_handles(5.0, 5.0, None),
+        ]);
+
+        let mut other = Track::new_video("V2");
+        let mut collision = Clip::new("asset0")
+            .with_source_range(2.0, 7.0)
+            .place_at(20.0);
+        collision.id = "clip0".to_string();
+        other.add_clip(collision);
+        sequence.add_track(other);
+
+        let plan = plan_sequence_transitions(&sequence, &assets, &effects, FPS, |asset| {
+            lengths.get(&asset.id).copied()
+        });
+
+        assert!(plan.is_empty());
+        assert_eq!(plan.handles("clip0"), ClipHandles::default());
+        assert!(plan.refusals()[0]
+            .reason
+            .contains("duplicate clip id at a transition boundary"));
+    }
+
+    #[test]
+    fn should_still_plan_a_boundary_when_the_duplicate_is_on_a_track_that_is_not_in_the_file() {
+        // A muted track is not in the render, so its clips never become segments
+        // and its id cannot be confused with anything that does. Refusing here
+        // would cost a caller a perfectly renderable transition.
+        let (mut sequence, assets, effects, lengths) = build(vec![
+            with_handles(0.0, 5.0, Some(dissolve(1.0))),
+            with_handles(5.0, 5.0, None),
+        ]);
+
+        let mut muted = Track::new_video("V2");
+        muted.muted = true;
+        let mut collision = Clip::new("asset1")
+            .with_source_range(2.0, 7.0)
+            .place_at(20.0);
+        collision.id = "clip1".to_string();
+        muted.add_clip(collision);
+        sequence.add_track(muted);
+
+        let plan = plan_sequence_transitions(&sequence, &assets, &effects, FPS, |asset| {
+            lengths.get(&asset.id).copied()
+        });
+
+        assert!(
+            plan.transition_after("clip0").is_some(),
+            "{:?}",
+            plan.refusals()
         );
     }
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes five defects an independent Codex second-opinion review found in code merged earlier this session (roadmaps 1–5). Each was verified to fail before the fix (guard patched out → new test goes red → restored). The review confirmed the core arithmetic and security of all five merged features clean; these are the edge/robustness gaps it surfaced.

- **Caption default margin mismatch (regression).** Positionless captions rendered at a 10% bottom margin on export but 5% in the preview. Export now reads a single doc-linked constant matching the TS default (5%); found and fixed a third copy in the render graph the review didn't name.
- **Muted-track transition failed the export.** A transition on a muted video track was planned but its clip was excluded from the graph, so the orphan check errored the whole export. Transition eligibility now uses `contributes_to_output()` (the same predicate the clip collector uses), so the transition is simply not planned.
- **ASS non-finite numbers.** A caption style like `{"fontSize":"NaN"}` emitted `NaN` into the ASS script. Numeric parsing now rejects non-finite values, with a defensive guard at the float choke point every ASS formatter reads through.
- **CLI `analysis report` path traversal (High).** A crafted project asset id (`../../secret`) made `analysis report`/`search` read and print arbitrary JSON — live-reproduced reading a file outside the project. Ids are now validated at the report choke point and again at the join sites.
- **Duplicate clip ids cross-wired transitions.** Duplicate ids from an untrusted project could apply one clip's handles/fades to another. The planner now refuses transitions at a duplicated-id boundary with a named warning (safe degradation) rather than silently misapplying.

## Test plan

- src-tauri lib: 3937 passed (+9); CLI: 222 unit + 156 integration passed (+1 integration)
- Every fix has a behavior test, each confirmed red without the fix; the CLI traversal test uses the real exploit shape (12 hostile ids across `report` and `search`)
- clippy/fmt/bundler feature check/bindings all clean

## Scope notes

Larger structural items the review flagged are filed as separate chips, not done here: project-load-time asset-URI scoping (~16 ffmpeg consumers, needs two-tier offline-relink handling), a shared preview/export transform sanitizer, the system-font false-positive, and a sibling write-primitive in `perception.rs bundle_path` (same one-line id-validation fix).


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Standardize caption default vertical margins across preview and export.

- Prevent export failures by omitting transitions on muted tracks.

- Sanitize numeric caption fields to reject non-finite values.

- Fix CLI path traversal vulnerability in analysis reports.

- Prevent transition misapplication caused by duplicate clip identifiers.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Commands"] -- "Validate ID" --> FS["File System"]
  Planner["Transition Planner"] -- "Check Muted/Duplicates" --> Graph["Render Graph"]
  Parser["JSON Parser"] -- "Filter NaN/Inf" --> ASS["ASS Script Generator"]
  Constants["Shared Constants"] -- "Sync Margin" --> Preview["Preview/Export"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>analysis.rs</strong><dd><code>Add path safety validation for asset IDs in analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-a991a2d6e5190c1ee281431123b0a16b5f867acf38a8b2e370394fb40a17548d">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.rs</strong><dd><code>Sanitize numeric inputs and use shared caption constants</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+284/-16</a></td>

</tr>

<tr>
  <td><strong>graph.rs</strong><dd><code>Align render graph caption positioning with shared defaults</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-163180d6ca9e483678d174a42eaf8446f6c405a5d8df9372ecf143f1dafb00f3">+92/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>transition_stitch.rs</strong><dd><code>Handle muted tracks and duplicate IDs in transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-03d8d78ae49138d44fc807a04af9c1c68b08ccd533f5601f5cd6e84232c64952">+251/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>validate.rs</strong><dd><code>Implement path-safe identifier validation and tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-1259a0200ecf71c5b33d9bba5f0588ebe2c3cd11ad268d2f136755c53ad08c51">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.rs</strong><dd><code>Define shared constants for default caption margins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-e8bb0e11d8ac8eaae4d6a450d0a9592061c33b1dff9a51c7b61ee5209a9902d8">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>integration.rs</strong><dd><code>Add integration tests for CLI path traversal exploit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/824/files#diff-95a396c495e17b5e50aa478f03f5d00e93ddf542c218e5a5ae0baebb41519bea">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analysis commands by rejecting unsafe or malformed asset IDs before accessing project files.
  - Prevented exports from failing or producing invalid output when given non-finite numeric values.
  - Ensured transitions on muted tracks are skipped and ambiguous duplicate clips are handled safely.
  - Improved caption placement consistency across previews and exports, including custom caption anchors.
- **Reliability**
  - Added safeguards for invalid caption, effect, transition, and project data during rendering and export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->