### PR TITLE
fix(core): replay SetClipSpeed & slow-motion interpolation; harden atomicity

### DIFF
--- a/src-tauri/src/core/commands/clip.rs
+++ b/src-tauri/src/core/commands/clip.rs
@@ -3379,29 +3379,42 @@ impl Command for SetClipSpeedCommand {
             .position(|c| c.id == self.clip_id)
             .ok_or_else(|| CoreError::ClipNotFound(self.clip_id.clone()))?;
 
-        {
+        // Compute and validate the new duration and placement WITHOUT mutating,
+        // so a rejected command leaves the clip untouched. The executor only
+        // logs an operation after `execute` returns `Ok`, so a mutation made
+        // before a late `Err` would live in memory yet never reach the op log —
+        // exactly the live/reopen divergence this command must not create.
+        let (previous_speed, previous_reverse, previous_duration_sec, new_duration_sec) = {
             let clip = &sequence.tracks[track_idx].clips[clip_idx];
-            self.previous_speed = Some(clip.speed);
-            self.previous_reverse = Some(clip.reverse);
-            self.previous_duration_sec = Some(clip.place.duration_sec);
-        }
+            let new_duration_sec = clip.range.duration() / self.speed as f64;
+            if !new_duration_sec.is_finite() || new_duration_sec <= 0.0 {
+                return Err(CoreError::ValidationError(
+                    "Clip duration must be finite and > 0 after speed change".to_string(),
+                ));
+            }
+            let mut candidate_place = clip.place.clone();
+            candidate_place.duration_sec = new_duration_sec;
+            validate_no_overlap(
+                &sequence.tracks[track_idx],
+                &candidate_place,
+                Some(&self.clip_id),
+            )?;
+            (
+                clip.speed,
+                clip.reverse,
+                clip.place.duration_sec,
+                new_duration_sec,
+            )
+        };
 
+        // All validation passed — commit.
+        self.previous_speed = Some(previous_speed);
+        self.previous_reverse = Some(previous_reverse);
+        self.previous_duration_sec = Some(previous_duration_sec);
         let clip = &mut sequence.tracks[track_idx].clips[clip_idx];
         clip.speed = self.speed;
         clip.reverse = self.reverse;
-        clip.place.duration_sec = clip.range.duration() / self.speed as f64;
-
-        if !clip.place.duration_sec.is_finite() || clip.place.duration_sec <= 0.0 {
-            return Err(CoreError::ValidationError(
-                "Clip duration must be finite and > 0 after speed change".to_string(),
-            ));
-        }
-
-        {
-            let clip_ref = &sequence.tracks[track_idx].clips[clip_idx];
-            let track = &sequence.tracks[track_idx];
-            validate_no_overlap(track, &clip_ref.place, Some(&clip_ref.id))?;
-        }
+        clip.place.duration_sec = new_duration_sec;
 
         let op_id = ulid::Ulid::new().to_string();
         Ok(
@@ -8246,6 +8259,54 @@ mod tests {
         let err = speed_cmd.execute(&mut state).unwrap_err();
         assert!(matches!(err, CoreError::ValidationError(_)));
         assert!(err.to_string().contains("locked"));
+    }
+
+    #[test]
+    fn test_set_clip_speed_leaves_clip_unchanged_when_it_would_overlap() {
+        // A rejected speed change must not mutate the clip: the executor logs
+        // nothing when `execute` errors, so any mutation made before the error
+        // would live only in memory and vanish on reopen.
+        let mut state = create_test_state();
+        let seq_id = state.active_sequence_id.clone().unwrap();
+        let track_id = state.sequences[&seq_id].tracks[0].id.clone();
+        let asset_id = state.assets.keys().next().unwrap().clone();
+
+        // Clip A occupies [0, 5); clip B occupies [5, 10) on the same track.
+        let mut insert_a =
+            InsertClipCommand::new(&seq_id, &track_id, &asset_id, 0.0).with_source_range(0.0, 5.0);
+        insert_a.execute(&mut state).unwrap();
+        let clip_a_id = state.sequences[&seq_id].tracks[0].clips[0].id.clone();
+
+        let mut insert_b =
+            InsertClipCommand::new(&seq_id, &track_id, &asset_id, 5.0).with_source_range(0.0, 5.0);
+        insert_b.execute(&mut state).unwrap();
+
+        let before = state.sequences[&seq_id].tracks[0]
+            .clips
+            .iter()
+            .find(|c| c.id == clip_a_id)
+            .unwrap()
+            .clone();
+
+        // Slowing A to 0.5x would double its duration to 10 s, running it into B.
+        let mut speed_cmd = SetClipSpeedCommand::new(&seq_id, &track_id, &clip_a_id, 0.5, false);
+        let err = speed_cmd.execute(&mut state).unwrap_err();
+        assert!(
+            matches!(err, CoreError::ClipOverlap { .. }),
+            "expected ClipOverlap, got {err:?}"
+        );
+
+        let after = state.sequences[&seq_id].tracks[0]
+            .clips
+            .iter()
+            .find(|c| c.id == clip_a_id)
+            .unwrap();
+        assert_eq!(after.speed, before.speed, "speed must be unchanged");
+        assert_eq!(after.reverse, before.reverse, "reverse must be unchanged");
+        assert_eq!(
+            after.place.duration_sec, before.place.duration_sec,
+            "duration must be unchanged"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/commands/executor.rs
+++ b/src-tauri/src/core/commands/executor.rs
@@ -1448,14 +1448,25 @@ impl CommandExecutor {
                 // holds keeps replay idempotent.
                 //
                 // They go under `CLIP_FLAGS_PAYLOAD_KEY` rather than at the
-                // payload root because the root is shared: `SetClipSpeed` also
-                // writes `reverse` there, and replay — which sees only the
-                // `ClipUpdate` op kind — would otherwise apply that command's
-                // reverse without its speed.
+                // payload root because the root is shared: sixteen commands emit
+                // `ClipUpdate`, and replay sees only the op kind, never the
+                // command behind it. Nesting each command's owned fields under a
+                // namespace only that command writes is what lets replay apply
+                // "this command's speed and reverse together" without an unrelated
+                // command's root `reverse` leaking in. `SetClipSpeed` writes both
+                // `speed` and `reverse` here so replay applies the whole command
+                // or none of it.
                 let clip_flags = match type_name {
                     "SetClipOpacity" => Some(serde_json::json!({ "opacity": clip.opacity })),
                     "SetClipEnabled" => Some(serde_json::json!({ "enabled": clip.enabled })),
                     "ReverseClip" => Some(serde_json::json!({ "reverse": clip.reverse })),
+                    "SetClipSpeed" => Some(serde_json::json!({
+                        "speed": clip.speed,
+                        "reverse": clip.reverse,
+                    })),
+                    "SetClipSlowMotionInterpolation" => Some(serde_json::json!({
+                        "slowMotionInterpolation": clip.slow_motion_interpolation,
+                    })),
                     _ => None,
                 };
                 if let Some(clip_flags) = clip_flags {
@@ -2314,13 +2325,14 @@ mod tests {
         LinkClipsCommand, MoveClipCommand, OverwriteEditCommand, ReverseClipCommand,
         RippleDeleteCommand, SetAudioFadeInCommand, SetAudioFadeOutCommand,
         SetClipBlendModeCommand, SetClipEnabledCommand, SetClipMotionKeyframesCommand,
-        SetClipOpacityCommand, SetClipSpeedCommand, SetMasterVolumeCommand,
-        SetTrackBlendModeCommand, SplitClipCommand, StateChange, TrimClipCommand,
-        UngroupClipsCommand, UnlinkClipsCommand, UnnestCompoundClipCommand,
+        SetClipOpacityCommand, SetClipSlowMotionInterpolationCommand, SetClipSpeedCommand,
+        SetMasterVolumeCommand, SetTrackBlendModeCommand, SplitClipCommand, StateChange,
+        TrimClipCommand, UngroupClipsCommand, UnlinkClipsCommand, UnnestCompoundClipCommand,
     };
     use crate::core::effects::{EffectType, ParamValue};
     use crate::core::masks::{MaskShape, RectMask};
     use crate::core::project::{OpKind, Operation, OpsLog, ProjectMeta, ProjectState};
+    use crate::core::timeline::SlowMotionInterpolation;
     use crate::core::timeline::{
         BlendMode, Clip, FadeType, KeyframeInterpolation, Sequence, SequenceFormat, Track,
         TrackKind, Transform, TransformKeyframe,
@@ -4029,15 +4041,15 @@ mod tests {
         assert_eq!(replayed_clip.reverse, live_clip.reverse);
     }
 
-    /// Replay must never apply part of a command it does not replay in full.
+    /// `SetClipSpeed` must replay in full — speed, reverse, and the derived
+    /// timeline duration — so a project reopened from its op log matches the
+    /// live session that produced it.
     ///
-    /// `SetClipSpeed` shares the `ClipUpdate` op kind with `ReverseClip` and
-    /// logs its own root-level `reverse`. Replaying that field on its own would
-    /// leave the clip reversed at the wrong speed — a half-applied command,
-    /// strictly worse than the skipped one. Full `SetClipSpeed` replay is a
-    /// separate gap; the invariant here is all-or-nothing.
+    /// It shares the `ClipUpdate` op kind with fifteen other commands, so its
+    /// owned fields ride under `CLIP_FLAGS_PAYLOAD_KEY`; replay applies both
+    /// `speed` and `reverse` together, never one without the other.
     #[test]
-    fn test_replay_does_not_half_apply_a_speed_change_as_a_reverse() {
+    fn test_replay_applies_a_speed_change_in_full() {
         let temp_dir = TempDir::new().unwrap();
         let ops_path = temp_dir.path().join("ops.jsonl");
 
@@ -4081,6 +4093,13 @@ mod tests {
             )
             .unwrap();
 
+        let live_clip = state.sequences[&seq_id]
+            .get_track(&track_id)
+            .unwrap()
+            .get_clip(&clip_id)
+            .unwrap();
+        let live_duration = live_clip.place.duration_sec;
+
         let replayed =
             ProjectState::from_ops_log(&OpsLog::new(&ops_path), ProjectMeta::new("Replay"))
                 .unwrap();
@@ -4092,8 +4111,85 @@ mod tests {
 
         assert_eq!(
             (replayed_clip.speed, replayed_clip.reverse),
-            (1.0, false),
-            "SetClipSpeed replays neither field or both, never just reverse"
+            (2.0, true),
+            "SetClipSpeed replays both its speed and its reverse"
+        );
+        assert_eq!(
+            replayed_clip.place.duration_sec, live_duration,
+            "replayed timeline duration matches the live-derived duration"
+        );
+        // 5 s of source at 2x plays back in 2.5 s.
+        assert!(
+            (replayed_clip.place.duration_sec - 2.5).abs() < 1e-9,
+            "duration derives from source range and speed: got {}",
+            replayed_clip.place.duration_sec
+        );
+    }
+
+    /// `SetClipSlowMotionInterpolation` shares the `ClipUpdate` op kind and its
+    /// interpolation mode was silently dropped on reopen before it rode under
+    /// `CLIP_FLAGS_PAYLOAD_KEY`. Replay must now restore it.
+    #[test]
+    fn test_replay_applies_a_slow_motion_interpolation_change() {
+        let temp_dir = TempDir::new().unwrap();
+        let ops_path = temp_dir.path().join("ops.jsonl");
+
+        let mut executor = CommandExecutor::with_ops_log(OpsLog::new(&ops_path));
+        let mut state = ProjectState::new_empty("Test Project");
+
+        let seq_result = executor
+            .execute(
+                Box::new(CreateSequenceCommand::new("Sequence", "1080p")),
+                &mut state,
+            )
+            .unwrap();
+        let seq_id = seq_result.created_ids[0].clone();
+        let track_id = state.sequences[&seq_id].tracks[0].id.clone();
+
+        let asset_path = temp_dir.path().join("test.mp4");
+        std::fs::write(&asset_path, b"test").unwrap();
+        let asset_uri = asset_path.to_string_lossy().to_string();
+        let import_cmd = ImportAssetCommand::new("test.mp4", &asset_uri).with_duration(30.0);
+        executor
+            .execute(Box::new(import_cmd.clone()), &mut state)
+            .unwrap();
+
+        let insert_result = executor
+            .execute(
+                Box::new(
+                    InsertClipCommand::new(&seq_id, &track_id, import_cmd.asset_id(), 0.0)
+                        .with_source_range(0.0, 5.0),
+                ),
+                &mut state,
+            )
+            .unwrap();
+        let clip_id = insert_result.created_ids[0].clone();
+
+        executor
+            .execute(
+                Box::new(SetClipSlowMotionInterpolationCommand::new(
+                    &seq_id,
+                    &track_id,
+                    &clip_id,
+                    SlowMotionInterpolation::FrameBlend,
+                )),
+                &mut state,
+            )
+            .unwrap();
+
+        let replayed =
+            ProjectState::from_ops_log(&OpsLog::new(&ops_path), ProjectMeta::new("Replay"))
+                .unwrap();
+        let replayed_clip = replayed.sequences[&seq_id]
+            .get_track(&track_id)
+            .unwrap()
+            .get_clip(&clip_id)
+            .unwrap();
+
+        assert_eq!(
+            replayed_clip.slow_motion_interpolation,
+            SlowMotionInterpolation::FrameBlend,
+            "SetClipSlowMotionInterpolation replays its interpolation mode"
         );
     }
 

--- a/src-tauri/src/core/project/state.rs
+++ b/src-tauri/src/core/project/state.rs
@@ -18,8 +18,8 @@ use crate::core::{
     masks::MaskGroup,
     project::{OpKind, Operation, OpsLog},
     timeline::{
-        AudioSettings, BlendMode, Clip, Marker, Sequence, SequenceHdrSettings, Track,
-        TransformKeyframe,
+        AudioSettings, BlendMode, Clip, Marker, Sequence, SequenceHdrSettings,
+        SlowMotionInterpolation, Track, TransformKeyframe,
     },
     AssetId, CoreError, CoreResult, EffectId, SequenceId,
 };
@@ -29,13 +29,16 @@ use crate::core::{
 /// An [`Operation`] carries an [`OpKind`] and no record of the command behind
 /// it, and `ClipUpdate` is shared by sixteen commands whose payload roots
 /// overlap — `SetClipSpeed` writes a root-level `reverse`, exactly like
-/// `ReverseClip`. Nesting the replayable flags under a key that only
-/// `SetClipOpacity`, `SetClipEnabled` and `ReverseClip` write is what lets
+/// `ReverseClip`. Nesting the replayable fields under a key that only the
+/// commands which own them write (`SetClipOpacity`, `SetClipEnabled`,
+/// `ReverseClip`, `SetClipSpeed`, `SetClipSlowMotionInterpolation`) is what lets
 /// replay tell "this command owns this field" from "this field happens to be
-/// here", so no command is ever half-applied.
+/// here", so no command is ever half-applied. `SetClipSpeed` writes both its
+/// `speed` and `reverse` here so replay applies the whole command at once.
 ///
-/// The three commands became executable in this same change, so no operation
-/// written by a released build carries these flags at the payload root.
+/// Operations written by builds before this key existed carry none of these
+/// fields under it, so their flag-only commands replay as no-ops rather than
+/// incorrectly — a clean skip, never a half-applied mutation.
 pub(crate) const CLIP_FLAGS_PAYLOAD_KEY: &str = "clipFlags";
 
 // =============================================================================
@@ -1255,10 +1258,13 @@ impl ProjectState {
     ///
     /// The flags are read only from [`CLIP_FLAGS_PAYLOAD_KEY`], never from the
     /// payload root. An [`Operation`] records an [`OpKind`] and nothing about
-    /// the command that produced it, and `ClipUpdate` covers sixteen commands:
-    /// `SetClipSpeed` logs a root-level `reverse` of its own, so reading the
-    /// root would replay half of that command — its reverse without its speed —
-    /// which is worse than replaying none of it.
+    /// the command that produced it, and `ClipUpdate` covers sixteen commands
+    /// whose payload roots overlap — `SetClipSpeed` writes a root-level `reverse`
+    /// exactly like `ReverseClip`. Reading only this namespace lets replay tell
+    /// "this command owns this field" from "this field happens to be at the
+    /// root," so no command is ever half-applied. `SetClipSpeed` logs both its
+    /// `speed` and `reverse` here, and its timeline duration is recomputed from
+    /// the clip's source range and speed exactly as live execution does.
     fn apply_replayed_clip_flags(clip: &mut Clip, payload: &serde_json::Value) -> CoreResult<()> {
         let Some(flags) = payload.get(CLIP_FLAGS_PAYLOAD_KEY) else {
             return Ok(());
@@ -1272,8 +1278,13 @@ impl ProjectState {
             )));
         }
 
-        if let Some(value) = flags.get("opacity") {
-            if !value.is_null() {
+        // ── Phase 1: parse and validate every field; mutate nothing. ──
+        // A malformed value in any field must abort the whole op cleanly rather
+        // than leave earlier fields half-applied — a corrupted or hand-edited
+        // log is untrusted input, and this namespace exists precisely so a
+        // `ClipUpdate` op replays whole or not at all.
+        let opacity = match flags.get("opacity") {
+            Some(value) if !value.is_null() => {
                 let opacity = value.as_f64().ok_or_else(|| {
                     CoreError::InvalidCommand("Invalid opacity value (expected number)".to_string())
                 })?;
@@ -1282,28 +1293,84 @@ impl ProjectState {
                         "Invalid opacity value (expected finite number)".to_string(),
                     ));
                 }
-                clip.opacity = (opacity as f32).clamp(0.0, 1.0);
+                Some((opacity as f32).clamp(0.0, 1.0))
             }
-        }
+            _ => None,
+        };
 
-        if let Some(value) = flags.get("enabled") {
-            if !value.is_null() {
-                clip.enabled = value.as_bool().ok_or_else(|| {
-                    CoreError::InvalidCommand(
-                        "Invalid enabled value (expected boolean)".to_string(),
-                    )
-                })?;
-            }
-        }
+        let enabled = match flags.get("enabled") {
+            Some(value) if !value.is_null() => Some(value.as_bool().ok_or_else(|| {
+                CoreError::InvalidCommand("Invalid enabled value (expected boolean)".to_string())
+            })?),
+            _ => None,
+        };
 
-        if let Some(value) = flags.get("reverse") {
-            if !value.is_null() {
-                clip.reverse = value.as_bool().ok_or_else(|| {
-                    CoreError::InvalidCommand(
-                        "Invalid reverse value (expected boolean)".to_string(),
-                    )
+        let reverse = match flags.get("reverse") {
+            Some(value) if !value.is_null() => Some(value.as_bool().ok_or_else(|| {
+                CoreError::InvalidCommand("Invalid reverse value (expected boolean)".to_string())
+            })?),
+            _ => None,
+        };
+
+        let slow_motion_interpolation = match flags.get("slowMotionInterpolation") {
+            Some(value) if !value.is_null() => Some(
+                serde_json::from_value::<SlowMotionInterpolation>(value.clone()).map_err(|e| {
+                    CoreError::InvalidCommand(format!("Invalid slowMotionInterpolation value: {e}"))
+                })?,
+            ),
+            _ => None,
+        };
+
+        // Speed also drives the clip's timeline duration, derived from the source
+        // range and the realized f32 speed with the same formula live execution
+        // uses (`SetClipSpeedCommand::execute`) — dividing by the f32 promoted to
+        // f64 makes replay bit-identical to live. Validating the f32 cast (not
+        // just the f64) closes the hole where a huge finite f64 overflows to
+        // infinity. Deriving rather than logging the duration keeps replay
+        // identical to live even if an earlier op changed the source range.
+        let speed_change = match flags.get("speed") {
+            Some(value) if !value.is_null() => {
+                let speed = value.as_f64().ok_or_else(|| {
+                    CoreError::InvalidCommand("Invalid speed value (expected number)".to_string())
                 })?;
+                if !speed.is_finite() || speed <= 0.0 {
+                    return Err(CoreError::InvalidCommand(
+                        "Invalid speed value (expected finite number > 0)".to_string(),
+                    ));
+                }
+                let speed_f32 = speed as f32;
+                if !speed_f32.is_finite() || speed_f32 <= 0.0 {
+                    return Err(CoreError::InvalidCommand(
+                        "Invalid speed value (out of range for a clip speed)".to_string(),
+                    ));
+                }
+                let duration_sec = clip.range.duration() / speed_f32 as f64;
+                if !duration_sec.is_finite() || duration_sec <= 0.0 {
+                    return Err(CoreError::InvalidCommand(
+                        "Clip duration must be finite and > 0 after speed change".to_string(),
+                    ));
+                }
+                Some((speed_f32, duration_sec))
             }
+            _ => None,
+        };
+
+        // ── Phase 2: every field parsed and validated — apply them all. ──
+        if let Some(opacity) = opacity {
+            clip.opacity = opacity;
+        }
+        if let Some(enabled) = enabled {
+            clip.enabled = enabled;
+        }
+        if let Some(reverse) = reverse {
+            clip.reverse = reverse;
+        }
+        if let Some(slow_motion_interpolation) = slow_motion_interpolation {
+            clip.slow_motion_interpolation = slow_motion_interpolation;
+        }
+        if let Some((speed, duration_sec)) = speed_change {
+            clip.speed = speed;
+            clip.place.duration_sec = duration_sec;
         }
 
         Ok(())
@@ -2880,6 +2947,66 @@ mod tests {
             .tracks
             .iter()
             .any(|track| track.name.contains("Recovered")));
+    }
+
+    #[test]
+    fn clip_flags_replay_is_atomic_when_a_later_field_is_invalid() {
+        // A corrupted or hand-edited log is untrusted input. A `clipFlags`
+        // object whose `speed` is invalid must abort the whole op cleanly, never
+        // half-apply the `reverse` that parsed before it.
+        let mut sequence = Sequence::new("Seq", SequenceFormat::youtube_1080());
+        let seq_id = sequence.id.clone();
+        let track = Track::new("Video 1", TrackKind::Video);
+        let track_id = track.id.clone();
+        sequence.add_track(track);
+
+        let clip = Clip::new("asset_a")
+            .with_source_range(0.0, 5.0)
+            .place_at(0.0);
+        let clip_id = clip.id.clone();
+
+        let mut state = ProjectState::new_empty("Test Project");
+        state
+            .apply_operation(&Operation::new(
+                OpKind::SequenceCreate,
+                serde_json::to_value(&sequence).unwrap(),
+            ))
+            .unwrap();
+        state
+            .apply_operation(&Operation::new(
+                OpKind::ClipAdd,
+                serde_json::json!({
+                    "sequenceId": seq_id,
+                    "trackId": track_id,
+                    "clip": clip,
+                }),
+            ))
+            .unwrap();
+
+        let err = state
+            .apply_operation(&Operation::new(
+                OpKind::ClipUpdate,
+                serde_json::json!({
+                    "sequenceId": seq_id,
+                    "clipId": clip_id,
+                    "clipFlags": { "reverse": true, "speed": 0.0 },
+                }),
+            ))
+            .unwrap_err();
+        assert!(matches!(err, CoreError::InvalidCommand(_)));
+
+        let clip = state
+            .get_sequence(&seq_id)
+            .unwrap()
+            .tracks
+            .iter()
+            .find_map(|t| t.get_clip(&clip_id))
+            .unwrap();
+        assert!(
+            !clip.reverse,
+            "reverse must not be applied when the op is rejected"
+        );
+        assert_eq!(clip.speed, 1.0, "speed must be unchanged when rejected");
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## Problem (P0 — silent data loss on reopen)

A third-party review flagged, and direct verification confirmed, that `SetClipSpeed` and `SetClipSlowMotionInterpolation` were **executed and logged but never replayed**. `ProjectState::apply_clip_update` never read their fields, so reopening a project (which fully replays `ops.jsonl` — the snapshot branch is dead for app-created projects because `history.json` always exists) silently reverted a clip's speed to `1.0x` and its interpolation to the default. Reachable from the UI (`handleSetClipSpeed`, one-click Ken Burns / speed inspector). A prior test even locked the loss in as "expected".

## Root cause

16 commands share the `ClipUpdate` op kind; replay sees only the op kind, never the command behind it. Command-owned fields therefore ride under the `CLIP_FLAGS_PAYLOAD_KEY` (`clipFlags`) namespace so replay can tell "this command owns this field" from "this field happens to be at the root." `SetClipSpeed`/`SetClipSlowMotionInterpolation` were missing from that namespace.

## Fix

- **Writer** (`executor.rs`): `SetClipSpeed` now logs `clipFlags { speed, reverse }`; `SetClipSlowMotionInterpolation` logs `clipFlags { slowMotionInterpolation }`.
- **Reader** (`state.rs`): applies them on replay. Timeline duration is re-derived from the source range and the realized **f32** speed with the exact formula live execution uses, so `live == replay` bit-for-bit.

## Atomicity hardening (found in adversarial review)

- **Non-transactional live command**: `SetClipSpeedCommand::execute` mutated speed/reverse/duration *before* its overlap check, so a rejected speed change (clip would run into its neighbor) left the clip mutated in memory while nothing was logged — the change vanished on reopen. Validation now runs **before** any mutation.
- **Half-apply on corrupted log**: `apply_replayed_clip_flags` now parses/validates **every** field before applying any, so a malformed value in a hand-edited/corrupted log aborts the whole op instead of half-applying earlier fields. The op log is untrusted input.
- **f32 overflow**: replay validates the `f32` speed cast, not just the source `f64`, so a huge finite `f64` can no longer overflow to an infinite clip speed.

## Backward compatibility

Ops written before this key existed carry root `speed`/`reverse` but no `clipFlags`; the reader ignores the root, so they replay as clean no-ops — no regression, no panic (unchanged from prior behavior for those already-broken projects).

## Tests

- `test_replay_applies_a_speed_change_in_full` — replay restores speed, reverse, and derived duration; asserts replay == live duration.
- `test_replay_applies_a_slow_motion_interpolation_change` — interpolation mode survives reopen.
- `test_set_clip_speed_leaves_clip_unchanged_when_it_would_overlap` — rejected speed change leaves the clip untouched.
- `clip_flags_replay_is_atomic_when_a_later_field_is_invalid` — corrupted `clipFlags {reverse:true, speed:0.0}` aborts whole; reverse not applied.

Full lib suite green (4099 passed, 0 failed); fmt + clippy clean.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Fixes silent data loss where clip speed and interpolation were not replayed.

- Hardens `SetClipSpeedCommand` atomicity by validating before any mutation.

- Implements two-phase parsing in replay to ensure all-or-nothing application.

- Adds comprehensive tests for replay integrity and command atomicity.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Executor ["Command Executor"]
    E1["Log clipFlags"]
  end
  subgraph State ["Project State Replay"]
    S1["Phase 1: Parse & Validate All"]
    S2["Phase 2: Atomic Apply"]
    S1 -- "Success" --> S2
  end
  E1 -- "ops.jsonl" --> S1
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clip.rs</strong><dd><code>Harden SetClipSpeed atomicity with pre-mutation validation</code></dd></summary>
<hr>

src-tauri/src/core/commands/clip.rs

<ul><li>Refactored <code>SetClipSpeedCommand::execute</code> to perform all calculations <br>and overlap checks before mutating the state.<br> <li> Added a regression test <br><code>test_set_clip_speed_leaves_clip_unchanged_when_it_would_overlap</code> to <br>ensure atomicity.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/832/files#diff-2b6c9e796cc9a63d9e704761fef21629435147a53fdf5249a85cf03e4e9cf6d0">+79/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Log realized speed and interpolation flags for replay</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/commands/executor.rs

<ul><li>Updated <code>CommandExecutor</code> to include <code>speed</code>, <code>reverse</code>, and <br><code>slowMotionInterpolation</code> in the <code>clipFlags</code> payload during logging.<br> <li> Added integration tests to verify that speed and interpolation changes <br>are correctly restored during project replay.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/832/files#diff-ef781f77e71d37b770c063002c84fcc01b122dc1b694a44036f644fa4106d946">+112/-16</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>state.rs</strong><dd><code>Implement atomic two-phase replay for clip flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/project/state.rs

<ul><li>Implemented a two-phase update in <code>apply_replayed_clip_flags</code> to ensure <br>atomic application of replayed flags.<br> <li> Added logic to re-derive timeline duration from source range and speed <br>during replay to maintain bit-identical state.<br> <li> Added a test case to verify that malformed log entries do not result <br>in partial state updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/832/files#diff-0fc2d8061589576bbb640630c10ba515b1532fafe1de0524754a126d0f551b0e">+157/-30</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented invalid clip speed changes from partially modifying clip settings.
  - Improved replay reliability by validating clip updates before applying them.
  - Preserved clip speed, reverse state, duration, and interpolation settings consistently across saved changes and reloads.
  - Added support for restoring slow-motion interpolation settings during project replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->