### PR TITLE
test(effects): route ffmpeg test helpers through the no-window command helper

### DIFF
--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -5807,7 +5807,9 @@ mod tests {
         std::fs::write(&graph_file, filtergraph).expect("write filtergraph");
 
         let input_file = dir.path().join("input.mp4");
-        let fixture = std::process::Command::new(ffmpeg_binary_for_tests())
+        let mut fixture_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut fixture_cmd);
+        let fixture = fixture_cmd
             .args([
                 "-y",
                 "-hide_banner",
@@ -5829,7 +5831,9 @@ mod tests {
             return None;
         }
 
-        let output = std::process::Command::new(ffmpeg_binary_for_tests())
+        let mut render_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut render_cmd);
+        let output = render_cmd
             .args(["-hide_banner", "-v", "debug", "-nostdin", "-i"])
             .arg(&input_file)
             .arg("-/filter_complex")
@@ -5858,8 +5862,9 @@ mod tests {
 
     /// Whether the local ffmpeg advertises `filter_name`.
     fn ffmpeg_has_filter(filter_name: &str) -> bool {
-        std::process::Command::new(ffmpeg_binary_for_tests())
-            .args(["-hide_banner", "-filters"])
+        let mut cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        crate::core::process::configure_std_command(&mut cmd);
+        cmd.args(["-hide_banner", "-filters"])
             .output()
             .is_ok_and(|output| {
                 String::from_utf8_lossy(&output.stdout).contains(&format!(" {filter_name} "))


### PR DESCRIPTION
### **User description**
## Summary

The `processCommandWindowGuard` architecture test scans every `.rs` file under `src-tauri/src` (test code included) and requires each `std::process::Command` to pass through `configure_std_command`, so a console window cannot flash on Windows. Three ffmpeg-backed test helpers in `filter_builder.rs` (added by 6ef1109b) spawned ffmpeg directly, so the guard — and thus `Frontend Tests (shard 7)` — has been **red on main** since they landed.

Fix: bind each command to a variable, run `configure_std_command(&mut cmd)` on it, then build and spawn — the exact pattern the guard enforces and every production spawn site already uses. Test-only, no behaviour change on the render path.

## Test plan

- `cargo fmt --check` clean
- `crate::core::process::configure_std_command(&mut _)` is already the compiled spawn pattern in 4 production files, so the path resolves
- CI `Frontend Tests (shard 7)` (the guard) goes green; full pipeline verifies the Rust compile


___

### **PR Type**
Tests


___

### **Description**
- Configure `std::process::Command` to prevent console windows.

- Update ffmpeg test helpers in `filter_builder.rs`.

- Ensure compliance with the `processCommandWindowGuard` architecture test.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ffmpeg Command Creation"] -- "Pass through" --> B["configure_std_command"]
  B -- "Execute" --> C["ffmpeg Process (No Window)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter_builder.rs</strong><dd><code>Configure ffmpeg test commands to suppress console windows</code></dd></summary>
<hr>

src-tauri/src/core/effects/filter_builder.rs

<ul><li>Updated <code>parsed_filter_node_names</code> and <code>ffmpeg_has_filter</code> test helpers to <br>use <code>configure_std_command</code>.<br> <li> Wrapped <code>std::process::Command</code> initialization to ensure Windows console <br>windows do not flash during tests.<br> <li> Aligned test code with the project's architectural guard for process <br>spawning.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/829/files#diff-86aaa5bbc7d4304dce89d4a4bb017d4044971db7e1ef672b58072d452c2ab8de">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

