### PR TITLE
feat(render): export preflight validation with jump-to-clip findings

### DIFF
--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -166,7 +166,11 @@ pub(super) fn clip_audio_is_suppressed_by_companion(
         && audio_companion_keys.contains(&create_audio_companion_key(clip))
 }
 
-fn has_layered_visual_overlap(sequence: &Sequence) -> bool {
+/// Returns the id of the first clip that starts before an earlier one ended.
+///
+/// Reported as an id rather than a bare `bool` so the caller can point at the
+/// clip the user has to move, instead of leaving them to find it themselves.
+fn first_layered_visual_overlap(sequence: &Sequence) -> Option<&str> {
     let mut intervals = Vec::new();
 
     for track in &sequence.tracks {
@@ -179,17 +183,21 @@ fn has_layered_visual_overlap(sequence: &Sequence) -> bool {
                 continue;
             }
 
-            intervals.push((clip.place.timeline_in_sec, clip.place.timeline_out_sec()));
+            intervals.push((
+                clip.place.timeline_in_sec,
+                clip.place.timeline_out_sec(),
+                clip.id.as_str(),
+            ));
         }
     }
 
     intervals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
     let mut latest_end: Option<f64> = None;
-    for (start, end) in intervals {
+    for (start, end, clip_id) in intervals {
         if let Some(current_end) = latest_end {
             if start < current_end - 0.001 {
-                return true;
+                return Some(clip_id);
             }
             latest_end = Some(current_end.max(end));
         } else {
@@ -197,7 +205,7 @@ fn has_layered_visual_overlap(sequence: &Sequence) -> bool {
         }
     }
 
-    false
+    None
 }
 
 fn sequence_has_exportable_audio(
@@ -6593,6 +6601,32 @@ pub fn calculate_export_progress(
 // Export Validation
 // =============================================================================
 
+/// How badly a validation finding affects the export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportFindingSeverity {
+    /// The export cannot run until the caller fixes this.
+    Error,
+    /// The export runs, but the file differs from what the timeline shows.
+    Warning,
+}
+
+/// A single validation finding, addressed at the thing that caused it.
+///
+/// The flat `errors`/`warnings` string lists say only *what* is wrong; a caller
+/// that wants to take the user to the offending clip needs the id too, and every
+/// clip-specific validator already has it in scope when it formats the message.
+#[derive(Debug, Clone)]
+pub struct ExportFinding {
+    /// Whether this blocks the export or only degrades it.
+    pub severity: ExportFindingSeverity,
+    /// Human-readable description, identical to the `errors`/`warnings` entry.
+    pub message: String,
+    /// Sequence the finding belongs to, when the validator knows it.
+    pub sequence_id: Option<String>,
+    /// Clip the finding is about, when the finding is about one clip.
+    pub clip_id: Option<String>,
+}
+
 /// Validation result for export settings
 #[derive(Debug, Clone)]
 pub struct ExportValidation {
@@ -6602,6 +6636,11 @@ pub struct ExportValidation {
     pub errors: Vec<String>,
     /// List of warnings (non-blocking)
     pub warnings: Vec<String>,
+    /// Structured view of the same findings, carrying the ids of what caused them.
+    ///
+    /// This is the source of truth; `is_valid`, `errors` and `warnings` are kept
+    /// in sync with it so existing consumers keep working unchanged.
+    pub findings: Vec<ExportFinding>,
 }
 
 impl ExportValidation {
@@ -6611,32 +6650,85 @@ impl ExportValidation {
             is_valid: true,
             errors: Vec::new(),
             warnings: Vec::new(),
+            findings: Vec::new(),
         }
     }
 
     /// Create an invalid result with errors
     pub fn invalid(errors: Vec<String>) -> Self {
-        Self {
-            is_valid: false,
-            errors,
-            warnings: Vec::new(),
+        let mut validation = Self::valid();
+        for error in errors {
+            validation.add_error(error);
         }
+        validation
     }
 
     /// Add an error
     pub fn add_error(&mut self, error: impl Into<String>) {
-        self.errors.push(error.into());
-        self.is_valid = false;
+        self.push(ExportFindingSeverity::Error, error.into(), None, None);
     }
 
     /// Add a warning
     pub fn add_warning(&mut self, warning: impl Into<String>) {
-        self.warnings.push(warning.into());
+        self.push(ExportFindingSeverity::Warning, warning.into(), None, None);
+    }
+
+    /// Add an error a caller can navigate to.
+    pub fn add_clip_error(
+        &mut self,
+        sequence_id: impl Into<String>,
+        clip_id: impl Into<String>,
+        error: impl Into<String>,
+    ) {
+        self.push(
+            ExportFindingSeverity::Error,
+            error.into(),
+            Some(sequence_id.into()),
+            Some(clip_id.into()),
+        );
+    }
+
+    /// Add a warning a caller can navigate to.
+    pub fn add_clip_warning(
+        &mut self,
+        sequence_id: impl Into<String>,
+        clip_id: impl Into<String>,
+        warning: impl Into<String>,
+    ) {
+        self.push(
+            ExportFindingSeverity::Warning,
+            warning.into(),
+            Some(sequence_id.into()),
+            Some(clip_id.into()),
+        );
+    }
+
+    fn push(
+        &mut self,
+        severity: ExportFindingSeverity,
+        message: String,
+        sequence_id: Option<String>,
+        clip_id: Option<String>,
+    ) {
+        match severity {
+            ExportFindingSeverity::Error => {
+                self.errors.push(message.clone());
+                self.is_valid = false;
+            }
+            ExportFindingSeverity::Warning => self.warnings.push(message.clone()),
+        }
+        self.findings.push(ExportFinding {
+            severity,
+            message,
+            sequence_id,
+            clip_id,
+        });
     }
 }
 
 fn validate_clip_effect_contract(
     validation: &mut ExportValidation,
+    sequence_id: &str,
     clip: &Clip,
     track: &Track,
     effects: &std::collections::HashMap<String, Effect>,
@@ -6648,10 +6740,14 @@ fn validate_clip_effect_contract(
 
     for effect_id in &clip.effects {
         let Some(effect) = effects.get(effect_id) else {
-            validation.add_error(format!(
-                "Clip '{}' on track '{}' references missing effect '{}'",
-                clip.id, track.name, effect_id
-            ));
+            validation.add_clip_error(
+                sequence_id,
+                &clip.id,
+                format!(
+                    "Clip '{}' on track '{}' references missing effect '{}'",
+                    clip.id, track.name, effect_id
+                ),
+            );
             continue;
         };
 
@@ -6679,12 +6775,12 @@ fn validate_clip_effect_contract(
         if effect.effect_type.is_two_input_transition() {
             for refusal in transition_plan.refusals() {
                 if refusal.clip_id == clip.id && refusal.effect_id == *effect_id {
-                    validation.add_warning(refusal.warning());
+                    validation.add_clip_warning(sequence_id, &clip.id, refusal.warning());
                 }
             }
             for advisory in transition_plan.advisories() {
                 if advisory.clip_id == clip.id && advisory.effect_id == *effect_id {
-                    validation.add_warning(advisory.warning());
+                    validation.add_clip_warning(sequence_id, &clip.id, advisory.warning());
                 }
             }
         }
@@ -6693,23 +6789,32 @@ fn validate_clip_effect_contract(
             let reason = capability
                 .export_reason
                 .unwrap_or("This effect is not implemented by final export.");
-            validation.add_error(format!(
-                "Effect '{}' on clip '{}' is not supported in final export: {}",
-                label, clip.id, reason
-            ));
+            validation.add_clip_error(
+                sequence_id,
+                &clip.id,
+                format!(
+                    "Effect '{}' on clip '{}' is not supported in final export: {}",
+                    label, clip.id, reason
+                ),
+            );
         }
 
         if !effect.keyframes.is_empty() {
-            validation.add_error(format!(
-                "Keyframed effect '{}' on clip '{}' is not supported in final export yet; export would otherwise render a static sampled value",
-                label, clip.id
-            ));
+            validation.add_clip_error(
+                sequence_id,
+                &clip.id,
+                format!(
+                    "Keyframed effect '{}' on clip '{}' is not supported in final export yet; export would otherwise render a static sampled value",
+                    label, clip.id
+                ),
+            );
         }
     }
 }
 
 fn validate_clip_frame_alignment(
     validation: &mut ExportValidation,
+    sequence_id: &str,
     clock: &TimelineClock,
     clip: &Clip,
     track: &Track,
@@ -6718,13 +6823,17 @@ fn validate_clip_frame_alignment(
     let end = clip.place.timeline_out_sec();
 
     if !clock.is_frame_aligned(start) || !clock.is_frame_aligned(end) {
-        validation.add_warning(format!(
-            "Clip '{}' on track '{}' is not aligned to sequence frame boundaries at {}/{} fps",
-            clip.id,
-            track.name,
-            clock.fps().num,
-            clock.fps().den
-        ));
+        validation.add_clip_warning(
+            sequence_id,
+            &clip.id,
+            format!(
+                "Clip '{}' on track '{}' is not aligned to sequence frame boundaries at {}/{} fps",
+                clip.id,
+                track.name,
+                clock.fps().num,
+                clock.fps().den
+            ),
+        );
     }
 }
 
@@ -6764,18 +6873,26 @@ fn validate_clip_asset_qc(
     settings: &ExportSettings,
 ) {
     if asset.missing {
-        validation.add_error(format!(
-            "Asset '{}' is marked missing/offline for clip '{}'",
-            asset.id, clip.id
-        ));
+        validation.add_clip_error(
+            &sequence.id,
+            &clip.id,
+            format!(
+                "Asset '{}' is marked missing/offline for clip '{}'",
+                asset.id, clip.id
+            ),
+        );
     }
 
     if let Some(video) = asset.video.as_ref() {
         if video.is_hdr && !settings.is_hdr() && !has_active_tonemap(settings) {
-            validation.add_warning(format!(
-                "HDR source asset '{}' on clip '{}' is exporting to SDR without tonemapping; verify gamut/clipping in scopes or enable HDR export/tonemap",
-                asset.id, clip.id
-            ));
+            validation.add_clip_warning(
+                &sequence.id,
+                &clip.id,
+                format!(
+                    "HDR source asset '{}' on clip '{}' is exporting to SDR without tonemapping; verify gamut/clipping in scopes or enable HDR export/tonemap",
+                    asset.id, clip.id
+                ),
+            );
         }
     }
 
@@ -6788,10 +6905,14 @@ fn validate_clip_asset_qc(
             + sequence.master_volume_db as f64;
 
         if combined_gain_db > 3.0 {
-            validation.add_warning(format!(
-                "Clip '{}' on track '{}' has {:.1} dB combined gain; verify loudness and clipping before export",
-                clip.id, track.name, combined_gain_db
-            ));
+            validation.add_clip_warning(
+                &sequence.id,
+                &clip.id,
+                format!(
+                    "Clip '{}' on track '{}' has {:.1} dB combined gain; verify loudness and clipping before export",
+                    clip.id, track.name, combined_gain_db
+                ),
+            );
         }
     }
 }
@@ -6843,10 +6964,14 @@ fn validate_text_render_fidelity(
 
             let line_height = effect_float_param(&effect, "line_height", ASS_DEFAULT_LINE_HEIGHT);
             if (line_height - ASS_DEFAULT_LINE_HEIGHT).abs() > ASS_LINE_HEIGHT_WARNING_TOLERANCE {
-                validation.add_warning(format!(
-                    "Line height {line_height:.2} on clip '{}' on track '{}' is honored only by the drawtext fallback; the libass burn-in path an export normally takes follows the font's own line metrics",
-                    clip.id, track.name
-                ));
+                validation.add_clip_warning(
+                    &sequence.id,
+                    &clip.id,
+                    format!(
+                        "Line height {line_height:.2} on clip '{}' on track '{}' is honored only by the drawtext fallback; the libass burn-in path an export normally takes follows the font's own line metrics",
+                        clip.id, track.name
+                    ),
+                );
             }
 
             let requested_family = ass_sanitize_style_field(
@@ -6856,10 +6981,14 @@ fn validate_text_render_fidelity(
             if let FontResolution::Substituted(replacement) =
                 resolve_text_font_family(&requested_family)
             {
-                validation.add_warning(format!(
-                    "Font '{requested_family}' on clip '{}' on track '{}' is neither bundled nor installed; the clip renders in the bundled '{replacement}' instead",
-                    clip.id, track.name
-                ));
+                validation.add_clip_warning(
+                    &sequence.id,
+                    &clip.id,
+                    format!(
+                        "Font '{requested_family}' on clip '{}' on track '{}' is neither bundled nor installed; the clip renders in the bundled '{replacement}' instead",
+                        clip.id, track.name
+                    ),
+                );
             }
         }
     }
@@ -6867,6 +6996,7 @@ fn validate_text_render_fidelity(
 
 fn validate_caption_track_qc(
     validation: &mut ExportValidation,
+    sequence_id: &str,
     clock: &TimelineClock,
     track: &Track,
 ) {
@@ -6874,27 +7004,39 @@ fn validate_caption_track_qc(
         track.clips.iter().filter(|clip| clip.enabled).collect();
 
     for clip in &enabled_caption_clips {
-        validate_clip_frame_alignment(validation, clock, clip, track);
+        validate_clip_frame_alignment(validation, sequence_id, clock, clip, track);
 
         let caption_text = clip.label.as_deref().unwrap_or("").trim();
         if caption_text.is_empty() {
-            validation.add_warning(format!(
-                "Caption clip '{}' on track '{}' has empty text",
-                clip.id, track.name
-            ));
+            validation.add_clip_warning(
+                sequence_id,
+                &clip.id,
+                format!(
+                    "Caption clip '{}' on track '{}' has empty text",
+                    clip.id, track.name
+                ),
+            );
         }
 
         let duration = clip.place.duration_sec;
         if duration <= 0.0 {
-            validation.add_warning(format!(
-                "Caption clip '{}' on track '{}' has no visible duration",
-                clip.id, track.name
-            ));
+            validation.add_clip_warning(
+                sequence_id,
+                &clip.id,
+                format!(
+                    "Caption clip '{}' on track '{}' has no visible duration",
+                    clip.id, track.name
+                ),
+            );
         } else if duration < 0.5 {
-            validation.add_warning(format!(
-                "Caption clip '{}' on track '{}' is shorter than 0.5 seconds",
-                clip.id, track.name
-            ));
+            validation.add_clip_warning(
+                sequence_id,
+                &clip.id,
+                format!(
+                    "Caption clip '{}' on track '{}' is shorter than 0.5 seconds",
+                    clip.id, track.name
+                ),
+            );
         }
     }
 
@@ -6909,10 +7051,14 @@ fn validate_caption_track_qc(
         let previous = pair[0];
         let next = pair[1];
         if previous.place.overlaps(&next.place) {
-            validation.add_warning(format!(
-                "Caption clips '{}' and '{}' overlap on track '{}'",
-                previous.id, next.id, track.name
-            ));
+            validation.add_clip_warning(
+                sequence_id,
+                &next.id,
+                format!(
+                    "Caption clips '{}' and '{}' overlap on track '{}'",
+                    previous.id, next.id, track.name
+                ),
+            );
         }
     }
 }
@@ -6999,16 +7145,22 @@ pub fn validate_export_settings_with_dimensions(
         return validation;
     }
 
-    let has_enabled_unsupported_overlay_clips = sequence.tracks.iter().any(|track| {
-        track.kind == TrackKind::Overlay
-            && track_included_in_export(track)
-            && track
-                .clips
-                .iter()
-                .any(|clip| clip.enabled && !is_text_clip(clip))
-    });
-    if has_enabled_unsupported_overlay_clips {
-        validation.add_error("Overlay tracks are not supported in final render export yet");
+    // Kept as one message rather than one per clip, but addressed at the first
+    // offending clip so the caller has somewhere to jump to.
+    let first_unsupported_overlay_clip = sequence
+        .tracks
+        .iter()
+        .filter(|track| track.kind == TrackKind::Overlay && track_included_in_export(track))
+        .flat_map(|track| track.clips.iter())
+        .find(|clip| clip.enabled && !is_text_clip(clip))
+        .map(|clip| clip.id.clone());
+    let has_enabled_unsupported_overlay_clips = first_unsupported_overlay_clip.is_some();
+    if let Some(clip_id) = first_unsupported_overlay_clip {
+        validation.add_clip_error(
+            &sequence.id,
+            clip_id,
+            "Overlay tracks are not supported in final render export yet",
+        );
     }
 
     let visual_clip_count: usize = sequence
@@ -7046,7 +7198,7 @@ pub fn validate_export_settings_with_dimensions(
 
         if track.kind == TrackKind::Caption {
             // Caption tracks are burned in separately and do not use file-backed assets.
-            validate_caption_track_qc(&mut validation, &timeline_clock, track);
+            validate_caption_track_qc(&mut validation, &sequence.id, &timeline_clock, track);
             continue;
         }
 
@@ -7059,14 +7211,31 @@ pub fn validate_export_settings_with_dimensions(
                 continue;
             }
 
-            validate_clip_frame_alignment(&mut validation, &timeline_clock, clip, track);
-            validate_clip_effect_contract(&mut validation, clip, track, effects, &transition_plan);
+            validate_clip_frame_alignment(
+                &mut validation,
+                &sequence.id,
+                &timeline_clock,
+                clip,
+                track,
+            );
+            validate_clip_effect_contract(
+                &mut validation,
+                &sequence.id,
+                clip,
+                track,
+                effects,
+                &transition_plan,
+            );
 
             if track.kind == TrackKind::Video && uses_non_normal_blend_mode(clip, track) {
-                validation.add_error(format!(
-                    "Blend mode export is not supported yet for clip '{}' on track '{}'",
-                    clip.id, track.name
-                ));
+                validation.add_clip_error(
+                    &sequence.id,
+                    &clip.id,
+                    format!(
+                        "Blend mode export is not supported yet for clip '{}' on track '{}'",
+                        clip.id, track.name
+                    ),
+                );
             }
 
             // Motion is stored, round-trips through the project, and animates in
@@ -7078,10 +7247,14 @@ pub fn validate_export_settings_with_dimensions(
                 && !clip.is_adjustment_layer()
                 && !is_text_clip(clip)
             {
-                validation.add_warning(format!(
-                    "Motion keyframes on clip '{}' on track '{}' are not yet rendered; the clip renders with its base transform",
-                    clip.id, track.name
-                ));
+                validation.add_clip_warning(
+                    &sequence.id,
+                    &clip.id,
+                    format!(
+                        "Motion keyframes on clip '{}' on track '{}' are not yet rendered; the clip renders with its base transform",
+                        clip.id, track.name
+                    ),
+                );
             }
 
             if is_text_clip(clip) {
@@ -7092,10 +7265,14 @@ pub fn validate_export_settings_with_dimensions(
                         .is_some_and(|e| e.effect_type == EffectType::TextOverlay && e.enabled)
                 });
                 if !has_text_overlay {
-                    validation.add_error(format!(
-                        "Text clip '{}' is missing an enabled TextOverlay effect",
-                        clip.id
-                    ));
+                    validation.add_clip_error(
+                        &sequence.id,
+                        &clip.id,
+                        format!(
+                            "Text clip '{}' is missing an enabled TextOverlay effect",
+                            clip.id
+                        ),
+                    );
                 }
                 continue;
             }
@@ -7107,31 +7284,37 @@ pub fn validate_export_settings_with_dimensions(
                         && effect.is_video()
                         && !effect_type_supports_timeline_enable(&effect.effect_type)
                     {
-                        validation.add_error(untimeable_adjustment_effect_message(
-                            &effect_type_label(&effect.effect_type),
+                        validation.add_clip_error(
+                            &sequence.id,
                             &clip.id,
-                            &track.name,
-                        ));
+                            untimeable_adjustment_effect_message(
+                                &effect_type_label(&effect.effect_type),
+                                &clip.id,
+                                &track.name,
+                            ),
+                        );
                     }
                 }
                 continue;
             }
 
             let Some(asset) = assets.get(&clip.asset_id) else {
-                validation.add_error(format!(
-                    "Asset '{}' not found for clip '{}'",
-                    clip.asset_id, clip.id
-                ));
+                validation.add_clip_error(
+                    &sequence.id,
+                    &clip.id,
+                    format!("Asset '{}' not found for clip '{}'", clip.asset_id, clip.id),
+                );
                 continue;
             };
 
             // Defense-in-depth: validate local file path early to avoid starting an export
             // that will certainly fail (or could be abused if the state is compromised).
             if let Err(err) = validate_local_input_path(&asset.uri, "Asset file") {
-                validation.add_error(format!(
-                    "Invalid asset path for asset '{}': {}",
-                    asset.id, err
-                ));
+                validation.add_clip_error(
+                    &sequence.id,
+                    &clip.id,
+                    format!("Invalid asset path for asset '{}': {}", asset.id, err),
+                );
             }
 
             // Placing a transformed clip needs the source's real pixel size. An
@@ -7139,10 +7322,14 @@ pub fn validate_export_settings_with_dimensions(
             // this and never fails on it.
             if track.kind == TrackKind::Video && clip_needs_transform_composition(clip) {
                 match resolve_asset_source_dimensions(asset, &mut source_dimensions) {
-                    None => validation.add_error(format!(
-                        "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
-                        asset.id, clip.id
-                    )),
+                    None => validation.add_clip_error(
+                        &sequence.id,
+                        &clip.id,
+                        format!(
+                            "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
+                            asset.id, clip.id
+                        ),
+                    ),
                     Some(probed_dimensions) => {
                         // The clip's own effects can resize the picture before
                         // the transform sees it. Failing loudly beats scaling
@@ -7161,8 +7348,11 @@ pub fn validate_export_settings_with_dimensions(
                         if let Err(effect_label) =
                             effective_source_dimensions(probed_dimensions, &graph)
                         {
-                            validation
-                                .add_error(unmeasurable_effect_message(&effect_label, &clip.id));
+                            validation.add_clip_error(
+                                &sequence.id,
+                                &clip.id,
+                                unmeasurable_effect_message(&effect_label, &clip.id),
+                            );
                         }
                     }
                 }
@@ -7172,8 +7362,10 @@ pub fn validate_export_settings_with_dimensions(
         }
     }
 
-    if has_layered_visual_overlap(sequence) {
-        validation.add_error(
+    if let Some(clip_id) = first_layered_visual_overlap(sequence) {
+        validation.add_clip_error(
+            sequence.id.clone(),
+            clip_id.to_string(),
             "Final render export does not support simultaneous layered video clips yet".to_string(),
         );
     }
@@ -9547,6 +9739,165 @@ mod tests {
         assert!(
             warning.contains("base transform"),
             "the warning must say what happens instead: {warning}"
+        );
+    }
+
+    /// Feature: Export preflight
+    /// Scenario: a degrading clip is reported with somewhere to go
+    ///
+    /// The export dialog turns each finding into a row the user can click to
+    /// land on the offending clip. A warning that carries only prose leaves the
+    /// user to hunt for the clip themselves, which is the whole failure mode the
+    /// preflight exists to avoid.
+    #[test]
+    fn test_findings_carry_clip_id_for_motion_keyframe_warning() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track, TransformKeyframe};
+        use crate::core::Point2D;
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_video("Video 1");
+
+        let mut clip = Clip::new("video_asset")
+            .with_source_range(0.0, 3.0)
+            .place_at(0.0);
+        clip.id = "moving-clip".to_string();
+        clip.motion_keyframes = vec![
+            TransformKeyframe {
+                time_offset: 0.0,
+                transform: Transform::default(),
+                interpolation: Default::default(),
+            },
+            TransformKeyframe {
+                time_offset: 3.0,
+                transform: Transform {
+                    position: Point2D::new(0.75, 0.5),
+                    ..Transform::default()
+                },
+                interpolation: Default::default(),
+            },
+        ];
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let video_path = create_temp_media_file("findings_motion.mp4");
+        let mut assets = HashMap::new();
+        let mut video_asset =
+            Asset::new_video("findings_motion.mp4", &video_path, VideoInfo::default())
+                .with_duration(3.0)
+                .with_file_size(3_000_000);
+        video_asset.id = "video_asset".to_string();
+        assets.insert("video_asset".to_string(), video_asset);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+
+        assert!(
+            validation.is_valid,
+            "a degrading clip must not block the export: {:?}",
+            validation.errors
+        );
+
+        let finding = validation
+            .findings
+            .iter()
+            .find(|finding| finding.message.contains("Motion keyframes"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "keyframed motion must produce a finding: {:?}",
+                    validation.findings
+                )
+            });
+
+        assert_eq!(finding.severity, ExportFindingSeverity::Warning);
+        assert_eq!(finding.clip_id.as_deref(), Some("moving-clip"));
+        assert_eq!(finding.sequence_id.as_deref(), Some(sequence.id.as_str()));
+        assert!(
+            validation.warnings.contains(&finding.message),
+            "the flat warning list must stay in sync with the findings"
+        );
+    }
+
+    /// Feature: Export preflight
+    /// Scenario: a blocking overlap names the clip that has to move
+    #[test]
+    fn test_findings_carry_clip_id_for_layered_overlap_error() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+
+        let mut top_track = Track::new_video("Video 1");
+        let mut top_clip = Clip::new("asset_top")
+            .with_source_range(0.0, 5.0)
+            .place_at(0.0);
+        top_clip.id = "base-clip".to_string();
+        top_track.add_clip(top_clip);
+        sequence.add_track(top_track);
+
+        let mut bottom_track = Track::new_video("Video 2");
+        let mut bottom_clip = Clip::new("asset_bottom")
+            .with_source_range(0.0, 5.0)
+            .place_at(2.0);
+        bottom_clip.id = "pip-clip".to_string();
+        bottom_track.add_clip(bottom_clip);
+        sequence.add_track(bottom_track);
+
+        let top_path = create_temp_media_file("findings_layered_top.mp4");
+        let mut top_asset =
+            Asset::new_video("findings_layered_top.mp4", &top_path, VideoInfo::default())
+                .with_duration(5.0)
+                .with_file_size(5_000_000);
+        top_asset.id = "asset_top".to_string();
+
+        let bottom_path = create_temp_media_file("findings_layered_bottom.mp4");
+        let mut bottom_asset = Asset::new_video(
+            "findings_layered_bottom.mp4",
+            &bottom_path,
+            VideoInfo::default(),
+        )
+        .with_duration(5.0)
+        .with_file_size(5_000_000);
+        bottom_asset.id = "asset_bottom".to_string();
+
+        let mut assets = HashMap::new();
+        assets.insert(top_asset.id.clone(), top_asset);
+        assets.insert(bottom_asset.id.clone(), bottom_asset);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+
+        assert!(!validation.is_valid, "layered video must block the export");
+
+        let finding = validation
+            .findings
+            .iter()
+            .find(|finding| finding.message.contains("simultaneous layered video clips"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "layered video must produce a finding: {:?}",
+                    validation.findings
+                )
+            });
+
+        assert_eq!(finding.severity, ExportFindingSeverity::Error);
+        assert_eq!(
+            finding.clip_id.as_deref(),
+            Some("pip-clip"),
+            "the finding must name the clip that starts the overlap"
+        );
+        assert_eq!(finding.sequence_id.as_deref(), Some(sequence.id.as_str()));
+        assert!(
+            validation.errors.contains(&finding.message),
+            "the flat error list must stay in sync with the findings"
         );
     }
 

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -43,9 +43,167 @@ async fn validate_export_settings_off_runtime(
     .map_err(|error| format!("Export validation task failed: {}", error))
 }
 
+/// Everything an export checks before it is allowed to start.
+///
+/// An export runs two independent validation passes — the settings pass and the
+/// render-plan pass — and refuses on either. Keeping them together in one type
+/// is what lets the preflight command report exactly the set of problems the
+/// render enforces, instead of a second opinion that can drift from it.
+pub(crate) struct ExportPreflight {
+    settings: crate::core::render::ExportValidation,
+    plan: crate::core::render::RenderPlan,
+}
+
+impl ExportPreflight {
+    /// Whether a render started right now would be allowed to proceed.
+    fn is_valid(&self) -> bool {
+        self.settings.is_valid && self.plan.validation.is_valid
+    }
+
+    /// Refuses the export exactly as the render commands always have.
+    ///
+    /// The settings pass is reported before the plan pass, and each keeps its
+    /// own message prefix, so an existing caller reading the error string sees
+    /// the same text it saw before.
+    fn enforce(&self) -> Result<(), String> {
+        if !self.settings.is_valid {
+            return Err(format!(
+                "Export validation failed: {}",
+                self.settings.errors.join("; ")
+            ));
+        }
+        if !self.plan.validation.is_valid {
+            return Err(format!(
+                "Render plan validation failed: {}",
+                self.plan.validation.errors.join("; ")
+            ));
+        }
+        Ok(())
+    }
+
+    /// Logs the non-blocking findings; `scope` names the export that produced them.
+    fn log_warnings(&self, scope: &str) {
+        for warning in &self.settings.warnings {
+            tracing::warn!("{} warning: {}", scope, warning);
+        }
+        for warning in &self.plan.validation.warnings {
+            tracing::warn!("Render plan warning: {}", warning);
+        }
+    }
+
+    /// Flattens both passes into one navigable list for the UI.
+    fn findings(&self) -> Vec<ExportFindingDto> {
+        use crate::core::render::ExportFindingSeverity;
+
+        let mut findings: Vec<ExportFindingDto> = self
+            .settings
+            .findings
+            .iter()
+            .map(|finding| ExportFindingDto {
+                severity: match finding.severity {
+                    ExportFindingSeverity::Error => ExportFindingSeverityDto::Error,
+                    ExportFindingSeverity::Warning => ExportFindingSeverityDto::Warning,
+                },
+                message: finding.message.clone(),
+                clip_id: finding.clip_id.clone(),
+                sequence_id: finding.sequence_id.clone(),
+            })
+            .collect();
+
+        // The render-plan pass reports findings as plain strings, so even the
+        // ones that name a clip carry no structured id to point at yet; these
+        // rows render as (clip-named) plain text rather than jump-to-clip
+        // buttons. Threading structured clip ids through RenderPlanValidation
+        // the way ExportValidation now does is a follow-up.
+        let plan_sequence_id = Some(self.plan.sequence_id.clone());
+        findings.extend(
+            self.plan
+                .validation
+                .errors
+                .iter()
+                .map(|message| ExportFindingDto {
+                    severity: ExportFindingSeverityDto::Error,
+                    message: message.clone(),
+                    clip_id: None,
+                    sequence_id: plan_sequence_id.clone(),
+                }),
+        );
+        findings.extend(
+            self.plan
+                .validation
+                .warnings
+                .iter()
+                .map(|message| ExportFindingDto {
+                    severity: ExportFindingSeverityDto::Warning,
+                    message: message.clone(),
+                    clip_id: None,
+                    sequence_id: plan_sequence_id.clone(),
+                }),
+        );
+
+        findings
+    }
+}
+
+/// Runs both validation passes an export performs, without starting one.
+///
+/// `start_render`, `render_range` and the `validate_export` preflight all go
+/// through here so the dialog can never warn about something the render does
+/// not enforce, or stay silent about something it does.
+pub(crate) async fn run_export_preflight(
+    sequence: &crate::core::timeline::Sequence,
+    assets: &std::collections::HashMap<String, crate::core::assets::Asset>,
+    effects: &std::collections::HashMap<String, crate::core::effects::Effect>,
+    render_graph: &crate::core::render::RenderGraph,
+    settings: &crate::core::render::ExportSettings,
+) -> Result<ExportPreflight, String> {
+    let settings_validation =
+        validate_export_settings_off_runtime(sequence, assets, effects, settings).await?;
+    let plan = crate::core::render::build_render_plan(render_graph, assets, effects, settings);
+
+    Ok(ExportPreflight {
+        settings: settings_validation,
+        plan,
+    })
+}
+
 // =============================================================================
 // DTOs
 // =============================================================================
+
+/// How badly a preflight finding affects the export (IPC DTO).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Type)]
+#[serde(rename_all = "lowercase")]
+pub enum ExportFindingSeverityDto {
+    /// The export is blocked until this is fixed.
+    Error,
+    /// The export runs, but the file differs from the timeline.
+    Warning,
+}
+
+/// One preflight finding, carrying the ids needed to navigate to its cause.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportFindingDto {
+    /// Whether this blocks the export or only degrades it.
+    pub severity: ExportFindingSeverityDto,
+    /// Human-readable description of the problem.
+    pub message: String,
+    /// Clip the finding is about, when it is about one clip.
+    pub clip_id: Option<String>,
+    /// Sequence the finding belongs to.
+    pub sequence_id: Option<String>,
+}
+
+/// Result of an export preflight (IPC DTO).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportValidationDto {
+    /// Whether a render started with these settings would be allowed to run.
+    pub is_valid: bool,
+    /// Every finding from both validation passes, errors and warnings alike.
+    pub findings: Vec<ExportFindingDto>,
+}
 
 /// Result of starting a render export job.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Type)]
@@ -346,6 +504,112 @@ async fn resolve_export_hardware_preferences(
 // Commands
 // =============================================================================
 
+/// Runs the export's validation passes without starting a render.
+///
+/// The dialog calls this first so a project that would be refused — or silently
+/// degraded — is reported against the clips that caused it, before any encoding
+/// work begins. It takes the same inputs `start_render`/`render_range` use to
+/// build their settings, and runs them through the same helper those commands
+/// enforce with, so a clean preflight means a render that will not be refused.
+///
+/// Pass `in_point`/`out_point` for the range case; omit both for a full export.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip(state), fields(sequence_id = %sequence_id, preset = %preset))]
+pub async fn validate_export(
+    sequence_id: String,
+    output_path: String,
+    preset: String,
+    settings: Option<VideoExportRequest>,
+    in_point: Option<f64>,
+    out_point: Option<f64>,
+    state: State<'_, AppState>,
+) -> Result<ExportValidationDto, String> {
+    if let (Some(in_pt), Some(out_pt)) = (in_point, out_point) {
+        if in_pt >= out_pt {
+            return Err("In point must be before Out point".to_string());
+        }
+        if in_pt < 0.0 {
+            return Err("In point must be non-negative".to_string());
+        }
+    }
+
+    let (sequence, assets, effects, render_graph, project_path) = {
+        let guard = state.project.lock().await;
+
+        let project = guard
+            .as_ref()
+            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+
+        let sequence = project
+            .state
+            .sequences
+            .get(&sequence_id)
+            .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
+            .clone();
+
+        let render_graph = crate::core::render::build_render_graph(&project.state, &sequence_id)
+            .map_err(|e| e.to_ipc_error())?;
+
+        let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
+            .state
+            .assets
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        let effects: std::collections::HashMap<String, crate::core::effects::Effect> = project
+            .state
+            .effects
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        (
+            sequence,
+            assets,
+            effects,
+            render_graph,
+            project.path.clone(),
+        )
+    };
+
+    // The output path decides the container, which the settings pass validates,
+    // so the preflight has to resolve it exactly the way the render does.
+    let approved_dirs = state.approved_export_dirs_snapshot().await;
+    let roots = export_allowed_roots(&project_path, &approved_dirs);
+    let root_refs: Vec<&std::path::Path> = roots.iter().map(|p| p.as_path()).collect();
+    let validated_output_path =
+        validate_scoped_output_path(&output_path, "Output path", &root_refs)?;
+
+    // Hardware preferences are deliberately not resolved here: they only pick an
+    // encoder and a GPU device, neither of which any validator inspects, and
+    // resolving them would spawn two FFmpeg probes for a check that is supposed
+    // to be cheap enough to run on every Export click.
+    let export_settings = build_export_settings(
+        validated_output_path,
+        &preset,
+        settings.as_ref(),
+        in_point,
+        out_point,
+    )?;
+
+    let preflight = run_export_preflight(
+        &sequence,
+        &assets,
+        &effects,
+        &render_graph,
+        &export_settings,
+    )
+    .await?;
+
+    Ok(ExportValidationDto {
+        is_valid: preflight.is_valid(),
+        findings: preflight.findings(),
+    })
+}
+
 /// Starts final render export
 ///
 /// This command validates the export settings before starting the render,
@@ -440,28 +704,15 @@ pub async fn start_render(
     resolve_export_hardware_preferences(&app_handle, &ffmpeg.info().ffmpeg_path, &mut settings)
         .await?;
 
-    // Validate export settings before starting
-    let validation =
-        validate_export_settings_off_runtime(&sequence, &assets, &effects, &settings).await?;
-    if !validation.is_valid {
-        let error_msg = validation.errors.join("; ");
-        return Err(format!("Export validation failed: {}", error_msg));
-    }
+    // Validate export settings and the render plan before starting. This is the
+    // same helper the `validate_export` preflight calls, so the dialog's warning
+    // list and this refusal can never disagree.
+    let preflight =
+        run_export_preflight(&sequence, &assets, &effects, &render_graph, &settings).await?;
+    preflight.enforce()?;
+    preflight.log_warnings("Export");
 
-    // Log warnings but continue
-    for warning in &validation.warnings {
-        tracing::warn!("Export warning: {}", warning);
-    }
-
-    let render_plan =
-        crate::core::render::build_render_plan(&render_graph, &assets, &effects, &settings);
-    if !render_plan.validation.is_valid {
-        let error_msg = render_plan.validation.errors.join("; ");
-        return Err(format!("Render plan validation failed: {}", error_msg));
-    }
-    for warning in &render_plan.validation.warnings {
-        tracing::warn!("Render plan warning: {}", warning);
-    }
+    let render_plan = preflight.plan;
     let plan_hash = render_plan.plan_hash.clone();
 
     // Create export engine
@@ -697,33 +948,16 @@ pub async fn render_range(
     resolve_export_hardware_preferences(&app_handle, &ffmpeg.info().ffmpeg_path, &mut settings)
         .await?;
 
-    let validation =
-        validate_export_settings_off_runtime(&sequence, &assets, &effects, &settings).await?;
-    if !validation.is_valid {
-        return Err(format!(
-            "Export validation failed: {}",
-            validation.errors.join("; ")
-        ));
-    }
+    let preflight =
+        run_export_preflight(&sequence, &assets, &effects, &render_graph, &settings).await?;
+    preflight.enforce()?;
 
     // Same warnings `start_render` logs: motion keyframes and the rest describe
     // ways the file will differ from the preview, and a range export differs the
     // same way.
-    for warning in &validation.warnings {
-        tracing::warn!("Range export warning: {}", warning);
-    }
+    preflight.log_warnings("Range export");
 
-    let render_plan =
-        crate::core::render::build_render_plan(&render_graph, &assets, &effects, &settings);
-    if !render_plan.validation.is_valid {
-        return Err(format!(
-            "Render plan validation failed: {}",
-            render_plan.validation.errors.join("; ")
-        ));
-    }
-    for warning in &render_plan.validation.warnings {
-        tracing::warn!("Render plan warning: {}", warning);
-    }
+    let render_plan = preflight.plan;
     let plan_hash = render_plan.plan_hash.clone();
 
     let engine = ExportEngine::new(ffmpeg.clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1642,6 +1642,7 @@ mod tauri_app {
                 $crate::ipc::cancel_job,
                 $crate::ipc::get_job_stats,
                 // Render commands
+                $crate::ipc::validate_export,
                 $crate::ipc::start_render,
                 $crate::ipc::render_range,
                 $crate::ipc::batch_render,
@@ -2173,6 +2174,7 @@ mod tauri_app {
             ipc::cancel_job,
             ipc::get_job_stats,
             // Render commands
+            ipc::validate_export,
             ipc::start_render,
             ipc::render_range,
             ipc::batch_render,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -537,6 +537,24 @@ async getJobStats() : Promise<Result<JsonValue, string>> {
 }
 },
 /**
+ * Runs the export's validation passes without starting a render.
+ * 
+ * The dialog calls this first so a project that would be refused — or silently
+ * degraded — is reported against the clips that caused it, before any encoding
+ * work begins. It takes the same inputs `start_render`/`render_range` use to
+ * build their settings, and runs them through the same helper those commands
+ * enforce with, so a clean preflight means a render that will not be refused.
+ * 
+ * Pass `in_point`/`out_point` for the range case; omit both for a full export.
+ */
+async validateExport(sequenceId: string, outputPath: string, preset: string, settings: VideoExportRequest | null, inPoint: number | null, outPoint: number | null) : Promise<Result<ExportValidationDto, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("validate_export", { sequenceId, outputPath, preset, settings, inPoint, outPoint }) };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
+/**
  * Starts final render export
  * 
  * This command validates the export settings before starting the render,
@@ -5342,6 +5360,38 @@ name: string;
  */
 extensions: string[] }
 /**
+ * One preflight finding, carrying the ids needed to navigate to its cause.
+ */
+export type ExportFindingDto = { 
+/**
+ * Whether this blocks the export or only degrades it.
+ */
+severity: ExportFindingSeverityDto; 
+/**
+ * Human-readable description of the problem.
+ */
+message: string; 
+/**
+ * Clip the finding is about, when it is about one clip.
+ */
+clipId: string | null; 
+/**
+ * Sequence the finding belongs to.
+ */
+sequenceId: string | null }
+/**
+ * How badly a preflight finding affects the export (IPC DTO).
+ */
+export type ExportFindingSeverityDto = 
+/**
+ * The export is blocked until this is fixed.
+ */
+"error" | 
+/**
+ * The export runs, but the file differs from the timeline.
+ */
+"warning"
+/**
  * User-facing quality tier that maps to concrete encoder settings.
  */
 export type ExportQualityTier =
@@ -5366,6 +5416,18 @@ export type ExportQualityTier =
  */
 "custom"
 export type ExportSettingsDto = { defaultFormat: string; defaultVideoCodec: string; defaultAudioCodec: string; defaultExportLocation: string | null; openFolderAfterExport: boolean }
+/**
+ * Result of an export preflight (IPC DTO).
+ */
+export type ExportValidationDto = { 
+/**
+ * Whether a render started with these settings would be allowed to run.
+ */
+isValid: boolean; 
+/**
+ * Every finding from both validation passes, errors and warnings alike.
+ */
+findings: ExportFindingDto[] }
 export type ExternalAgentApprovalTokenGrant = { token: string; tokenId: string; sessionId: string; runId: string | null; planId: string | null; projectId: string; runtimeId: string; scopes: string[]; createdAt: number; expiresAt: number }
 export type ExternalAgentApprovalTokenInfo = { tokenId: string; sessionId: string; runId: string | null; planId: string | null; projectId: string; runtimeId: string; scopes: string[]; createdAt: number; expiresAt: number }
 export type ExternalAgentApprovalTokenValidation = { valid: boolean; reason: string | null; grant: ExternalAgentApprovalTokenInfo | null }

--- a/src/components/features/export/ExportDialog.test.tsx
+++ b/src/components/features/export/ExportDialog.test.tsx
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ExportDialog } from './ExportDialog';
+import { usePlaybackStore } from '@/stores/playbackStore';
+import { useProjectStore } from '@/stores/projectStore';
+import { useTimelineStore } from '@/stores/timelineStore';
+import type { Sequence } from '@/types';
 
 const { mockUseExportDialog, mockUseRenderQueue, mockGetAvailableEncoders } = vi.hoisted(() => ({
   mockUseExportDialog: vi.fn(),
@@ -32,6 +36,8 @@ describe('ExportDialog', () => {
   const handleBrowse = vi.fn();
   const handleExport = vi.fn();
   const handleRetry = vi.fn();
+  const confirmExport = vi.fn();
+  const cancelValidation = vi.fn();
   const resetQueue = vi.fn();
   const addToQueue = vi.fn();
   const startBatchRender = vi.fn();
@@ -68,6 +74,8 @@ describe('ExportDialog', () => {
       canExport: true,
       handleBrowse,
       handleExport,
+      confirmExport,
+      cancelValidation,
       handleRetry,
     };
     mockUseExportDialog.mockImplementation(() => exportDialogState);
@@ -187,5 +195,112 @@ describe('ExportDialog', () => {
     );
 
     expect(screen.getByRole('button', { name: /export timeline/i })).not.toBeDisabled();
+  });
+
+  describe('preflight findings', () => {
+    const OFFENDING_CLIP_ID = 'pip-clip';
+    const CLIP_TIMELINE_IN_SEC = 4.5;
+
+    const showFindings = (blocked: boolean) => {
+      exportDialogState = {
+        ...exportDialogState,
+        showSettings: false,
+        status: {
+          type: 'validation',
+          blocked,
+          findings: [
+            {
+              severity: blocked ? 'error' : 'warning',
+              message: 'Motion keyframes render static',
+              clipId: OFFENDING_CLIP_ID,
+              sequenceId: 'sequence-1',
+            },
+            {
+              severity: 'warning',
+              message: 'Sequence-level advisory',
+              clipId: null,
+              sequenceId: 'sequence-1',
+            },
+          ],
+        },
+      };
+    };
+
+    beforeEach(() => {
+      const sequence = {
+        id: 'sequence-1',
+        tracks: [
+          {
+            clips: [
+              {
+                id: OFFENDING_CLIP_ID,
+                place: { timelineInSec: CLIP_TIMELINE_IN_SEC },
+              },
+            ],
+          },
+        ],
+      } as unknown as Sequence;
+
+      useProjectStore.setState({
+        sequences: new Map([['sequence-1', sequence]]),
+        activeSequenceId: 'sequence-1',
+      });
+      useTimelineStore.getState().clearClipSelection();
+      usePlaybackStore.setState({ duration: 60, currentTime: 0 });
+    });
+
+    it('reveals the offending clip when a finding row is selected', async () => {
+      showFindings(false);
+
+      render(
+        <ExportDialog isOpen onClose={vi.fn()} sequenceId="sequence-1" sequenceName="Sequence" />,
+      );
+      // The dialog probes the encoder list on open; let it settle first.
+      await waitFor(() => expect(mockGetAvailableEncoders).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByTestId(`export-finding-${OFFENDING_CLIP_ID}`));
+
+      expect(useTimelineStore.getState().selectedClipIds).toEqual([OFFENDING_CLIP_ID]);
+      expect(usePlaybackStore.getState().currentTime).toBe(CLIP_TIMELINE_IN_SEC);
+    });
+
+    it('offers no way past a blocking finding', async () => {
+      showFindings(true);
+
+      render(
+        <ExportDialog isOpen onClose={vi.fn()} sequenceId="sequence-1" sequenceName="Sequence" />,
+      );
+      // The dialog probes the encoder list on open; let it settle first.
+      await waitFor(() => expect(mockGetAvailableEncoders).toHaveBeenCalled());
+
+      expect(screen.queryByTestId('export-validation-proceed')).not.toBeInTheDocument();
+      expect(screen.getByTestId('export-validation-cancel')).toBeInTheDocument();
+    });
+
+    it('lets the user export past warnings', async () => {
+      showFindings(false);
+
+      render(
+        <ExportDialog isOpen onClose={vi.fn()} sequenceId="sequence-1" sequenceName="Sequence" />,
+      );
+      // The dialog probes the encoder list on open; let it settle first.
+      await waitFor(() => expect(mockGetAvailableEncoders).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByTestId('export-validation-proceed'));
+
+      expect(confirmExport).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a finding with no clip as plain text', async () => {
+      showFindings(false);
+
+      render(
+        <ExportDialog isOpen onClose={vi.fn()} sequenceId="sequence-1" sequenceName="Sequence" />,
+      );
+      // The dialog probes the encoder list on open; let it settle first.
+      await waitFor(() => expect(mockGetAvailableEncoders).toHaveBeenCalled());
+
+      expect(screen.getByText('Sequence-level advisory').tagName).toBe('P');
+    });
   });
 });

--- a/src/components/features/export/ExportDialog.tsx
+++ b/src/components/features/export/ExportDialog.tsx
@@ -13,6 +13,8 @@ import {
   RangeControls,
   RenderQueuePanel,
 } from './ExportHelpers';
+import { ExportValidationNotice } from './ExportValidationNotice';
+import { useExportFindingNavigation } from './useExportFindingNavigation';
 import { AUDIO_EXPORT_FORMATS, EXPORT_PRESETS, TIMELINE_EXPORT_FORMATS } from './constants';
 import type { ExportDialogProps } from './types';
 import { commands } from '@/bindings';
@@ -51,6 +53,8 @@ export function ExportDialog({
     canExport,
     handleBrowse,
     handleExport,
+    confirmExport,
+    cancelValidation,
     handleRetry,
   } = useExportDialog({
     isOpen,
@@ -61,6 +65,7 @@ export function ExportDialog({
     outPoint: renderQueue.outPoint,
     initialExportKind,
   });
+  const jumpToClip = useExportFindingNavigation();
   const dialogRef = useRef<HTMLDivElement>(null);
   const wasOpenRef = useRef(isOpen);
   const wasBatchRenderingRef = useRef(isBatchRendering);
@@ -106,11 +111,20 @@ export function ExportDialog({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape' && status.type === 'idle' && !isBatchRendering) {
+      if (e.key !== 'Escape' || isBatchRendering) {
+        return;
+      }
+      // Escaping out of the preflight returns to the settings rather than
+      // closing the dialog, so the user keeps the export they configured.
+      if (status.type === 'validation') {
+        cancelValidation();
+        return;
+      }
+      if (status.type === 'idle') {
         handleClose();
       }
     },
-    [handleClose, isBatchRendering, status.type],
+    [cancelValidation, handleClose, isBatchRendering, status.type],
   );
 
   if (!isOpen) return null;
@@ -385,6 +399,14 @@ export function ExportDialog({
             batchProgress={renderQueue.batchProgress}
             onCancelJob={(jobId) => void renderQueue.cancelJob(jobId)}
             onRemoveItem={renderQueue.removeFromQueue}
+          />
+        ) : status.type === 'validation' ? (
+          <ExportValidationNotice
+            findings={status.findings}
+            blocked={status.blocked}
+            onJumpToClip={jumpToClip}
+            onExportAnyway={() => void confirmExport()}
+            onCancel={cancelValidation}
           />
         ) : (
           <ProgressDisplay status={status} onClose={handleClose} onRetry={handleRetry} />

--- a/src/components/features/export/ExportValidationNotice.tsx
+++ b/src/components/features/export/ExportValidationNotice.tsx
@@ -1,0 +1,162 @@
+/**
+ * ExportValidationNotice
+ *
+ * Presents what the export preflight found, grouped by severity. Errors block
+ * the export outright; warnings only describe how the file will differ from the
+ * timeline, so the user is offered the choice to export anyway.
+ *
+ * Every finding that knows its clip is rendered as a button that jumps to it.
+ */
+
+import { AlertTriangle, XCircle } from 'lucide-react';
+import type { ExportFinding } from './types';
+import type { JumpToClipHandler } from './useExportFindingNavigation';
+
+/** Props for {@link ExportValidationNotice}. */
+export interface ExportValidationNoticeProps {
+  /** Findings returned by the preflight, in validator order */
+  findings: ExportFinding[];
+  /** Whether at least one finding is an error, which blocks the export */
+  blocked: boolean;
+  /** Reveal the clip a finding points at */
+  onJumpToClip: JumpToClipHandler;
+  /** Proceed with the export despite the warnings */
+  onExportAnyway: () => void;
+  /** Close without exporting */
+  onCancel: () => void;
+}
+
+interface FindingListProps {
+  findings: ExportFinding[];
+  onJumpToClip: JumpToClipHandler;
+  testId: string;
+}
+
+const ROW_BASE_CLASS = 'block w-full rounded-md px-3 py-2 text-left text-xs leading-relaxed';
+
+const SEVERITY_ROW_CLASS: Record<ExportFinding['severity'], string> = {
+  error: 'border border-red-500/30 bg-red-500/10 text-red-200',
+  warning: 'border border-amber-500/30 bg-amber-500/10 text-amber-200',
+};
+
+function FindingList({ findings, onJumpToClip, testId }: FindingListProps): JSX.Element {
+  return (
+    <ul className="mt-2 space-y-1.5" data-testid={testId}>
+      {findings.map((finding, index) => {
+        const rowClass = `${ROW_BASE_CLASS} ${SEVERITY_ROW_CLASS[finding.severity]}`;
+        const key = `${finding.severity}-${finding.clipId ?? 'sequence'}-${index}`;
+
+        if (!finding.clipId) {
+          return (
+            <li key={key}>
+              <p className={rowClass}>{finding.message}</p>
+            </li>
+          );
+        }
+
+        const clipId = finding.clipId;
+        return (
+          <li key={key}>
+            <button
+              type="button"
+              className={`${rowClass} transition-colors hover:brightness-125 focus:outline-none focus:ring-1 focus:ring-primary-500`}
+              data-testid={`export-finding-${clipId}`}
+              onClick={() => onJumpToClip(clipId, finding.sequenceId)}
+            >
+              {finding.message}
+              <span className="mt-1 block text-[11px] uppercase tracking-[0.08em] opacity-70">
+                Go to clip
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * Lists the preflight findings and offers the only actions that make sense for
+ * their severity.
+ */
+export function ExportValidationNotice({
+  findings,
+  blocked,
+  onJumpToClip,
+  onExportAnyway,
+  onCancel,
+}: ExportValidationNoticeProps): JSX.Element {
+  const errors = findings.filter((finding) => finding.severity === 'error');
+  const warnings = findings.filter((finding) => finding.severity === 'warning');
+
+  return (
+    <div className="py-2" data-testid="export-validation-notice">
+      <div className="flex items-start gap-3">
+        {blocked ? (
+          <XCircle className="mt-0.5 h-5 w-5 shrink-0 text-red-500" aria-hidden="true" />
+        ) : (
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" aria-hidden="true" />
+        )}
+        <div>
+          <h3 className="text-sm font-medium text-editor-text">
+            {blocked
+              ? 'This sequence cannot be exported yet'
+              : 'Export will differ from the timeline'}
+          </h3>
+          <p className="mt-1 text-xs text-editor-text-muted">
+            {blocked
+              ? 'Fix the problems below, then export again. Select a row to jump to the clip.'
+              : 'The export can run, but these details will not survive the render. Select a row to jump to the clip.'}
+          </p>
+        </div>
+      </div>
+
+      {errors.length > 0 && (
+        <section className="mt-4">
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-red-400">
+            Blocking ({errors.length})
+          </p>
+          <FindingList
+            findings={errors}
+            onJumpToClip={onJumpToClip}
+            testId="export-validation-errors"
+          />
+        </section>
+      )}
+
+      {warnings.length > 0 && (
+        <section className="mt-4">
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-amber-400">
+            Warnings ({warnings.length})
+          </p>
+          <FindingList
+            findings={warnings}
+            onJumpToClip={onJumpToClip}
+            testId="export-validation-warnings"
+          />
+        </section>
+      )}
+
+      <div className="mt-5 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          data-testid="export-validation-cancel"
+          className="rounded-md border border-editor-border px-4 py-2 text-sm text-editor-text transition-colors hover:bg-editor-sidebar"
+        >
+          {blocked ? 'Close' : 'Cancel'}
+        </button>
+        {!blocked && (
+          <button
+            type="button"
+            onClick={onExportAnyway}
+            data-testid="export-validation-proceed"
+            className="rounded-md bg-primary-600 px-4 py-2 text-sm text-white transition-colors hover:bg-primary-700"
+          >
+            Export anyway
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/export/index.ts
+++ b/src/components/features/export/index.ts
@@ -3,7 +3,12 @@
  */
 
 export { ExportDialog } from './ExportDialog';
-export type { ExportDialogProps, ExportPreset, ExportStatus } from './types';
+export type { ExportDialogProps, ExportFinding, ExportPreset, ExportStatus } from './types';
+
+// Export preflight
+export { ExportValidationNotice } from './ExportValidationNotice';
+export type { ExportValidationNoticeProps } from './ExportValidationNotice';
+export { useExportFindingNavigation } from './useExportFindingNavigation';
 
 // Helper components
 export { PresetOption, ProgressDisplay } from './ExportHelpers';

--- a/src/components/features/export/types.ts
+++ b/src/components/features/export/types.ts
@@ -4,7 +4,13 @@
  * Type definitions for the ExportDialog component and related sub-components.
  */
 
-import type { VideoExportRequest } from '@/bindings';
+import type { ExportFindingDto, VideoExportRequest } from '@/bindings';
+
+/**
+ * A single problem the export preflight found, with the ids needed to navigate
+ * to whatever caused it.
+ */
+export type ExportFinding = ExportFindingDto;
 
 // =============================================================================
 // Export Preset Types
@@ -86,12 +92,27 @@ export interface ExportStatusFailed {
   error: string;
 }
 
+/**
+ * Validation state - the preflight found something worth showing.
+ *
+ * Only reached when there is at least one finding; a clean project goes
+ * straight from `idle` to `exporting` without ever entering this state.
+ */
+export interface ExportStatusValidation {
+  type: 'validation';
+  /** Findings in the order the validators produced them */
+  findings: ExportFinding[];
+  /** Whether at least one finding is an error, which blocks the export */
+  blocked: boolean;
+}
+
 /** Export status union type */
 export type ExportStatus =
   | ExportStatusIdle
   | ExportStatusExporting
   | ExportStatusCompleted
-  | ExportStatusFailed;
+  | ExportStatusFailed
+  | ExportStatusValidation;
 
 // =============================================================================
 // Component Props Types

--- a/src/components/features/export/useExportFindingNavigation.ts
+++ b/src/components/features/export/useExportFindingNavigation.ts
@@ -1,0 +1,48 @@
+/**
+ * Navigation for export preflight findings.
+ *
+ * A warning the user cannot act on is worse than no warning: it names a problem
+ * and leaves them to search a timeline for it. Every finding that knows its clip
+ * gets a row that puts the playhead on that clip and selects it.
+ */
+
+import { useCallback } from 'react';
+import { usePlaybackStore } from '@/stores/playbackStore';
+import { useProjectStore } from '@/stores/projectStore';
+import { useTimelineStore } from '@/stores/timelineStore';
+
+/**
+ * Fallback viewport width used to bring the playhead back into view.
+ *
+ * The dialog has no access to the timeline's measured width, and the keyboard
+ * shortcut that scrolls to the playhead already assumes the same figure.
+ */
+const DEFAULT_TIMELINE_VIEWPORT_WIDTH_PX = 800;
+
+/** Marks the seek so playback listeners can tell where it came from. */
+const SEEK_SOURCE = 'export-preflight';
+
+/** Moves the playhead to a clip and selects it. */
+export type JumpToClipHandler = (clipId: string, sequenceId?: string | null) => void;
+
+/**
+ * Returns a handler that reveals a clip named by an export finding.
+ */
+export function useExportFindingNavigation(): JumpToClipHandler {
+  return useCallback((clipId: string, sequenceId?: string | null) => {
+    const projectState = useProjectStore.getState();
+    const sequence = sequenceId
+      ? (projectState.sequences.get(sequenceId) ?? projectState.getActiveSequence())
+      : projectState.getActiveSequence();
+
+    useTimelineStore.getState().selectClip(clipId);
+
+    const clip = sequence?.tracks.flatMap((track) => track.clips).find((c) => c.id === clipId);
+    if (!clip) {
+      return;
+    }
+
+    usePlaybackStore.getState().seek(clip.place.timelineInSec, SEEK_SOURCE);
+    useTimelineStore.getState().scrollToPlayhead(DEFAULT_TIMELINE_VIEWPORT_WIDTH_PX);
+  }, []);
+}

--- a/src/hooks/useExportDialog.test.ts
+++ b/src/hooks/useExportDialog.test.ts
@@ -11,6 +11,24 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { useExportDialog } from './useExportDialog';
 
+/** What the preflight returns for a project with nothing worth reporting. */
+const CLEAN_PREFLIGHT = { isValid: true, findings: [] };
+
+/**
+ * Answers the preflight with a clean result and every other command with
+ * `result`, so a test only has to describe the call it cares about.
+ */
+function mockBackend(result: unknown): void {
+  vi.mocked(invoke).mockImplementation(async (command) =>
+    command === 'validate_export' ? CLEAN_PREFLIGHT : result,
+  );
+}
+
+/** Builds one preflight finding. */
+function finding(severity: 'error' | 'warning', message: string, clipId: string | null) {
+  return { severity, message, clipId, sequenceId: 'sequence-1' };
+}
+
 describe('useExportDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -45,7 +63,7 @@ describe('useExportDialog', () => {
   });
 
   it('should call render_range when range export is enabled', async () => {
-    vi.mocked(invoke).mockResolvedValue({
+    mockBackend({
       jobId: 'job-1',
       outputPath: '/tmp/out.mp4',
       status: 'started',
@@ -152,7 +170,7 @@ describe('useExportDialog', () => {
   });
 
   it('should call start_render with structured video settings for video export', async () => {
-    vi.mocked(invoke).mockResolvedValue({
+    mockBackend({
       jobId: 'job-1',
       outputPath: '/tmp/out.mp4',
       status: 'started',
@@ -190,6 +208,9 @@ describe('useExportDialog', () => {
 
   it('should merge sequence HDR settings into video export requests', async () => {
     vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'validate_export') {
+        return CLEAN_PREFLIGHT;
+      }
       if (command === 'get_sequence_hdr_settings') {
         return {
           hdrMode: 'hdr10',
@@ -346,6 +367,124 @@ describe('useExportDialog', () => {
       type: 'completed',
       outputPath: '/tmp/sequence.fcpxml',
       duration: 0,
+    });
+  });
+
+  describe('export preflight', () => {
+    const renderVideoDialog = () =>
+      renderHook(() =>
+        useExportDialog({
+          isOpen: true,
+          sequenceId: 'sequence-1',
+          sequenceName: 'Sequence',
+        }),
+      );
+
+    const configureVideoExport = (result: ReturnType<typeof renderVideoDialog>['result']) => {
+      act(() => {
+        result.current.setOutputPath('/tmp/out.mp4');
+        result.current.setSelectedPreset('mp4_high');
+      });
+    };
+
+    it('should start the render without a prompt when the preflight finds nothing', async () => {
+      mockBackend({ jobId: 'job-1', outputPath: '/tmp/out.mp4', status: 'started' });
+
+      const { result } = renderVideoDialog();
+      configureVideoExport(result);
+
+      await act(async () => {
+        await result.current.handleExport();
+      });
+
+      expect(invoke).toHaveBeenCalledWith('start_render', expect.anything());
+      expect(result.current.status.type).toBe('exporting');
+    });
+
+    it('should block the export and never render when the preflight reports an error', async () => {
+      vi.mocked(invoke).mockImplementation(async (command) => {
+        if (command === 'validate_export') {
+          return {
+            isValid: false,
+            findings: [finding('error', 'Layered video is not supported', 'pip-clip')],
+          };
+        }
+        return { jobId: 'job-1', outputPath: '/tmp/out.mp4', status: 'started' };
+      });
+
+      const { result } = renderVideoDialog();
+      configureVideoExport(result);
+
+      await act(async () => {
+        await result.current.handleExport();
+      });
+
+      expect(result.current.status).toEqual({
+        type: 'validation',
+        blocked: true,
+        findings: [finding('error', 'Layered video is not supported', 'pip-clip')],
+      });
+      expect(invoke).not.toHaveBeenCalledWith('start_render', expect.anything());
+    });
+
+    it('should render only after the user confirms a warning-only preflight', async () => {
+      vi.mocked(invoke).mockImplementation(async (command) => {
+        if (command === 'validate_export') {
+          return {
+            isValid: true,
+            findings: [finding('warning', 'Motion keyframes render static', 'moving-clip')],
+          };
+        }
+        return { jobId: 'job-1', outputPath: '/tmp/out.mp4', status: 'started' };
+      });
+
+      const { result } = renderVideoDialog();
+      configureVideoExport(result);
+
+      await act(async () => {
+        await result.current.handleExport();
+      });
+
+      expect(result.current.status).toEqual({
+        type: 'validation',
+        blocked: false,
+        findings: [finding('warning', 'Motion keyframes render static', 'moving-clip')],
+      });
+      expect(invoke).not.toHaveBeenCalledWith('start_render', expect.anything());
+
+      await act(async () => {
+        await result.current.confirmExport();
+      });
+
+      expect(invoke).toHaveBeenCalledWith('start_render', expect.anything());
+      expect(result.current.status.type).toBe('exporting');
+    });
+
+    it('should return to the settings without rendering when the preflight is cancelled', async () => {
+      vi.mocked(invoke).mockImplementation(async (command) => {
+        if (command === 'validate_export') {
+          return {
+            isValid: true,
+            findings: [finding('warning', 'Motion keyframes render static', 'moving-clip')],
+          };
+        }
+        return { jobId: 'job-1', outputPath: '/tmp/out.mp4', status: 'started' };
+      });
+
+      const { result } = renderVideoDialog();
+      configureVideoExport(result);
+
+      await act(async () => {
+        await result.current.handleExport();
+      });
+
+      act(() => {
+        result.current.cancelValidation();
+      });
+
+      expect(result.current.status).toEqual({ type: 'idle' });
+      expect(result.current.showSettings).toBe(true);
+      expect(invoke).not.toHaveBeenCalledWith('start_render', expect.anything());
     });
   });
 

--- a/src/hooks/useExportDialog.ts
+++ b/src/hooks/useExportDialog.ts
@@ -8,7 +8,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { pickExportDestination } from '@/services/exportDestination';
-import { commands } from '@/bindings';
+import { commands, type VideoExportRequest } from '@/bindings';
 import type {
   AudioExportFormat,
   ExportKind,
@@ -99,8 +99,12 @@ export interface UseExportDialogResult {
   canExport: boolean;
   /** Browse for output file location */
   handleBrowse: () => Promise<void>;
-  /** Start the export */
+  /** Run the preflight and, if the project is clean, start the export */
   handleExport: () => Promise<void>;
+  /** Start the export the preflight warned about, after the user chose to proceed */
+  confirmExport: () => Promise<void>;
+  /** Dismiss the preflight findings without exporting */
+  cancelValidation: () => void;
   /** Retry after failure */
   handleRetry: () => void;
 }
@@ -138,6 +142,8 @@ export function useExportDialog({
   // ===========================================================================
   const unlistenRefs = useRef<UnlistenFn[]>([]);
   const currentJobIdRef = useRef<string | null>(null);
+  /** Request the preflight validated, held so "Export anyway" reuses it verbatim. */
+  const pendingVideoRequestRef = useRef<VideoExportRequest | null>(null);
 
   // ===========================================================================
   // Reset on Dialog Open
@@ -152,6 +158,7 @@ export function useExportDialog({
       setStatus({ type: 'idle' });
       setCurrentJobId(null);
       currentJobIdRef.current = null;
+      pendingVideoRequestRef.current = null;
     }
   }, [initialExportKind, isOpen]);
 
@@ -308,8 +315,135 @@ export function useExportDialog({
     }
   }, [exportKind, selectedAudioFormat, selectedPreset, selectedTimelineFormat, sequenceName]);
 
+  const failWith = useCallback((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    setStatus({ type: 'failed', error: message });
+    currentJobIdRef.current = null;
+    setCurrentJobId(null);
+  }, []);
+
   /**
-   * Start the export process.
+   * Resolve the video request the backend renders, HDR settings included.
+   *
+   * The preflight and the render must be handed the identical request, or the
+   * preflight would be validating settings the render never uses.
+   */
+  const resolveVideoExportRequest = useCallback(async (): Promise<VideoExportRequest> => {
+    if (!sequenceId) {
+      throw new Error('No sequence selected.');
+    }
+    const request = getVideoExportRequest(selectedPreset);
+    const hdrResult = await commands.getSequenceHdrSettings(sequenceId);
+    if (hdrResult.status === 'error') {
+      throw new Error(String(hdrResult.error));
+    }
+    return applyHdrSettingsToVideoExportRequest(request, hdrResult.data);
+  }, [selectedPreset, sequenceId]);
+
+  /**
+   * Hand the export to the backend. Assumes the caller already decided it may run.
+   */
+  const startExport = useCallback(
+    async (videoRequest: VideoExportRequest | null) => {
+      if (!sequenceId || !outputPath) return;
+
+      setStatus({
+        type: 'exporting',
+        progress: 0,
+        message:
+          exportKind === 'audio'
+            ? 'Starting audio export...'
+            : exportKind === 'timeline'
+              ? 'Exporting editable timeline...'
+              : 'Starting export...',
+      });
+
+      try {
+        if (exportKind === 'timeline') {
+          const res =
+            selectedTimelineFormat === 'edl'
+              ? await commands.exportEdl(sequenceId, outputPath)
+              : await commands.exportFcpxml(sequenceId, outputPath);
+
+          if (res.status === 'error') {
+            failWith(String(res.error));
+            return;
+          }
+
+          setStatus({
+            type: 'completed',
+            outputPath: res.data.outputPath,
+            duration: 0,
+          });
+          currentJobIdRef.current = null;
+          setCurrentJobId(null);
+          return;
+        }
+
+        const res =
+          exportKind === 'audio'
+            ? await commands.exportAudioOnly(
+                sequenceId,
+                selectedAudioFormat,
+                outputPath,
+                null,
+                null,
+                useRange ? inPoint : null,
+                useRange ? outPoint : null,
+              )
+            : useRange
+              ? await commands.renderRange(
+                  sequenceId,
+                  outputPath,
+                  selectedPreset,
+                  videoRequest,
+                  inPoint,
+                  outPoint,
+                )
+              : await commands.startRender(sequenceId, outputPath, selectedPreset, videoRequest);
+
+        if (res.status === 'error') {
+          failWith(String(res.error));
+          return;
+        }
+
+        const result = res.data;
+        currentJobIdRef.current = result.jobId;
+        setCurrentJobId(result.jobId);
+
+        if (result.status === 'completed') {
+          setStatus({
+            type: 'completed',
+            outputPath: result.outputPath,
+            duration: 0,
+          });
+          currentJobIdRef.current = null;
+          setCurrentJobId(null);
+        }
+      } catch (error) {
+        failWith(error);
+      }
+    },
+    [
+      exportKind,
+      failWith,
+      inPoint,
+      outPoint,
+      outputPath,
+      selectedAudioFormat,
+      selectedPreset,
+      selectedTimelineFormat,
+      sequenceId,
+      useRange,
+    ],
+  );
+
+  /**
+   * Validate first, then export.
+   *
+   * A clean project never sees a dialog: the preflight returns no findings and
+   * the export starts exactly as it did before. Anything the render would refuse
+   * is reported before a single frame is encoded, against the clip that caused it.
    */
   const handleExport = useCallback(async () => {
     if (!sequenceId || !outputPath) return;
@@ -318,114 +452,98 @@ export function useExportDialog({
       return;
     }
 
-    setStatus({
-      type: 'exporting',
-      progress: 0,
-      message:
-        exportKind === 'audio'
-          ? 'Starting audio export...'
-          : exportKind === 'timeline'
-            ? 'Exporting editable timeline...'
-            : 'Starting export...',
-    });
+    // Audio-only and editable-timeline exports do not go through the video
+    // render path the preflight validates, so there is nothing for it to check.
+    if (exportKind !== 'video') {
+      await startExport(null);
+      return;
+    }
+
+    let videoRequest: VideoExportRequest;
+    try {
+      videoRequest = await resolveVideoExportRequest();
+    } catch (error) {
+      failWith(error);
+      return;
+    }
 
     try {
-      if (exportKind === 'timeline') {
-        const res =
-          selectedTimelineFormat === 'edl'
-            ? await commands.exportEdl(sequenceId, outputPath)
-            : await commands.exportFcpxml(sequenceId, outputPath);
-
-        if (res.status === 'error') {
-          setStatus({ type: 'failed', error: String(res.error) });
-          currentJobIdRef.current = null;
-          setCurrentJobId(null);
-          return;
-        }
-
-        setStatus({
-          type: 'completed',
-          outputPath: res.data.outputPath,
-          duration: 0,
-        });
-        currentJobIdRef.current = null;
-        setCurrentJobId(null);
-        return;
-      }
-
-      const resolveVideoExportRequest = async () => {
-        const request = getVideoExportRequest(selectedPreset);
-        const hdrResult = await commands.getSequenceHdrSettings(sequenceId);
-        if (hdrResult.status === 'error') {
-          throw new Error(String(hdrResult.error));
-        }
-        return applyHdrSettingsToVideoExportRequest(request, hdrResult.data);
-      };
-
-      const res =
-        exportKind === 'audio'
-          ? await commands.exportAudioOnly(
-              sequenceId,
-              selectedAudioFormat,
-              outputPath,
-              null,
-              null,
-              useRange ? inPoint : null,
-              useRange ? outPoint : null,
-            )
-          : useRange
-            ? await commands.renderRange(
-                sequenceId,
-                outputPath,
-                selectedPreset,
-                await resolveVideoExportRequest(),
-                inPoint,
-                outPoint,
-              )
-            : await commands.startRender(
-                sequenceId,
-                outputPath,
-                selectedPreset,
-                await resolveVideoExportRequest(),
-              );
+      const res = await commands.validateExport(
+        sequenceId,
+        outputPath,
+        selectedPreset,
+        videoRequest,
+        useRange ? inPoint : null,
+        useRange ? outPoint : null,
+      );
 
       if (res.status === 'error') {
-        setStatus({ type: 'failed', error: String(res.error) });
-        currentJobIdRef.current = null;
-        setCurrentJobId(null);
+        failWith(String(res.error));
         return;
       }
 
-      const result = res.data;
-      currentJobIdRef.current = result.jobId;
-      setCurrentJobId(result.jobId);
-
-      if (result.status === 'completed') {
+      const { findings } = res.data;
+      if (findings.length > 0) {
+        pendingVideoRequestRef.current = videoRequest;
         setStatus({
-          type: 'completed',
-          outputPath: result.outputPath,
-          duration: 0,
+          type: 'validation',
+          findings,
+          blocked: findings.some((finding) => finding.severity === 'error'),
         });
-        currentJobIdRef.current = null;
-        setCurrentJobId(null);
+        return;
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      setStatus({ type: 'failed', error: errorMessage });
-      currentJobIdRef.current = null;
-      setCurrentJobId(null);
+      failWith(error);
+      return;
     }
+
+    pendingVideoRequestRef.current = null;
+    await startExport(videoRequest);
   }, [
     exportKind,
+    failWith,
     inPoint,
     outPoint,
     outputPath,
-    selectedAudioFormat,
+    resolveVideoExportRequest,
     selectedPreset,
-    selectedTimelineFormat,
     sequenceId,
+    startExport,
     useRange,
   ]);
+
+  /**
+   * Export past the preflight's warnings, at the user's explicit request.
+   */
+  const confirmExport = useCallback(async () => {
+    if (status.type !== 'validation' || status.blocked) {
+      return;
+    }
+
+    // Reuse the request the preflight validated. Re-resolving is only a
+    // safety net: rendering a different request than the one that was
+    // validated is exactly the drift the preflight exists to prevent.
+    let videoRequest = pendingVideoRequestRef.current;
+    if (!videoRequest) {
+      try {
+        videoRequest = await resolveVideoExportRequest();
+      } catch (error) {
+        failWith(error);
+        return;
+      }
+    }
+
+    pendingVideoRequestRef.current = null;
+    await startExport(videoRequest);
+  }, [failWith, resolveVideoExportRequest, startExport, status]);
+
+  /**
+   * Dismiss the preflight findings and return to the export settings.
+   */
+  const cancelValidation = useCallback(() => {
+    pendingVideoRequestRef.current = null;
+    setStatus({ type: 'idle' });
+  }, []);
 
   /**
    * Reset to idle state for retry.
@@ -433,6 +551,7 @@ export function useExportDialog({
   const handleRetry = useCallback(() => {
     currentJobIdRef.current = null;
     setCurrentJobId(null);
+    pendingVideoRequestRef.current = null;
     setStatus({ type: 'idle' });
   }, []);
 
@@ -466,6 +585,8 @@ export function useExportDialog({
     canExport,
     handleBrowse,
     handleExport,
+    confirmExport,
+    cancelValidation,
     handleRetry,
   };
 }


### PR DESCRIPTION
### **User description**
## Problem (A2 — export silently degrades, GUI user is never told)

Motion keyframes render static, caption `lineHeight` is ignored, and blend/PiP/overlay clips are refused — the warnings reached only `tracing::warn!` and the CLI, and the errors surfaced as one flattened string. GUI users saw none of it until the exported file was wrong.

## What real editors do (this shaped the design)

Prior research (Premiere, Resolve, FCP, Shotcut, + prosumer/web tools) confirmed: **no NLE ships an InDesign-style "unsupported features" panel** — that's a print pattern. Real tools warn **only on a real problem**, **name/point at the offending clip**, **block only what genuinely can't render**, and **let you proceed past soft warnings**. The decisive rule from both tools and UX literature: a preflight is worth it only if it (i) never fires on a clean project, (ii) has near-zero false positives, (iii) **deep-links each finding to the clip** ("a warning with no pointer" is the #1 user complaint), (iv) always offers "proceed anyway."

## What this ships

Clicking Export runs the **exact validation the render enforces**, before any job starts:
- **Clean project → exports with no interruption** (silent when clean).
- **Findings → a modal**: errors block; warnings offer **"Export anyway"**; every finding that names a clip is a **button that selects the clip and moves the playhead to it**.

## Implementation

- `ExportValidation` gains structured `findings` (severity + message + sequence/clip ids) as the source of truth, kept in sync with the existing `errors`/`warnings`/`is_valid` so **every current consumer is unchanged**. Clip-specific validators attribute their finding to the clip via `add_clip_error`/`add_clip_warning` (motion keyframes, lineHeight, transitions, PiP, blend, overlay, captions, **offline/missing media**, unmeasurable effects).
- `start_render`, `render_range` and the new `validate_export` command share one `run_export_preflight` helper, so **the dialog can never warn about something the render does not enforce, or stay silent about something it does**. `enforce()` reproduces the prior refusal strings and order byte-for-byte.
- New `validate_export` IPC command → `ExportValidationDto`; the dialog runs it before rendering and **reuses the validated request** so the render can never run different settings than were checked.
- Deep-link uses the sanctioned playback write path (`playbackStore.seek`, respects `playbackWritePathGuard`), not `setCurrentTime`.

## Verification

- Rust: `cargo fmt`/`clippy` clean; full lib suite **4121 passed, 0 failed**; 2 new tests assert findings carry the clip id (motion-keyframe warning, PiP error).
- Frontend: `tsc` clean, eslint/prettier clean; **26** export tests pass covering the four flow branches (clean → no modal/render; error → modal/no render; warning → render only after confirm; row click → selects the clip).
- Adversarial cross-review (Codex) confirmed preflight==enforcement (incl. the deliberate hardware-prefs skip is safe — no validator reads those fields), silent-when-clean, findings/errors/warnings sync, and byte-identical `enforce()`.

## Follow-up (tracked)

Render-plan-pass findings render as clip-named **plain text** (no structured id yet); threading ids through `RenderPlanValidation` so they also deep-link is a separate PR. All the A2 target cases come from the settings pass and **are** deep-linked.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements export preflight validation with structured findings.

- Adds "jump-to-clip" navigation for export warnings/errors.

- Introduces a validation modal in the Export Dialog.

- Synchronizes backend validation logic across all render commands.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User clicks Export"] -- "validate_export (IPC)" --> Backend["Backend Preflight"]
  Backend -- "Findings (Clip IDs)" --> UI["Export Dialog Modal"]
  UI -- "Click Finding" --> Timeline["Seek & Select Clip"]
  UI -- "Export Anyway" --> Render["Start Render"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>export.rs</strong><dd><code>Add structured findings and clip-specific validation helpers</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+466/-115</a></td>

</tr>

<tr>
  <td><strong>render.rs</strong><dd><code>Implement validate_export command and unify preflight logic</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+277/-43</a></td>

</tr>

<tr>
  <td><strong>useExportDialog.ts</strong><dd><code>Integrate preflight validation into export workflow hook</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-100a1cde52e3715f4addc673c125cd63085a97836165b45cc23bd47bbf36c4ed">+208/-87</a></td>

</tr>

<tr>
  <td><strong>ExportDialog.tsx</strong><dd><code>Update UI to handle validation state and navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-435be970dfffe7fa90ce2c85836395abde148304581bf3d5f8f1b5bdb9b673ff">+24/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExportValidationNotice.tsx</strong><dd><code>New component to display grouped preflight findings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-980fe52d0893589b45b24a408608063c05fdad121abf5614803559d7c8566941">+162/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useExportFindingNavigation.ts</strong><dd><code>Hook for navigating timeline based on finding IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-35cb1b86b895615f8588064f8bf243555792e35a05b99a4dbad341c349ece65a">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Define frontend types for export validation status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-e24ba796c7f8e7f49b7813bbc101c378c32af6676f72ce6396aae099d8017929">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>useExportDialog.test.ts</strong><dd><code>Add tests for export preflight and blocking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-3796e2cd9baf4a19931f854a9170f2434b76d91307d7579e9ed1028ded66abf4">+141/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ExportDialog.test.tsx</strong><dd><code>Test UI interactions with preflight findings modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-c4084e10be3133b45cd2190b1617f709d8d59645aff5989c792a812f4224659a">+115/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Update TypeScript bindings for new IPC commands/types</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register new validate_export IPC command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/837/files#diff-5b8c79f4f572e578270f3456b5770cfab7b73f11bde77aef00882445ceca4630">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added export preflight validation before rendering.
- Displays blocking errors and non-blocking warnings with clear guidance.
- Select findings to jump directly to the affected clip and timeline position.
- Choose to export anyway when only warnings are present.
- Added clearer clip-specific messages for export issues.

## Bug Fixes
- Prevents exports with blocking validation errors.
- Improves identification of overlapping and unsupported clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->