### PR TITLE
fix(render): correct the broken zoompan and effect-chain label collision

### DIFF
--- a/src-tauri/src/core/assets/metadata.rs
+++ b/src-tauri/src/core/assets/metadata.rs
@@ -333,6 +333,73 @@ impl MetadataExtractor {
         Ratio::new(30, 1)
     }
 
+    /// Counts the pictures the primary video stream holds.
+    ///
+    /// Neither the stream's `duration` nor its `nb_frames` answers this for the
+    /// image formats that can be either a photo or an animation. Measured
+    /// against ffprobe 9.0.1: a still JPEG advertises `duration=0.040000` and no
+    /// frame count, a single-frame GIF advertises `duration=0.030000` and
+    /// `nb_frames=1`, and an animated APNG or WebP advertises *neither* — so a
+    /// classification built on the declared metadata calls a photo an animation
+    /// and an animation a photo, in both directions.
+    ///
+    /// `-count_packets` is what actually separates them. It demuxes the file
+    /// without decoding it, which is cheap even for a long animation, and gives
+    /// `1` for every still and the true frame count for every animation.
+    ///
+    /// Returns `None` when the file carries no video stream or the count cannot
+    /// be read, so a caller can tell "one picture" from "could not tell".
+    pub fn count_video_frames<P: AsRef<Path>>(path: P) -> CoreResult<Option<u64>> {
+        let path = path.as_ref();
+
+        if !path.exists() {
+            return Err(CoreError::FileNotFound(path.to_string_lossy().to_string()));
+        }
+
+        let mut command = Command::new(resolved_ffprobe_path());
+        configure_std_command(&mut command);
+        let output = command
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-count_packets",
+                "-show_entries",
+                "stream=nb_read_packets",
+                "-print_format",
+                "json",
+            ])
+            .arg(path)
+            .output()
+            .map_err(|e| CoreError::FFprobeError(format!("Failed to run ffprobe: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(CoreError::FFprobeError(format!(
+                "FFprobe failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(Self::parse_packet_count(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    }
+
+    /// Reads `nb_read_packets` out of a `-count_packets` probe.
+    fn parse_packet_count(json: &str) -> Option<u64> {
+        let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
+        parsed
+            .get("streams")?
+            .as_array()?
+            .first()?
+            .get("nb_read_packets")?
+            .as_str()?
+            .parse()
+            .ok()
+    }
+
     /// Check if FFprobe is available on the system
     pub fn is_available() -> bool {
         let mut command = Command::new(resolved_ffprobe_path());

--- a/src-tauri/src/core/effects/capabilities.rs
+++ b/src-tauri/src/core/effects/capabilities.rs
@@ -203,16 +203,21 @@ pub fn effect_type_supports_export(effect_type: &EffectType) -> bool {
 /// layer has to be refused before the command is built, or the export dies on a
 /// message that names an FFmpeg filter the editor never chose.
 ///
-/// The list is what the local FFmpeg (9.0.1) actually refuses, checked filter by
-/// filter against every body [`crate::core::effects::Effect::build_filter_params`]
-/// can emit: `zoompan`, `fps`, `scale` and `pad` (`Zoom`), `crop` (`Crop`,
-/// `AutoReframe`), `format` (`Opacity`), `subtitles` (`Subtitle`),
-/// `vidstabtransform` (`Stabilize`) and `xfade` (the three transition types).
+/// The rule, not a hand-count: an effect belongs here when the filter body
+/// [`crate::core::effects::Effect::build_filter_params`] emits *opens with* a
+/// filter the local FFmpeg (9.0.1) refuses an `enable=` on — a geometry or
+/// pixel-format conversion has to run before the graded pixels exist, and those
+/// conversions are untimeable by nature. Any new effect whose leading filter is
+/// untimeable must be added here, or an adjustment-layer export dies on a
+/// message naming an FFmpeg filter the editor never chose.
 ///
-/// `Opacity` is here for the `format=rgba` its body opens with, not for the
-/// `colorchannelmixer` that does the work: a translucency the timeline could
-/// gate still has to reach an alpha channel first, and the conversion that
-/// creates one is untimeable by nature.
+/// The current members, each confirmed against FFmpeg 9.0.1: `zoompan`, `fps`,
+/// `scale` and `pad` (`Zoom`), `crop` (`Crop`, `AutoReframe`), `subtitles`
+/// (`Subtitle`), `vidstabtransform` (`Stabilize`), `xfade` (the three transition
+/// types), and the `format=` conversion that opens `Opacity` (`format=rgba`),
+/// `Curves` (`format=yuv444p`, the Luma-vs-Sat leg) and `HSLQualifier`
+/// (`format=rgba`). For the `format` cases it is the conversion, not the
+/// `colorchannelmixer`/`geq` that does the work, that FFmpeg cannot gate.
 pub fn effect_type_supports_timeline_enable(effect_type: &EffectType) -> bool {
     !matches!(
         effect_type,
@@ -220,6 +225,8 @@ pub fn effect_type_supports_timeline_enable(effect_type: &EffectType) -> bool {
             | EffectType::Crop
             | EffectType::AutoReframe
             | EffectType::Opacity
+            | EffectType::Curves
+            | EffectType::HSLQualifier
             | EffectType::Subtitle
             | EffectType::Stabilize
             | EffectType::CrossDissolve

--- a/src-tauri/src/core/effects/capabilities.rs
+++ b/src-tauri/src/core/effects/capabilities.rs
@@ -206,14 +206,20 @@ pub fn effect_type_supports_export(effect_type: &EffectType) -> bool {
 /// The list is what the local FFmpeg (9.0.1) actually refuses, checked filter by
 /// filter against every body [`crate::core::effects::Effect::build_filter_params`]
 /// can emit: `zoompan`, `fps`, `scale` and `pad` (`Zoom`), `crop` (`Crop`,
-/// `AutoReframe`), `subtitles` (`Subtitle`), `vidstabtransform` (`Stabilize`) and
-/// `xfade` (the three transition types).
+/// `AutoReframe`), `format` (`Opacity`), `subtitles` (`Subtitle`),
+/// `vidstabtransform` (`Stabilize`) and `xfade` (the three transition types).
+///
+/// `Opacity` is here for the `format=rgba` its body opens with, not for the
+/// `colorchannelmixer` that does the work: a translucency the timeline could
+/// gate still has to reach an alpha channel first, and the conversion that
+/// creates one is untimeable by nature.
 pub fn effect_type_supports_timeline_enable(effect_type: &EffectType) -> bool {
     !matches!(
         effect_type,
         EffectType::Zoom
             | EffectType::Crop
             | EffectType::AutoReframe
+            | EffectType::Opacity
             | EffectType::Subtitle
             | EffectType::Stabilize
             | EffectType::CrossDissolve

--- a/src-tauri/src/core/effects/capabilities.rs
+++ b/src-tauri/src/core/effects/capabilities.rs
@@ -193,6 +193,35 @@ pub fn effect_type_supports_export(effect_type: &EffectType) -> bool {
     effect_capability(effect_type).export.is_supported()
 }
 
+/// Whether the filter this effect emits accepts FFmpeg's timeline `enable=`.
+///
+/// An adjustment layer grades only the stretch of timeline it covers, which the
+/// render expresses by gating each of the layer's filters with
+/// `enable='between(t,…)'`. FFmpeg rejects the whole filtergraph when a filter
+/// that has no timeline support is given one — `Timeline ('enable' option) not
+/// supported with filter 'zoompan'` — so an effect listed here on an adjustment
+/// layer has to be refused before the command is built, or the export dies on a
+/// message that names an FFmpeg filter the editor never chose.
+///
+/// The list is what the local FFmpeg (9.0.1) actually refuses, checked filter by
+/// filter against every body [`crate::core::effects::Effect::build_filter_params`]
+/// can emit: `zoompan`, `fps`, `scale` and `pad` (`Zoom`), `crop` (`Crop`,
+/// `AutoReframe`), `subtitles` (`Subtitle`), `vidstabtransform` (`Stabilize`) and
+/// `xfade` (the three transition types).
+pub fn effect_type_supports_timeline_enable(effect_type: &EffectType) -> bool {
+    !matches!(
+        effect_type,
+        EffectType::Zoom
+            | EffectType::Crop
+            | EffectType::AutoReframe
+            | EffectType::Subtitle
+            | EffectType::Stabilize
+            | EffectType::CrossDissolve
+            | EffectType::Wipe
+            | EffectType::Slide
+    )
+}
+
 pub fn effect_capability_dto(effect_type: &EffectType) -> EffectCapabilityDto {
     let capability = effect_capability(effect_type);
 

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -1045,13 +1045,23 @@ impl Effect {
             return "null".to_string();
         }
 
-        // Build zoom expression based on type
-        // For zoom in: start at 1.0, end at zoom_factor
-        // For zoom out: start at zoom_factor, end at 1.0
-        let step = (zoom_factor - 1.0) / total_frames as f64;
+        // `on` is 0 on the first output frame, so the move is divided by the
+        // number of *steps* between frames — one fewer than the number of frames
+        // — for the last frame of the move to land exactly on the target. Divided
+        // by the frame count instead, as this used to be, the move stopped a step
+        // short and a zoom-out never came back to 1.0.
+        let steps = (total_frames - 1).max(1);
+
+        // The ratio is handed to FFmpeg unevaluated. Pre-computing it here meant
+        // rounding it to six decimals, and a move spread thin enough rounds to
+        // `0.000000` — a 1% zoom over eleven minutes at 30fps does — which turns
+        // a zoom-in into no zoom at all and a zoom-out into a permanent hold at
+        // the zoomed size. FFmpeg divides at full double precision instead.
+        let factor = format!("{:.4}", zoom_factor);
+        let travelled = format!("(({}-1)/{})*on", factor, steps);
         let zoom_expr = match zoom_type {
-            "out" => format!("z='max({:.4}-{:.6}*on,1)'", zoom_factor, step),
-            _ => format!("z='min(1+{:.6}*on,{:.4})'", step, zoom_factor),
+            "out" => format!("z='max({}-{},1)'", factor, travelled),
+            _ => format!("z='min(1+{},{})'", travelled, factor),
         };
 
         // Build x/y position expressions to keep centered
@@ -3446,9 +3456,10 @@ mod tests {
         assert!(filter.contains("fps=60"));
         // One output frame per input frame, whatever the rate
         assert!(filter.contains("d=1"), "got: {}", filter);
-        // Duration 1.0s at 60fps is a 60-frame move to the default 1.5x
+        // Duration 1.0s at 60fps is a 60-frame move to the default 1.5x, which
+        // is 59 steps between the first frame and the last.
         assert!(
-            filter.contains("min(1+0.008333*on,1.5000)"),
+            filter.contains("min(1+((1.5000-1)/59)*on,1.5000)"),
             "got: {}",
             filter
         );
@@ -3616,7 +3627,7 @@ mod tests {
         zoom_in.set_param("zoom_factor", ParamValue::Float(1.5));
         let filter = zoom_on_canvas(zoom_in, 1920, 1080, 30.0);
         assert!(
-            filter.contains("z='min(1+0.008333*on,1.5000)'"),
+            filter.contains("z='min(1+((1.5000-1)/59)*on,1.5000)'"),
             "got: {filter}"
         );
 
@@ -3626,7 +3637,7 @@ mod tests {
         zoom_out.set_param("zoom_factor", ParamValue::Float(1.5));
         let filter = zoom_on_canvas(zoom_out, 1920, 1080, 30.0);
         assert!(
-            filter.contains("z='max(1.5000-0.008333*on,1)'"),
+            filter.contains("z='max(1.5000-((1.5000-1)/59)*on,1)'"),
             "got: {filter}"
         );
 
@@ -3695,6 +3706,55 @@ mod tests {
             .build_filter_params();
 
         assert!(measured.contains(":s=1080x1920:"), "got: {measured}");
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: the move reaches its target on the last frame of the move
+    ///
+    /// `on` is 0 on the first output frame and `frames - 1` on the last, so a
+    /// step of `(factor - 1) / frames` — what this used to emit — stops one step
+    /// short of the target and a zoom-out never gets back to 1.0.
+    #[test]
+    fn should_reach_the_zoom_target_on_the_last_frame_of_the_move() {
+        for (duration, fps, frames) in [(2.0, 30.0, 60), (1.0, 24.0, 24), (0.5, 60.0, 30)] {
+            let mut effect = Effect::new(EffectType::Zoom);
+            effect.set_param("duration", ParamValue::Float(duration));
+            effect.set_param("zoom_factor", ParamValue::Float(2.0));
+            let filter = zoom_on_canvas(effect, 1920, 1080, fps);
+
+            assert!(
+                filter.contains(&format!("/{})*on", frames - 1)),
+                "a {frames}-frame move has {} steps, got: {filter}",
+                frames - 1
+            );
+        }
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: a small zoom over a long clip still moves
+    ///
+    /// The per-frame step used to be baked into the expression as a `{:.6}`
+    /// constant. A 1% zoom over eleven minutes at 30fps steps by 5e-7, which
+    /// rounds to a literal `0.000000` — the zoom-in then does nothing at all and
+    /// the zoom-out holds at the zoomed size forever instead of returning.
+    #[test]
+    fn should_not_round_a_slow_zoom_down_to_no_movement() {
+        for zoom_type in ["in", "out"] {
+            let mut effect = Effect::new(EffectType::Zoom);
+            effect.set_param("zoom_type", ParamValue::String(zoom_type.to_string()));
+            effect.set_param("duration", ParamValue::Float(660.0));
+            effect.set_param("zoom_factor", ParamValue::Float(1.01));
+            let filter = zoom_on_canvas(effect, 1920, 1080, 30.0);
+
+            assert!(
+                !filter.contains("0.000000"),
+                "the {zoom_type} move rounded away to nothing: {filter}"
+            );
+            assert!(
+                filter.contains("((1.0100-1)/19799)*on"),
+                "expected the ratio left for FFmpeg to divide, got: {filter}"
+            );
+        }
     }
 
     // =========================================================================
@@ -3813,9 +3873,9 @@ mod tests {
             "Expected one output frame per input frame, got: {}",
             filter
         );
-        // 2s at 30fps is a 60-frame move, so the zoom steps 0.5/60 per frame.
+        // 2s at 30fps is a 60-frame move, so the zoom steps 0.5/59 per frame.
         assert!(
-            filter.contains("min(1+0.008333*on,1.5000)"),
+            filter.contains("min(1+((1.5000-1)/59)*on,1.5000)"),
             "Expected a 60-frame ramp to 1.5x, got: {}",
             filter
         );
@@ -6361,6 +6421,215 @@ mod tests {
             "expected {SOURCE_FRAMES} frames of {CANVAS_WIDTH}x{CANVAS_HEIGHT}, \
              got {} bytes",
             render.stdout.len()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Empirical zoom-geometry helpers
+    // -------------------------------------------------------------------------
+
+    /// A test clip: a white rectangle centred on black, encoded to a real file.
+    ///
+    /// A file rather than `-f lavfi` so that the graph under test is the only
+    /// filtergraph in the command, and the frames it is handed have been through
+    /// a decoder exactly as a render's would be.
+    fn white_box_clip(
+        dir: &std::path::Path,
+        name: &str,
+        canvas: (usize, usize),
+        box_size: (usize, usize),
+    ) -> Option<std::path::PathBuf> {
+        let (width, height) = canvas;
+        let (box_width, box_height) = box_size;
+        let path = dir.join(name);
+        let source = format!(
+            "color=c=black:s={width}x{height}:r=30:d=0.2,\
+             drawbox=x={}:y={}:w={box_width}:h={box_height}:color=white:t=fill",
+            (width - box_width) / 2,
+            (height - box_height) / 2,
+        );
+
+        let built = std::process::Command::new(ffmpeg_binary_for_tests())
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                &source,
+                "-pix_fmt",
+                "yuv420p",
+            ])
+            .arg(&path)
+            .output()
+            .ok()?;
+
+        (built.status.success() && path.exists()).then_some(path)
+    }
+
+    /// Renders `graph` over `input` and hands back its frames as single-plane luma.
+    ///
+    /// One byte per pixel, so a frame is exactly `width * height` bytes and the
+    /// white pixels can be counted without decoding anything.
+    fn render_luma_frames(
+        input: &std::path::Path,
+        graph: &str,
+        width: usize,
+        height: usize,
+    ) -> Option<Vec<Vec<u8>>> {
+        let dir = tempfile::tempdir().ok()?;
+        let graph_file = dir.path().join("graph.txt");
+        std::fs::write(&graph_file, graph).ok()?;
+
+        let render = std::process::Command::new(ffmpeg_binary_for_tests())
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
+            .arg(input)
+            .arg("-/filter_complex")
+            .arg(&graph_file)
+            .args(["-map", "[out]", "-pix_fmt", "gray", "-f", "rawvideo", "-"])
+            .output()
+            .ok()?;
+
+        assert!(
+            render.status.success(),
+            "ffmpeg refused the graph: {}\n{graph}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+
+        Some(
+            render
+                .stdout
+                .chunks_exact(width * height)
+                .map(<[u8]>::to_vec)
+                .collect(),
+        )
+    }
+
+    /// Width, height and area of the white region of one luma frame.
+    fn white_region(frame: &[u8], width: usize) -> (usize, usize, usize) {
+        let lit: Vec<(usize, usize)> = frame
+            .iter()
+            .enumerate()
+            .filter(|(_, luma)| **luma > 127)
+            .map(|(index, _)| (index % width, index / width))
+            .collect();
+        if lit.is_empty() {
+            return (0, 0, 0);
+        }
+
+        let span = |values: &mut dyn Iterator<Item = usize>| {
+            let (min, max) = values.fold((usize::MAX, 0), |(min, max), value| {
+                (min.min(value), max.max(value))
+            });
+            max - min + 1
+        };
+        (
+            span(&mut lit.iter().map(|(x, _)| *x)),
+            span(&mut lit.iter().map(|(_, y)| *y)),
+            lit.len(),
+        )
+    }
+
+    /// The zoom graph the export builds, wired for a one-input ffmpeg command.
+    fn zoom_graph_for_ffmpeg(effect: Effect, width: i32, height: i32, fps: f64) -> String {
+        let mut graph = FilterGraph::new().with_dimensions(width, height);
+        graph.set_fps(fps);
+        graph.add_effect(effect);
+        graph.to_video_filter_complex("0:v", "out")
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: the last frame of the move is at the zoom the editor asked for
+    ///
+    /// The area a zoom of `f` shows grows by `f²`, so a white rectangle of known
+    /// size measures the zoom the render actually reached. The move is six frames
+    /// long, which makes a one-frame shortfall a sixth of the whole move rather
+    /// than something hiding inside rounding.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1, 320x180 canvas, 3520 white source
+    /// pixels, 2x zoom over six frames): dividing the move by the frame count
+    /// instead of by the steps between frames — what this replaced — reached
+    /// 11906 white pixels instead of 14080, a zoom of 1.83x where 2.0x was asked
+    /// for.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored zoom
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_zoom_in_reaches_its_target_on_the_last_frame_of_the_move() {
+        const CANVAS: (usize, usize) = (320, 180);
+        const FACTOR: f64 = 2.0;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(input) = white_box_clip(dir.path(), "box.mp4", CANVAS, (80, 44)) else {
+            eprintln!("Skipping: ffmpeg could not build the fixture");
+            return;
+        };
+
+        let mut effect = Effect::new(EffectType::Zoom);
+        effect.set_param("duration", ParamValue::Float(0.2));
+        effect.set_param("zoom_factor", ParamValue::Float(FACTOR));
+        let graph = zoom_graph_for_ffmpeg(effect, CANVAS.0 as i32, CANVAS.1 as i32, 30.0);
+
+        let Some(frames) = render_luma_frames(&input, &graph, CANVAS.0, CANVAS.1) else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+        assert_eq!(frames.len(), 6, "the zoom must not change the frame count");
+
+        let (_, _, unzoomed) = white_region(&frames[0], CANVAS.0);
+        let (_, _, zoomed) = white_region(frames.last().expect("frames"), CANVAS.0);
+        let expected = unzoomed as f64 * FACTOR * FACTOR;
+
+        assert!(
+            (zoomed as f64 - expected).abs() <= expected * 0.02,
+            "expected the move to end at {FACTOR}x — {expected} white pixels — \
+             got {zoomed} from {unzoomed}"
+        );
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: a zoom-out ends on the picture it started from
+    ///
+    /// A zoom-out that stops a step short never gets back to 1.0, so the clip
+    /// hands the rest of the timeline a picture that is still slightly enlarged.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1, same fixture): the old step
+    /// finished a 2x zoom-out at 4885 white pixels against the source's 3520 —
+    /// still 1.18x in.
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_zoom_out_returns_to_the_unzoomed_frame() {
+        const CANVAS: (usize, usize) = (320, 180);
+        // The fixture is an 80x44 white box, which is what an untouched frame
+        // measures.
+        const UNZOOMED: usize = 80 * 44;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(input) = white_box_clip(dir.path(), "box.mp4", CANVAS, (80, 44)) else {
+            eprintln!("Skipping: ffmpeg could not build the fixture");
+            return;
+        };
+
+        let mut effect = Effect::new(EffectType::Zoom);
+        effect.set_param("zoom_type", ParamValue::String("out".to_string()));
+        effect.set_param("duration", ParamValue::Float(0.2));
+        effect.set_param("zoom_factor", ParamValue::Float(2.0));
+        let graph = zoom_graph_for_ffmpeg(effect, CANVAS.0 as i32, CANVAS.1 as i32, 30.0);
+
+        let Some(frames) = render_luma_frames(&input, &graph, CANVAS.0, CANVAS.1) else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+
+        let (_, _, landed) = white_region(frames.last().expect("frames"), CANVAS.0);
+
+        assert!(
+            (landed as f64 - UNZOOMED as f64).abs() <= UNZOOMED as f64 * 0.02,
+            "a zoom-out must land back on the whole frame — {UNZOOMED} white \
+             pixels — got {landed}"
         );
     }
 

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -22,7 +22,7 @@ use super::{
     curve_points_to_ffmpeg, default_flat_curve, effect_type_supports_export,
     is_flat_identity_curve, is_identity_curve, mask_filters::apply_effect_through_mask_group,
     parse_curve_points, parse_curve_points_with_fallback, sample_curve_at, CurvePoint, Effect,
-    EffectType,
+    EffectType, ParamValue,
 };
 use tracing::warn;
 
@@ -995,13 +995,28 @@ impl Effect {
 
     /// Builds FFmpeg zoompan filter for zoom effect.
     ///
+    /// `zoompan` emits `d` output frames for *each* input frame, so `d` is a
+    /// frame multiplier and not, as it reads, the length of the move. It is
+    /// pinned to 1 here: one frame in, one frame out, which is the only setting
+    /// that leaves the clip the length the timeline says it is. The move itself
+    /// is driven by `on`, the output frame counter, ramping over the effect's
+    /// duration and then holding. (The `zoom+step` accumulator this used to
+    /// build cannot replace it: FFmpeg resets `zoom` for every input frame, so
+    /// at `d=1` it never moves off 1.0 and nothing zooms at all.)
+    ///
+    /// Both remaining options describe the frame rather than the move, and
+    /// FFmpeg will not take an expression for either, so the graph has to supply
+    /// them — see [`apply_canvas_to_effect`]. Without them FFmpeg applies its own
+    /// `hd720` default and squeezes the whole chain through 720p.
+    ///
     /// Parameters:
     /// - `zoom_type`: Zoom direction ("in", "out") (default: "in")
-    /// - `duration`: Effect duration in seconds (default: 1.0)
-    /// - `zoom_factor`: Maximum zoom level (default: 1.5)
+    /// - `duration`: Length of the zoom move in seconds (default: 1.0)
+    /// - `zoom_factor`: Zoom level at the end of the move (default: 1.5)
     /// - `center_x`: Horizontal center (0.0-1.0) (default: 0.5)
     /// - `center_y`: Vertical center (0.0-1.0) (default: 0.5)
-    /// - `fps`: Output framerate (default: 30)
+    /// - `canvas_fps` / `fps`: Frame rate of the canvas (default: 30)
+    /// - `canvas_width` / `canvas_height`: Size of the canvas (default: FFmpeg's)
     fn build_zoom_filter(&self) -> String {
         let zoom_type = self
             .get_param("zoom_type")
@@ -1011,15 +1026,19 @@ impl Effect {
         let zoom_factor = self.get_float("zoom_factor").unwrap_or(1.5);
         let center_x = self.get_float("center_x").unwrap_or(0.5);
         let center_y = self.get_float("center_y").unwrap_or(0.5);
-        let fps = self.get_float("fps").unwrap_or(30.0) as i64;
+
+        // The canvas rate wins over the effect's own param: `zoompan` restamps
+        // its output at this rate, so it has to be the rate the render runs at.
+        let canvas_fps = self.get_float(CANVAS_FPS_PARAM);
+        let fps = canvas_fps.or_else(|| self.get_float("fps")).unwrap_or(30.0);
 
         // Guard against invalid duration or fps that would cause division by zero
-        if !duration.is_finite() || duration <= 0.0 || fps <= 0 {
+        if !duration.is_finite() || duration <= 0.0 || !fps.is_finite() || fps <= 0.0 {
             return "null".to_string();
         }
 
-        // Calculate total frames for the duration
-        let total_frames = (duration * fps as f64) as i64;
+        // How many frames the move lasts. Beyond it the zoom holds.
+        let total_frames = (duration * fps) as i64;
 
         // Guard against zero total frames (edge case with very small duration)
         if total_frames <= 0 {
@@ -1029,17 +1048,10 @@ impl Effect {
         // Build zoom expression based on type
         // For zoom in: start at 1.0, end at zoom_factor
         // For zoom out: start at zoom_factor, end at 1.0
+        let step = (zoom_factor - 1.0) / total_frames as f64;
         let zoom_expr = match zoom_type {
-            "out" => format!(
-                "z='if(lte(zoom,1.0),{:.4},max(1.001,zoom-{:.6}))'",
-                zoom_factor,
-                (zoom_factor - 1.0) / total_frames as f64
-            ),
-            _ => format!(
-                "z='min(zoom+{:.6},{:.4})'",
-                (zoom_factor - 1.0) / total_frames as f64,
-                zoom_factor
-            ),
+            "out" => format!("z='max({:.4}-{:.6}*on,1)'", zoom_factor, step),
+            _ => format!("z='min(1+{:.6}*on,{:.4})'", step, zoom_factor),
         };
 
         // Build x/y position expressions to keep centered
@@ -1047,9 +1059,36 @@ impl Effect {
         let x_expr = format!("x='iw*{:.4}-(iw/zoom*{:.4})'", center_x, center_x);
         let y_expr = format!("y='ih*{:.4}-(ih/zoom*{:.4})'", center_y, center_y);
 
+        let size = match (
+            self.get_float(CANVAS_WIDTH_PARAM),
+            self.get_float(CANVAS_HEIGHT_PARAM),
+        ) {
+            (Some(width), Some(height)) if width >= 1.0 && height >= 1.0 => {
+                format!(":s={}x{}", width as i64, height as i64)
+            }
+            // Nothing truthful to say. FFmpeg then applies its own `hd720`
+            // default, which is why every render path tells the graph its canvas.
+            _ => String::new(),
+        };
+
+        // `on` counts frames leaving `zoompan`, which run at `fps` — so the move
+        // only lasts `duration` seconds if the frames arriving are at that rate
+        // too. Pinning the rate in front of the zoom makes that true whatever
+        // the source was shot at, and stops `zoompan`'s restamping from
+        // stretching or squashing the clip.
+        let rate_pin = match canvas_fps {
+            Some(_) => format!("fps={},", format_frame_rate(fps)),
+            None => String::new(),
+        };
+
         format!(
-            "zoompan={}:{}:{}:d={}:s=hd720:fps={}",
-            zoom_expr, x_expr, y_expr, total_frames, fps
+            "{}zoompan={}:{}:{}:d=1{}:fps={}",
+            rate_pin,
+            zoom_expr,
+            x_expr,
+            y_expr,
+            size,
+            format_frame_rate(fps)
         )
     }
 
@@ -1907,6 +1946,13 @@ impl Effect {
 // Filter Graph Composition
 // =============================================================================
 
+/// Parameter an effect reads to learn the canvas width it is drawing into.
+pub(crate) const CANVAS_WIDTH_PARAM: &str = "canvas_width";
+/// Parameter an effect reads to learn the canvas height it is drawing into.
+pub(crate) const CANVAS_HEIGHT_PARAM: &str = "canvas_height";
+/// Parameter an effect reads to learn the frame rate the canvas runs at.
+pub(crate) const CANVAS_FPS_PARAM: &str = "canvas_fps";
+
 /// Composes multiple effects into a single FFmpeg filter complex string
 pub struct FilterGraph {
     /// List of effects in order
@@ -1915,6 +1961,8 @@ pub struct FilterGraph {
     width: Option<i32>,
     /// Video height in pixels (for mask calculations)
     height: Option<i32>,
+    /// Frame rate of the canvas the chain feeds, in frames per second
+    fps: Option<f64>,
 }
 
 impl FilterGraph {
@@ -1924,13 +1972,13 @@ impl FilterGraph {
             effects: vec![],
             width: None,
             height: None,
+            fps: None,
         }
     }
 
     /// Sets video dimensions for mask-aware filter generation
     pub fn with_dimensions(mut self, width: i32, height: i32) -> Self {
-        self.width = Some(width);
-        self.height = Some(height);
+        self.set_dimensions(width, height);
         self
     }
 
@@ -1938,11 +1986,33 @@ impl FilterGraph {
     pub fn set_dimensions(&mut self, width: i32, height: i32) {
         self.width = Some(width);
         self.height = Some(height);
+        self.publish_canvas();
+    }
+
+    /// Tells the graph what frame rate the canvas it feeds runs at.
+    pub fn set_fps(&mut self, fps: f64) {
+        self.fps = Some(fps);
+        self.publish_canvas();
+    }
+
+    /// Writes the canvas onto every effect that cannot work it out for itself.
+    ///
+    /// The values are stored on the effects rather than applied while emitting,
+    /// because the emitted string is not the only reader: the export measures
+    /// the same effect bodies to find out how big a picture the chain hands the
+    /// transform. Both have to be told the same thing or the transform places
+    /// the clip against a size the render never produces.
+    fn publish_canvas(&mut self) {
+        let (width, height, fps) = (self.width, self.height, self.fps);
+        for effect in &mut self.effects {
+            apply_canvas_to_effect(effect, width, height, fps);
+        }
     }
 
     /// Adds an effect to the graph
-    pub fn add_effect(&mut self, effect: Effect) {
+    pub fn add_effect(&mut self, mut effect: Effect) {
         if effect.enabled && effect.is_ffmpeg_compatible() {
+            apply_canvas_to_effect(&mut effect, self.width, self.height, self.fps);
             self.effects.push(effect);
         }
     }
@@ -2166,6 +2236,53 @@ impl Default for FilterGraph {
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/// Writes a frame rate the way FFmpeg's video-rate option parser reads it.
+///
+/// Whole rates stay whole so that `30` does not become `30.000000`, and a
+/// fractional rate such as 29.97 keeps enough digits to stay distinguishable
+/// from 30.
+fn format_frame_rate(fps: f64) -> String {
+    if (fps - fps.round()).abs() < 1e-9 {
+        return format!("{}", fps.round() as i64);
+    }
+    let mut formatted = format!("{fps:.6}");
+    let trimmed = formatted.trim_end_matches('0').trim_end_matches('.').len();
+    formatted.truncate(trimmed);
+    formatted
+}
+
+/// Hands an effect the canvas the graph is drawing into.
+///
+/// Only `zoompan` needs it so far. FFmpeg parses its `s` option as a literal
+/// frame size — no expressions, no "same as the input" — and defaults it to
+/// `hd720`, so a zoom that is not told the canvas resizes every picture that
+/// passes through it to 720p. Its `fps` matters for the same reason: `zoompan`
+/// regenerates output timestamps at that rate, so a wrong one changes how long
+/// the clip lasts.
+fn apply_canvas_to_effect(
+    effect: &mut Effect,
+    width: Option<i32>,
+    height: Option<i32>,
+    fps: Option<f64>,
+) {
+    if effect.effect_type != EffectType::Zoom {
+        return;
+    }
+
+    if let (Some(width), Some(height)) = (width, height) {
+        if width > 0 && height > 0 {
+            effect.set_param(CANVAS_WIDTH_PARAM, ParamValue::Float(f64::from(width)));
+            effect.set_param(CANVAS_HEIGHT_PARAM, ParamValue::Float(f64::from(height)));
+        }
+    }
+
+    if let Some(fps) = fps {
+        if fps.is_finite() && fps > 0.0 {
+            effect.set_param(CANVAS_FPS_PARAM, ParamValue::Float(fps));
+        }
+    }
+}
 
 /// Names the stream that carries the picture (or the sound) between two effects
 /// of one clip's chain.
@@ -3275,9 +3392,9 @@ mod tests {
             "Expected zoompan filter, got: {}",
             filter
         );
-        // Zoom in increases zoom, so expression should contain 'min'
+        // Zoom in ramps upwards from 1.0, so the expression should cap with 'min'
         assert!(
-            filter.contains("min(zoom+"),
+            filter.contains("min(1+"),
             "Expected zoom in expression, got: {}",
             filter
         );
@@ -3327,8 +3444,14 @@ mod tests {
 
         let filter = effect.to_filter_string("in", "out");
         assert!(filter.contains("fps=60"));
-        // Duration 1.0s at 60fps = 60 frames
-        assert!(filter.contains("d=60"));
+        // One output frame per input frame, whatever the rate
+        assert!(filter.contains("d=1"), "got: {}", filter);
+        // Duration 1.0s at 60fps is a 60-frame move to the default 1.5x
+        assert!(
+            filter.contains("min(1+0.008333*on,1.5000)"),
+            "got: {}",
+            filter
+        );
     }
 
     #[test]
@@ -3448,6 +3571,133 @@ mod tests {
     }
 
     // =========================================================================
+    // Zoom output-frame and canvas tests
+    // =========================================================================
+
+    /// Builds the zoom the export builds: through a graph that knows its canvas.
+    fn zoom_on_canvas(effect: Effect, width: i32, height: i32, fps: f64) -> String {
+        let mut graph = FilterGraph::new().with_dimensions(width, height);
+        graph.set_fps(fps);
+        graph.add_effect(effect);
+        graph.to_video_filter_complex("trim0", "v0")
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: a zoom must not change how many frames the clip has
+    ///
+    /// `zoompan`'s `d` is how many output frames it emits for *each* input
+    /// frame, not the length of the move. Setting it to the move's frame count,
+    /// as this used to, multiplied a 60-frame clip into 3600 frames — two
+    /// seconds of picture stretched over two minutes.
+    #[test]
+    fn should_emit_one_frame_per_input_frame_when_zooming() {
+        let mut effect = Effect::new(EffectType::Zoom);
+        effect.set_param("duration", ParamValue::Float(2.0));
+        effect.set_param("zoom_factor", ParamValue::Float(1.5));
+
+        let filter = zoom_on_canvas(effect, 1920, 1080, 30.0);
+
+        assert!(
+            filter.contains(":d=1:"),
+            "a zoom must emit one frame per input frame, got: {filter}"
+        );
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: the move is driven by a frame counter, not by `zoom` itself
+    ///
+    /// FFmpeg resets the `zoom` variable for every input frame, so the
+    /// `min(zoom+step, factor)` accumulator this used to build never leaves 1.0
+    /// once `d` is 1 — the picture would not zoom at all.
+    #[test]
+    fn should_drive_the_zoom_move_from_the_frame_counter() {
+        let mut zoom_in = Effect::new(EffectType::Zoom);
+        zoom_in.set_param("duration", ParamValue::Float(2.0));
+        zoom_in.set_param("zoom_factor", ParamValue::Float(1.5));
+        let filter = zoom_on_canvas(zoom_in, 1920, 1080, 30.0);
+        assert!(
+            filter.contains("z='min(1+0.008333*on,1.5000)'"),
+            "got: {filter}"
+        );
+
+        let mut zoom_out = Effect::new(EffectType::Zoom);
+        zoom_out.set_param("zoom_type", ParamValue::String("out".to_string()));
+        zoom_out.set_param("duration", ParamValue::Float(2.0));
+        zoom_out.set_param("zoom_factor", ParamValue::Float(1.5));
+        let filter = zoom_on_canvas(zoom_out, 1920, 1080, 30.0);
+        assert!(
+            filter.contains("z='max(1.5000-0.008333*on,1)'"),
+            "got: {filter}"
+        );
+
+        assert!(
+            !filter.contains("zoom+") && !filter.contains("zoom-"),
+            "the move must not read back the zoom of the previous frame: {filter}"
+        );
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: the zoom draws into the sequence canvas, not a fixed 720p frame
+    ///
+    /// `zoompan` takes no expression for `s` and defaults it to `hd720`, so a
+    /// zoom that is not told the canvas silently squeezes the whole chain
+    /// through 1280x720 — including a vertical sequence, which it also reshapes.
+    #[test]
+    fn should_zoom_into_the_canvas_the_graph_draws() {
+        for (width, height) in [(1920, 1080), (1080, 1920), (3840, 2160)] {
+            let filter = zoom_on_canvas(Effect::new(EffectType::Zoom), width, height, 30.0);
+
+            assert!(
+                filter.contains(&format!(":s={width}x{height}:")),
+                "expected the {width}x{height} canvas, got: {filter}"
+            );
+            assert!(
+                !filter.contains("hd720"),
+                "the canvas must not be hard-coded: {filter}"
+            );
+        }
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: the zoom keeps the clip's running time
+    ///
+    /// `zoompan` restamps its output at `fps`, so the frames reaching it have to
+    /// arrive at that rate — otherwise a 24fps source in a 30fps sequence comes
+    /// out a quarter shorter than the timeline slot it was cut for.
+    #[test]
+    fn should_pin_the_frame_rate_the_zoom_restamps_to() {
+        let filter = zoom_on_canvas(Effect::new(EffectType::Zoom), 1920, 1080, 24.0);
+
+        assert!(
+            filter.contains("]fps=24,zoompan="),
+            "expected the canvas rate in front of the zoom, got: {filter}"
+        );
+        assert!(filter.contains(":fps=24"), "got: {filter}");
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: the size the export measures is the size the render produces
+    ///
+    /// The transform is placed against whatever size the effect chain hands it,
+    /// which the export reads back off these same filter bodies. Publishing the
+    /// canvas onto the stored effect — rather than onto a copy made while
+    /// emitting — is what keeps the two answers the same.
+    #[test]
+    fn should_report_the_canvas_as_the_zooms_output_size() {
+        let mut graph = FilterGraph::new().with_dimensions(1080, 1920);
+        graph.set_fps(30.0);
+        graph.add_effect(Effect::new(EffectType::Zoom));
+
+        let measured = graph
+            .video_effects()
+            .next()
+            .expect("the zoom is a video effect")
+            .build_filter_params();
+
+        assert!(measured.contains(":s=1080x1920:"), "got: {measured}");
+    }
+
+    // =========================================================================
     // Zoom Filter Edge Case Tests (Division by Zero Prevention)
     // =========================================================================
 
@@ -3559,8 +3809,14 @@ mod tests {
             filter
         );
         assert!(
-            filter.contains("d=60"),
-            "Expected 60 frames (2s * 30fps), got: {}",
+            filter.contains("d=1"),
+            "Expected one output frame per input frame, got: {}",
+            filter
+        );
+        // 2s at 30fps is a 60-frame move, so the zoom steps 0.5/60 per frame.
+        assert!(
+            filter.contains("min(1+0.008333*on,1.5000)"),
+            "Expected a 60-frame ramp to 1.5x, got: {}",
             filter
         );
     }
@@ -6020,6 +6276,93 @@ mod tests {
     /// `vidstabdetect=result=`. So the `== 1` assertions below genuinely discriminate;
     /// they are not satisfied by every possible input.
     const INJECTION_PAYLOAD: &str = "/proj/x';anullsrc=r=48000";
+
+    /// Feature: Zoom effect
+    /// Scenario: a zoom over a 60-frame clip renders 60 frames at the canvas size
+    ///
+    /// The string assertions above encode a belief about what `zoompan`'s `d`
+    /// and `s` mean. This one hands the real FFmpeg the graph the export would
+    /// build and counts what comes out: one luma plane per frame at the canvas
+    /// size, so a wrong frame count and a wrong frame size both show up as a
+    /// wrong byte count.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1): the `d={move_frames}:s=hd720`
+    /// this replaced turned the same 60-frame source into 3600 frames of
+    /// 1280x720 — a 60x frame explosion and a canvas the sequence never asked
+    /// for.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored zoom
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_zoom_renders_one_frame_per_input_frame_at_the_canvas_size() {
+        const CANVAS_WIDTH: usize = 320;
+        const CANVAS_HEIGHT: usize = 180;
+        const SOURCE_FRAMES: usize = 60;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input_file = dir.path().join("input.mp4");
+        let fixture = std::process::Command::new(ffmpeg_binary_for_tests())
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=640x360:rate=30:duration=2",
+                "-pix_fmt",
+                "yuv420p",
+            ])
+            .arg(&input_file)
+            .output();
+        let Ok(fixture) = fixture else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+        if !fixture.status.success() || !input_file.exists() {
+            eprintln!("Skipping: ffmpeg could not build the fixture");
+            return;
+        }
+
+        let mut effect = Effect::new(EffectType::Zoom);
+        effect.set_param("duration", ParamValue::Float(2.0));
+        effect.set_param("zoom_factor", ParamValue::Float(1.5));
+
+        let mut graph =
+            FilterGraph::new().with_dimensions(CANVAS_WIDTH as i32, CANVAS_HEIGHT as i32);
+        graph.set_fps(30.0);
+        graph.add_effect(effect);
+
+        let graph_file = dir.path().join("graph.txt");
+        std::fs::write(&graph_file, graph.to_video_filter_complex("0:v", "out"))
+            .expect("write filtergraph");
+
+        // One byte per pixel of luma, so the byte count is the frame count times
+        // the frame size — both properties under test, measured at once.
+        let render = std::process::Command::new(ffmpeg_binary_for_tests())
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
+            .arg(&input_file)
+            .arg("-/filter_complex")
+            .arg(&graph_file)
+            .args(["-map", "[out]", "-pix_fmt", "gray", "-f", "rawvideo", "-"])
+            .output()
+            .expect("run ffmpeg");
+
+        assert!(
+            render.status.success(),
+            "ffmpeg refused the zoom graph: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+        assert_eq!(
+            render.stdout.len(),
+            SOURCE_FRAMES * CANVAS_WIDTH * CANVAS_HEIGHT,
+            "expected {SOURCE_FRAMES} frames of {CANVAS_WIDTH}x{CANVAS_HEIGHT}, \
+             got {} bytes",
+            render.stdout.len()
+        );
+    }
 
     #[test]
     #[ignore = "requires an ffmpeg binary; run with --ignored"]

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -2191,7 +2191,10 @@ impl FilterGraph {
             let has_masks = effect.masks.has_enabled_masks();
             let filter = if let (true, Some(w), Some(h)) = (has_masks, self.width, self.height) {
                 let effect_body = effect.build_filter_params();
-                if effect_body.is_empty() || !effect.enabled || !effect.is_ffmpeg_compatible() {
+                if is_pass_through_body(&effect_body)
+                    || !effect.enabled
+                    || !effect.is_ffmpeg_compatible()
+                {
                     format!("[{current_label}]null[{next_label}]")
                 } else {
                     // For timed mask effects, append enable clause to the effect body
@@ -2214,7 +2217,7 @@ impl FilterGraph {
                 format!("[{current_label}]null[{next_label}]")
             } else {
                 let filter_body = effect.to_filter_body();
-                if filter_body.is_empty() {
+                if is_pass_through_body(&filter_body) {
                     format!("[{current_label}]null[{next_label}]")
                 } else {
                     let enabled_body = add_enable_to_each_filter(&filter_body, &enable_clause);
@@ -2349,6 +2352,20 @@ fn effect_chain_label(output_label: &str, effect_index: usize) -> String {
     format!("{output_label}_fx{effect_index}")
 }
 
+/// Whether an effect body describes no picture change at all.
+///
+/// [`IntoFFmpegFilter::to_filter_body`] answers `null` for a disabled effect,
+/// for one the export cannot render, and for every effect
+/// [`Effect::build_filter_params`] has no arm for — `Levels`, `Glow`,
+/// `MotionBlur`, `BlendMode` and the rest of its `_` fallthrough. That body is a
+/// pass-through, and it must be *emitted* as one: `null` takes no options, so
+/// gating it with `enable=` produces `null:enable='between(t,…)'`, which FFmpeg
+/// refuses to parse at all ("No option name near 'between(…)'") and which
+/// therefore failed the whole export rather than the one effect.
+fn is_pass_through_body(body: &str) -> bool {
+    body.is_empty() || body == "null"
+}
+
 /// Injects an FFmpeg `enable` clause into every top-level filter in a
 /// comma-separated filter chain. FFmpeg requires `enable` on each individual
 /// filter; appending it once only gates the last filter in the chain.
@@ -2401,6 +2418,58 @@ mod tests {
         assert!(filter.contains("eq=brightness=0.5"));
         assert!(filter.starts_with("[0:v]"));
         assert!(filter.ends_with("[out]"));
+    }
+
+    /// Feature: Adjustment layers
+    /// Scenario: an effect with no filter of its own stays a plain pass-through
+    ///
+    /// `null` takes no options, so gating it produced
+    /// `null:enable='between(t,…)'` — which FFmpeg cannot parse at all ("No
+    /// option name near 'between(…)'") and which therefore failed the entire
+    /// export rather than the one effect that had nothing to say.
+    #[test]
+    fn should_emit_an_ungated_no_op_for_a_timed_effect_with_no_filter_body() {
+        let mut disabled_grade = Effect::new(EffectType::Brightness);
+        disabled_grade.set_param("value", ParamValue::Float(0.5));
+        disabled_grade.enabled = false;
+
+        for effect in [
+            Effect::new(EffectType::Levels),
+            Effect::new(EffectType::Glow),
+            Effect::new(EffectType::MotionBlur),
+            Effect::new(EffectType::BlendMode),
+            Effect::new(EffectType::Custom("nonesuch".to_string())),
+            disabled_grade,
+        ] {
+            let effect_type = effect.effect_type.clone();
+            let mut graph = FilterGraph::new();
+            graph.add_effect(effect);
+
+            let filter = graph.to_video_filter_complex_timed("0:v", "out", 0.0, 1.0);
+
+            assert_eq!(
+                filter, "[0:v]null[out]",
+                "a no-op {effect_type:?} must pass the picture through ungated"
+            );
+        }
+    }
+
+    /// Feature: Adjustment layers
+    /// Scenario: an effect that does have a filter body is still gated
+    #[test]
+    fn should_still_gate_a_timed_effect_that_has_a_filter_body() {
+        let mut effect = Effect::new(EffectType::Brightness);
+        effect.set_param("value", ParamValue::Float(0.5));
+
+        let mut graph = FilterGraph::new();
+        graph.add_effect(effect);
+
+        let filter = graph.to_video_filter_complex_timed("0:v", "out", 0.0, 1.0);
+
+        assert!(
+            filter.contains("eq=brightness=0.5000:enable='between(t,0.000000,1.000000)'"),
+            "a colour grade still applies only over the layer: {filter}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -6493,7 +6493,9 @@ mod tests {
 
         let dir = tempfile::tempdir().expect("temp dir");
         let input_file = dir.path().join("input.mp4");
-        let fixture = std::process::Command::new(ffmpeg_binary_for_tests())
+        let mut fixture_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut fixture_cmd);
+        let fixture = fixture_cmd
             .args([
                 "-y",
                 "-hide_banner",
@@ -6532,7 +6534,9 @@ mod tests {
 
         // One byte per pixel of luma, so the byte count is the frame count times
         // the frame size — both properties under test, measured at once.
-        let render = std::process::Command::new(ffmpeg_binary_for_tests())
+        let mut render_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut render_cmd);
+        let render = render_cmd
             .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
             .arg(&input_file)
             .arg("-/filter_complex")
@@ -6580,7 +6584,9 @@ mod tests {
             (height - box_height) / 2,
         );
 
-        let built = std::process::Command::new(ffmpeg_binary_for_tests())
+        let mut built_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut built_cmd);
+        let built = built_cmd
             .args([
                 "-y",
                 "-hide_banner",
@@ -6614,7 +6620,9 @@ mod tests {
         let graph_file = dir.path().join("graph.txt");
         std::fs::write(&graph_file, graph).ok()?;
 
-        let render = std::process::Command::new(ffmpeg_binary_for_tests())
+        let mut render_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut render_cmd);
+        let render = render_cmd
             .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
             .arg(input)
             .arg("-/filter_complex")

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -1007,7 +1007,10 @@ impl Effect {
     /// Both remaining options describe the frame rather than the move, and
     /// FFmpeg will not take an expression for either, so the graph has to supply
     /// them — see [`apply_canvas_to_effect`]. Without them FFmpeg applies its own
-    /// `hd720` default and squeezes the whole chain through 720p.
+    /// `hd720` default and squeezes the whole chain through 720p. `s` is a
+    /// force-scale with no aspect handling of its own, so the frame is
+    /// letterboxed into the canvas in front of the zoom and `s` only restates the
+    /// size it is already being handed.
     ///
     /// Parameters:
     /// - `zoom_type`: Zoom direction ("in", "out") (default: "in")
@@ -1069,16 +1072,30 @@ impl Effect {
         let x_expr = format!("x='iw*{:.4}-(iw/zoom*{:.4})'", center_x, center_x);
         let y_expr = format!("y='ih*{:.4}-(ih/zoom*{:.4})'", center_y, center_y);
 
-        let size = match (
+        // `zoompan` force-scales whatever reaches it to `s` and offers no aspect
+        // handling of its own, so a 4:3 source in a 16:9 sequence came out
+        // stretched sideways. Fitting the frame to the canvas *before* the zoom —
+        // the same letterbox the render's downstream normalization applies —
+        // makes `s` an exact restatement of the size already flowing through, and
+        // leaves that normalization a no-op rather than a second letterbox.
+        let (size, fit) = match (
             self.get_float(CANVAS_WIDTH_PARAM),
             self.get_float(CANVAS_HEIGHT_PARAM),
         ) {
             (Some(width), Some(height)) if width >= 1.0 && height >= 1.0 => {
-                format!(":s={}x{}", width as i64, height as i64)
+                let (width, height) = (width as i64, height as i64);
+                (
+                    format!(":s={}x{}", width, height),
+                    format!(
+                        "scale={}:{}:force_original_aspect_ratio=decrease,\
+                         pad={}:{}:(ow-iw)/2:(oh-ih)/2,",
+                        width, height, width, height
+                    ),
+                )
             }
             // Nothing truthful to say. FFmpeg then applies its own `hd720`
             // default, which is why every render path tells the graph its canvas.
-            _ => String::new(),
+            _ => (String::new(), String::new()),
         };
 
         // `on` counts frames leaving `zoompan`, which run at `fps` — so the move
@@ -1092,8 +1109,9 @@ impl Effect {
         };
 
         format!(
-            "{}zoompan={}:{}:{}:d=1{}:fps={}",
+            "{}{}zoompan={}:{}:{}:d=1{}:fps={}",
             rate_pin,
+            fit,
             zoom_expr,
             x_expr,
             y_expr,
@@ -3680,7 +3698,7 @@ mod tests {
         let filter = zoom_on_canvas(Effect::new(EffectType::Zoom), 1920, 1080, 24.0);
 
         assert!(
-            filter.contains("]fps=24,zoompan="),
+            filter.contains("]fps=24,scale="),
             "expected the canvas rate in front of the zoom, got: {filter}"
         );
         assert!(filter.contains(":fps=24"), "got: {filter}");
@@ -3753,6 +3771,29 @@ mod tests {
             assert!(
                 filter.contains("((1.0100-1)/19799)*on"),
                 "expected the ratio left for FFmpeg to divide, got: {filter}"
+            );
+        }
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: a source shaped unlike the canvas is letterboxed, not stretched
+    ///
+    /// `zoompan` force-scales its output to `s` and offers no aspect handling, so
+    /// a 4:3 source in a 16:9 sequence used to leave the zoom stretched sideways.
+    /// The fit in front of it is the same one the render's downstream
+    /// normalization applies, which makes that normalization a no-op rather than
+    /// a second letterbox.
+    #[test]
+    fn should_letterbox_into_the_canvas_before_zooming() {
+        for (width, height) in [(1920, 1080), (1080, 1920)] {
+            let filter = zoom_on_canvas(Effect::new(EffectType::Zoom), width, height, 30.0);
+
+            assert!(
+                filter.contains(&format!(
+                    "scale={width}:{height}:force_original_aspect_ratio=decrease,\
+                     pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,zoompan="
+                )),
+                "expected an aspect-preserving fit in front of the zoom, got: {filter}"
             );
         }
     }
@@ -6631,6 +6672,48 @@ mod tests {
             "a zoom-out must land back on the whole frame — {UNZOOMED} white \
              pixels — got {landed}"
         );
+    }
+
+    /// Feature: Zoom effect
+    /// Scenario: a source shaped unlike the canvas keeps its shape
+    ///
+    /// `zoompan` force-scales to `s`, so a 4:3 source in a 16:9 sequence used to
+    /// come out stretched sideways — and a vertical sequence stretched it the
+    /// other way, much harder.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1): a 120x120 square in a 320x240
+    /// source rendered 120x90 into a 320x180 canvas and 68x160 into a 180x320
+    /// one. With the fit in front of the zoom both come out square.
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_zoom_letterboxes_a_source_shaped_unlike_the_canvas() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(input) = white_box_clip(dir.path(), "square.mp4", (320, 240), (120, 120)) else {
+            eprintln!("Skipping: ffmpeg could not build the fixture");
+            return;
+        };
+
+        for (width, height) in [(320_usize, 180_usize), (180, 320)] {
+            let mut effect = Effect::new(EffectType::Zoom);
+            effect.set_param("duration", ParamValue::Float(0.2));
+            effect.set_param("zoom_factor", ParamValue::Float(1.5));
+            let graph = zoom_graph_for_ffmpeg(effect, width as i32, height as i32, 30.0);
+
+            let Some(frames) = render_luma_frames(&input, &graph, width, height) else {
+                eprintln!("Skipping: ffmpeg could not be launched");
+                return;
+            };
+
+            // The first frame of the move is at 1.0x, so the only thing that can
+            // have reshaped the square is the fit into the canvas.
+            let (box_width, box_height, _) = white_region(&frames[0], width);
+
+            assert!(
+                box_width.abs_diff(box_height) <= 2,
+                "a square subject must stay square in a {width}x{height} canvas, \
+                 got {box_width}x{box_height}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -1060,8 +1060,22 @@ impl Effect {
         // `0.000000` — a 1% zoom over eleven minutes at 30fps does — which turns
         // a zoom-in into no zoom at all and a zoom-out into a permanent hold at
         // the zoomed size. FFmpeg divides at full double precision instead.
+        // A clip in a transition is decoded from before its in point, so `on` is
+        // already counting while the picture the editor drew the move under has
+        // not started yet. Holding the move at its first frame until then is what
+        // keeps a zoom on a dissolving clip landing where it was authored.
+        let clock = match self
+            .get_float(BRANCH_OFFSET_PARAM)
+            .filter(|offset| offset.is_finite() && *offset > 0.0)
+            .map(|offset| (offset * fps).round() as i64)
+            .filter(|frames| *frames > 0)
+        {
+            Some(frames) => format!("max(on-{},0)", frames),
+            None => "on".to_string(),
+        };
+
         let factor = format!("{:.4}", zoom_factor);
-        let travelled = format!("(({}-1)/{})*on", factor, steps);
+        let travelled = format!("(({}-1)/{})*{}", factor, steps, clock);
         let zoom_expr = match zoom_type {
             "out" => format!("z='max({}-{},1)'", factor, travelled),
             _ => format!("z='min(1+{},{})'", travelled, factor),
@@ -1980,6 +1994,13 @@ pub(crate) const CANVAS_WIDTH_PARAM: &str = "canvas_width";
 pub(crate) const CANVAS_HEIGHT_PARAM: &str = "canvas_height";
 /// Parameter an effect reads to learn the frame rate the canvas runs at.
 pub(crate) const CANVAS_FPS_PARAM: &str = "canvas_fps";
+/// Parameter an effect reads to learn how far before the clip's in point the
+/// stream carrying it begins — the head handle a transition decodes.
+///
+/// The render sets it on the effects of a clip taking part in a transition; see
+/// `anchor_effect_to_branch` in the export. Effects counted in seconds from the
+/// clip's start read it and move by that much; everything else ignores it.
+pub(crate) const BRANCH_OFFSET_PARAM: &str = "branch_offset_sec";
 
 /// Composes multiple effects into a single FFmpeg filter complex string
 pub struct FilterGraph {
@@ -6684,6 +6705,58 @@ mod tests {
     /// Measured negative control (ffmpeg 9.0.1): a 120x120 square in a 320x240
     /// source rendered 120x90 into a 320x180 canvas and 68x160 into a 180x320
     /// one. With the fit in front of the zoom both come out square.
+    /// Feature: Zoom effect
+    /// Scenario: a zoom on a clip in a transition waits out the head handle
+    ///
+    /// The stream a dissolving clip renders from starts before its in point, and
+    /// `on` counts from the first frame of *that* stream. Unanchored, the move is
+    /// already part-way through when the clip's own picture appears.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1, 320x180, six frames, a 2x move
+    /// three frames long behind a three-frame handle): without the offset the
+    /// move is finished by the fourth frame — 14080 white pixels where the
+    /// handle should still be showing the source's 3520.
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_zoom_behind_a_head_handle_starts_on_the_clips_own_picture() {
+        const CANVAS: (usize, usize) = (320, 180);
+        const UNZOOMED: usize = 80 * 44;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(input) = white_box_clip(dir.path(), "box.mp4", CANVAS, (80, 44)) else {
+            eprintln!("Skipping: ffmpeg could not build the fixture");
+            return;
+        };
+
+        let mut effect = Effect::new(EffectType::Zoom);
+        effect.set_param("duration", ParamValue::Float(0.1));
+        effect.set_param("zoom_factor", ParamValue::Float(2.0));
+        // Three frames of the six-frame branch belong to the handle.
+        effect.set_param(BRANCH_OFFSET_PARAM, ParamValue::Float(0.1));
+        let graph = zoom_graph_for_ffmpeg(effect, CANVAS.0 as i32, CANVAS.1 as i32, 30.0);
+
+        let Some(frames) = render_luma_frames(&input, &graph, CANVAS.0, CANVAS.1) else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+        assert_eq!(frames.len(), 6);
+
+        let (_, _, held) = white_region(&frames[3], CANVAS.0);
+        assert!(
+            (held as f64 - UNZOOMED as f64).abs() <= UNZOOMED as f64 * 0.02,
+            "the last frame of the handle must still be unzoomed — {UNZOOMED} \
+             white pixels — got {held}"
+        );
+
+        let (_, _, landed) = white_region(frames.last().expect("frames"), CANVAS.0);
+        let expected = UNZOOMED as f64 * 4.0;
+        assert!(
+            (landed as f64 - expected).abs() <= expected * 0.02,
+            "the move must still finish on the clip's last frame — {expected} \
+             white pixels — got {landed}"
+        );
+    }
+
     #[test]
     #[ignore = "requires an ffmpeg binary; run with --ignored"]
     fn a_zoom_letterboxes_a_source_shaped_unlike_the_canvas() {

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -1992,7 +1992,7 @@ impl FilterGraph {
             let next_label = if is_last {
                 output_label.to_string()
             } else {
-                format!("v{}", i)
+                effect_chain_label(output_label, i)
             };
 
             // Check if this effect has power window masks and dimensions are available
@@ -2065,7 +2065,7 @@ impl FilterGraph {
             let next_label = if is_last {
                 output_label.to_string()
             } else {
-                format!("{}_{}", output_label, i)
+                effect_chain_label(output_label, i)
             };
 
             // Check if this effect has power window masks and dimensions are available
@@ -2131,7 +2131,7 @@ impl FilterGraph {
             let next_label = if is_last {
                 output_label.to_string()
             } else {
-                format!("a{}", i)
+                effect_chain_label(output_label, i)
             };
 
             let filter = effect.to_filter_string(&current_label, &next_label);
@@ -2166,6 +2166,22 @@ impl Default for FilterGraph {
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/// Names the stream that carries the picture (or the sound) between two effects
+/// of one clip's chain.
+///
+/// The name is derived from the chain's own output label, which the caller has
+/// already made unique per clip — the export's per-clip labels are `v{input}`
+/// and `a{input}`. Numbering the intermediates by effect index alone, as this
+/// used to, produced `v0`, `v1`, … for *every* clip, so a clip carrying two
+/// effects re-declared the label its own chain ends on and a clip carrying more
+/// than two re-declared the label a *different* clip's chain ends on. A
+/// filtergraph is only well defined when each label is declared once, so the
+/// export was leaning on how one particular FFmpeg build happens to pair up
+/// repeated names.
+fn effect_chain_label(output_label: &str, effect_index: usize) -> String {
+    format!("{output_label}_fx{effect_index}")
+}
 
 /// Injects an FFmpeg `enable` clause into every top-level filter in a
 /// comma-separated filter chain. FFmpeg requires `enable` on each individual
@@ -2319,10 +2335,134 @@ mod tests {
         graph.sort_by_order();
         let complex = graph.to_video_filter_complex("0:v", "vout");
 
-        // Should chain: [0:v]blur[v0];[v0]brightness[vout]
+        // Should chain: [0:v]blur[vout_fx0];[vout_fx0]brightness[vout]
         assert!(complex.contains("gblur"));
         assert!(complex.contains("eq=brightness"));
         assert!(complex.contains(";"));
+    }
+
+    /// Every stream label a filtergraph declares, in declaration order.
+    ///
+    /// A filter's output labels are the bracketed names trailing it, so this
+    /// reads the tail of each `;`-separated link.
+    fn declared_labels(filter_complex: &str) -> Vec<String> {
+        let mut labels = Vec::new();
+        for link in filter_complex.split(';') {
+            let mut rest = link.trim_end();
+            let mut trailing = Vec::new();
+            while rest.ends_with(']') {
+                let Some(open) = rest.rfind('[') else { break };
+                trailing.push(rest[open + 1..rest.len() - 1].to_string());
+                rest = &rest[..open];
+            }
+            trailing.reverse();
+            labels.extend(trailing);
+        }
+        labels
+    }
+
+    /// Feature: Per-clip effect chains
+    /// Scenario: two video effects on the clip that owns the label `v0`
+    ///
+    /// The export names a clip's finished picture `v{input_index}`, so an
+    /// effect chain that numbered its own intermediates `v{effect_index}`
+    /// declared `[v0]` twice on the very first clip of the timeline.
+    #[test]
+    fn should_declare_every_video_chain_label_once_when_chain_ends_on_a_clip_label() {
+        let mut graph = FilterGraph::new();
+
+        let mut blur = Effect::new(EffectType::GaussianBlur);
+        blur.order = 0;
+        graph.add_effect(blur);
+
+        let mut brightness = Effect::new(EffectType::Brightness);
+        brightness.order = 1;
+        brightness.set_param("value", ParamValue::Float(0.2));
+        graph.add_effect(brightness);
+
+        graph.sort_by_order();
+        let complex = graph.to_video_filter_complex("trim0", "v0");
+
+        let labels = declared_labels(&complex);
+        let mut unique = labels.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(
+            labels.len(),
+            unique.len(),
+            "a label is declared twice in: {complex}"
+        );
+        assert_eq!(
+            labels.last().map(String::as_str),
+            Some("v0"),
+            "the chain must still end on the label the export wired up: {complex}"
+        );
+    }
+
+    /// Feature: Per-clip effect chains
+    /// Scenario: three video effects on the first clip of a two-clip timeline
+    ///
+    /// The old scheme's third intermediate was `v1`, which is the finished
+    /// picture of the clip at input index 1 — one clip's chain quietly
+    /// re-declaring another clip's output.
+    #[test]
+    fn should_keep_video_chain_labels_clear_of_other_clips_labels() {
+        let mut graph = FilterGraph::new();
+        for (order, effect_type) in [
+            EffectType::GaussianBlur,
+            EffectType::Brightness,
+            EffectType::Contrast,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut effect = Effect::new(effect_type);
+            effect.order = order as u32;
+            graph.add_effect(effect);
+        }
+        graph.sort_by_order();
+
+        let complex = graph.to_video_filter_complex("trim0", "v0");
+        let other_clip_labels = ["v1", "v2", "vfx1", "trim1"];
+
+        for label in declared_labels(&complex) {
+            assert!(
+                label == "v0" || !other_clip_labels.contains(&label.as_str()),
+                "chain declared '{label}', which belongs to another clip: {complex}"
+            );
+        }
+    }
+
+    /// Feature: Per-clip effect chains
+    /// Scenario: two audio effects on the clip that owns the label `a0`
+    ///
+    /// The audio chain numbered its intermediates `a{effect_index}` and had the
+    /// same collision as the video one.
+    #[test]
+    fn should_declare_every_audio_chain_label_once_when_chain_ends_on_a_clip_label() {
+        let mut graph = FilterGraph::new();
+
+        let mut volume = Effect::new(EffectType::Volume);
+        volume.order = 0;
+        graph.add_effect(volume);
+
+        let mut gain = Effect::new(EffectType::Gain);
+        gain.order = 1;
+        graph.add_effect(gain);
+
+        graph.sort_by_order();
+        let complex = graph.to_audio_filter_complex("atrim0", "a0");
+
+        let labels = declared_labels(&complex);
+        let mut unique = labels.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(
+            labels.len(),
+            unique.len(),
+            "a label is declared twice in: {complex}"
+        );
+        assert_eq!(labels.last().map(String::as_str), Some("a0"));
     }
 
     #[test]

--- a/src-tauri/src/core/effects/mod.rs
+++ b/src-tauri/src/core/effects/mod.rs
@@ -24,6 +24,7 @@ pub use capabilities::{
 #[allow(unused_imports)]
 pub(crate) use filter_builder::{
     build_vidstabdetect_filter, escape_ffmpeg_filter_path, escape_ffmpeg_filter_value,
+    BRANCH_OFFSET_PARAM,
 };
 pub use filter_builder::{FilterGraph, IntoFFmpegFilter};
 pub use gpu_filters::{GpuFilterBackend, GpuFilterContext};

--- a/src-tauri/src/core/effects/mod.rs
+++ b/src-tauri/src/core/effects/mod.rs
@@ -13,7 +13,8 @@ mod qualifier_filters;
 
 pub use capabilities::{
     all_effect_capabilities, effect_capability, effect_capability_dto, effect_type_label,
-    effect_type_supports_export, EffectCapability, EffectCapabilityDto, EffectRuntimeSupport,
+    effect_type_supports_export, effect_type_supports_timeline_enable, EffectCapability,
+    EffectCapabilityDto, EffectRuntimeSupport,
 };
 /// Canonical filtergraph escapers, shared with the render pipeline and the IPC
 /// commands that build filter strings outside of the effect builders.

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2231,19 +2231,76 @@ pub(super) enum TrimSourceKind {
 }
 
 impl TrimSourceKind {
-    /// Classifies an asset by whether it decodes to one frame or to many.
-    pub(super) fn for_asset(asset: &Asset) -> Self {
-        match asset.kind {
-            AssetKind::Image => Self::StillImage,
-            _ => Self::Motion,
+    /// Classifies a source by whether it decodes to one picture or to many.
+    ///
+    /// `probed_frame_count` is what the file actually holds, from
+    /// [`resolve_trim_source_kind`]. The asset's *kind* cannot answer this on
+    /// its own: `AssetKind::Image` is assigned from the file extension alone,
+    /// and `gif`, `webp`, `avif` and `png` are all extensions an animation can
+    /// wear. Treating every one of them as a still froze animated media to its
+    /// first frame — the reaction GIFs the meme pack serves included.
+    ///
+    /// An unreadable count falls back to the still path for an image, which is
+    /// what a photo — the overwhelmingly common case — needs, and is also the
+    /// only reading under which a one-frame source fills its slot at all.
+    pub(super) fn for_asset(asset: &Asset, probed_frame_count: Option<u64>) -> Self {
+        if asset.kind != AssetKind::Image {
+            return Self::Motion;
+        }
+
+        match probed_frame_count {
+            Some(frames) if frames > 1 => Self::Motion,
+            _ => Self::StillImage,
         }
     }
 }
 
+/// How many pictures each asset's stream holds, cached for one export run.
+///
+/// Keyed by asset id, with the same "a `None` entry means already looked at and
+/// unmeasurable" contract as [`SourceDurationCache`], so an unreadable file is
+/// probed once rather than once per clip that uses it.
+pub(super) type SourceFrameCountCache = HashMap<String, Option<u64>>;
+
+/// Decides which trim branch a clip's source needs, probing it if necessary.
+///
+/// Only an image is probed: every other kind is moving media by construction,
+/// and paying an FFprobe per video asset to learn what the container already
+/// says would be waste.
+pub(super) fn resolve_trim_source_kind(
+    asset: &Asset,
+    cache: &mut SourceFrameCountCache,
+) -> TrimSourceKind {
+    if asset.kind != AssetKind::Image {
+        return TrimSourceKind::Motion;
+    }
+
+    if let Some(cached) = cache.get(&asset.id) {
+        return TrimSourceKind::for_asset(asset, *cached);
+    }
+
+    let frames = match crate::core::assets::MetadataExtractor::count_video_frames(&asset.uri) {
+        Ok(frames) => frames,
+        Err(error) => {
+            tracing::warn!(
+                asset_id = %asset.id,
+                error = %error,
+                "Could not probe image asset for its frame count; treating it as a still"
+            );
+            None
+        }
+    };
+
+    cache.insert(asset.id.clone(), frames);
+    TrimSourceKind::for_asset(asset, frames)
+}
+
 /// How long a still has to hold to fill its timeline slot, handles included.
 ///
-/// Floored at one frame's worth of time so the `trim` this feeds can never be
+/// Floored at [`TIMELINE_EPSILON_SEC`] so the `trim` this feeds can never be
 /// asked for an empty window, which FFmpeg answers with a stream of no frames.
+/// That floor is the timeline's own resolution, not a frame's: a slot shorter
+/// than it is a slot the timeline cannot express in the first place.
 fn still_image_slot_duration(clip: &Clip, handles: ClipHandles) -> f64 {
     (clip.place.duration_sec + handles.head_sec + handles.tail_sec).max(TIMELINE_EPSILON_SEC)
 }
@@ -3350,9 +3407,10 @@ fn split_filter_arguments(arguments: &str) -> Vec<&str> {
 /// Reads the output size of a single filter.
 ///
 /// Every arm here was checked against `Effect::build_filter_params`: of the
-/// filters that builder can emit, only `crop` (`Crop`, `AutoReframe`) and
-/// `zoompan` (`Zoom`) resize. `scale`/`pad`/`transpose` never come out of it
-/// today and are listed so a future effect that emits one is caught loudly by
+/// filters that builder can emit, `crop` (`Crop`, `AutoReframe`), `zoompan` and
+/// the `scale`/`pad` pair a `Zoom` fits its source to the canvas with are the
+/// ones that resize. `transpose` never comes out of it today and is listed so a
+/// future effect that emits one is caught loudly by
 /// [`effective_source_dimensions`] rather than mis-sizing a transform.
 fn filter_segment_dimensions(segment: &str) -> SegmentDimensions {
     let (name, arguments) = match segment.split_once('=') {
@@ -15375,18 +15433,69 @@ mod tests {
     }
 
     /// Feature: Still images on the timeline
-    /// Scenario: only images are held; a video is still cut from its window
+    /// Scenario: only a source that really holds one picture is held
     #[test]
-    fn should_classify_only_image_assets_as_stills() {
+    fn should_classify_only_single_frame_images_as_stills() {
         use crate::core::assets::{Asset, VideoInfo};
 
         let video = Asset::new_video("clip", "file:///a.mp4", VideoInfo::default());
-        assert_eq!(TrimSourceKind::for_asset(&video), TrimSourceKind::Motion);
+        assert_eq!(
+            TrimSourceKind::for_asset(&video, None),
+            TrimSourceKind::Motion,
+            "a video is cut from its window whatever a frame count says"
+        );
+        assert_eq!(
+            TrimSourceKind::for_asset(&video, Some(1)),
+            TrimSourceKind::Motion
+        );
 
         let image = Asset::new_image("photo", "file:///a.png", 1920, 1080);
         assert_eq!(
-            TrimSourceKind::for_asset(&image),
+            TrimSourceKind::for_asset(&image, Some(1)),
             TrimSourceKind::StillImage
+        );
+        assert_eq!(
+            TrimSourceKind::for_asset(&image, None),
+            TrimSourceKind::StillImage,
+            "an unmeasurable image falls back to the still path"
+        );
+    }
+
+    /// Feature: Animated images on the timeline
+    /// Scenario: a GIF, WebP or APNG that holds many frames keeps its motion
+    ///
+    /// `AssetKind::Image` is decided by file extension alone, and `gif`, `webp`,
+    /// `avif` and `png` are all extensions an animation can wear. Classifying on
+    /// the kind froze every one of them to its first frame.
+    #[test]
+    fn should_cut_an_animated_image_from_its_window_like_any_other_motion() {
+        use crate::core::assets::Asset;
+
+        let animated = Asset::new_image("reaction", "file:///a.gif", 320, 240);
+        assert_eq!(
+            TrimSourceKind::for_asset(&animated, Some(30)),
+            TrimSourceKind::Motion,
+            "an animation must keep its frames and its source-in window"
+        );
+
+        let clip = Clip::new("asset").with_source_range(0.5, 1.5).place_at(0.0);
+        let mut filter_complex = String::new();
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter_complex,
+            ClipHandles::default(),
+            TrimSourceKind::for_asset(&animated, Some(30)),
+        );
+
+        assert!(
+            filter_complex.contains("trim=start=0.5:end=1.5"),
+            "an animation keeps the window the edit asked for: {filter_complex}"
+        );
+        assert!(
+            !filter_complex.contains("end_frame=1"),
+            "an animation must not be cut to a single frame: {filter_complex}"
         );
     }
 
@@ -15450,6 +15559,22 @@ mod tests {
         let mut clip = Clip::new("photo").with_source_range(0.0, SLOT_SEC);
         clip.place.duration_sec = SLOT_SEC;
 
+        // Classified the way the export classifies it, so this also guards the
+        // photo against being mistaken for an animation and cut to its window.
+        let asset = crate::core::assets::Asset::new_image(
+            "photo",
+            &photo.to_string_lossy(),
+            CANVAS_WIDTH,
+            CANVAS_HEIGHT,
+        );
+        let mut frame_counts = SourceFrameCountCache::new();
+        let source_kind = resolve_trim_source_kind(&asset, &mut frame_counts);
+        assert_eq!(
+            source_kind,
+            TrimSourceKind::StillImage,
+            "a real PNG holds one picture and must take the still path"
+        );
+
         for zoomed in [false, true] {
             let mut filter_complex = String::new();
             build_video_trim_filter(
@@ -15458,7 +15583,7 @@ mod tests {
                 "trim0",
                 &mut filter_complex,
                 ClipHandles::default(),
-                TrimSourceKind::StillImage,
+                source_kind,
             );
 
             if zoomed {
@@ -15515,6 +15640,153 @@ mod tests {
                 render.stdout.len() / frame_bytes.max(1)
             );
         }
+    }
+
+    /// Feature: Animated images on the timeline
+    /// Scenario: a GIF, WebP or APNG exports its animation, not its first frame
+    ///
+    /// `AssetKind::Image` comes from the file extension alone, so holding every
+    /// image across its slot held the animated ones too: a reaction GIF exported
+    /// as one frame cloned for the length of the clip. Measured against ffmpeg
+    /// 9.0.1, a 30-frame GIF rendered 30 identical frames — one unique picture
+    /// where 30 were due — and `freezedetect` fired at 0.133s and never ended.
+    ///
+    /// The classification is measured here rather than asserted from the
+    /// extension, because the declared metadata cannot answer it: a still JPEG
+    /// advertises a duration, a one-frame GIF advertises a frame count of 1, and
+    /// an animated APNG or WebP advertises neither.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored animated
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn an_animated_image_renders_its_animation_and_not_a_frozen_frame() {
+        use crate::core::assets::Asset;
+        use crate::core::timeline::Clip;
+        use std::collections::HashSet;
+
+        const CANVAS_WIDTH: u32 = 320;
+        const CANVAS_HEIGHT: u32 = 180;
+        const FPS: f64 = 30.0;
+        const SLOT_SEC: f64 = 1.0;
+        const SOURCE_FRAMES: usize = 30;
+
+        let ffmpeg = std::env::var_os("OPENREELIO_FFMPEG_PATH")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let build = |name: &str, frames: usize, rate: u32| -> Option<std::path::PathBuf> {
+            let path = dir.path().join(name);
+            let built = std::process::Command::new(&ffmpeg)
+                .args([
+                    "-y",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    &format!("testsrc=size=320x240:rate={rate}"),
+                    "-frames:v",
+                    &frames.to_string(),
+                ])
+                .arg(&path)
+                .output()
+                .ok()?;
+            (built.status.success() && path.exists()).then_some(path)
+        };
+
+        let (Some(animated), Some(single_frame), Some(apng)) = (
+            build("anim.gif", SOURCE_FRAMES, 30),
+            build("one.gif", 1, 30),
+            build("anim.apng", 20, 10),
+        ) else {
+            eprintln!("Skipping: ffmpeg could not build the fixtures");
+            return;
+        };
+
+        let mut frame_counts = SourceFrameCountCache::new();
+        let kind_of = |path: &std::path::Path, cache: &mut SourceFrameCountCache| {
+            let asset = Asset::new_image("image", &path.to_string_lossy(), 320, 240);
+            resolve_trim_source_kind(&asset, cache)
+        };
+
+        assert_eq!(
+            kind_of(&animated, &mut frame_counts),
+            TrimSourceKind::Motion,
+            "a 30-frame GIF is moving media"
+        );
+        assert_eq!(
+            kind_of(&apng, &mut frame_counts),
+            TrimSourceKind::Motion,
+            "an animated APNG is moving media, though it advertises no duration \
+             and no frame count"
+        );
+        assert_eq!(
+            kind_of(&single_frame, &mut frame_counts),
+            TrimSourceKind::StillImage,
+            "a one-frame GIF is a photo, though it advertises a duration"
+        );
+
+        let mut clip = Clip::new("anim").with_source_range(0.0, SLOT_SEC);
+        clip.place.duration_sec = SLOT_SEC;
+
+        let mut filter_complex = String::new();
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter_complex,
+            ClipHandles::default(),
+            kind_of(&animated, &mut frame_counts),
+        );
+        filter_complex.push_str("[trim0]null[v0];");
+        append_video_stream_normalization(
+            &mut filter_complex,
+            "v0",
+            "out",
+            CANVAS_WIDTH,
+            CANVAS_HEIGHT,
+            FPS,
+            "yuv420p",
+            None,
+        );
+
+        let graph_file = dir.path().join("graph.txt");
+        std::fs::write(&graph_file, filter_complex.trim_end_matches(';')).expect("write graph");
+
+        let render = std::process::Command::new(&ffmpeg)
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
+            .arg(&animated)
+            .arg("-/filter_complex")
+            .arg(&graph_file)
+            .args(["-map", "[out]", "-pix_fmt", "gray", "-f", "rawvideo", "-"])
+            .output()
+            .expect("run ffmpeg");
+
+        assert!(
+            render.status.success(),
+            "ffmpeg refused the animated-image graph: {}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+
+        let frame_bytes = CANVAS_WIDTH as usize * CANVAS_HEIGHT as usize;
+        let frames: Vec<&[u8]> = render.stdout.chunks_exact(frame_bytes).collect();
+        assert_eq!(
+            frames.len(),
+            (SLOT_SEC * FPS).round() as usize,
+            "the clip still has to fill its slot"
+        );
+
+        let unique: HashSet<&[u8]> = frames.iter().copied().collect();
+        assert!(
+            unique.len() > 1,
+            "an animated GIF must render its animation, got {} unique picture(s) \
+             across {} frames — the still path cloned one frame",
+            unique.len(),
+            frames.len()
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -20,8 +20,8 @@ use crate::core::{
     },
     commands::TEXT_ASSET_PREFIX,
     effects::{
-        effect_capability, effect_type_label, Effect, EffectType, FilterGraph, IntoFFmpegFilter,
-        ParamValue,
+        effect_capability, effect_type_label, effect_type_supports_timeline_enable, Effect,
+        EffectType, FilterGraph, IntoFFmpegFilter, ParamValue,
     },
     ffmpeg::FFmpegRunner,
     fs::validate_local_input_path,
@@ -3158,6 +3158,27 @@ pub(super) fn unmeasurable_effect_message(effect_label: &str, clip_id: &str) -> 
         "Effect '{}' on clip '{}' changes the picture size in a way the export cannot measure, \
          so the clip's transform cannot be placed",
         effect_label, clip_id
+    )
+}
+
+/// The error text for an adjustment-layer effect the render cannot time-gate.
+///
+/// An adjustment layer applies only over the timeline it covers, which the render
+/// expresses by gating each of its filters with `enable='between(t,…)'`. FFmpeg
+/// refuses a filtergraph that puts `enable` on a filter without timeline support
+/// and the whole export dies, quoting an FFmpeg filter name the editor never
+/// chose. Naming the clip and the effect instead is the difference between a
+/// fixable message and a crash.
+pub(super) fn untimeable_adjustment_effect_message(
+    effect_label: &str,
+    clip_id: &str,
+    track_name: &str,
+) -> String {
+    format!(
+        "Effect '{}' is not supported on an adjustment layer (clip '{}' on track '{}'): \
+         it cannot be limited to the layer's timeline range. Apply it to the clips \
+         underneath instead",
+        effect_label, clip_id, track_name
     )
 }
 
@@ -6929,6 +6950,18 @@ pub fn validate_export_settings_with_dimensions(
 
             // Adjustment layers have no source media — skip file validation
             if clip.is_adjustment_layer() {
+                for effect in clip.effects.iter().filter_map(|id| effects.get(id)) {
+                    if effect.enabled
+                        && effect.is_video()
+                        && !effect_type_supports_timeline_enable(&effect.effect_type)
+                    {
+                        validation.add_error(untimeable_adjustment_effect_message(
+                            &effect_type_label(&effect.effect_type),
+                            &clip.id,
+                            &track.name,
+                        ));
+                    }
+                }
                 continue;
             }
 
@@ -12130,6 +12163,160 @@ mod tests {
         assert!(
             filter_complex.contains("color=c=black:s=1920x1080:r=30:d=7"),
             "the render must reach the adjustment layer's out point. Got: {filter_complex}"
+        );
+    }
+
+    /// Builds a sequence whose second video track is an adjustment layer
+    /// carrying one enabled effect of the given type.
+    fn sequence_with_adjustment_layer_effect(
+        effect_type: EffectType,
+    ) -> (
+        Sequence,
+        std::collections::HashMap<String, Asset>,
+        std::collections::HashMap<String, Effect>,
+    ) {
+        use crate::core::timeline::Clip;
+
+        let effect = Effect::new(effect_type);
+        let effect_id = effect.id.clone();
+
+        let mut adjustment_track = Track::new_video("Adjustments");
+        let mut adjustment = Clip::new("adjustment")
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        adjustment.is_adjustment_layer = true;
+        adjustment.effects.push(effect_id.clone());
+        adjustment_track.add_clip(adjustment);
+
+        let (sequence, assets) = sequence_with_video_body_and_tail(adjustment_track);
+        let mut effects = std::collections::HashMap::new();
+        effects.insert(effect_id, effect);
+
+        (sequence, assets, effects)
+    }
+
+    /// Feature: Adjustment layers
+    /// Scenario: an effect that cannot be time-gated is refused by name
+    ///
+    /// An adjustment layer's effects are gated with `enable='between(t,…)'` so
+    /// they apply only over the layer. FFmpeg refuses `enable` on `zoompan`
+    /// outright — "Timeline ('enable' option) not supported with filter
+    /// 'zoompan'" — and the whole export died on that message, quoting a filter
+    /// the editor never chose. Validation now refuses the edit instead.
+    #[test]
+    fn should_refuse_an_untimeable_effect_on_an_adjustment_layer() {
+        let (sequence, assets, effects) = sequence_with_adjustment_layer_effect(EffectType::Zoom);
+
+        let validation =
+            validate_export_settings(&sequence, &assets, &effects, &ExportSettings::default());
+
+        assert!(!validation.is_valid, "the export must be refused up front");
+        let reported = validation.errors.join("; ");
+        assert!(
+            reported.contains("Zoom") && reported.contains("adjustment layer"),
+            "the refusal must name the effect and why: {reported}"
+        );
+        assert!(
+            reported.contains("adjustment"),
+            "the refusal must name the clip: {reported}"
+        );
+    }
+
+    /// Feature: Adjustment layers
+    /// Scenario: an effect that can be time-gated is still allowed
+    #[test]
+    fn should_allow_a_timeable_effect_on_an_adjustment_layer() {
+        let (sequence, assets, effects) =
+            sequence_with_adjustment_layer_effect(EffectType::Brightness);
+
+        let validation =
+            validate_export_settings(&sequence, &assets, &effects, &ExportSettings::default());
+
+        assert!(
+            validation.is_valid,
+            "a colour grade is exactly what an adjustment layer is for: {:?}",
+            validation.errors
+        );
+    }
+
+    /// Feature: Adjustment layers
+    /// Scenario: FFmpeg really does refuse the graph the refusal replaces
+    ///
+    /// The refusal above is only worth having if the alternative is a failed
+    /// render. This hands the real FFmpeg the gated graph the adjustment path
+    /// would otherwise emit for each effect the table calls untimeable, and
+    /// asserts FFmpeg rejects it *for that reason* — and that a gated colour
+    /// grade in the same shape still renders, so the assertion discriminates.
+    ///
+    /// `Subtitle`, `Stabilize` and the `xfade` transitions are in the table too
+    /// but are not checkable this way: they fail on a missing file, a missing
+    /// build option or a missing second input before FFmpeg gets as far as the
+    /// timeline check. They were measured by hand against ffmpeg 9.0.1 with
+    /// valid arguments and all three refuse `enable`.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored adjustment
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn ffmpeg_refuses_a_time_gated_effect_on_an_adjustment_layer() {
+        let ffmpeg = std::env::var_os("OPENREELIO_FFMPEG_PATH")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+
+        let gated = |effect_type: EffectType| {
+            let mut graph = FilterGraph::new().with_dimensions(320, 180);
+            graph.set_fps(30.0);
+            graph.add_effect(Effect::new(effect_type));
+            graph.to_video_filter_complex_timed("0:v", "out", 0.0, 1.0)
+        };
+
+        let run = |filtergraph: &str| {
+            std::process::Command::new(&ffmpeg)
+                .args([
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-nostdin",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=black:s=320x180:r=30:d=0.2",
+                    "-filter_complex",
+                    filtergraph,
+                    "-map",
+                    "[out]",
+                    "-frames:v",
+                    "1",
+                    "-f",
+                    "null",
+                    "-",
+                ])
+                .output()
+        };
+
+        for effect_type in [EffectType::Zoom, EffectType::Crop] {
+            assert!(
+                !effect_type_supports_timeline_enable(&effect_type),
+                "{effect_type:?} is claimed to be untimeable"
+            );
+
+            let Ok(refused) = run(&gated(effect_type.clone())) else {
+                eprintln!("Skipping: ffmpeg could not be launched");
+                return;
+            };
+            let stderr = String::from_utf8_lossy(&refused.stderr);
+            assert!(
+                !refused.status.success() && stderr.contains("not supported with filter"),
+                "a time-gated {effect_type:?} must be refused by ffmpeg for its lack of \
+                 timeline support, got: {stderr}"
+            );
+        }
+
+        let allowed = run(&gated(EffectType::Brightness)).expect("run ffmpeg");
+        assert!(
+            allowed.status.success(),
+            "a time-gated colour grade must still render: {}",
+            String::from_utf8_lossy(&allowed.stderr)
         );
     }
 

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -2221,6 +2221,33 @@ fn handled_source_window(clip: &Clip, handles: ClipHandles) -> (f64, f64) {
     )
 }
 
+/// What kind of picture the input of a video trim decodes to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TrimSourceKind {
+    /// A moving stream: the trim cuts a window out of it.
+    Motion,
+    /// A single still frame, which has to be held across the clip's slot.
+    StillImage,
+}
+
+impl TrimSourceKind {
+    /// Classifies an asset by whether it decodes to one frame or to many.
+    pub(super) fn for_asset(asset: &Asset) -> Self {
+        match asset.kind {
+            AssetKind::Image => Self::StillImage,
+            _ => Self::Motion,
+        }
+    }
+}
+
+/// How long a still has to hold to fill its timeline slot, handles included.
+///
+/// Floored at one frame's worth of time so the `trim` this feeds can never be
+/// asked for an empty window, which FFmpeg answers with a stream of no frames.
+fn still_image_slot_duration(clip: &Clip, handles: ClipHandles) -> f64 {
+    (clip.place.duration_sec + handles.head_sec + handles.tail_sec).max(TIMELINE_EPSILON_SEC)
+}
+
 /// Build video trim filter with speed, reverse, freeze frame, and time remap support.
 ///
 /// Generates the complete video filter chain from input to the trim output label:
@@ -2231,19 +2258,38 @@ fn handled_source_window(clip: &Clip, handles: ClipHandles) -> (f64, f64) {
 /// transition planner refuses frozen, reversed and time-remapped clips
 /// precisely because their timeline-to-source mapping makes the extension
 /// undefined.
+///
+/// `source` says whether the input decodes to moving pictures or to a single
+/// still — see [`TrimSourceKind`].
 pub(super) fn build_video_trim_filter(
     clip: &Clip,
     input_index: usize,
     trim_label: &str,
     filter_complex: &mut String,
     handles: ClipHandles,
+    source: TrimSourceKind,
 ) {
     debug_assert!(
         handles.is_none() || (!clip.freeze_frame && !clip.has_time_remap() && !clip.reverse),
         "transition handles are only defined for constant-speed clips"
     );
 
-    if clip.freeze_frame {
+    if source == TrimSourceKind::StillImage {
+        // A still decodes to exactly one frame, so every other branch here — all
+        // of which cut a *window* out of a moving stream — leaves the clip one
+        // frame long however many seconds the timeline gave it. Cloning that
+        // frame across the slot is what makes a photo a clip: without it a Ken
+        // Burns move exports as a single-frame flash, and an unzoomed still does
+        // the same. The source window is deliberately ignored, because a still
+        // has nothing to seek into: trimming from a non-zero in point would find
+        // no frame at all and render nothing.
+        let slot = format_speed_number(still_image_slot_duration(clip, handles));
+        let filter = format!(
+            "[{}:v]trim=end_frame=1,setpts=PTS-STARTPTS,tpad=stop_mode=clone:stop_duration={},trim=0:{},setpts=PTS-STARTPTS[{}]",
+            input_index, slot, slot, trim_label
+        );
+        filter_complex.push_str(&filter);
+    } else if clip.freeze_frame {
         // Freeze frame: extract single frame, loop to fill duration
         let tpad_duration = format_speed_number(clip.place.duration_sec);
         let filter = format!(
@@ -14805,7 +14851,14 @@ mod tests {
         clip.slow_motion_interpolation = SlowMotionInterpolation::Nearest;
 
         let mut filter = String::new();
-        build_video_trim_filter(&clip, 0, "vtrim0", &mut filter, ClipHandles::default());
+        build_video_trim_filter(
+            &clip,
+            0,
+            "vtrim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::Motion,
+        );
 
         assert!(
             !filter.contains("minterpolate"),
@@ -14822,7 +14875,14 @@ mod tests {
         clip.slow_motion_interpolation = SlowMotionInterpolation::FrameBlend;
 
         let mut filter = String::new();
-        build_video_trim_filter(&clip, 0, "vtrim0", &mut filter, ClipHandles::default());
+        build_video_trim_filter(
+            &clip,
+            0,
+            "vtrim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::Motion,
+        );
 
         assert!(
             filter.contains("minterpolate=mi_mode=blend"),
@@ -14839,7 +14899,14 @@ mod tests {
         clip.slow_motion_interpolation = SlowMotionInterpolation::MotionCompensated;
 
         let mut filter = String::new();
-        build_video_trim_filter(&clip, 0, "vtrim0", &mut filter, ClipHandles::default());
+        build_video_trim_filter(
+            &clip,
+            0,
+            "vtrim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::Motion,
+        );
 
         assert!(
             filter.contains("minterpolate=mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1"),
@@ -14932,7 +14999,14 @@ mod tests {
         clip.reverse = true;
 
         let mut filter = String::new();
-        build_video_trim_filter(&clip, 0, "trim0", &mut filter, ClipHandles::default());
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::Motion,
+        );
 
         // Then filter includes the reverse filter
         assert!(
@@ -14955,13 +15029,258 @@ mod tests {
         clip.place.duration_sec = 3.0;
 
         let mut filter = String::new();
-        build_video_trim_filter(&clip, 0, "trim0", &mut filter, ClipHandles::default());
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::Motion,
+        );
 
         // Then filter includes tpad clone
         assert!(
             filter.contains("tpad=stop_mode=clone:stop_duration=3"),
             "should contain tpad: {filter}"
         );
+    }
+
+    /// Feature: Still images on the timeline
+    /// Scenario: a photo fills the slot the editor gave it
+    ///
+    /// An image decodes to exactly one frame, so cutting a window out of it —
+    /// what every other branch of the trim builder does — leaves the clip one
+    /// frame long however many seconds it occupies. The slot is filled by cloning
+    /// that frame, the same way a freeze frame is.
+    #[test]
+    fn should_hold_a_still_image_across_its_whole_slot() {
+        use crate::core::timeline::Clip;
+
+        let mut clip = Clip::new("photo").with_source_range(0.0, 5.0);
+        clip.place.duration_sec = 5.0;
+
+        let mut filter = String::new();
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::StillImage,
+        );
+
+        assert!(
+            filter.contains("tpad=stop_mode=clone:stop_duration=5"),
+            "a still must be cloned across its slot: {filter}"
+        );
+        assert!(
+            filter.contains("trim=0:5"),
+            "the clone must be cut back to the slot: {filter}"
+        );
+    }
+
+    /// Feature: Still images on the timeline
+    /// Scenario: a photo trimmed away from its start still renders
+    ///
+    /// A still has one frame at t=0 and nothing after it, so a `trim` starting at
+    /// the clip's source in point finds no frame at all and the clip renders
+    /// nothing. The source window is not a thing a still has.
+    #[test]
+    fn should_ignore_the_source_window_of_a_still_image() {
+        use crate::core::timeline::Clip;
+
+        let mut clip = Clip::new("photo").with_source_range(2.0, 6.0);
+        clip.place.duration_sec = 4.0;
+
+        let mut filter = String::new();
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::StillImage,
+        );
+
+        assert!(
+            filter.contains("trim=end_frame=1"),
+            "a still is read as its single frame, not as a window: {filter}"
+        );
+        assert!(
+            !filter.contains("trim=start=2"),
+            "there is no frame at the source in point to seek to: {filter}"
+        );
+    }
+
+    /// Feature: Still images on the timeline
+    /// Scenario: the hold covers the handles a transition decodes as well
+    #[test]
+    fn should_hold_a_still_image_across_its_transition_handles() {
+        use crate::core::timeline::Clip;
+
+        let mut clip = Clip::new("photo").with_source_range(0.0, 2.0);
+        clip.place.duration_sec = 2.0;
+
+        let mut filter = String::new();
+        build_video_trim_filter(
+            &clip,
+            0,
+            "trim0",
+            &mut filter,
+            ClipHandles {
+                head_sec: 0.5,
+                tail_sec: 0.25,
+            },
+            TrimSourceKind::StillImage,
+        );
+
+        assert!(
+            filter.contains("stop_duration=2.75"),
+            "the hold must cover the handles too: {filter}"
+        );
+    }
+
+    /// Feature: Still images on the timeline
+    /// Scenario: only images are held; a video is still cut from its window
+    #[test]
+    fn should_classify_only_image_assets_as_stills() {
+        use crate::core::assets::{Asset, VideoInfo};
+
+        let video = Asset::new_video("clip", "file:///a.mp4", VideoInfo::default());
+        assert_eq!(TrimSourceKind::for_asset(&video), TrimSourceKind::Motion);
+
+        let image = Asset::new_image("photo", "file:///a.png", 1920, 1080);
+        assert_eq!(
+            TrimSourceKind::for_asset(&image),
+            TrimSourceKind::StillImage
+        );
+    }
+
+    /// Feature: Still images on the timeline
+    /// Scenario: a photo renders every frame of its slot, zoomed or not
+    ///
+    /// The string assertions above encode a belief about what `tpad` does to a
+    /// one-frame input. This one hands the real FFmpeg the graph the export
+    /// builds around a real PNG and counts what comes out: one luma plane per
+    /// frame at the canvas size, so a wrong frame count and a wrong frame size
+    /// both show up as a wrong byte count.
+    ///
+    /// Measured negative control (ffmpeg 9.0.1, 320x180 canvas, 2s at 30fps): the
+    /// plain source-window trim this replaced rendered one frame — 57600 bytes
+    /// where 3456000 were due — whether or not a zoom was in the chain. A Ken
+    /// Burns move on a photo exported as a single-frame flash.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored still
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_still_image_renders_every_frame_of_its_slot() {
+        use crate::core::effects::{Effect, EffectType, FilterGraph};
+        use crate::core::timeline::Clip;
+
+        const CANVAS_WIDTH: u32 = 320;
+        const CANVAS_HEIGHT: u32 = 180;
+        const FPS: f64 = 30.0;
+        const SLOT_SEC: f64 = 2.0;
+
+        let ffmpeg = std::env::var_os("OPENREELIO_FFMPEG_PATH")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let photo = dir.path().join("photo.png");
+        let built = std::process::Command::new(&ffmpeg)
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=640x360:rate=1:duration=1",
+                "-frames:v",
+                "1",
+            ])
+            .arg(&photo)
+            .output();
+        let Ok(built) = built else {
+            eprintln!("Skipping: ffmpeg could not be launched");
+            return;
+        };
+        if !built.status.success() || !photo.exists() {
+            eprintln!("Skipping: ffmpeg could not build the fixture");
+            return;
+        }
+
+        let mut clip = Clip::new("photo").with_source_range(0.0, SLOT_SEC);
+        clip.place.duration_sec = SLOT_SEC;
+
+        for zoomed in [false, true] {
+            let mut filter_complex = String::new();
+            build_video_trim_filter(
+                &clip,
+                0,
+                "trim0",
+                &mut filter_complex,
+                ClipHandles::default(),
+                TrimSourceKind::StillImage,
+            );
+
+            if zoomed {
+                let mut graph =
+                    FilterGraph::new().with_dimensions(CANVAS_WIDTH as i32, CANVAS_HEIGHT as i32);
+                graph.set_fps(FPS);
+                let mut effect = Effect::new(EffectType::Zoom);
+                effect.set_param("duration", ParamValue::Float(SLOT_SEC));
+                effect.set_param("zoom_factor", ParamValue::Float(1.5));
+                graph.add_effect(effect);
+                filter_complex.push_str(&graph.to_video_filter_complex("trim0", "v0"));
+            } else {
+                filter_complex.push_str("[trim0]null[v0]");
+            }
+            filter_complex.push(';');
+
+            append_video_stream_normalization(
+                &mut filter_complex,
+                "v0",
+                "out",
+                CANVAS_WIDTH,
+                CANVAS_HEIGHT,
+                FPS,
+                "yuv420p",
+                None,
+            );
+
+            let graph_file = dir.path().join("graph.txt");
+            std::fs::write(&graph_file, filter_complex.trim_end_matches(';'))
+                .expect("write filtergraph");
+
+            let render = std::process::Command::new(&ffmpeg)
+                .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
+                .arg(&photo)
+                .arg("-/filter_complex")
+                .arg(&graph_file)
+                .args(["-map", "[out]", "-pix_fmt", "gray", "-f", "rawvideo", "-"])
+                .output()
+                .expect("run ffmpeg");
+
+            assert!(
+                render.status.success(),
+                "ffmpeg refused the still-image graph (zoomed={zoomed}): {}",
+                String::from_utf8_lossy(&render.stderr)
+            );
+
+            let expected_frames = (SLOT_SEC * FPS).round() as usize;
+            let frame_bytes = CANVAS_WIDTH as usize * CANVAS_HEIGHT as usize;
+            assert_eq!(
+                render.stdout.len(),
+                expected_frames * frame_bytes,
+                "a {SLOT_SEC}s still at {FPS}fps must render {expected_frames} frames \
+                 of {CANVAS_WIDTH}x{CANVAS_HEIGHT} (zoomed={zoomed}), got {} frames",
+                render.stdout.len() / frame_bytes.max(1)
+            );
+        }
     }
 
     #[test]
@@ -15157,7 +15476,14 @@ mod tests {
         ]));
 
         let mut filter = String::new();
-        build_video_trim_filter(&clip, 0, "vtrim0", &mut filter, ClipHandles::default());
+        build_video_trim_filter(
+            &clip,
+            0,
+            "vtrim0",
+            &mut filter,
+            ClipHandles::default(),
+            TrimSourceKind::Motion,
+        );
 
         assert!(
             filter.contains("setpts="),

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -12291,6 +12291,59 @@ mod tests {
     }
 
     /// Feature: Adjustment layers
+    /// Scenario: an opacity is refused by name rather than crashing the render
+    ///
+    /// `Opacity` emits `format=rgba,colorchannelmixer=aa=…`, and `format` has no
+    /// timeline support: the gated graph died on "Timeline ('enable' option) not
+    /// supported with filter 'format'", naming a filter the editor never chose.
+    #[test]
+    fn should_refuse_an_opacity_on_an_adjustment_layer() {
+        let (sequence, assets, effects) =
+            sequence_with_adjustment_layer_effect(EffectType::Opacity);
+
+        let validation =
+            validate_export_settings(&sequence, &assets, &effects, &ExportSettings::default());
+
+        assert!(!validation.is_valid, "the export must be refused up front");
+        let reported = validation.errors.join("; ");
+        assert!(
+            reported.contains("Opacity") && reported.contains("adjustment layer"),
+            "the refusal must name the effect and why: {reported}"
+        );
+    }
+
+    /// Feature: Adjustment layers
+    /// Scenario: an effect the export has no filter for is a no-op, not a crash
+    ///
+    /// `Levels`, `Glow`, `MotionBlur`, `BlendMode`, `Custom` and every disabled
+    /// effect reach the adjustment path as a bare `null`. Gating that produced
+    /// `null:enable='between(t,…)'`, which FFmpeg cannot parse, so a layer
+    /// carrying one of them failed the whole export.
+    #[test]
+    fn should_allow_an_effect_with_no_filter_of_its_own_on_an_adjustment_layer() {
+        // `Custom` is left out: it is refused a step earlier, by the
+        // unsupported-in-export check that applies to any clip.
+        for effect_type in [
+            EffectType::Levels,
+            EffectType::Glow,
+            EffectType::MotionBlur,
+            EffectType::BlendMode,
+        ] {
+            let (sequence, assets, effects) =
+                sequence_with_adjustment_layer_effect(effect_type.clone());
+
+            let validation =
+                validate_export_settings(&sequence, &assets, &effects, &ExportSettings::default());
+
+            assert!(
+                validation.is_valid,
+                "a {effect_type:?} renders as a no-op and must not be refused: {:?}",
+                validation.errors
+            );
+        }
+    }
+
+    /// Feature: Adjustment layers
     /// Scenario: an effect that can be time-gated is still allowed
     #[test]
     fn should_allow_a_timeable_effect_on_an_adjustment_layer() {
@@ -12331,11 +12384,20 @@ mod tests {
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
 
-        let gated = |effect_type: EffectType| {
+        let graph_of = |effect: Effect| {
             let mut graph = FilterGraph::new().with_dimensions(320, 180);
             graph.set_fps(30.0);
-            graph.add_effect(Effect::new(effect_type));
-            graph.to_video_filter_complex_timed("0:v", "out", 0.0, 1.0)
+            graph.add_effect(effect);
+            graph
+        };
+        let gated =
+            |effect: Effect| graph_of(effect).to_video_filter_complex_timed("0:v", "out", 0.0, 1.0);
+        let ungated = |effect: Effect| graph_of(effect).to_video_filter_complex("0:v", "out");
+
+        let translucent = || {
+            let mut effect = Effect::new(EffectType::Opacity);
+            effect.set_param("value", ParamValue::Float(0.5));
+            effect
         };
 
         let run = |filtergraph: &str| {
@@ -12362,13 +12424,18 @@ mod tests {
                 .output()
         };
 
-        for effect_type in [EffectType::Zoom, EffectType::Crop] {
+        for effect in [
+            Effect::new(EffectType::Zoom),
+            Effect::new(EffectType::Crop),
+            translucent(),
+        ] {
+            let effect_type = effect.effect_type.clone();
             assert!(
                 !effect_type_supports_timeline_enable(&effect_type),
                 "{effect_type:?} is claimed to be untimeable"
             );
 
-            let Ok(refused) = run(&gated(effect_type.clone())) else {
+            let Ok(refused) = run(&gated(effect)) else {
                 eprintln!("Skipping: ffmpeg could not be launched");
                 return;
             };
@@ -12380,12 +12447,55 @@ mod tests {
             );
         }
 
-        let allowed = run(&gated(EffectType::Brightness)).expect("run ffmpeg");
+        let allowed = run(&gated(Effect::new(EffectType::Brightness))).expect("run ffmpeg");
         assert!(
             allowed.status.success(),
             "a time-gated colour grade must still render: {}",
             String::from_utf8_lossy(&allowed.stderr)
         );
+
+        // Every effect the export has no filter body for — and every disabled
+        // one — reaches the adjustment path as a `null`. Decorating that with
+        // `enable=` produced `null:enable='between(t,…)'`, which FFmpeg cannot
+        // even parse ("No option name near 'between(…)'"), so a layer carrying
+        // one of these killed the whole render. They have to render as the
+        // no-ops they are.
+        let mut disabled_grade = Effect::new(EffectType::Brightness);
+        disabled_grade.enabled = false;
+        for effect in [
+            Effect::new(EffectType::Levels),
+            Effect::new(EffectType::Glow),
+            Effect::new(EffectType::MotionBlur),
+            Effect::new(EffectType::BlendMode),
+            Effect::new(EffectType::Custom("nonesuch".to_string())),
+            disabled_grade,
+        ] {
+            let effect_type = effect.effect_type.clone();
+            let graph = gated(effect);
+            assert!(
+                !graph.contains("enable="),
+                "a no-op {effect_type:?} must not be gated at all: {graph}"
+            );
+
+            let rendered = run(&graph).expect("run ffmpeg");
+            assert!(
+                rendered.status.success(),
+                "a {effect_type:?} on an adjustment layer must render as a no-op: {}",
+                String::from_utf8_lossy(&rendered.stderr)
+            );
+        }
+
+        // The same effects on an ordinary clip are untouched by all of this: an
+        // opacity still composites and a bodiless effect still passes through.
+        for effect in [translucent(), Effect::new(EffectType::Levels)] {
+            let effect_type = effect.effect_type.clone();
+            let rendered = run(&ungated(effect)).expect("run ffmpeg");
+            assert!(
+                rendered.status.success(),
+                "an ungated {effect_type:?} must still render: {}",
+                String::from_utf8_lossy(&rendered.stderr)
+            );
+        }
     }
 
     /// Feature: Render output length

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -12313,6 +12313,39 @@ mod tests {
     }
 
     /// Feature: Adjustment layers
+    /// Scenario: a colour tool that opens with `format=` is refused by name
+    ///
+    /// `Curves` (its Luma-vs-Sat leg emits `format=yuv444p,geq=…`) and
+    /// `HSLQualifier` (`format=rgba,geq=…`) both lead with a `format` conversion
+    /// once a curve or a qualifier is set, and `format` has no timeline support,
+    /// so the gated graph died on "Timeline ('enable' option) not supported with
+    /// filter 'format'" — a path a user reaches from the Color panel. They are
+    /// refused up front by name, like `Opacity`, rather than crashing the render.
+    #[test]
+    fn should_refuse_a_format_leading_colour_effect_on_an_adjustment_layer() {
+        for (effect_type, label) in [
+            (EffectType::Curves, "Curves"),
+            (EffectType::HSLQualifier, "HSL Qualifier"),
+        ] {
+            let (sequence, assets, effects) =
+                sequence_with_adjustment_layer_effect(effect_type.clone());
+
+            let validation =
+                validate_export_settings(&sequence, &assets, &effects, &ExportSettings::default());
+
+            assert!(
+                !validation.is_valid,
+                "a {effect_type:?} on an adjustment layer must be refused up front"
+            );
+            let reported = validation.errors.join("; ");
+            assert!(
+                reported.contains(label) && reported.contains("adjustment layer"),
+                "the refusal must name the effect and why: {reported}"
+            );
+        }
+    }
+
+    /// Feature: Adjustment layers
     /// Scenario: an effect the export has no filter for is a no-op, not a crash
     ///
     /// `Levels`, `Glow`, `MotionBlur`, `BlendMode`, `Custom` and every disabled
@@ -12401,27 +12434,28 @@ mod tests {
         };
 
         let run = |filtergraph: &str| {
-            std::process::Command::new(&ffmpeg)
-                .args([
-                    "-hide_banner",
-                    "-loglevel",
-                    "error",
-                    "-nostdin",
-                    "-f",
-                    "lavfi",
-                    "-i",
-                    "color=c=black:s=320x180:r=30:d=0.2",
-                    "-filter_complex",
-                    filtergraph,
-                    "-map",
-                    "[out]",
-                    "-frames:v",
-                    "1",
-                    "-f",
-                    "null",
-                    "-",
-                ])
-                .output()
+            let mut cmd = std::process::Command::new(&ffmpeg);
+            crate::core::process::configure_std_command(&mut cmd);
+            cmd.args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-nostdin",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:s=320x180:r=30:d=0.2",
+                "-filter_complex",
+                filtergraph,
+                "-map",
+                "[out]",
+                "-frames:v",
+                "1",
+                "-f",
+                "null",
+                "-",
+            ])
+            .output()
         };
 
         for effect in [
@@ -15642,7 +15676,9 @@ mod tests {
 
         let dir = tempfile::tempdir().expect("temp dir");
         let photo = dir.path().join("photo.png");
-        let built = std::process::Command::new(&ffmpeg)
+        let mut built_cmd = std::process::Command::new(&ffmpeg);
+        crate::core::process::configure_std_command(&mut built_cmd);
+        let built = built_cmd
             .args([
                 "-y",
                 "-hide_banner",
@@ -15725,7 +15761,9 @@ mod tests {
             std::fs::write(&graph_file, filter_complex.trim_end_matches(';'))
                 .expect("write filtergraph");
 
-            let render = std::process::Command::new(&ffmpeg)
+            let mut render_cmd = std::process::Command::new(&ffmpeg);
+            crate::core::process::configure_std_command(&mut render_cmd);
+            let render = render_cmd
                 .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
                 .arg(&photo)
                 .arg("-/filter_complex")
@@ -15788,7 +15826,9 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let build = |name: &str, frames: usize, rate: u32| -> Option<std::path::PathBuf> {
             let path = dir.path().join(name);
-            let built = std::process::Command::new(&ffmpeg)
+            let mut built_cmd = std::process::Command::new(&ffmpeg);
+            crate::core::process::configure_std_command(&mut built_cmd);
+            let built = built_cmd
                 .args([
                     "-y",
                     "-hide_banner",
@@ -15866,7 +15906,9 @@ mod tests {
         let graph_file = dir.path().join("graph.txt");
         std::fs::write(&graph_file, filter_complex.trim_end_matches(';')).expect("write graph");
 
-        let render = std::process::Command::new(&ffmpeg)
+        let mut render_cmd = std::process::Command::new(&ffmpeg);
+        crate::core::process::configure_std_command(&mut render_cmd);
+        let render = render_cmd
             .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
             .arg(&animated)
             .arg("-/filter_complex")

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -21,7 +21,7 @@ use crate::core::{
     commands::TEXT_ASSET_PREFIX,
     effects::{
         effect_capability, effect_type_label, effect_type_supports_timeline_enable, Effect,
-        EffectType, FilterGraph, IntoFFmpegFilter, ParamValue,
+        EffectType, FilterGraph, IntoFFmpegFilter, ParamValue, BRANCH_OFFSET_PARAM,
     },
     ffmpeg::FFmpegRunner,
     fs::validate_local_input_path,
@@ -5502,6 +5502,16 @@ fn anchor_effect_to_branch(effect: Effect, head_sec: f64) -> Effect {
             anchored
         }
         EffectType::AutoReframe => anchor_auto_reframe_keyframes(effect, head_sec),
+        EffectType::Zoom => {
+            // `zoompan` counts output frames rather than seconds, so the builder
+            // is told the offset in seconds and converts it against the canvas
+            // rate it is already given. Without it the move starts on the first
+            // frame of the *branch* and is `head_sec` through by the time the
+            // clip's own picture appears.
+            let mut anchored = effect;
+            anchored.set_param(BRANCH_OFFSET_PARAM, ParamValue::Float(head_sec));
+            anchored
+        }
         // Everything else is either time-invariant (a colour grade looks the
         // same on every frame) or keyframed, and keyframed effects are already
         // resolved to a single sampled value before they reach the graph — and
@@ -13495,6 +13505,43 @@ mod tests {
         assert_eq!(
             untouched_payload["keyframes"][0]["t"], 0.0,
             "a clip with no handle keeps the track it was given"
+        );
+    }
+
+    /// Feature: Transitions
+    /// Scenario: a zoom on a dissolving clip starts where it was authored
+    ///
+    /// A clip in a transition is decoded from `head_sec` before its in point, so
+    /// `zoompan`'s output-frame counter is already running while the picture the
+    /// editor drew the move under has not appeared yet. Unanchored, the move is
+    /// `head_sec` through by the time the clip's own footage starts.
+    #[test]
+    fn a_zoom_on_a_clip_with_handles_waits_for_the_clips_own_picture() {
+        use crate::core::effects::EffectType;
+
+        let mut effect = Effect::new(EffectType::Zoom);
+        effect.set_param("duration", ParamValue::Float(2.0));
+
+        let mut graph = FilterGraph::new().with_dimensions(1920, 1080);
+        graph.set_fps(30.0);
+        graph.add_effect(anchor_effect_to_branch(effect.clone(), 0.5));
+        let anchored = graph.to_video_filter_complex("trim0", "v0");
+
+        // Half a second of head handle at 30fps is fifteen frames of branch that
+        // are not the clip's own picture.
+        assert!(
+            anchored.contains("*max(on-15,0)"),
+            "the move must hold until the clip's own picture starts: {anchored}"
+        );
+
+        let mut unhandled = FilterGraph::new().with_dimensions(1920, 1080);
+        unhandled.set_fps(30.0);
+        unhandled.add_effect(anchor_effect_to_branch(effect, 0.0));
+        let plain = unhandled.to_video_filter_complex("trim0", "v0");
+
+        assert!(
+            plain.contains("*on,") && !plain.contains("max(on-"),
+            "a clip with no handle keeps the graph it has always had: {plain}"
         );
     }
 

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -5393,15 +5393,18 @@ impl ExportEngine {
     /// If effects have keyframes, they are resolved at the midpoint of the clip
     /// duration since FFmpeg filters cannot animate parameters directly.
     /// Dimensions are used for mask-aware (power window) filter generation.
+    /// Dimensions and frame rate are also handed to effects that cannot express
+    /// their output frame — `zoompan` is the one that cannot.
     pub(super) fn build_clip_filter_graph(
         &self,
         clip: &Clip,
         effects: &std::collections::HashMap<String, Effect>,
         width: Option<u32>,
         height: Option<u32>,
+        fps: Option<f64>,
         handles: ClipHandles,
     ) -> FilterGraph {
-        build_clip_filter_graph(clip, effects, width, height, handles)
+        build_clip_filter_graph(clip, effects, width, height, fps, handles)
     }
 }
 
@@ -5493,6 +5496,7 @@ pub(super) fn build_clip_filter_graph(
     effects: &std::collections::HashMap<String, Effect>,
     width: Option<u32>,
     height: Option<u32>,
+    fps: Option<f64>,
     handles: ClipHandles,
 ) -> FilterGraph {
     {
@@ -5501,6 +5505,9 @@ pub(super) fn build_clip_filter_graph(
         let mut graph = FilterGraph::new();
         if let (Some(w), Some(h)) = (width, height) {
             graph.set_dimensions(w as i32, h as i32);
+        }
+        if let Some(fps) = fps {
+            graph.set_fps(fps);
         }
 
         // Calculate midpoint of clip for keyframe interpolation
@@ -6917,6 +6924,7 @@ pub fn validate_export_settings_with_dimensions(
                             effects,
                             Some(canvas_width),
                             Some(canvas_height),
+                            Some(output_video_fps(sequence, settings)),
                             ClipHandles::default(),
                         );
                         if let Err(effect_label) =
@@ -11843,11 +11851,12 @@ mod tests {
     }
 
     /// Feature: Effect-aware transform placement
-    /// Scenario: a zoom hands the transform a fixed 1280x720 frame
+    /// Scenario: a zoom hands the transform the canvas it was told about
     ///
-    /// `zoompan` is emitted with `s=hd720`, so the picture reaching the
-    /// transform is 720p no matter how big the source was — this bites even a
-    /// clip whose only "transform" is an opacity change.
+    /// `zoompan` resizes, so the picture reaching the transform is whatever the
+    /// zoom's `s` says and not the size of the source — this bites even a clip
+    /// whose only "transform" is an opacity change. The graph publishes the
+    /// canvas onto the effect, so the measurement and the emitted filter agree.
     #[test]
     fn test_effective_source_dimensions_follows_a_zoom() {
         let mut zoom = Effect::new(EffectType::Zoom);
@@ -11855,8 +11864,29 @@ mod tests {
         zoom.set_param("duration", ParamValue::Float(2.0));
         zoom.set_param("zoom_factor", ParamValue::Float(1.5));
 
-        let dimensions = effective_source_dimensions((3840, 2160), &graph_with_effect(zoom))
+        let mut graph = FilterGraph::new().with_dimensions(1920, 1080);
+        graph.set_fps(30.0);
+        graph.add_effect(zoom);
+
+        let dimensions = effective_source_dimensions((3840, 2160), &graph)
             .expect("zoompan states its output size");
+
+        assert_eq!(dimensions, (1920, 1080));
+    }
+
+    /// Feature: Effect-aware transform placement
+    /// Scenario: a zoom on a graph that was never told its canvas
+    ///
+    /// FFmpeg's own `zoompan` default is `hd720`, so a chain that says nothing
+    /// still resizes to 720p. The measurement has to report that rather than
+    /// pretend the picture came through untouched.
+    #[test]
+    fn test_effective_source_dimensions_follows_a_zoom_without_a_canvas() {
+        let dimensions = effective_source_dimensions(
+            (3840, 2160),
+            &graph_with_effect(Effect::new(EffectType::Zoom)),
+        )
+        .expect("zoompan states its output size");
 
         assert_eq!(dimensions, (1280, 720));
     }

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -28,7 +28,7 @@ use super::{
         output_video_dimensions, output_video_fps, output_video_pixel_format,
         resolve_asset_source_dimensions, resolve_asset_source_duration,
         seed_source_dimension_cache, seed_source_duration_cache, unmeasurable_effect_message,
-        AssetAudioInfo, ExportEngine, ExportError, ExportSettings, VideoCodec,
+        AssetAudioInfo, ExportEngine, ExportError, ExportSettings, TrimSourceKind, VideoCodec,
         VideoTimelineSegment, TIMELINE_EPSILON_SEC,
     },
     transform_layout::compute_clip_transform_layout,
@@ -231,6 +231,7 @@ pub(super) fn build_sequence_ffmpeg_args(
                         &trim_label,
                         &mut filter_complex,
                         handles,
+                        TrimSourceKind::for_asset(asset),
                     );
 
                     if clip_filter_graph.has_video_effects() {

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -26,10 +26,10 @@ use super::{
         collect_overlay_text_drawtext_filters, effective_source_dimensions,
         generated_text_visual_end_sec, hdr_metadata_for_asset, is_text_clip,
         output_video_dimensions, output_video_fps, output_video_pixel_format,
-        resolve_asset_source_dimensions, resolve_asset_source_duration,
+        resolve_asset_source_dimensions, resolve_asset_source_duration, resolve_trim_source_kind,
         seed_source_dimension_cache, seed_source_duration_cache, unmeasurable_effect_message,
-        AssetAudioInfo, ExportEngine, ExportError, ExportSettings, TrimSourceKind, VideoCodec,
-        VideoTimelineSegment, TIMELINE_EPSILON_SEC,
+        AssetAudioInfo, ExportEngine, ExportError, ExportSettings, SourceFrameCountCache,
+        VideoCodec, VideoTimelineSegment, TIMELINE_EPSILON_SEC,
     },
     transform_layout::compute_clip_transform_layout,
     transition_stitch::{
@@ -116,6 +116,11 @@ pub(super) fn build_sequence_ffmpeg_args(
         plan_sequence_transitions(ctx.sequence, ctx.assets, ctx.effects, output_fps, |asset| {
             resolve_asset_source_duration(asset, &mut source_durations)
         });
+
+    // Which image assets are photos and which are animations. An extension says
+    // nothing about that, so the answer has to be measured; caching it keeps a
+    // timeline that reuses one GIF to a single probe.
+    let mut source_frame_counts = SourceFrameCountCache::new();
 
     let mut adjustment_layer_effects = Vec::new();
     for (clip, _track) in &all_clips {
@@ -231,7 +236,7 @@ pub(super) fn build_sequence_ffmpeg_args(
                         &trim_label,
                         &mut filter_complex,
                         handles,
-                        TrimSourceKind::for_asset(asset),
+                        resolve_trim_source_kind(asset, &mut source_frame_counts),
                     );
 
                     if clip_filter_graph.has_video_effects() {

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -127,6 +127,7 @@ pub(super) fn build_sequence_ffmpeg_args(
                 ctx.effects,
                 Some(output_width),
                 Some(output_height),
+                Some(output_fps),
                 ClipHandles::default(),
             );
             if graph.has_video_effects() {
@@ -183,6 +184,7 @@ pub(super) fn build_sequence_ffmpeg_args(
             ctx.effects,
             Some(output_width),
             Some(output_height),
+            Some(output_fps),
             handles,
         );
 
@@ -617,7 +619,7 @@ pub(super) fn build_audio_only_ffmpeg_args(
         let handles = transition_plan.handles(&clip.id);
         let clip_filter_graph =
             ctx.engine
-                .build_clip_filter_graph(clip, ctx.effects, None, None, handles);
+                .build_clip_filter_graph(clip, ctx.effects, None, None, None, handles);
         let audio_trim_label = format!("atrim{}", input_index);
         let audio_out_label = format!("a{}", input_index);
         let audio_effects_input = build_audio_trim_filter(


### PR DESCRIPTION
### **User description**
## Summary

Fixes two render-correctness bugs in the effects filtergraph builder, both surfaced during the transition-engine review, each verified against the bundled ffmpeg.

### Zoom effect (zoompan) was fundamentally broken

A 2s/1.5x zoom emitted `zoompan=…:d=60:s=hd720:fps=30`. Measured against a real 60-frame 1080p clip: **60 frames in → 3600 frames out at 1280×720** — two seconds of picture became two minutes, forced to 720p regardless of the sequence resolution. `d` (frames-out-per-frame-in) scaled with the move length, and `s=hd720` was hardcoded.

Fix: `d=1` (one frame out per frame in); the zoom move is driven by the frame counter `on` (a naive `d=1` alone does **not** zoom — ffmpeg resets the `zoom` variable per input frame, verified by flat luma; the `on`-driven expression was confirmed to actually zoom, luma rising to match the predicted zoom² area ratio); `s=` and `fps=` come from the sequence canvas, with an `fps=` pin ahead of the zoom so zoompan's restamping can't shorten a cross-rate clip (48-frame/24fps → 60 frames @30fps, 2.000s preserved). Canvas dims/fps are threaded through `FilterGraph` and written onto the stored effect so the transform sizer reads the same values.

### Effect-chain label collision

`FilterGraph::to_video_filter_complex` named intermediates `v{effect_index}`, colliding with the per-clip output label `v{input_index}`; a clip at input 0 with two video effects emitted a duplicate `[v0]`. (The bundled ffmpeg 9 happens to pair repeated labels FIFO so current graphs render, but it's unspecified behavior the export was leaning on, and a different resolver-selected ffmpeg could misroute it.) Fixed by deriving intermediates from the chain's own output label (`v0_fx0`, `v0_fx1`); the audio chain had the identical twin defect and is fixed the same way.

## Test plan

- src-tauri lib: 4044 passed; 8 ignored ffmpeg-backed tests pass (incl. an empirical zoom render that counts output luma bytes = 60 × frame size, and fails at 3600 frames on the old emission)
- New regression tests fail before each fix: chain-label uniqueness (video + audio), one-frame-per-input-frame zoom, frame-counter-driven move, canvas-size output, fps pin
- clippy/fmt/bundler-feature/bindings (no diff) clean

## Reviewer notes / known limits

- Zoom `s=` now upscales a small source to the canvas *inside* the zoom (zoompan takes no expression for `s`); deterministic and ends where the render ends anyway.
- Zoom on an adjustment layer is still broken (pre-existing): the timed chain appends `:enable=` and neither `zoompan` nor `fps` carries ffmpeg's timeline flag — unchanged by this PR.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixes `zoompan` filter to prevent frame multiplication.

- Resolves filtergraph label collisions using unique IDs.

- Propagates canvas dimensions and FPS to effects.

- Adds comprehensive tests for render correctness.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FilterGraph"] -- "Propagates Canvas Info" --> B["Effect (Zoom)"]
  B -- "Generates d=1, s=WxH" --> C["FFmpeg String"]
  D["FilterGraph Labels"] -- "Unique Suffixes" --> E["Non-colliding Streams"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter_builder.rs</strong><dd><code>Refactor zoom filter and filtergraph label generation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/effects/filter_builder.rs

<ul><li>Rewrote <code>zoompan</code> filter logic to use <code>d=1</code> and drive movement via the <code>on</code> <br>frame counter.<br> <li> Added <code>CANVAS_WIDTH_PARAM</code>, <code>CANVAS_HEIGHT_PARAM</code>, and <code>CANVAS_FPS_PARAM</code> to <br>synchronize effect settings with sequence properties.<br> <li> Updated <code>FilterGraph</code> to use <code>effect_chain_label</code> for intermediate <br>streams, preventing label collisions.<br> <li> Added extensive unit tests for zoom behavior and label uniqueness.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/828/files#diff-86aaa5bbc7d4304dce89d4a4bb017d4044971db7e1ef672b58072d452c2ab8de">+516/-33</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Propagate FPS and dimensions during export graph building</code></dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Updated <code>build_clip_filter_graph</code> to accept and propagate <code>fps</code> to the <br><code>FilterGraph</code>.<br> <li> Adjusted <code>validate_export_settings_with_dimensions</code> to include output <br>FPS when building graphs for measurement.<br> <li> Updated tests to verify that effective source dimensions correctly <br>follow zoom effects on specific canvases.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/828/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+36/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ffmpeg_plan.rs</strong><dd><code>Update FFmpeg plan to provide canvas FPS to filter graphs</code></dd></summary>
<hr>

src-tauri/src/core/render/ffmpeg_plan.rs

<ul><li>Passed <code>output_fps</code> into <code>build_clip_filter_graph</code> calls for both <br>adjustment layers and standard clips.<br> <li> Ensured audio-only export paths handle the new <code>fps</code> parameter (as <br><code>None</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/828/files#diff-7f93452cf29faaec41eb667dd7d07cf667603dace2d8f99aba49ae2e38c3e2df">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved zoom effects with smoother frame-by-frame animation, correct sizing, aspect-ratio preservation, and transition support.
  * Still images now remain visible across their full timeline and transition handles, while animated images continue to play normally.
  * Added more accurate video frame detection for improved rendering decisions.

* **Bug Fixes**
  * Improved effect timing and output frame rates during export.
  * Added validation to prevent unsupported effects from being used on adjustment layers, with clearer error messages.
  * Improved handling of image and video sources during trimming and export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->