### PR TITLE
ci: actually run the src-tauri ffmpeg-backed tests (against the bundled binary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,32 @@ jobs:
           REQUIRE_FFMPEG_TESTS: '1'
         run: cargo test --locked -p openreelio-cli
 
+      # The library's ffmpeg-backed tests hand a real FFmpeg the filtergraph the
+      # export builds and measure what comes out. They are `#[ignore]`d because
+      # they need a binary, so the `Run tests` step above never ran them and the
+      # properties they measure - zoom frame counts and geometry, still and
+      # animated image handling, the adjustment-layer refusal, filtergraph
+      # injection - went unexercised in CI.
+      #
+      # They are named by module rather than run as a bare `--ignored`, because
+      # the lib's other ignored tests download FFmpeg archives, drive a live
+      # `claude` login, or rewrite a checked-in manifest.
+      #
+      # `REQUIRE_FFMPEG_TESTS` turns their quiet skips into failures, so a
+      # broken FFmpeg install fails the job instead of passing vacuously.
+      - name: Run src-tauri ffmpeg-backed tests
+        working-directory: src-tauri
+        shell: bash
+        env:
+          REQUIRE_FFMPEG_TESTS: '1'
+        run: |
+          cargo test --locked --features dev-full --lib -- --ignored \
+            core::effects::filter_builder::tests:: \
+            core::render::export::tests:: 2>&1 | tee "${RUNNER_TEMP}/ffmpeg-tests.log"
+          # A renamed or moved test would leave the filters matching nothing,
+          # which libtest still reports as a pass. Require that something ran.
+          grep -qE 'test result: ok\. [1-9][0-9]* passed' "${RUNNER_TEMP}/ffmpeg-tests.log"
+
   # ==========================================================================
   # Build Check
   # ==========================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,14 @@ jobs:
           REQUIRE_FFMPEG_TESTS: '1'
         run: cargo test --locked -p openreelio-cli
 
+      # Fetch the bundled FFmpeg (9.x) the app ships. The job sets
+      # SKIP_FFMPEG_DOWNLOAD=1, so the build.rs never lays it down; this is the
+      # same script release.yml uses, writing ffmpeg/ffprobe into
+      # src-tauri/binaries/. ubuntu-latest is the x86_64 linux runner.
+      - name: Prepare bundled FFmpeg for the ffmpeg-backed tests
+        timeout-minutes: 15
+        run: node scripts/prepare-bundled-ffmpeg.mjs x86_64-unknown-linux-gnu
+
       # The library's ffmpeg-backed tests hand a real FFmpeg the filtergraph the
       # export builds and measure what comes out. They are `#[ignore]`d because
       # they need a binary, so the `Run tests` step above never ran them and the
@@ -253,17 +261,27 @@ jobs:
       # animated image handling, the adjustment-layer refusal, filtergraph
       # injection - went unexercised in CI.
       #
+      # They run against the BUNDLED FFmpeg, not apt's: the assertions were
+      # measured against the exact build the app ships (9.x), and most of them
+      # pass the filtergraph with `-/filter_complex <file>`, whose read-from-file
+      # syntax only exists in FFmpeg >= 7.0 - ubuntu-latest's apt build is 6.1.
+      # The `dev-full` builds above have already downloaded the bundled binaries
+      # into `src-tauri/binaries/` (the `bundled-ffmpeg` feature), so they are
+      # present here; pointing the resolver at them tests what users actually run.
+      #
       # They are named by module rather than run as a bare `--ignored`, because
       # the lib's other ignored tests download FFmpeg archives, drive a live
       # `claude` login, or rewrite a checked-in manifest.
       #
-      # `REQUIRE_FFMPEG_TESTS` turns their quiet skips into failures, so a
-      # broken FFmpeg install fails the job instead of passing vacuously.
+      # `REQUIRE_FFMPEG_TESTS` turns their quiet skips into failures, so a missing
+      # bundled binary fails the job instead of passing vacuously.
       - name: Run src-tauri ffmpeg-backed tests
         working-directory: src-tauri
         shell: bash
         env:
           REQUIRE_FFMPEG_TESTS: '1'
+          OPENREELIO_FFMPEG_PATH: ${{ github.workspace }}/src-tauri/binaries/ffmpeg
+          OPENREELIO_FFPROBE_PATH: ${{ github.workspace }}/src-tauri/binaries/ffprobe
         run: |
           cargo test --locked --features dev-full --lib -- --ignored \
             core::effects::filter_builder::tests:: \

--- a/src-tauri/src/core/effects/filter_builder.rs
+++ b/src-tauri/src/core/effects/filter_builder.rs
@@ -6367,14 +6367,13 @@ mod tests {
     //
     // Ignored by default because they need an `ffmpeg` binary. Run with:
     //   cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored injection
+    //
+    // Every one of them starts at `require_or_skip_ffmpeg`, which skips quietly
+    // on a machine without ffmpeg and fails when `REQUIRE_FFMPEG_TESTS` says the
+    // run was supposed to have one — so CI cannot pass these without running them.
     // =========================================================================
 
-    /// Resolves an ffmpeg binary for the empirical tests.
-    fn ffmpeg_binary_for_tests() -> std::path::PathBuf {
-        std::env::var_os("OPENREELIO_FFMPEG_PATH")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"))
-    }
+    use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
 
     /// Parses a filtergraph with the real FFmpeg and returns the node names it built.
     ///
@@ -6388,13 +6387,16 @@ mod tests {
     /// would be counted as if the payload had produced it.
     ///
     /// Returns `None` when ffmpeg could not be launched at all.
-    fn parsed_filter_node_names(filtergraph: &str) -> Option<Vec<String>> {
+    fn parsed_filter_node_names(
+        ffmpeg: &std::path::Path,
+        filtergraph: &str,
+    ) -> Option<Vec<String>> {
         let dir = tempfile::tempdir().expect("temp dir");
         let graph_file = dir.path().join("graph.txt");
         std::fs::write(&graph_file, filtergraph).expect("write filtergraph");
 
         let input_file = dir.path().join("input.mp4");
-        let mut fixture_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        let mut fixture_cmd = std::process::Command::new(ffmpeg);
         crate::core::process::configure_std_command(&mut fixture_cmd);
         let fixture = fixture_cmd
             .args([
@@ -6418,7 +6420,7 @@ mod tests {
             return None;
         }
 
-        let mut render_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        let mut render_cmd = std::process::Command::new(ffmpeg);
         crate::core::process::configure_std_command(&mut render_cmd);
         let output = render_cmd
             .args(["-hide_banner", "-v", "debug", "-nostdin", "-i"])
@@ -6448,8 +6450,8 @@ mod tests {
     }
 
     /// Whether the local ffmpeg advertises `filter_name`.
-    fn ffmpeg_has_filter(filter_name: &str) -> bool {
-        let mut cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+    fn ffmpeg_has_filter(ffmpeg: &std::path::Path, filter_name: &str) -> bool {
+        let mut cmd = std::process::Command::new(ffmpeg);
         crate::core::process::configure_std_command(&mut cmd);
         cmd.args(["-hide_banner", "-filters"])
             .output()
@@ -6491,9 +6493,13 @@ mod tests {
         const CANVAS_HEIGHT: usize = 180;
         const SOURCE_FRAMES: usize = 60;
 
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
         let dir = tempfile::tempdir().expect("temp dir");
         let input_file = dir.path().join("input.mp4");
-        let mut fixture_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        let mut fixture_cmd = std::process::Command::new(&ffmpeg);
         crate::core::process::configure_std_command(&mut fixture_cmd);
         let fixture = fixture_cmd
             .args([
@@ -6511,11 +6517,11 @@ mod tests {
             .arg(&input_file)
             .output();
         let Ok(fixture) = fixture else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+            skip_without_ffmpeg("ffmpeg could not be launched");
             return;
         };
         if !fixture.status.success() || !input_file.exists() {
-            eprintln!("Skipping: ffmpeg could not build the fixture");
+            skip_without_ffmpeg("ffmpeg could not build the fixture");
             return;
         }
 
@@ -6534,7 +6540,7 @@ mod tests {
 
         // One byte per pixel of luma, so the byte count is the frame count times
         // the frame size — both properties under test, measured at once.
-        let mut render_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        let mut render_cmd = std::process::Command::new(&ffmpeg);
         crate::core::process::configure_std_command(&mut render_cmd);
         let render = render_cmd
             .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
@@ -6569,6 +6575,7 @@ mod tests {
     /// filtergraph in the command, and the frames it is handed have been through
     /// a decoder exactly as a render's would be.
     fn white_box_clip(
+        ffmpeg: &std::path::Path,
         dir: &std::path::Path,
         name: &str,
         canvas: (usize, usize),
@@ -6584,7 +6591,7 @@ mod tests {
             (height - box_height) / 2,
         );
 
-        let mut built_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        let mut built_cmd = std::process::Command::new(ffmpeg);
         crate::core::process::configure_std_command(&mut built_cmd);
         let built = built_cmd
             .args([
@@ -6611,6 +6618,7 @@ mod tests {
     /// One byte per pixel, so a frame is exactly `width * height` bytes and the
     /// white pixels can be counted without decoding anything.
     fn render_luma_frames(
+        ffmpeg: &std::path::Path,
         input: &std::path::Path,
         graph: &str,
         width: usize,
@@ -6620,7 +6628,7 @@ mod tests {
         let graph_file = dir.path().join("graph.txt");
         std::fs::write(&graph_file, graph).ok()?;
 
-        let mut render_cmd = std::process::Command::new(ffmpeg_binary_for_tests());
+        let mut render_cmd = std::process::Command::new(ffmpeg);
         crate::core::process::configure_std_command(&mut render_cmd);
         let render = render_cmd
             .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
@@ -6701,9 +6709,13 @@ mod tests {
         const CANVAS: (usize, usize) = (320, 180);
         const FACTOR: f64 = 2.0;
 
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
         let dir = tempfile::tempdir().expect("temp dir");
-        let Some(input) = white_box_clip(dir.path(), "box.mp4", CANVAS, (80, 44)) else {
-            eprintln!("Skipping: ffmpeg could not build the fixture");
+        let Some(input) = white_box_clip(&ffmpeg, dir.path(), "box.mp4", CANVAS, (80, 44)) else {
+            skip_without_ffmpeg("ffmpeg could not build the fixture");
             return;
         };
 
@@ -6712,8 +6724,8 @@ mod tests {
         effect.set_param("zoom_factor", ParamValue::Float(FACTOR));
         let graph = zoom_graph_for_ffmpeg(effect, CANVAS.0 as i32, CANVAS.1 as i32, 30.0);
 
-        let Some(frames) = render_luma_frames(&input, &graph, CANVAS.0, CANVAS.1) else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+        let Some(frames) = render_luma_frames(&ffmpeg, &input, &graph, CANVAS.0, CANVAS.1) else {
+            skip_without_ffmpeg("ffmpeg could not render the zoom graph");
             return;
         };
         assert_eq!(frames.len(), 6, "the zoom must not change the frame count");
@@ -6746,9 +6758,13 @@ mod tests {
         // measures.
         const UNZOOMED: usize = 80 * 44;
 
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
         let dir = tempfile::tempdir().expect("temp dir");
-        let Some(input) = white_box_clip(dir.path(), "box.mp4", CANVAS, (80, 44)) else {
-            eprintln!("Skipping: ffmpeg could not build the fixture");
+        let Some(input) = white_box_clip(&ffmpeg, dir.path(), "box.mp4", CANVAS, (80, 44)) else {
+            skip_without_ffmpeg("ffmpeg could not build the fixture");
             return;
         };
 
@@ -6758,8 +6774,8 @@ mod tests {
         effect.set_param("zoom_factor", ParamValue::Float(2.0));
         let graph = zoom_graph_for_ffmpeg(effect, CANVAS.0 as i32, CANVAS.1 as i32, 30.0);
 
-        let Some(frames) = render_luma_frames(&input, &graph, CANVAS.0, CANVAS.1) else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+        let Some(frames) = render_luma_frames(&ffmpeg, &input, &graph, CANVAS.0, CANVAS.1) else {
+            skip_without_ffmpeg("ffmpeg could not render the zoom graph");
             return;
         };
 
@@ -6799,9 +6815,13 @@ mod tests {
         const CANVAS: (usize, usize) = (320, 180);
         const UNZOOMED: usize = 80 * 44;
 
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
         let dir = tempfile::tempdir().expect("temp dir");
-        let Some(input) = white_box_clip(dir.path(), "box.mp4", CANVAS, (80, 44)) else {
-            eprintln!("Skipping: ffmpeg could not build the fixture");
+        let Some(input) = white_box_clip(&ffmpeg, dir.path(), "box.mp4", CANVAS, (80, 44)) else {
+            skip_without_ffmpeg("ffmpeg could not build the fixture");
             return;
         };
 
@@ -6812,8 +6832,8 @@ mod tests {
         effect.set_param(BRANCH_OFFSET_PARAM, ParamValue::Float(0.1));
         let graph = zoom_graph_for_ffmpeg(effect, CANVAS.0 as i32, CANVAS.1 as i32, 30.0);
 
-        let Some(frames) = render_luma_frames(&input, &graph, CANVAS.0, CANVAS.1) else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+        let Some(frames) = render_luma_frames(&ffmpeg, &input, &graph, CANVAS.0, CANVAS.1) else {
+            skip_without_ffmpeg("ffmpeg could not render the zoom graph");
             return;
         };
         assert_eq!(frames.len(), 6);
@@ -6837,9 +6857,14 @@ mod tests {
     #[test]
     #[ignore = "requires an ffmpeg binary; run with --ignored"]
     fn a_zoom_letterboxes_a_source_shaped_unlike_the_canvas() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
         let dir = tempfile::tempdir().expect("temp dir");
-        let Some(input) = white_box_clip(dir.path(), "square.mp4", (320, 240), (120, 120)) else {
-            eprintln!("Skipping: ffmpeg could not build the fixture");
+        let Some(input) = white_box_clip(&ffmpeg, dir.path(), "square.mp4", (320, 240), (120, 120))
+        else {
+            skip_without_ffmpeg("ffmpeg could not build the fixture");
             return;
         };
 
@@ -6849,8 +6874,8 @@ mod tests {
             effect.set_param("zoom_factor", ParamValue::Float(1.5));
             let graph = zoom_graph_for_ffmpeg(effect, width as i32, height as i32, 30.0);
 
-            let Some(frames) = render_luma_frames(&input, &graph, width, height) else {
-                eprintln!("Skipping: ffmpeg could not be launched");
+            let Some(frames) = render_luma_frames(&ffmpeg, &input, &graph, width, height) else {
+                skip_without_ffmpeg("ffmpeg could not render the zoom graph");
                 return;
             };
 
@@ -6869,12 +6894,16 @@ mod tests {
     #[test]
     #[ignore = "requires an ffmpeg binary; run with --ignored"]
     fn subtitles_path_injection_creates_exactly_one_filter_node() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
         // Built exactly as `append_ass_text_overlay` builds it.
         let escaped = escape_ffmpeg_filter_value(&format!("{INJECTION_PAYLOAD}.ass"));
         let graph = format!("[0:v]subtitles=filename='{escaped}'[out]");
 
-        let Some(nodes) = parsed_filter_node_names(&graph) else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+        let Some(nodes) = parsed_filter_node_names(&ffmpeg, &graph) else {
+            skip_without_ffmpeg("ffmpeg could not parse the filtergraph under test");
             return;
         };
 
@@ -6892,8 +6921,15 @@ mod tests {
     #[test]
     #[ignore = "requires an ffmpeg binary built with libvidstab; run with --ignored"]
     fn vidstabdetect_path_injection_creates_exactly_one_filter_node() {
-        if !ffmpeg_has_filter("vidstabdetect") {
-            eprintln!("Skipping: this ffmpeg has no vidstabdetect filter");
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
+        // `libvidstab` is an optional build option rather than part of a working
+        // install, so this skip stays quiet even under `REQUIRE_FFMPEG_TESTS`:
+        // a build without the filter cannot answer the question at all.
+        if !ffmpeg_has_filter(&ffmpeg, "vidstabdetect") {
+            eprintln!("Skipping test: this ffmpeg has no vidstabdetect filter");
             return;
         }
 
@@ -6901,8 +6937,8 @@ mod tests {
             build_vidstabdetect_filter(std::path::Path::new(&format!("{INJECTION_PAYLOAD}.trf")));
         let graph = format!("[0:v]{detect}[out]");
 
-        let Some(nodes) = parsed_filter_node_names(&graph) else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+        let Some(nodes) = parsed_filter_node_names(&ffmpeg, &graph) else {
+            skip_without_ffmpeg("ffmpeg could not parse the filtergraph under test");
             return;
         };
 

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -59,3 +59,6 @@ pub use error::*;
 
 #[cfg(test)]
 mod tests_destructive;
+
+#[cfg(test)]
+mod test_ffmpeg;

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -12731,9 +12731,11 @@ mod tests {
     #[test]
     #[ignore = "requires an ffmpeg binary; run with --ignored"]
     fn ffmpeg_refuses_a_time_gated_effect_on_an_adjustment_layer() {
-        let ffmpeg = std::env::var_os("OPENREELIO_FFMPEG_PATH")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+        use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
+
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
 
         let graph_of = |effect: Effect| {
             let mut graph = FilterGraph::new().with_dimensions(320, 180);
@@ -12788,7 +12790,7 @@ mod tests {
             );
 
             let Ok(refused) = run(&gated(effect)) else {
-                eprintln!("Skipping: ffmpeg could not be launched");
+                skip_without_ffmpeg("ffmpeg could not be launched");
                 return;
             };
             let stderr = String::from_utf8_lossy(&refused.stderr);
@@ -15981,6 +15983,7 @@ mod tests {
     #[ignore = "requires an ffmpeg binary; run with --ignored"]
     fn a_still_image_renders_every_frame_of_its_slot() {
         use crate::core::effects::{Effect, EffectType, FilterGraph};
+        use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
         use crate::core::timeline::Clip;
 
         const CANVAS_WIDTH: u32 = 320;
@@ -15988,9 +15991,9 @@ mod tests {
         const FPS: f64 = 30.0;
         const SLOT_SEC: f64 = 2.0;
 
-        let ffmpeg = std::env::var_os("OPENREELIO_FFMPEG_PATH")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
 
         let dir = tempfile::tempdir().expect("temp dir");
         let photo = dir.path().join("photo.png");
@@ -16012,11 +16015,11 @@ mod tests {
             .arg(&photo)
             .output();
         let Ok(built) = built else {
-            eprintln!("Skipping: ffmpeg could not be launched");
+            skip_without_ffmpeg("ffmpeg could not be launched");
             return;
         };
         if !built.status.success() || !photo.exists() {
-            eprintln!("Skipping: ffmpeg could not build the fixture");
+            skip_without_ffmpeg("ffmpeg could not build the fixture");
             return;
         }
 
@@ -16128,6 +16131,7 @@ mod tests {
     #[ignore = "requires an ffmpeg binary; run with --ignored"]
     fn an_animated_image_renders_its_animation_and_not_a_frozen_frame() {
         use crate::core::assets::Asset;
+        use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
         use crate::core::timeline::Clip;
         use std::collections::HashSet;
 
@@ -16137,9 +16141,9 @@ mod tests {
         const SLOT_SEC: f64 = 1.0;
         const SOURCE_FRAMES: usize = 30;
 
-        let ffmpeg = std::env::var_os("OPENREELIO_FFMPEG_PATH")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
 
         let dir = tempfile::tempdir().expect("temp dir");
         let build = |name: &str, frames: usize, rate: u32| -> Option<std::path::PathBuf> {
@@ -16170,7 +16174,7 @@ mod tests {
             build("one.gif", 1, 30),
             build("anim.apng", 20, 10),
         ) else {
-            eprintln!("Skipping: ffmpeg could not build the fixtures");
+            skip_without_ffmpeg("ffmpeg could not build the fixtures");
             return;
         };
 

--- a/src-tauri/src/core/test_ffmpeg.rs
+++ b/src-tauri/src/core/test_ffmpeg.rs
@@ -1,0 +1,130 @@
+//! FFmpeg discovery for the ignored, FFmpeg-backed library tests.
+//!
+//! Several tests hand a real FFmpeg the filtergraph the export builds and
+//! measure what comes out. They are `#[ignore]`d because they need a binary
+//! the machine may not have, and each one used to resolve that binary and
+//! quietly `return` when it was missing.
+//!
+//! A test that skips itself still reports green, so a job that runs the suite
+//! without FFmpeg reports the same result as a job that runs it with FFmpeg and
+//! passes. `REQUIRE_FFMPEG_TESTS` closes that hole: the CI step that installs
+//! FFmpeg sets it, which turns every skip in here into a failure, while a
+//! developer without FFmpeg on their machine keeps the quiet skip.
+//!
+//! This mirrors the CLI end-to-end suite's helper
+//! (`crates/openreelio-cli/tests/integration.rs`) so both surfaces behave
+//! identically.
+
+use std::path::PathBuf;
+
+/// Environment override naming the FFmpeg binary the tests should use.
+const FFMPEG_PATH_ENV: &str = "OPENREELIO_FFMPEG_PATH";
+
+/// Environment flag that turns a quiet skip into a failure.
+const REQUIRE_FFMPEG_TESTS_ENV: &str = "REQUIRE_FFMPEG_TESTS";
+
+/// Whether `REQUIRE_FFMPEG_TESTS` carrying `value` demands that the tests run.
+///
+/// Split out from the environment lookup so the reading of the flag can be
+/// asserted without mutating the environment of a running test binary.
+fn require_flag_demands_a_run(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        !value.is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
+    })
+}
+
+/// Whether a missing FFmpeg must fail the run rather than quietly skip it.
+fn ffmpeg_tests_are_required() -> bool {
+    require_flag_demands_a_run(std::env::var(REQUIRE_FFMPEG_TESTS_ENV).ok().as_deref())
+}
+
+/// Records a skip, or fails when FFmpeg was supposed to be available.
+#[track_caller]
+pub(crate) fn skip_without_ffmpeg(reason: &str) {
+    assert!(
+        !ffmpeg_tests_are_required(),
+        "REQUIRE_FFMPEG_TESTS is set, so this test must run, but {reason}"
+    );
+    eprintln!("Skipping test: {reason}");
+}
+
+/// The FFmpeg binary the tests should use: the override, else whatever `ffmpeg`
+/// resolves to on `PATH`.
+fn ffmpeg_binary() -> PathBuf {
+    std::env::var_os(FFMPEG_PATH_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("ffmpeg"))
+}
+
+/// An FFmpeg binary that has been proven to launch, or `None` after recording a skip.
+///
+/// Use it as the first line of an FFmpeg-backed test:
+///
+/// ```ignore
+/// let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+///     return;
+/// };
+/// ```
+///
+/// With `REQUIRE_FFMPEG_TESTS` set this panics instead of returning `None`, so
+/// the test cannot pass without having run.
+#[track_caller]
+pub(crate) fn require_or_skip_ffmpeg() -> Option<PathBuf> {
+    let binary = ffmpeg_binary();
+
+    let mut cmd = std::process::Command::new(&binary);
+    crate::core::process::configure_std_command(&mut cmd);
+    let probe = cmd.args(["-hide_banner", "-version"]).output();
+
+    match probe {
+        Ok(output) if output.status.success() => Some(binary),
+        Ok(output) => {
+            skip_without_ffmpeg(&format!(
+                "`{} -version` exited with {}",
+                binary.display(),
+                output.status
+            ));
+            None
+        }
+        Err(error) => {
+            skip_without_ffmpeg(&format!(
+                "`{}` could not be launched: {error}",
+                binary.display()
+            ));
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feature: FFmpeg-backed tests in CI
+    /// Scenario: the require flag is read the way the CLI suite reads it
+    ///
+    /// The two suites are set from the same workflow variable, so a disagreement
+    /// over what counts as "set" would leave one of them skipping while the
+    /// other ran.
+    #[test]
+    fn the_require_flag_is_read_the_same_way_as_the_cli_suite() {
+        for value in ["1", "true", "TRUE", "yes"] {
+            assert!(
+                require_flag_demands_a_run(Some(value)),
+                "`REQUIRE_FFMPEG_TESTS={value}` must require the tests to run"
+            );
+        }
+
+        for value in ["", "0", "false", "False"] {
+            assert!(
+                !require_flag_demands_a_run(Some(value)),
+                "`REQUIRE_FFMPEG_TESTS={value}` must leave the quiet skip in place"
+            );
+        }
+
+        assert!(
+            !require_flag_demands_a_run(None),
+            "an unset flag must leave the quiet skip in place"
+        );
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary

The src-tauri lib's `#[ignore]` ffmpeg-backed tests (zoom frame counts/geometry, still + animated image handling, adjustment-layer refusal, filtergraph-injection node counts, caption libass) were **never run in CI** — the `Run tests` step has no `--ignored` and runs before FFmpeg is installed. So the empirical render assertions added for the zoom/still/caption work were dead weight in CI, and a broken setup would skip them silently.

## Changes

- **Part A** (`927a53af`): shared `#[cfg(test)]` helper `require_or_skip_ffmpeg()` mirroring the CLI suite's `REQUIRE_FFMPEG_TESTS` contract — with the flag set, a missing/unlaunchable ffmpeg is a **panic**, not a silent skip. 10 ignored tests refactored to use it (both directions verified: bogus path + flag → all 10 fail; flag unset → quiet skip).
- **Part B** (`1b576f3b`): a CI step runs those 10 by module filter with `REQUIRE_FFMPEG_TESTS=1`, plus a `grep` guard so a renamed test (0 run → libtest "ok") still fails the step.
- **Bundled binary** (`ab70fd27`): the job sets `SKIP_FFMPEG_DOWNLOAD=1` and apt's ffmpeg is 6.1, but 9 of the 10 tests use `-/filter_complex <file>` (FFmpeg ≥7.0 syntax). Fetch the bundled binary via the same prepare script release.yml uses and point `OPENREELIO_FFMPEG_PATH`/`OPENREELIO_FFPROBE_PATH` at it — so the tests run against the exact build users ship.

## Test plan

- Local ignored suite, bundled 9.0.1, `REQUIRE_FFMPEG_TESTS=1`: **10 passed, 0 skipped** (`--nocapture` shows zero skip lines)
- Negative control (bogus path + flag): 10 fail as intended
- lib 4096 / CLI 164 / clippy / fmt / process-command-window guard / bindings-in-sync all clean
- **This PR's own CI run is the cross-check that the Linux bundled binary passes the assertions measured on 9.0.1** — watching the new step


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enforces execution of ignored FFmpeg-backed tests in CI.

- Adds `REQUIRE_FFMPEG_TESTS` flag to prevent silent skips.

- Configures CI to use bundled FFmpeg 9.x binaries.

- Refactors 10 tests to use shared FFmpeg discovery.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI_Workflow["GitHub Actions CI"] -- "Sets REQUIRE_FFMPEG_TESTS=1" --> Test_Helper["test_ffmpeg helper"]
  Test_Helper -- "Resolves" --> Bundled_FFmpeg["Bundled FFmpeg 9.x"]
  Bundled_FFmpeg -- "Executes" --> Lib_Tests["Ignored Library Tests"]
  Lib_Tests -- "Asserts" --> Results["Verified Render Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ffmpeg.rs</strong><dd><code>New FFmpeg test discovery and enforcement utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/test_ffmpeg.rs

<ul><li>Created a new test utility module for FFmpeg discovery.<br> <li> Implemented <code>require_or_skip_ffmpeg</code> to handle binary resolution and <br>conditional skipping.<br> <li> Added logic to panic if <code>REQUIRE_FFMPEG_TESTS</code> is set but FFmpeg is <br>missing.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/831/files#diff-9d512991a2816dc6a67d781f6a8b64984b92f66a6de8dede2636d523a4e1a223">+130/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>CI workflow updates to run ignored FFmpeg tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added a step to prepare bundled FFmpeg binaries using a node script.<br> <li> Added a new test execution step for ignored library tests with <br>specific environment variables.<br> <li> Included a <code>grep</code> check to ensure tests actually ran and didn't just <br>report a vacuous success.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/831/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter_builder.rs</strong><dd><code>Refactor filter builder tests for enforced FFmpeg execution</code></dd></summary>
<hr>

src-tauri/src/core/effects/filter_builder.rs

<ul><li>Refactored multiple tests (zoom, injection) to use the new <br><code>require_or_skip_ffmpeg</code> helper.<br> <li> Updated internal test functions to accept a path to the FFmpeg binary.<br> <li> Replaced manual environment lookups with shared utility calls.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/831/files#diff-86aaa5bbc7d4304dce89d4a4bb017d4044971db7e1ef672b58072d452c2ab8de">+75/-39</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Update export tests to use shared FFmpeg helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Updated adjustment layer and image export tests to use the new FFmpeg <br>discovery helper.<br> <li> Replaced <code>eprintln!</code> skips with <code>skip_without_ffmpeg</code> to support CI <br>enforcement.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/831/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+17/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Register test_ffmpeg module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/mod.rs

<ul><li>Registered the new <code>test_ffmpeg</code> module under the test configuration.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/831/files#diff-2e54fa69a6cc2c4a47431aaa1543f7324a2e84beb82f894757985d0e63b93662">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of FFmpeg-backed tests by consistently locating and validating the bundled FFmpeg tools.
  - Tests now skip cleanly when FFmpeg or required filters are unavailable.
  - Added an option to require FFmpeg tests to run, failing when they cannot execute.
  - Expanded coverage for FFmpeg availability and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->