### PR TITLE
fix(core): stop the workspace watcher silently diverging memory from the op log

### DIFF
--- a/src-tauri/src/core/workspace/mod.rs
+++ b/src-tauri/src/core/workspace/mod.rs
@@ -7,6 +7,7 @@
 pub mod ignore;
 pub mod index;
 pub mod path_resolver;
+pub mod project_sync;
 pub mod scanner;
 pub mod service;
 pub mod watcher;

--- a/src-tauri/src/core/workspace/project_sync.rs
+++ b/src-tauri/src/core/workspace/project_sync.rs
@@ -1,0 +1,297 @@
+//! Workspace to project synchronization
+//!
+//! Applies workspace filesystem events to the in-memory project and records
+//! them in the operation log, so a session that watched a folder change ends
+//! up with the same state a reopen would replay.
+//!
+//! Kept out of the IPC layer deliberately. The watcher loop calls this while
+//! holding the project lock, so nothing here may emit Tauri events or grant
+//! asset-protocol access — those belong to the caller, after the lock is
+//! released. Being Tauri-free also means this module is compiled (and
+//! therefore testable) by `cargo test --lib`, unlike `ipc::commands`.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::core::project::{OpKind, Operation};
+use crate::ActiveProject;
+
+use super::service::WorkspaceService;
+use super::watcher::WorkspaceEvent;
+
+/// Result of applying one workspace filesystem event to the in-memory project.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceEventOutcome {
+    /// The event was applied to memory and persisted to the operation log.
+    Applied,
+    /// Nothing usable happened: either the project changed on disk before the
+    /// event could be applied, or the append that would have persisted it
+    /// failed. Either way this session's memory can no longer be trusted to
+    /// match a replay of the log, so the caller must ask the frontend to
+    /// reload from disk.
+    Diverged,
+}
+
+/// Applies one workspace filesystem event to the in-memory project and persists
+/// it as operations.
+///
+/// Refuses before touching memory when another process moved the operation log,
+/// the same way [`crate::core::commands::CommandExecutor`] does: a mutation that
+/// cannot be appended would leave this session's memory permanently disagreeing
+/// with what reopening the project replays, and a swallowed append error is
+/// exactly that divergence made silent.
+pub fn apply_workspace_event_to_project(
+    project: &mut ActiveProject,
+    event: &WorkspaceEvent,
+    service: &WorkspaceService,
+    project_root: &Path,
+) -> WorkspaceEventOutcome {
+    if let Err(e) = project.ensure_no_external_changes() {
+        tracing::warn!(
+            error = %e,
+            "Workspace watcher: project changed on disk; event not applied"
+        );
+        return WorkspaceEventOutcome::Diverged;
+    }
+
+    match event {
+        WorkspaceEvent::FileRemoved(rel_path) => {
+            let mut updated_asset_ids = Vec::new();
+            for asset in project.state.assets.values_mut() {
+                if !asset.missing && asset.relative_path.as_deref() == Some(rel_path.as_str()) {
+                    asset.missing = true;
+                    updated_asset_ids.push(asset.id.clone());
+                    tracing::info!(
+                        path = %rel_path,
+                        "Asset marked missing (file removed externally)"
+                    );
+                }
+            }
+
+            if let Err(e) = record_workspace_asset_updates(project, &updated_asset_ids) {
+                tracing::warn!(
+                    error = %e,
+                    "Workspace watcher: failed to persist missing-asset updates"
+                );
+                return WorkspaceEventOutcome::Diverged;
+            }
+
+            WorkspaceEventOutcome::Applied
+        }
+        WorkspaceEvent::FileAdded(rel_path) | WorkspaceEvent::FileModified(rel_path) => {
+            let existing_asset_ids: HashSet<String> =
+                project.state.assets.keys().cloned().collect();
+            let mut updated_asset_ids = Vec::new();
+
+            // Reconnect previously missing assets at this path
+            for asset in project.state.assets.values_mut() {
+                if asset.missing && asset.relative_path.as_deref() == Some(rel_path.as_str()) {
+                    asset.missing = false;
+                    updated_asset_ids.push(asset.id.clone());
+                    tracing::info!(
+                        path = %rel_path,
+                        "Asset reconnected (file re-appeared)"
+                    );
+                }
+            }
+            // Auto-register any brand-new files
+            if let Err(e) = service.auto_register_discovered_files(&mut project.state, project_root)
+            {
+                tracing::warn!(
+                    error = %e,
+                    "Workspace watcher: failed to auto-register files"
+                );
+            }
+
+            let new_asset_ids: Vec<String> = project
+                .state
+                .assets
+                .keys()
+                .filter(|asset_id| !existing_asset_ids.contains(*asset_id))
+                .cloned()
+                .collect();
+
+            if let Err(e) = record_workspace_asset_imports(project, &new_asset_ids) {
+                tracing::warn!(
+                    error = %e,
+                    "Workspace watcher: failed to persist auto-registered assets"
+                );
+                return WorkspaceEventOutcome::Diverged;
+            }
+
+            if let Err(e) = record_workspace_asset_updates(project, &updated_asset_ids) {
+                tracing::warn!(
+                    error = %e,
+                    "Workspace watcher: failed to persist asset reconnection updates"
+                );
+                return WorkspaceEventOutcome::Diverged;
+            }
+
+            WorkspaceEventOutcome::Applied
+        }
+        // Project state files are handled before indexing; the watcher loop
+        // never reaches here with one.
+        WorkspaceEvent::ProjectStateChanged(_) => WorkspaceEventOutcome::Applied,
+    }
+}
+
+/// Appends one workspace-originated operation and advances the project's
+/// bookkeeping the same way an edit command would.
+fn record_workspace_operation(
+    project: &mut ActiveProject,
+    operation: Operation,
+) -> Result<(), String> {
+    project
+        .ops_log
+        .append(&operation)
+        .map_err(|e| e.to_ipc_error())?;
+    project.state.last_op_id = Some(operation.id.clone());
+    project.state.op_count += 1;
+    project.state.is_dirty = true;
+    project.state.meta.touch_at(&operation.timestamp);
+    Ok(())
+}
+
+/// Records an `AssetImport` operation for each newly registered workspace asset.
+pub fn record_workspace_asset_imports(
+    project: &mut ActiveProject,
+    asset_ids: &[String],
+) -> Result<(), String> {
+    for asset_id in asset_ids {
+        let asset =
+            project.state.assets.get(asset_id).cloned().ok_or_else(|| {
+                format!("Workspace asset not found after registration: {asset_id}")
+            })?;
+        let payload = serde_json::to_value(&asset)
+            .map_err(|e| format!("Failed to serialize workspace asset import payload: {e}"))?;
+        record_workspace_operation(project, Operation::new(OpKind::AssetImport, payload))?;
+    }
+    Ok(())
+}
+
+/// Records an `AssetUpdate` operation for each workspace asset whose file
+/// availability changed.
+fn record_workspace_asset_updates(
+    project: &mut ActiveProject,
+    asset_ids: &[String],
+) -> Result<(), String> {
+    for asset_id in asset_ids {
+        let asset = project
+            .state
+            .assets
+            .get(asset_id)
+            .ok_or_else(|| format!("Workspace asset not found for update: {asset_id}"))?;
+        let payload = serde_json::json!({
+            "assetId": asset.id,
+            "uri": asset.uri,
+            "fileSize": asset.file_size,
+            "relativePath": asset.relative_path,
+            "workspaceManaged": asset.workspace_managed,
+            "missing": asset.missing,
+        });
+        record_workspace_operation(project, Operation::new(OpKind::AssetUpdate, payload))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::assets::Asset;
+    use std::fs;
+
+    /// Creates a project holding one registered, workspace-managed asset backed
+    /// by a real file, and returns the asset id.
+    fn project_with_workspace_asset(project_path: &Path) -> (ActiveProject, String) {
+        let mut project =
+            ActiveProject::create("Watcher Project", project_path.to_path_buf()).unwrap();
+
+        fs::create_dir_all(project_path.join("footage")).unwrap();
+        let media_path = project_path.join("footage/clip.png");
+        fs::write(&media_path, b"image bytes").unwrap();
+
+        let mut asset = Asset::new_image(
+            "clip.png",
+            media_path.to_string_lossy().as_ref(),
+            1920,
+            1080,
+        );
+        asset.relative_path = Some("footage/clip.png".to_string());
+        asset.workspace_managed = true;
+        let asset_id = asset.id.clone();
+        project.state.assets.insert(asset_id.clone(), asset);
+
+        (project, asset_id)
+    }
+
+    /// Appends an operation from a second process holding the same directory,
+    /// which moves the on-disk log past this session's watermark.
+    fn append_external_op(project_path: &Path) {
+        let other_process = ActiveProject::open(project_path.to_path_buf()).unwrap();
+        other_process
+            .ops_log
+            .append(&Operation::new(
+                OpKind::AssetImport,
+                serde_json::json!({ "assetId": "external_asset" }),
+            ))
+            .unwrap();
+    }
+
+    /// Scenario: another process moved the log before the watcher event landed.
+    #[test]
+    fn apply_workspace_event_diverges_without_mutating_after_an_external_edit() {
+        // Given a session that has gone stale behind another process
+        let temp = tempfile::tempdir().unwrap();
+        let project_path = temp.path().join("watched_project");
+        let (mut project, asset_id) = project_with_workspace_asset(&project_path);
+        let service = WorkspaceService::open(project_path.clone()).unwrap();
+
+        append_external_op(&project_path);
+        let ops_before = project.on_disk_op_count().unwrap();
+
+        // When the watcher reports the asset's file as removed
+        let outcome = apply_workspace_event_to_project(
+            &mut project,
+            &WorkspaceEvent::FileRemoved("footage/clip.png".to_string()),
+            &service,
+            &project_path,
+        );
+
+        // Then the event is refused and nothing is left half-applied
+        assert_eq!(outcome, WorkspaceEventOutcome::Diverged);
+        assert!(
+            !project.state.assets[&asset_id].missing,
+            "asset must not be marked missing when the event cannot be persisted"
+        );
+        assert_eq!(
+            project.on_disk_op_count().unwrap(),
+            ops_before,
+            "nothing may be appended on top of the external operations"
+        );
+    }
+
+    /// Scenario: the ordinary case, with the log still where this session left it.
+    #[test]
+    fn apply_workspace_event_marks_asset_missing_and_appends_one_update_op() {
+        // Given a project nobody else has touched
+        let temp = tempfile::tempdir().unwrap();
+        let project_path = temp.path().join("watched_project");
+        let (mut project, asset_id) = project_with_workspace_asset(&project_path);
+        let service = WorkspaceService::open(project_path.clone()).unwrap();
+
+        let ops_before = project.on_disk_op_count().unwrap();
+
+        // When the watcher reports the asset's file as removed
+        let outcome = apply_workspace_event_to_project(
+            &mut project,
+            &WorkspaceEvent::FileRemoved("footage/clip.png".to_string()),
+            &service,
+            &project_path,
+        );
+
+        // Then the asset is marked missing and the change is recorded once
+        assert_eq!(outcome, WorkspaceEventOutcome::Applied);
+        assert!(project.state.assets[&asset_id].missing);
+        assert_eq!(project.on_disk_op_count().unwrap(), ops_before + 1);
+    }
+}

--- a/src-tauri/src/ipc/commands/workspace.rs
+++ b/src-tauri/src/ipc/commands/workspace.rs
@@ -22,15 +22,17 @@ use crate::core::fs::{
     write_bytes_atomic_no_symlink,
 };
 use crate::core::process::configure_std_command;
-use crate::core::project::{OpKind, Operation};
 use crate::core::workspace::{
     ignore::IgnoreRules,
+    project_sync::{
+        apply_workspace_event_to_project, record_workspace_asset_imports, WorkspaceEventOutcome,
+    },
     service::{FileTreeEntry, WorkspaceService},
     watcher::{WorkspaceEvent, WorkspaceWatcher, WORKSPACE_EVENT_CHANNEL_CAPACITY},
 };
 use crate::core::CoreError;
 use crate::ipc::commands::project::{allow_confined_asset_protocol_file, canonical_project_root};
-use crate::{ActiveProject, AppState};
+use crate::AppState;
 use tauri::{Emitter, Manager};
 
 /// Tauri event emitted when the active project's state files were changed by
@@ -190,58 +192,14 @@ async fn external_change_payload(
     }))
 }
 
-fn record_workspace_operation(
-    project: &mut ActiveProject,
-    operation: Operation,
-) -> Result<(), String> {
-    project
-        .ops_log
-        .append(&operation)
-        .map_err(|e| e.to_ipc_error())?;
-    project.state.last_op_id = Some(operation.id.clone());
-    project.state.op_count += 1;
-    project.state.is_dirty = true;
-    project.state.meta.touch_at(&operation.timestamp);
-    Ok(())
-}
-
-fn record_workspace_asset_imports(
-    project: &mut ActiveProject,
-    asset_ids: &[String],
-) -> Result<(), String> {
-    for asset_id in asset_ids {
-        let asset =
-            project.state.assets.get(asset_id).cloned().ok_or_else(|| {
-                format!("Workspace asset not found after registration: {asset_id}")
-            })?;
-        let payload = serde_json::to_value(&asset)
-            .map_err(|e| format!("Failed to serialize workspace asset import payload: {e}"))?;
-        record_workspace_operation(project, Operation::new(OpKind::AssetImport, payload))?;
+/// The workspace-relative path an event refers to.
+fn workspace_event_relative_path(event: &WorkspaceEvent) -> &str {
+    match event {
+        WorkspaceEvent::FileAdded(path)
+        | WorkspaceEvent::FileRemoved(path)
+        | WorkspaceEvent::FileModified(path)
+        | WorkspaceEvent::ProjectStateChanged(path) => path.as_str(),
     }
-    Ok(())
-}
-
-fn record_workspace_asset_updates(
-    project: &mut ActiveProject,
-    asset_ids: &[String],
-) -> Result<(), String> {
-    for asset_id in asset_ids {
-        let asset = project
-            .state
-            .assets
-            .get(asset_id)
-            .ok_or_else(|| format!("Workspace asset not found for update: {asset_id}"))?;
-        let payload = serde_json::json!({
-            "assetId": asset.id,
-            "uri": asset.uri,
-            "fileSize": asset.file_size,
-            "relativePath": asset.relative_path,
-            "workspaceManaged": asset.workspace_managed,
-            "missing": asset.missing,
-        });
-        record_workspace_operation(project, Operation::new(OpKind::AssetUpdate, payload))?;
-    }
-    Ok(())
 }
 
 // =============================================================================
@@ -351,6 +309,9 @@ pub async fn stop_workspace_watcher(state: &AppState) {
 ///   3. Auto-registers newly discovered files as project assets
 ///   4. Emits `workspace:file-added`, `workspace:file-removed`, or
 ///      `workspace:file-modified` Tauri events so the frontend refreshes its tree
+///   5. Emits [`PROJECT_EXTERNAL_CHANGE_EVENT`] instead of any of the above when
+///      step 2 could not be applied or persisted, so the frontend reloads the
+///      authoritative on-disk state rather than trusting diverged memory
 async fn start_workspace_watcher(project_root: PathBuf, state: &AppState) -> Result<(), String> {
     use std::sync::Arc;
 
@@ -410,108 +371,69 @@ async fn start_workspace_watcher(project_root: PathBuf, state: &AppState) -> Res
             }
 
             // 2. Update the in-memory project state + auto-register
+            let mut diverged = false;
             {
                 let app_state = app_handle.state::<crate::AppState>();
                 let mut guard = app_state.project.lock().await;
                 if let Some(project) = guard.as_mut() {
-                    match &event {
-                        WorkspaceEvent::FileRemoved(rel_path) => {
-                            let mut updated_asset_ids = Vec::new();
-                            for asset in project.state.assets.values_mut() {
-                                if !asset.missing
-                                    && asset.relative_path.as_deref() == Some(rel_path.as_str())
-                                {
-                                    asset.missing = true;
-                                    updated_asset_ids.push(asset.id.clone());
-                                    tracing::info!(
-                                        path = %rel_path,
-                                        "Asset marked missing (file removed externally)"
-                                    );
-                                }
-                            }
-
-                            if let Err(e) =
-                                record_workspace_asset_updates(project, &updated_asset_ids)
-                            {
-                                tracing::warn!(
-                                    error = %e,
-                                    "Workspace watcher: failed to persist missing-asset updates"
-                                );
-                            }
-                        }
-                        WorkspaceEvent::FileAdded(rel_path)
-                        | WorkspaceEvent::FileModified(rel_path) => {
-                            let existing_asset_ids: std::collections::HashSet<String> =
-                                project.state.assets.keys().cloned().collect();
-                            let mut updated_asset_ids = Vec::new();
-
-                            // Reconnect previously missing assets at this path
-                            for asset in project.state.assets.values_mut() {
-                                if asset.missing
-                                    && asset.relative_path.as_deref() == Some(rel_path.as_str())
-                                {
-                                    asset.missing = false;
-                                    updated_asset_ids.push(asset.id.clone());
-                                    tracing::info!(
-                                        path = %rel_path,
-                                        "Asset reconnected (file re-appeared)"
-                                    );
-                                }
-                            }
-                            // Auto-register any brand-new files
-                            if let Err(e) = service.auto_register_discovered_files(
-                                &mut project.state,
-                                &project_root_for_loop,
+                    match apply_workspace_event_to_project(
+                        project,
+                        &event,
+                        &service,
+                        &project_root_for_loop,
+                    ) {
+                        WorkspaceEventOutcome::Applied => {
+                            if matches!(
+                                event,
+                                WorkspaceEvent::FileAdded(_) | WorkspaceEvent::FileModified(_)
                             ) {
-                                tracing::warn!(
-                                    error = %e,
-                                    "Workspace watcher: failed to auto-register files"
-                                );
-                            }
-
-                            let new_asset_ids: Vec<String> = project
-                                .state
-                                .assets
-                                .keys()
-                                .filter(|asset_id| !existing_asset_ids.contains(*asset_id))
-                                .cloned()
-                                .collect();
-
-                            if let Err(e) = record_workspace_asset_imports(project, &new_asset_ids)
-                            {
-                                tracing::warn!(
-                                    error = %e,
-                                    "Workspace watcher: failed to persist auto-registered assets"
-                                );
-                            }
-
-                            if let Err(e) =
-                                record_workspace_asset_updates(project, &updated_asset_ids)
-                            {
-                                tracing::warn!(
-                                    error = %e,
-                                    "Workspace watcher: failed to persist asset reconnection updates"
-                                );
-                            }
-
-                            // Allow asset-protocol access for all managed assets,
-                            // confined to the project the same way a project open is.
-                            let canonical_project = canonical_project_root(&project_root_for_loop);
-                            for asset in project.state.assets.values() {
-                                if asset.workspace_managed {
-                                    allow_confined_asset_protocol_file(
-                                        &app_state,
-                                        &canonical_project,
-                                        asset,
-                                    );
+                                // Allow asset-protocol access for all managed assets,
+                                // confined to the project the same way a project open is.
+                                // Every managed asset is re-granted, not just the newly
+                                // registered ones: a reconnected asset had no grant while
+                                // its file was gone.
+                                let canonical_project =
+                                    canonical_project_root(&project_root_for_loop);
+                                for asset in project.state.assets.values() {
+                                    if asset.workspace_managed {
+                                        allow_confined_asset_protocol_file(
+                                            &app_state,
+                                            &canonical_project,
+                                            asset,
+                                        );
+                                    }
                                 }
                             }
                         }
-                        // Handled before indexing; the loop never reaches here.
-                        WorkspaceEvent::ProjectStateChanged(_) => {}
+                        WorkspaceEventOutcome::Diverged => diverged = true,
                     }
                 }
             } // project lock released here
+
+            // 2b. The session no longer matches the log. Ask the frontend to
+            //     reload from disk — the authoritative rebuild — instead of
+            //     carrying a half-applied mutation forward silently. Emitted
+            //     only after the project lock is released, because
+            //     `external_change_payload` takes that same lock.
+            //
+            //     Then fall through to the per-file notify below rather than
+            //     `continue`: the project reload rebuilds the op-sourced project
+            //     state, but it does not rebuild the file-explorer tree, which
+            //     is refreshed only by the `workspace:file-*` events. Skipping
+            //     the notify would leave the tree showing the pre-change file
+            //     listing until the next unrelated event.
+            if diverged {
+                let rel_path = workspace_event_relative_path(&event);
+                if let Some(payload) = external_change_payload(&app_handle, rel_path).await {
+                    if let Err(e) = app_handle.emit(PROJECT_EXTERNAL_CHANGE_EVENT, payload) {
+                        tracing::warn!(
+                            event = PROJECT_EXTERNAL_CHANGE_EVENT,
+                            error = %e,
+                            "Workspace watcher: failed to emit external change event"
+                        );
+                    }
+                }
+            }
 
             // 3. Notify the frontend
             let (event_name, rel_path) = match &event {


### PR DESCRIPTION
### **User description**
## Problem (A3 from the external-review verification — MEDIUM-HIGH, live silent divergence)

The async workspace watcher (`start_workspace_watcher`) mutated in-memory project state **before** persisting to `ops.jsonl`, had **no** external-change precheck, and **swallowed** every `record_workspace_*` append failure as `tracing::warn!`. When another process (CLI, agent, second window) appended to the same log, the watcher's append was correctly refused — but this session's memory kept the mutation (`asset.missing = true`, reconnects, auto-registered assets) that **never reached disk**. Result: a permanent, silent divergence from what reopening the project replays. Unlike `CommandExecutor::execute_internal`, there was no `ensure_no_external_changes()` refuse-before-mutate, and unlike a real edit, the failure was never surfaced.

## Fix

- Extracted the per-event apply logic into a **Tauri-free** core module `core::workspace::project_sync`. This is required for testability: `ipc::commands` is declared `#[cfg(all(not(test), feature = "gui"))]`, so its colocated `#[cfg(test)]` tests **never compile under `cargo test`** (tracked separately as a test-integrity cleanup).
- `apply_workspace_event_to_project` **prechecks** `ensure_no_external_changes()` before any mutation and returns `Diverged` on precheck-fail **or** any `record_*` `Err` — no more silent swallow.
- On divergence, the watcher loop — **after releasing the project lock** (critical: `external_change_payload` re-locks it, so emitting inside the guard would deadlock) — emits `PROJECT_EXTERNAL_CHANGE_EVENT` so the existing reload banner rebuilds authoritative on-disk state, **then falls through to the `workspace:file-*` notify** so the file-explorer tree (which the project reload does **not** rebuild — verified in `workspaceStore.ts`) refreshes too.

## Success path unchanged

Same assets mutated, same `AssetImport`/`AssetUpdate` ops in the same order, same `allow_confined_asset_protocol_file` grants for every `workspace_managed` asset, gated to `FileAdded`/`FileModified` exactly as before.

## Tests (real `ActiveProject`/`OpsLog`/`WorkspaceService`, no mocks)

- `apply_workspace_event_diverges_without_mutating_after_an_external_edit` — a second process appends out-of-band; asserts `Diverged`, `missing` still `false`, on-disk op count unchanged.
- `apply_workspace_event_marks_asset_missing_and_appends_one_update_op` — clean project; asserts `Applied`, `missing == true`, exactly one op appended.

Full lib suite green (4101 passed, 0 failed); fmt + clippy clean.

## Review

Adversarial cross-review (Codex) confirmed no deadlock, byte-for-byte success-path parity, and pinning tests. It found one real defect — the file tree was left stale on the diverged path — **fixed in this branch** (fall through to the file notify instead of `continue`). A residual non-external persist-failure hardening (disk full etc.) and the pre-existing warning-only `auto_register` behavior are tracked as separate follow-ups.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Prevents silent memory divergence in workspace watcher.

- Adds external-change prechecks before mutating project state.

- Extracts synchronization logic into a testable core module.

- Emits reload events when disk and memory diverge.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Watcher["Workspace Watcher"] -- "1. Detect Change" --> Sync["project_sync::apply_event"]
  Sync -- "2. Precheck" --> Disk["Check ops.jsonl"]
  Disk -- "Diverged" --> Reload["Emit PROJECT_EXTERNAL_CHANGE_EVENT"]
  Disk -- "Consistent" --> Mutate["Mutate Memory & Append Log"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project_sync.rs</strong><dd><code>Core logic for workspace-to-project synchronization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/workspace/project_sync.rs

<ul><li>New module implementing <code>apply_workspace_event_to_project</code> to handle <br>filesystem events.<br> <li> Includes logic for marking assets missing, reconnecting them, and <br>auto-registering new files.<br> <li> Implements strict checks to ensure no mutations occur if the on-disk <br>operation log has diverged.<br> <li> Added unit tests to verify divergence handling and successful state <br>updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/833/files#diff-8fd5ca857a684d7d6f2db360a0f84bb823b70d37d1e7a6222d4a5a833731bc7f">+297/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.rs</strong><dd><code>Update IPC watcher loop to handle state divergence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/workspace.rs

<ul><li>Refactored <code>start_workspace_watcher</code> to use the new <code>project_sync</code> module.<br> <li> Added logic to emit <code>PROJECT_EXTERNAL_CHANGE_EVENT</code> when a divergence is <br>detected.<br> <li> Ensures asset-protocol grants are refreshed for reconnected workspace <br>assets.<br> <li> Removed redundant local helper functions moved to the core module.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/833/files#diff-2aa7e8c8079bfc9abff9c3d2b43e3c43adefcf6015e00370641c1b455c036f14">+66/-144</a></td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Module registration for project synchronization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/workspace/mod.rs

- Registered the new `project_sync` module.


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/833/files#diff-9a191411f4184e90052943a8d3e08708b55de36d5aa2facbe3a658a26f5262ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace synchronization for added, modified, and removed project files.
  * Missing project assets can be reconnected or automatically registered when detected.
  * Asset import and update activity is recorded automatically.
  * File changes that conflict with external project updates now trigger a divergence notification.
  * Asset access permissions are restored after successfully processing file additions or modifications.
* **Bug Fixes**
  * Prevented project updates from being applied when external changes are detected before synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->