### PR TITLE
feat(render): render clip motion keyframes in export (non-rotated Ken Burns)

### DIFF
--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2258,24 +2258,20 @@ fn test_render_transform_fills_the_slot_from_a_single_frame_source() {
     }
 }
 
-/// Feature: Truthful degradation
-/// Scenario: motion keyframes are reported as unrendered
+/// Renders a clip carrying two motion keyframes and returns the render warnings.
 ///
-/// Motion animates in the preview and does not animate in the export. Saying so
-/// is the difference between a known limitation and a silent one.
-#[test]
-fn test_render_reports_motion_keyframes_as_unrendered() {
-    if available_ffmpeg_path().is_none() {
-        return;
-    }
-
-    let dir = create_temp_project("render_motion_warning");
-    let path = project_path(&dir, "render_motion_warning");
-
+/// `rotation_deg` is applied to the second keyframe: zero gives a pure pan, which
+/// the export animates, and anything else gives a move that turns the picture,
+/// which it still cannot. `None` means the fixture could not be built.
+fn render_warnings_for_motion(name: &str, rotation_deg: f64) -> Option<Vec<String>> {
     const FIXTURE_SEC: f64 = 2.0;
+
+    let dir = create_temp_project(name);
+    let path = project_path(&dir, name);
+
     let source_path = dir.path().join("motion_source.mp4");
     if !create_solid_colour_video(&source_path, "red", "640x360", FIXTURE_SEC as u32) {
-        return;
+        return None;
     }
 
     let ids = place_trimmed_clip(&path, &source_path, FIXTURE_SEC);
@@ -2287,7 +2283,7 @@ fn test_render_reports_motion_keyframes_as_unrendered() {
 
     // Two keyframes that actually move the clip. A lone keyframe equal to the
     // base transform describes exactly the picture the export already produces
-    // and must not warn.
+    // and must not warn either way.
     run_cli_ok(&[
         "command",
         "execute",
@@ -2315,7 +2311,7 @@ fn test_render_reports_motion_keyframes_as_unrendered() {
                     "transform": {
                         "position": { "x": 0.75, "y": 0.5 },
                         "scale": { "x": 1.0, "y": 1.0 },
-                        "rotationDeg": 0.0,
+                        "rotationDeg": rotation_deg,
                         "anchor": { "x": 0.5, "y": 0.5 },
                     },
                 },
@@ -2339,18 +2335,48 @@ fn test_render_reports_motion_keyframes_as_unrendered() {
     );
 
     let rendered: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    let warnings: Vec<&str> = rendered["warnings"]
-        .as_array()
-        .expect("warnings")
-        .iter()
-        .filter_map(|warning| warning.as_str())
-        .collect();
-    assert!(
-        warnings
+    Some(
+        rendered["warnings"]
+            .as_array()
+            .expect("warnings")
             .iter()
-            .any(|warning| warning.contains("Motion keyframes")
-                && warning.contains("not yet rendered")),
-        "unrendered motion must be reported: {warnings:?}"
+            .filter_map(|warning| warning.as_str())
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+/// Feature: Truthful degradation
+/// Scenario: only the motion that really does not render is reported
+///
+/// Pan, zoom and anchor moves now animate in the export, so warning about them
+/// would train users to ignore the warning that still matters. A move that turns
+/// the picture is the one the export still cannot follow, and it has to keep
+/// saying so — a known limitation beats a silent one.
+#[test]
+fn test_render_reports_only_unrenderable_motion_as_unrendered() {
+    if available_ffmpeg_path().is_none() {
+        return;
+    }
+
+    fn is_motion_warning(warning: &String) -> bool {
+        warning.contains("Motion keyframes") && warning.contains("not yet rendered")
+    }
+
+    let Some(panning) = render_warnings_for_motion("render_motion_pan", 0.0) else {
+        return;
+    };
+    assert!(
+        !panning.iter().any(is_motion_warning),
+        "a pan renders, so it must not be reported as unrendered: {panning:?}"
+    );
+
+    let Some(rotating) = render_warnings_for_motion("render_motion_rotate", 30.0) else {
+        return;
+    };
+    assert!(
+        rotating.iter().any(is_motion_warning),
+        "motion that turns the picture is still unrendered and must be reported: {rotating:?}"
     );
 }
 

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -3068,6 +3068,32 @@ pub fn clip_needs_transform_composition(clip: &Clip) -> bool {
             || clip_motion_renders_animated(clip))
 }
 
+/// Whether a clip is composited *only* because of its motion keyframes.
+///
+/// Compositing needs the source's real pixel size, and an asset whose size
+/// cannot be measured fails that requirement. For a clip whose own transform
+/// places it, that is a genuine error: there is no honest picture to draw.
+///
+/// A clip carrying nothing but motion is different. Before motion animated, such
+/// a clip was fitted to the canvas like any other and the export succeeded — so
+/// refusing it now would turn a working export into a blocked one over a feature
+/// the user never asked for. These degrade back to that fit, with a warning, and
+/// keep exporting.
+pub(super) fn clip_composition_is_motion_only(clip: &Clip) -> bool {
+    clip_has_identity_transform(clip)
+        && (f64::from(clip.opacity) - 1.0).abs() <= TRANSFORM_EPSILON
+        && clip_motion_renders_animated(clip)
+}
+
+/// The warning for a motion clip the render had to fall back to a canvas fit.
+pub(super) fn unmeasurable_motion_message(clip_id: &str, track_name: &str, reason: &str) -> String {
+    format!(
+        "Motion keyframes on clip '{}' on track '{}' are not rendered because {}; \
+         the clip renders fitted to the canvas",
+        clip_id, track_name, reason
+    )
+}
+
 /// Pixel dimensions of the media a clip decodes, cached for one export run.
 ///
 /// Keyed by asset id. A `None` entry records that the asset was already looked at
@@ -3635,7 +3661,7 @@ pub(super) fn append_video_transform_composition(
 /// same shape — `setsar=1,fps=,trim=,format=` on a full-canvas frame — so the
 /// downstream concat cannot tell an animated segment from a static one.
 ///
-/// Three things differ from the static chain, and each is load-bearing:
+/// Four things differ from the static chain, and each is load-bearing:
 ///
 /// 1. `scale` carries per-frame expressions under `eval=frame`. This is the only
 ///    stock filter that resizes per frame while keeping a usable output link.
@@ -3646,7 +3672,10 @@ pub(super) fn append_video_transform_composition(
 ///    also mandatory here — `rgba` staging re-freezes the same way once
 ///    `overlay`'s own `format` is a `yuv420` mode, so the static path's cheaper
 ///    `rgba` shortcut for opacity-only clips cannot be reused.
-/// 3. `overlay` positions by expression, likewise under `eval=frame`.
+/// 3. The animated `scale` is the **last** filter of the staged chain. Ordering
+///    is a correctness constraint here, not a style choice — see the comment on
+///    the emitted chain below.
+/// 4. `overlay` positions by expression, likewise under `eval=frame`.
 ///
 /// Rotation is absent by construction: the caller only routes a clip here when
 /// its motion never turns the picture. `rotate` does not re-configure when its
@@ -3675,10 +3704,19 @@ pub(super) fn append_animated_video_transform_composition(
     let height_expr =
         build_motion_lerp_expression(keyframes, |keyframe| f64::from(keyframe.scaled_height));
 
-    filter_complex.push_str(&format!(
-        "[{}]scale=w='{}':h='{}':eval=frame,setsar=1,format={}",
-        input_label, width_expr, height_expr, alpha_format
-    ));
+    // Everything that converts pixel format runs *before* the animated `scale`,
+    // and nothing runs after it. A filter placed downstream of `scale` that needs
+    // a format conversion gets an auto-inserted converter, and that converter is
+    // configured once — it keeps rescaling every later frame back to the first
+    // frame's dimensions, so the picture pans but stops resizing.
+    //
+    // `colorchannelmixer` is the filter that trips this: it works in RGB, so in a
+    // `yuva*` graph FFmpeg wraps it in a yuva -> argb -> yuva round trip. Left
+    // after `scale` it froze a translucent clip's zoom outright (measured on
+    // FFmpeg 9.0.1: a 0.4x -> 0.9x zoom held one single frame size for all 60
+    // frames). Attenuating alpha does not depend on the frame's size, so hoisting
+    // it above `scale` costs nothing and the animation survives.
+    filter_complex.push_str(&format!("[{}]format={}", input_label, alpha_format));
 
     if opacity_needs_alpha_filter(opacity) {
         filter_complex.push_str(&format!(
@@ -3687,7 +3725,10 @@ pub(super) fn append_animated_video_transform_composition(
         ));
     }
 
-    filter_complex.push_str(&format!("[{}];", staged_label));
+    filter_complex.push_str(&format!(
+        ",scale=w='{}':h='{}':eval=frame,setsar=1[{}];",
+        width_expr, height_expr, staged_label
+    ));
 
     // Canvas sizing, padding and frame pinning are the static path's, unchanged
     // — see `append_video_transform_composition` for why each is shaped this way.
@@ -3780,12 +3821,21 @@ fn build_motion_lerp_expression(
             depth += 1;
         }
 
-        let span = end.time_sec - start.time_sec;
+        // The guard has to test the span FFmpeg will actually divide by, not the
+        // one Rust computed. Times are emitted through `format_speed_number`, so
+        // a span of, say, 1e-7 s survives `span > 0.0` here and then formats to a
+        // literal `0` in the graph — a divide-by-zero FFmpeg would meet at run
+        // time. Rounding first means the emitted denominator is the tested one.
+        let span_text = format_speed_number(end.time_sec - start.time_sec);
+        let span_is_usable = span_text
+            .parse::<f64>()
+            .is_ok_and(|span| span.is_finite() && span > 0.0);
+
         // A zero-length span is unreachable — the previous branch already
         // consumed every `t` below this one — but `hold` and a degenerate span
         // both resolve to the segment's *start* value, which is what the preview
         // returns when it divides by a zero duration.
-        if start.hold || span <= 0.0 {
+        if start.hold || !span_is_usable {
             expression.push_str(&format!(
                 ",if(lt(t,{}),{}",
                 format_speed_number(end.time_sec),
@@ -3799,7 +3849,7 @@ fn build_motion_lerp_expression(
                 if end_value >= start_value { "+" } else { "-" },
                 format_speed_number((end_value - start_value).abs()),
                 format_speed_number(start.time_sec),
-                format_speed_number(span)
+                span_text
             ));
         }
         depth += 1;
@@ -7540,7 +7590,22 @@ pub fn validate_export_settings_with_dimensions(
             // identity clip is only fitted to the canvas, so it never pays for
             // this and never fails on it.
             if track.kind == TrackKind::Video && clip_needs_transform_composition(clip) {
+                // A clip composited only for its motion has somewhere to fall
+                // back to — the plain canvas fit it rendered as before motion
+                // animated — so an unmeasurable source costs it the animation
+                // rather than the whole export. The render degrades to the same
+                // fit, so the two passes agree on what the file will contain.
+                let motion_only = clip_composition_is_motion_only(clip);
                 match resolve_asset_source_dimensions(asset, &mut source_dimensions) {
+                    None if motion_only => validation.add_clip_warning(
+                        &sequence.id,
+                        &clip.id,
+                        unmeasurable_motion_message(
+                            &clip.id,
+                            &track.name,
+                            &format!("the source dimensions of asset '{}' are unknown", asset.id),
+                        ),
+                    ),
                     None => validation.add_clip_error(
                         &sequence.id,
                         &clip.id,
@@ -7567,11 +7632,26 @@ pub fn validate_export_settings_with_dimensions(
                         if let Err(effect_label) =
                             effective_source_dimensions(probed_dimensions, &graph)
                         {
-                            validation.add_clip_error(
-                                &sequence.id,
-                                &clip.id,
-                                unmeasurable_effect_message(&effect_label, &clip.id),
-                            );
+                            if motion_only {
+                                validation.add_clip_warning(
+                                    &sequence.id,
+                                    &clip.id,
+                                    unmeasurable_motion_message(
+                                        &clip.id,
+                                        &track.name,
+                                        &format!(
+                                            "effect '{}' changes the picture size unpredictably",
+                                            effect_label
+                                        ),
+                                    ),
+                                );
+                            } else {
+                                validation.add_clip_error(
+                                    &sequence.id,
+                                    &clip.id,
+                                    unmeasurable_effect_message(&effect_label, &clip.id),
+                                );
+                            }
                         }
                     }
                 }
@@ -18147,9 +18227,21 @@ mod tests {
 
             let video_path = create_temp_media_file(name);
             let mut assets = HashMap::new();
-            let mut video_asset = Asset::new_video(name, &video_path, VideoInfo::default())
-                .with_duration(3.0)
-                .with_file_size(3_000_000);
+            // Real stored dimensions, not the `VideoInfo::default()` placeholder:
+            // the placeholder means "nobody measured this", which sends the clip
+            // down the unmeasurable-source fallback and would have this test
+            // asserting about a warning it never meant to provoke.
+            let mut video_asset = Asset::new_video(
+                name,
+                &video_path,
+                VideoInfo {
+                    width: 1280,
+                    height: 720,
+                    ..VideoInfo::default()
+                },
+            )
+            .with_duration(3.0)
+            .with_file_size(3_000_000);
             video_asset.id = "video_asset".to_string();
             assets.insert("video_asset".to_string(), video_asset);
 
@@ -18266,12 +18358,20 @@ mod tests {
             .collect()
     }
 
-    /// Lit-pixel count and centroid of one luma frame.
+    /// White-pixel count and centroid of one luma frame.
     fn motion_white_region(frame: &[u8], width: u32) -> Option<(usize, f64, f64)> {
+        motion_lit_region(frame, width, 127)
+    }
+
+    /// Count and centroid of the pixels of one luma frame above `threshold`.
+    ///
+    /// A translucent clip composites to a mid grey, so it has to be measured
+    /// against "not black" rather than against white.
+    fn motion_lit_region(frame: &[u8], width: u32, threshold: u8) -> Option<(usize, f64, f64)> {
         let lit: Vec<(usize, usize)> = frame
             .iter()
             .enumerate()
-            .filter(|(_, luma)| **luma > 127)
+            .filter(|(_, luma)| **luma > threshold)
             .map(|(index, _)| (index % width as usize, index / width as usize))
             .collect();
         if lit.is_empty() {
@@ -18507,6 +18607,389 @@ mod tests {
         assert!(
             !plain.contains(":eval=frame") && !plain.contains("overlay=x='"),
             "a clip without motion must build exactly as it always did: {plain}"
+        );
+    }
+
+    /// The animated composition a clip's keyframes produce, at a given opacity.
+    fn animated_motion_graph_with_opacity(
+        clip: &Clip,
+        source: (u32, u32),
+        canvas: (u32, u32),
+        fps: f64,
+        slot_sec: f64,
+        head_sec: f64,
+        opacity: f64,
+    ) -> String {
+        let track = super::super::transform_layout::resolve_clip_motion_track(
+            source.0, source.1, canvas.0, canvas.1, clip, head_sec,
+        )
+        .expect("clip has motion keyframes");
+
+        let mut graph = String::new();
+        append_animated_video_transform_composition(
+            &mut graph, "0:v", "out", &track, opacity, slot_sec, canvas.0, canvas.1, fps, "yuv420p",
+        );
+        graph
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: alpha attenuation runs before the animated scale
+    ///
+    /// `colorchannelmixer` works in RGB, so in a `yuva*` graph FFmpeg wraps it in
+    /// a yuva -> argb -> yuva conversion. Placed after the animated `scale` that
+    /// conversion is configured once and keeps rescaling every later frame back to
+    /// the first frame's size, freezing the animation outright. Attenuating alpha
+    /// does not depend on the frame's size, so it belongs above `scale`.
+    #[test]
+    fn a_translucent_animated_clip_attenuates_before_it_scales() {
+        let clip = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.4, 0.4), 0.0), false),
+            (2.0, motion_transform((0.5, 0.5), (0.9, 0.9), 0.0), false),
+        ]);
+
+        let graph =
+            animated_motion_graph_with_opacity(&clip, (640, 360), (1280, 720), 30.0, 2.0, 0.0, 0.5);
+
+        let mixer = graph
+            .find("colorchannelmixer")
+            .expect("a translucent clip must attenuate its alpha");
+        let scale = graph
+            .find("scale=w='")
+            .expect("an animated clip must scale by expression");
+        assert!(
+            mixer < scale,
+            "the alpha filter must precede the animated scale or the size freezes: {graph}"
+        );
+
+        // Nothing may sit between the animated scale and the staged label but
+        // `setsar`, which converts no formats and so inserts no converter.
+        let staged = &graph[scale..graph.find("[out_tx]").expect("staged label")];
+        assert!(
+            staged.ends_with("eval=frame,setsar=1"),
+            "no format-converting filter may follow the animated scale: {staged}"
+        );
+
+        // An opaque clip emits no attenuation at all, and still stages in yuva.
+        let opaque =
+            animated_motion_graph_with_opacity(&clip, (640, 360), (1280, 720), 30.0, 2.0, 0.0, 1.0);
+        assert!(
+            !opaque.contains("colorchannelmixer"),
+            "an opaque clip must not pay for an alpha filter: {opaque}"
+        );
+        assert!(
+            opaque.starts_with("[0:v]format=yuva420p,scale=w='"),
+            "the staged chain must convert format before it scales: {opaque}"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: a sub-microsecond keyframe span cannot divide by zero
+    ///
+    /// Times are emitted through `format_speed_number`, which rounds to six
+    /// decimals. A raw span of 1e-7 is comfortably greater than zero in Rust and
+    /// formats to a literal `0` in the graph, so guarding on the raw value would
+    /// hand FFmpeg `…*(t-0)/0`.
+    #[test]
+    fn a_sub_microsecond_keyframe_span_never_emits_a_zero_divisor() {
+        let clip = motion_clip(&[
+            (0.0, motion_transform((0.3, 0.5), (0.4, 0.4), 0.0), false),
+            (1e-7, motion_transform((0.7, 0.5), (0.9, 0.9), 0.0), false),
+            (2.0, motion_transform((0.7, 0.5), (0.9, 0.9), 0.0), false),
+        ]);
+
+        let graph = animated_motion_graph(&clip, (640, 360), (1280, 720), 30.0, 2.0, 0.0);
+
+        assert!(
+            !graph.contains("/0)") && !graph.contains("/0,"),
+            "a span that rounds to zero must not become a divisor: {graph}"
+        );
+        assert!(
+            graph.contains(":eval=frame"),
+            "the rest of the move must still animate: {graph}"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: motion the render cannot animate leaves the graph untouched
+    ///
+    /// The byte-for-byte guarantee, driven through the real argument builder
+    /// rather than the composer alone: a clip whose keyframes cannot be animated
+    /// must produce exactly the graph it produced before motion rendered at all.
+    #[test]
+    fn unanimatable_motion_builds_the_same_graph_as_no_motion_at_all() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{SequenceFormat, TransformKeyframe};
+
+        let build = |keyframes: Vec<TransformKeyframe>| {
+            let mut sequence = Sequence::new("Motion", SequenceFormat::youtube_1080());
+            let mut track = Track::new_video("Video 1");
+            let mut clip = Clip::new("video_asset")
+                .with_source_range(0.0, 3.0)
+                .place_at(0.0);
+            clip.transform = motion_transform((0.4, 0.6), (0.5, 0.5), 0.0);
+            clip.motion_keyframes = keyframes;
+            track.add_clip(clip);
+            sequence.add_track(track);
+
+            let video_path = create_temp_media_file("no_regression.mp4");
+            let mut video_asset = Asset::new_video(
+                "no_regression.mp4",
+                &video_path,
+                VideoInfo {
+                    width: 1280,
+                    height: 720,
+                    ..VideoInfo::default()
+                },
+            )
+            .with_duration(3.0)
+            .with_file_size(3_000_000);
+            video_asset.id = "video_asset".to_string();
+            let mut assets = HashMap::new();
+            assets.insert(video_asset.id.clone(), video_asset);
+
+            let args = build_complex_filter_args_with_audio_info(
+                &sequence,
+                &assets,
+                &HashMap::new(),
+                &HashMap::new(),
+                &ExportSettings::default(),
+            )
+            .expect("the clip should build a filtergraph");
+            filter_complex_of(&args).to_string()
+        };
+
+        let keyframe_at = |time_offset: f64, transform: Transform| TransformKeyframe {
+            time_offset,
+            transform,
+            interpolation: Default::default(),
+        };
+
+        let baseline = build(Vec::new());
+
+        // One keyframe describes a still picture.
+        let single = build(vec![keyframe_at(
+            0.0,
+            motion_transform((0.2, 0.2), (0.9, 0.9), 0.0),
+        )]);
+        assert_eq!(
+            single, baseline,
+            "a lone keyframe must not change the emitted graph"
+        );
+
+        // Keyframes that agree describe a still picture too.
+        let unmoving = build(vec![
+            keyframe_at(0.0, motion_transform((0.2, 0.2), (0.9, 0.9), 0.0)),
+            keyframe_at(3.0, motion_transform((0.2, 0.2), (0.9, 0.9), 0.0)),
+        ]);
+        assert_eq!(
+            unmoving, baseline,
+            "keyframes that agree must not change the emitted graph"
+        );
+
+        // And motion that turns the picture stays on the static path.
+        let rotating = build(vec![
+            keyframe_at(0.0, motion_transform((0.2, 0.2), (0.9, 0.9), 0.0)),
+            keyframe_at(3.0, motion_transform((0.6, 0.6), (1.2, 1.2), 25.0)),
+        ]);
+        assert_eq!(
+            rotating, baseline,
+            "rotating motion must not change the emitted graph"
+        );
+
+        // The control: motion the render *can* animate must differ, or the three
+        // assertions above would pass for the wrong reason.
+        let panning = build(vec![
+            keyframe_at(0.0, motion_transform((0.2, 0.2), (0.9, 0.9), 0.0)),
+            keyframe_at(3.0, motion_transform((0.6, 0.6), (1.2, 1.2), 0.0)),
+        ]);
+        assert_ne!(
+            panning, baseline,
+            "animatable motion must actually change the emitted graph"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: an unmeasurable source costs the animation, not the export
+    ///
+    /// Compositing needs the source's real pixel size. Widening the composition
+    /// gate to cover motion meant an identity-transform clip that merely carried
+    /// keyframes started demanding that size — and an asset whose size cannot be
+    /// measured turned a previously working export into a blocked one. Such a
+    /// clip has somewhere to fall back to: the plain canvas fit it always had.
+    #[test]
+    fn a_motion_clip_with_an_unmeasurable_source_still_exports() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{SequenceFormat, TransformKeyframe};
+
+        // `VideoInfo::default()` is the 1920x1080 placeholder an unenriched
+        // import stores, which `stored_asset_source_dimensions` refuses, and the
+        // file does not exist so the probe cannot rescue it either.
+        let build = |transform: Transform, opacity: f32| {
+            let mut sequence = Sequence::new("Motion", SequenceFormat::youtube_1080());
+            let mut track = Track::new_video("Video 1");
+            let mut clip = Clip::new("video_asset")
+                .with_source_range(0.0, 3.0)
+                .place_at(0.0);
+            clip.id = "motion-clip".to_string();
+            clip.transform = transform;
+            clip.opacity = opacity;
+            clip.motion_keyframes = vec![
+                TransformKeyframe {
+                    time_offset: 0.0,
+                    transform: motion_transform((0.3, 0.5), (0.5, 0.5), 0.0),
+                    interpolation: Default::default(),
+                },
+                TransformKeyframe {
+                    time_offset: 3.0,
+                    transform: motion_transform((0.7, 0.5), (1.0, 1.0), 0.0),
+                    interpolation: Default::default(),
+                },
+            ];
+            track.add_clip(clip);
+            sequence.add_track(track);
+
+            let video_path = create_temp_media_file("unmeasurable.mp4");
+            let mut video_asset =
+                Asset::new_video("unmeasurable.mp4", &video_path, VideoInfo::default())
+                    .with_duration(3.0)
+                    .with_file_size(3_000_000);
+            video_asset.id = "video_asset".to_string();
+            let mut assets = HashMap::new();
+            assets.insert(video_asset.id.clone(), video_asset);
+
+            (sequence, assets)
+        };
+
+        // Motion alone: the export survives, fitted to the canvas, and says so.
+        let (sequence, assets) = build(Transform::default(), 1.0);
+        let validation = validate_export_settings(
+            &sequence,
+            &assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+        assert!(
+            validation.is_valid,
+            "motion alone must not block an export over an unmeasurable source: {:?}",
+            validation.errors
+        );
+        assert!(
+            validation
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("Motion keyframes")
+                    && warning.contains("fitted to the canvas")),
+            "the lost animation has to be reported: {:?}",
+            validation.warnings
+        );
+
+        let graph = filter_complex_of(
+            &build_complex_filter_args_with_audio_info(
+                &sequence,
+                &assets,
+                &HashMap::new(),
+                &HashMap::new(),
+                &ExportSettings::default(),
+            )
+            .expect("an unmeasurable motion clip must still build a graph"),
+        )
+        .to_string();
+        assert!(
+            !graph.contains(":eval=frame"),
+            "the degraded clip must not animate: {graph}"
+        );
+
+        // A clip whose own transform places it still needs the size, and still
+        // fails loudly without it — that error is not a regression, it is the
+        // point of the check.
+        let (placed, placed_assets) = build(motion_transform((0.25, 0.25), (0.5, 0.5), 0.0), 1.0);
+        let placed_validation = validate_export_settings(
+            &placed,
+            &placed_assets,
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+        assert!(
+            !placed_validation.is_valid,
+            "a clip whose own transform needs placing must still fail without a size"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: a translucent clip animates as readily as an opaque one
+    ///
+    /// Alpha attenuation is the one filter in the staged chain that converts pixel
+    /// format, and a converter downstream of the animated `scale` is configured
+    /// once and then rescales every later frame back to the first frame's size.
+    /// With `colorchannelmixer` left after `scale` this measured 3676 lit pixels
+    /// on frame 0 and 3676 on frame 59 of a 0.4x -> 0.9x zoom — seven distinct
+    /// sizes across sixty frames, i.e. frozen. Hoisting it above `scale` gives
+    /// 3676 -> 14306 across sixty distinct sizes.
+    ///
+    /// This is a silent wrong render rather than a loud one: the clip still pans,
+    /// FFmpeg prints no warning, and the motion warning is suppressed because the
+    /// export believes it animated the clip. Only the pixels tell.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib --features dev-full -- --ignored translucent
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn a_translucent_animated_clip_still_moves_its_pixels() {
+        use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
+
+        const CANVAS: (u32, u32) = (320, 180);
+        const SOURCE: (u32, u32) = (320, 180);
+        const FPS: f64 = 30.0;
+        const SLOT_SEC: f64 = 2.0;
+        // Half-opaque white over black lands near luma 128, right on the white
+        // threshold, so the region is measured against "not black" instead.
+        const LIT: u8 = 40;
+
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(input) = motion_white_box_clip(&ffmpeg, dir.path(), SOURCE, (160, 90), SLOT_SEC)
+        else {
+            skip_without_ffmpeg("the white-box fixture could not be encoded");
+            return;
+        };
+
+        let zooming = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.4, 0.4), 0.0), false),
+            (2.0, motion_transform((0.5, 0.5), (0.9, 0.9), 0.0), false),
+        ]);
+        let graph =
+            animated_motion_graph_with_opacity(&zooming, SOURCE, CANVAS, FPS, SLOT_SEC, 0.0, 0.5);
+        let frames = motion_luma_frames(&ffmpeg, &input, &graph, CANVAS);
+        assert_eq!(frames.len(), 60, "the slot must render every frame");
+
+        let areas: Vec<usize> = frames
+            .iter()
+            .map(|frame| {
+                motion_lit_region(frame, CANVAS.0, LIT)
+                    .expect("a translucent clip is still visible")
+                    .0
+            })
+            .collect();
+
+        assert!(
+            areas.last().unwrap() > &(areas[0] * 3),
+            "a translucent 0.4x -> 0.9x zoom must still grow several fold: {} -> {}",
+            areas[0],
+            areas.last().unwrap()
+        );
+        assert!(
+            areas.iter().collect::<std::collections::HashSet<_>>().len() > 20,
+            "a translucent clip must resize continuously, not freeze at frame one: {areas:?}"
+        );
+
+        // And it really is translucent: half-opaque white over black must land
+        // well below the full-white the opaque path produces.
+        let centre = frames[frames.len() - 1][(CANVAS.1 / 2 * CANVAS.0 + CANVAS.0 / 2) as usize];
+        assert!(
+            (LIT..200).contains(&centre),
+            "the clip must be dimmed by its opacity, got luma {centre}"
         );
     }
 }

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -26,7 +26,10 @@ use crate::core::{
     ffmpeg::FFmpegRunner,
     fs::validate_local_input_path,
     render::hdr::{build_tonemap_filter, HdrMetadata, TonemapMode, TonemapParams},
-    render::transform_layout::ClipTransformLayout,
+    render::transform_layout::{
+        clip_motion_renders_animated, opacity_needs_alpha_filter, ClipMotionTrack,
+        ClipTransformLayout, MotionKeyframeLayout,
+    },
     render::transition_stitch::{
         plan_sequence_transitions, ClipHandles, EngineAudioFades, TransitionPlan,
     },
@@ -3058,7 +3061,11 @@ pub fn clip_needs_transform_composition(clip: &Clip) -> bool {
     !is_text_clip(clip)
         && !clip.is_adjustment_layer()
         && (!clip_has_identity_transform(clip)
-            || (f64::from(clip.opacity) - 1.0).abs() > TRANSFORM_EPSILON)
+            || (f64::from(clip.opacity) - 1.0).abs() > TRANSFORM_EPSILON
+            // Motion the render can animate needs the composite even when the
+            // clip's own transform is the identity, because the picture the
+            // keyframes describe is never the plain canvas fit.
+            || clip_motion_renders_animated(clip))
 }
 
 /// Pixel dimensions of the media a clip decodes, cached for one export run.
@@ -3620,6 +3627,192 @@ pub(super) fn append_video_transform_composition(
         pixel_format,
         output_label
     ));
+}
+
+/// Emits the filter chain that animates one clip's motion across the canvas.
+///
+/// The animated twin of [`append_video_transform_composition`]. It ends in the
+/// same shape — `setsar=1,fps=,trim=,format=` on a full-canvas frame — so the
+/// downstream concat cannot tell an animated segment from a static one.
+///
+/// Three things differ from the static chain, and each is load-bearing:
+///
+/// 1. `scale` carries per-frame expressions under `eval=frame`. This is the only
+///    stock filter that resizes per frame while keeping a usable output link.
+/// 2. The staged clip is **always** given an alpha channel. `overlay` only
+///    notices that its overlay input changed size when that input carries alpha;
+///    handed an opaque `yuv420p` overlay it silently keeps compositing the first
+///    frame's dimensions forever, with no warning. The planar `yuva*` format is
+///    also mandatory here — `rgba` staging re-freezes the same way once
+///    `overlay`'s own `format` is a `yuv420` mode, so the static path's cheaper
+///    `rgba` shortcut for opacity-only clips cannot be reused.
+/// 3. `overlay` positions by expression, likewise under `eval=frame`.
+///
+/// Rotation is absent by construction: the caller only routes a clip here when
+/// its motion never turns the picture. `rotate` does not re-configure when its
+/// input size changes, so an animated `scale` feeding it freezes the picture at
+/// its first frame's size — a rotated motion clip keeps the static fallback.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn append_animated_video_transform_composition(
+    filter_complex: &mut String,
+    input_label: &str,
+    output_label: &str,
+    track: &ClipMotionTrack,
+    opacity: f64,
+    duration_sec: f64,
+    width: u32,
+    height: u32,
+    fps: f64,
+    pixel_format: &str,
+) {
+    let staged_label = format!("{}_tx", output_label);
+    let canvas_label = format!("{}_bg", output_label);
+    let (alpha_format, overlay_format) = transform_composition_formats(pixel_format);
+    let keyframes = track.keyframes.as_slice();
+
+    let width_expr =
+        build_motion_lerp_expression(keyframes, |keyframe| f64::from(keyframe.scaled_width));
+    let height_expr =
+        build_motion_lerp_expression(keyframes, |keyframe| f64::from(keyframe.scaled_height));
+
+    filter_complex.push_str(&format!(
+        "[{}]scale=w='{}':h='{}':eval=frame,setsar=1,format={}",
+        input_label, width_expr, height_expr, alpha_format
+    ));
+
+    if opacity_needs_alpha_filter(opacity) {
+        filter_complex.push_str(&format!(
+            ",colorchannelmixer=aa={}",
+            format_speed_number(opacity)
+        ));
+    }
+
+    filter_complex.push_str(&format!("[{}];", staged_label));
+
+    // Canvas sizing, padding and frame pinning are the static path's, unchanged
+    // — see `append_video_transform_composition` for why each is shaped this way.
+    let minimum_duration_sec = if fps.is_finite() && fps > 0.0 {
+        1.0 / fps
+    } else {
+        TIMELINE_EPSILON_SEC
+    };
+    let slot_duration_sec = duration_sec.max(minimum_duration_sec);
+    append_black_video_gap(
+        filter_complex,
+        &canvas_label,
+        slot_duration_sec + minimum_duration_sec,
+        width,
+        height,
+        fps,
+        pixel_format,
+    );
+
+    // With rotation ruled out, the static layout's placement collapses to
+    // `position * canvas - anchor * scaled`, because the bounding box `overlay`
+    // is given is exactly the scaled frame. Reading the frame's own size back out
+    // of `overlay_w`/`overlay_h` rather than recomputing it keeps the placement
+    // on the same clock as the size even when the clip's frame rate differs from
+    // the canvas rate.
+    let position_x_expr = build_motion_lerp_expression(keyframes, |keyframe| keyframe.position_x);
+    let position_y_expr = build_motion_lerp_expression(keyframes, |keyframe| keyframe.position_y);
+    let anchor_x_expr = build_motion_lerp_expression(keyframes, |keyframe| keyframe.anchor_x);
+    let anchor_y_expr = build_motion_lerp_expression(keyframes, |keyframe| keyframe.anchor_y);
+
+    let slot_frame_count = ((slot_duration_sec * fps).round() as i64).max(1);
+    filter_complex.push_str(&format!(
+        "[{}][{}]overlay=x='({})*{}-({})*overlay_w':y='({})*{}-({})*overlay_h':eval=frame:format={},setsar=1,fps={},trim=end_frame={},setpts=PTS-STARTPTS,format={}[{}];",
+        canvas_label,
+        staged_label,
+        position_x_expr,
+        width,
+        anchor_x_expr,
+        position_y_expr,
+        height,
+        anchor_y_expr,
+        overlay_format,
+        format_speed_number(fps),
+        slot_frame_count,
+        pixel_format,
+        output_label
+    ));
+}
+
+/// Builds a piecewise-linear FFmpeg expression in `t` through motion keyframes.
+///
+/// Produces the same nested-`if` shape the effect keyframe builder uses:
+///
+/// ```text
+/// if(lt(t,T0),V0, if(lt(t,T1),V0+(V1-V0)*(t-T0)/(T1-T0), … , Vlast))
+/// ```
+///
+/// The value is held constant before the first keyframe and after the last, and
+/// a keyframe marked `hold` holds its own value for the whole segment that starts
+/// at it. That is precisely what `getClipMotionTransformAtTime` does in
+/// `src/utils/clipMotion.ts`, so the export samples the curve the preview drew.
+///
+/// The result is wrapped in `'…'` by the caller, so its commas are literal and no
+/// backslash escaping is needed.
+fn build_motion_lerp_expression(
+    keyframes: &[MotionKeyframeLayout],
+    value_of: impl Fn(&MotionKeyframeLayout) -> f64,
+) -> String {
+    let Some(first) = keyframes.first() else {
+        return "0".to_string();
+    };
+    if keyframes.len() == 1 {
+        return format_speed_number(value_of(first));
+    }
+
+    let mut expression = String::new();
+    let mut depth = 0usize;
+
+    for (index, pair) in keyframes.windows(2).enumerate() {
+        let (start, end) = (&pair[0], &pair[1]);
+        let start_value = value_of(start);
+        let end_value = value_of(end);
+
+        if index == 0 {
+            expression.push_str(&format!(
+                "if(lt(t,{}),{}",
+                format_speed_number(start.time_sec),
+                format_speed_number(start_value)
+            ));
+            depth += 1;
+        }
+
+        let span = end.time_sec - start.time_sec;
+        // A zero-length span is unreachable — the previous branch already
+        // consumed every `t` below this one — but `hold` and a degenerate span
+        // both resolve to the segment's *start* value, which is what the preview
+        // returns when it divides by a zero duration.
+        if start.hold || span <= 0.0 {
+            expression.push_str(&format!(
+                ",if(lt(t,{}),{}",
+                format_speed_number(end.time_sec),
+                format_speed_number(start_value)
+            ));
+        } else {
+            expression.push_str(&format!(
+                ",if(lt(t,{}),{}{}{}*(t-{})/{}",
+                format_speed_number(end.time_sec),
+                format_speed_number(start_value),
+                if end_value >= start_value { "+" } else { "-" },
+                format_speed_number((end_value - start_value).abs()),
+                format_speed_number(start.time_sec),
+                format_speed_number(span)
+            ));
+        }
+        depth += 1;
+    }
+
+    expression.push_str(&format!(
+        ",{}",
+        format_speed_number(value_of(&keyframes[keyframes.len() - 1]))
+    ));
+    for _ in 0..depth {
+        expression.push(')');
+    }
+    expression
 }
 
 /// The alpha-carrying format to stage an opacity-only clip in.
@@ -6010,6 +6203,18 @@ impl ExportEngine {
 
         // Add progress output to stdout for real-time tracking.
         insert_output_option_args(&mut args, ["-progress".to_string(), "pipe:1".to_string()])?;
+
+        // The graph goes to FFmpeg as a file, not as an argv value: an animated
+        // clip's motion expressions alone can outgrow the command-line limit.
+        // Only FFmpeg 7.0 and later can read one, so an older or unrecognised
+        // binary keeps the inline graph it has always been given.
+        let (args, filter_script_dir) = super::ffmpeg_graph::materialize_filter_script(
+            args,
+            super::ffmpeg_graph::ffmpeg_supports_filter_script(&self.ffmpeg.info().version),
+        )
+        .map_err(ExportError::IoError)?;
+        let _keep_filter_script_dir_alive = filter_script_dir;
+
         let invocation = if let Some(plan) = render_plan {
             build_ffmpeg_invocation_for_render_plan(plan, args)
         } else {
@@ -6402,6 +6607,16 @@ impl ExportEngine {
             normalized_settings.end_time,
         );
         let total_frames = (duration * sequence.format.fps.as_f64()).ceil() as u64;
+
+        // Same script-file delivery, and the same version gate, as the video
+        // path, so both exports agree on how the graph reaches FFmpeg.
+        let (args, filter_script_dir) = super::ffmpeg_graph::materialize_filter_script(
+            args,
+            super::ffmpeg_graph::ffmpeg_supports_filter_script(&self.ffmpeg.info().version),
+        )
+        .map_err(ExportError::IoError)?;
+        let _keep_filter_script_dir_alive = filter_script_dir;
+
         let invocation = if let Some(plan) = render_plan {
             build_ffmpeg_invocation_for_render_plan(plan, args)
         } else {
@@ -7238,12 +7453,16 @@ pub fn validate_export_settings_with_dimensions(
                 );
             }
 
-            // Motion is stored, round-trips through the project, and animates in
-            // the preview; what it is not is rendered. The export composites the
-            // clip once, at its base transform, so the caller is told what the
-            // file will actually show rather than left to discover it.
+            // Pan, zoom and anchor moves now render: the composite animates them
+            // straight from the keyframes. What still does not render is motion
+            // that turns the picture — FFmpeg cannot resize a frame per-frame and
+            // rotate it in the same pass — along with keyframes too degenerate to
+            // animate, such as a lone keyframe that disagrees with the clip's own
+            // transform. Those still composite once at the base transform, so the
+            // caller is told rather than left to discover it.
             if track.kind == TrackKind::Video
                 && clip_motion_differs_from_base_transform(clip)
+                && !clip_motion_renders_animated(clip)
                 && !clip.is_adjustment_layer()
                 && !is_text_clip(clip)
             {
@@ -9667,11 +9886,12 @@ mod tests {
     /// Feature: Transformed clips in the final render
     /// Scenario: keyframed motion renders static, and says so
     ///
-    /// The preview animates `motion_keyframes`; the export composites the clip
-    /// once. Silently rendering the base transform would hand back a file that
-    /// disagrees with what the editor just watched.
+    /// The preview animates `motion_keyframes` and so, now, does the export —
+    /// but only for motion that does not turn the picture. A move that rotates
+    /// still composites once, and silently rendering the base transform would
+    /// hand back a file that disagrees with what the editor just watched.
     #[test]
-    fn test_validation_warns_that_motion_keyframes_render_static() {
+    fn test_validation_warns_that_rotating_motion_keyframes_render_static() {
         use crate::core::assets::VideoInfo;
         use crate::core::timeline::{Clip, SequenceFormat, Track, TransformKeyframe};
         use crate::core::Point2D;
@@ -9693,6 +9913,9 @@ mod tests {
                 time_offset: 3.0,
                 transform: Transform {
                     position: Point2D::new(0.75, 0.5),
+                    // The turn is what keeps this clip on the static path:
+                    // `rotate` cannot follow a frame that resizes under it.
+                    rotation_deg: 30.0,
                     ..Transform::default()
                 },
                 interpolation: Default::default(),
@@ -9772,6 +9995,8 @@ mod tests {
                 time_offset: 3.0,
                 transform: Transform {
                     position: Point2D::new(0.75, 0.5),
+                    // Rotating motion is the kind that still degrades.
+                    rotation_deg: 30.0,
                     ..Transform::default()
                 },
                 interpolation: Default::default(),
@@ -17655,5 +17880,633 @@ mod tests {
         let deserialized: AudioExportResult = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.file_size, 204800);
         assert!((deserialized.duration_sec - 120.5).abs() < 0.01);
+    }
+
+    // -------------------------------------------------------------------------
+    // Animated motion keyframes
+    // -------------------------------------------------------------------------
+
+    /// A clip carrying `keyframes` as `(time_offset, transform, hold)`.
+    fn motion_clip(keyframes: &[(f64, Transform, bool)]) -> Clip {
+        use crate::core::timeline::{KeyframeInterpolation, TransformKeyframe};
+
+        let mut clip = Clip::new("asset").with_source_range(0.0, 3.0).place_at(0.0);
+        clip.id = "motion-clip".to_string();
+        clip.motion_keyframes = keyframes
+            .iter()
+            .map(|(time_offset, transform, hold)| TransformKeyframe {
+                time_offset: *time_offset,
+                transform: transform.clone(),
+                interpolation: if *hold {
+                    KeyframeInterpolation::Hold
+                } else {
+                    KeyframeInterpolation::Linear
+                },
+            })
+            .collect();
+        clip
+    }
+
+    /// A transform with the fields motion actually animates.
+    fn motion_transform(position: (f64, f64), scale: (f64, f64), rotation_deg: f64) -> Transform {
+        use crate::core::Point2D;
+
+        Transform {
+            position: Point2D::new(position.0, position.1),
+            scale: Point2D::new(scale.0, scale.1),
+            rotation_deg,
+            anchor: Point2D::center(),
+        }
+    }
+
+    /// The animated composition a clip's keyframes produce on a given canvas.
+    fn animated_motion_graph(
+        clip: &Clip,
+        source: (u32, u32),
+        canvas: (u32, u32),
+        fps: f64,
+        slot_sec: f64,
+        head_sec: f64,
+    ) -> String {
+        let track = super::super::transform_layout::resolve_clip_motion_track(
+            source.0, source.1, canvas.0, canvas.1, clip, head_sec,
+        )
+        .expect("clip has motion keyframes");
+
+        let mut graph = String::new();
+        append_animated_video_transform_composition(
+            &mut graph, "0:v", "out", &track, 1.0, slot_sec, canvas.0, canvas.1, fps, "yuv420p",
+        );
+        graph
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: a pan-and-zoom clip is composited by expression, not by constant
+    ///
+    /// The static composition bakes every number into the graph, so it can only
+    /// draw one picture. Animating means the frame size and the overlay corner
+    /// both have to become expressions FFmpeg re-reads each frame.
+    #[test]
+    fn an_animated_clip_scales_and_overlays_by_expression() {
+        let clip = motion_clip(&[
+            (0.0, motion_transform((0.3, 0.5), (0.5, 0.5), 0.0), false),
+            (3.0, motion_transform((0.7, 0.5), (1.0, 1.0), 0.0), false),
+        ]);
+        let graph = animated_motion_graph(&clip, (640, 360), (1280, 720), 30.0, 3.0, 0.0);
+
+        assert!(
+            graph.contains("scale=w='if(lt(t,0),640") && graph.contains(":eval=frame"),
+            "the frame size must be a per-frame expression: {graph}"
+        );
+        assert!(
+            graph.contains("overlay=x='") && graph.contains("*overlay_w"),
+            "the overlay corner must be an expression reading the staged size: {graph}"
+        );
+        assert!(
+            graph.contains(":eval=frame:format=yuv420,"),
+            "the overlay must re-read its expressions per frame: {graph}"
+        );
+        assert!(
+            graph.contains("format=yuva420p"),
+            "the staged clip must carry alpha or overlay silently freezes its size: {graph}"
+        );
+        assert!(
+            !graph.contains("rotate="),
+            "the animated path never rotates: {graph}"
+        );
+        assert!(
+            graph.contains(
+                "setsar=1,fps=30,trim=end_frame=90,setpts=PTS-STARTPTS,format=yuv420p[out];"
+            ),
+            "the segment must end in the same shape a static one does: {graph}"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: `hold` steps instead of ramping
+    ///
+    /// `getClipMotionTransformAtTime` returns the *start* keyframe's transform
+    /// for a whole `hold` segment, so the expression must carry a constant over
+    /// that span rather than a slope.
+    #[test]
+    fn a_held_motion_segment_emits_a_constant_not_a_ramp() {
+        let held = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.5, 0.5), 0.0), true),
+            (1.5, motion_transform((0.5, 0.5), (1.0, 1.0), 0.0), false),
+            (3.0, motion_transform((0.5, 0.5), (1.0, 1.0), 0.0), false),
+        ]);
+        let graph = animated_motion_graph(&held, (640, 360), (1280, 720), 30.0, 3.0, 0.0);
+
+        assert!(
+            graph.contains("if(lt(t,1.5),640,"),
+            "a held segment must carry its start value flat across the span: {graph}"
+        );
+        assert!(
+            !graph.contains("*(t-0)/1.5"),
+            "a held segment must not interpolate: {graph}"
+        );
+    }
+
+    /// Feature: Keyframed motion across a transition handle
+    /// Scenario: keyframe times move into branch time
+    ///
+    /// Every branch ends in `setpts=PTS-STARTPTS`, so `t` is measured from the
+    /// start of the *handle*, not the start of the clip. Leaving the keyframe
+    /// times alone would run the whole move early by the handle's length.
+    #[test]
+    fn motion_keyframe_times_shift_into_branch_time_by_the_head_handle() {
+        let clip = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.5, 0.5), 0.0), false),
+            (2.0, motion_transform((0.5, 0.5), (1.0, 1.0), 0.0), false),
+        ]);
+
+        let unhandled = animated_motion_graph(&clip, (640, 360), (1280, 720), 30.0, 3.0, 0.0);
+        assert!(
+            unhandled.contains("if(lt(t,0),640,if(lt(t,2),640"),
+            "without a handle the move starts at the clip's own zero: {unhandled}"
+        );
+
+        let handled = animated_motion_graph(&clip, (640, 360), (1280, 720), 30.0, 3.0, 0.5);
+        assert!(
+            handled.contains("if(lt(t,0.5),640,if(lt(t,2.5),640"),
+            "a half-second handle must push every keyframe time out by it: {handled}"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: motion that turns the picture keeps the static composite
+    ///
+    /// `rotate` never re-configures when its input changes size, so an animated
+    /// `scale` feeding it freezes the picture at its first frame's dimensions —
+    /// silently, with no FFmpeg warning. Until that is solved a rotating move
+    /// composites once and the export says so.
+    #[test]
+    fn rotating_motion_is_refused_by_the_animated_path() {
+        let rotating = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.5, 0.5), 0.0), false),
+            (3.0, motion_transform((0.5, 0.5), (1.0, 1.0), 15.0), false),
+        ]);
+        assert!(
+            !clip_motion_renders_animated(&rotating),
+            "a move that rotates must not take the animated path"
+        );
+
+        let panning = motion_clip(&[
+            (0.0, motion_transform((0.3, 0.5), (1.0, 1.0), 0.0), false),
+            (3.0, motion_transform((0.7, 0.5), (1.0, 1.0), 0.0), false),
+        ]);
+        assert!(
+            clip_motion_renders_animated(&panning),
+            "a pan must take the animated path"
+        );
+
+        let single = motion_clip(&[(0.0, motion_transform((0.3, 0.5), (1.0, 1.0), 0.0), false)]);
+        assert!(
+            !clip_motion_renders_animated(&single),
+            "one keyframe describes a still picture, not a move"
+        );
+
+        let unmoving = motion_clip(&[
+            (0.0, motion_transform((0.3, 0.5), (1.0, 1.0), 0.0), false),
+            (3.0, motion_transform((0.3, 0.5), (1.0, 1.0), 0.0), false),
+        ]);
+        assert!(
+            !clip_motion_renders_animated(&unmoving),
+            "keyframes that agree describe a still picture too"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: a clip with no motion emits exactly the graph it always did
+    ///
+    /// The animated path is additive. A clip without keyframes must come out of
+    /// the composer byte-for-byte as before, or every existing render changes
+    /// under a feature nobody switched on.
+    #[test]
+    fn a_clip_without_motion_keeps_the_static_composition_byte_for_byte() {
+        use crate::core::Point2D;
+
+        let transform = Transform {
+            position: Point2D::new(0.5, 0.5),
+            scale: Point2D::new(0.5, 0.5),
+            rotation_deg: 0.0,
+            anchor: Point2D::center(),
+        };
+        let layout = super::super::transform_layout::compute_clip_transform_layout(
+            640, 360, 1280, 720, &transform, 1.0,
+        );
+
+        let mut graph = String::new();
+        append_video_transform_composition(
+            &mut graph, "0:v", "out", &layout, 3.0, 1280, 720, 30.0, "yuv420p",
+        );
+
+        assert_eq!(
+            graph,
+            concat!(
+                "[0:v]scale=640:360,setsar=1[out_tx];",
+                "color=c=black:s=1280x720:r=30:d=3.033333,format=yuv420p[out_bg];",
+                "[out_bg][out_tx]overlay=x=320:y=180:format=yuv420,setsar=1,fps=30,",
+                "trim=end_frame=90,setpts=PTS-STARTPTS,format=yuv420p[out];"
+            ),
+            "the static composition must be untouched by the animated path"
+        );
+
+        let still = Clip::new("asset").with_source_range(0.0, 3.0).place_at(0.0);
+        assert!(
+            !clip_motion_renders_animated(&still),
+            "a clip with no keyframes has no motion to render"
+        );
+    }
+
+    /// Feature: Export preflight
+    /// Scenario: motion that now renders stops warning
+    ///
+    /// The warning existed because the export ignored motion. Now that pan, zoom
+    /// and anchor moves render, warning about them would train users to ignore
+    /// the warning that still matters.
+    #[test]
+    fn test_motion_warning_is_silent_for_motion_the_export_now_renders() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{SequenceFormat, Track};
+
+        let build = |rotation_deg: f64, name: &str| {
+            let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+            let mut track = Track::new_video("Video 1");
+            let mut clip = motion_clip(&[
+                (0.0, motion_transform((0.3, 0.5), (0.5, 0.5), 0.0), false),
+                (
+                    3.0,
+                    motion_transform((0.7, 0.5), (1.0, 1.0), rotation_deg),
+                    false,
+                ),
+            ]);
+            clip.asset_id = "video_asset".to_string();
+            track.add_clip(clip);
+            sequence.add_track(track);
+
+            let video_path = create_temp_media_file(name);
+            let mut assets = HashMap::new();
+            let mut video_asset = Asset::new_video(name, &video_path, VideoInfo::default())
+                .with_duration(3.0)
+                .with_file_size(3_000_000);
+            video_asset.id = "video_asset".to_string();
+            assets.insert("video_asset".to_string(), video_asset);
+
+            validate_export_settings(
+                &sequence,
+                &assets,
+                &HashMap::new(),
+                &ExportSettings::default(),
+            )
+        };
+
+        let panning = build(0.0, "motion_pan.mp4");
+        assert!(
+            !panning
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("Motion keyframes")),
+            "a pan-and-zoom move renders, so it must not warn: {:?}",
+            panning.warnings
+        );
+
+        let rotating = build(30.0, "motion_rotate.mp4");
+        assert!(
+            rotating
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("Motion keyframes")),
+            "a rotating move still degrades, so it must warn: {:?}",
+            rotating.warnings
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Animated motion, measured against real FFmpeg output
+    // -------------------------------------------------------------------------
+
+    /// A white rectangle centred on black, encoded to a real file.
+    ///
+    /// A file rather than `-f lavfi` so the graph under test is the only
+    /// filtergraph in the command and its frames have been through a decoder,
+    /// exactly as a render's would be.
+    fn motion_white_box_clip(
+        ffmpeg: &std::path::Path,
+        dir: &std::path::Path,
+        canvas: (u32, u32),
+        box_size: (u32, u32),
+        seconds: f64,
+    ) -> Option<std::path::PathBuf> {
+        let (width, height) = canvas;
+        let (box_width, box_height) = box_size;
+        let path = dir.join("motion-source.mp4");
+        let source = format!(
+            "color=c=black:s={width}x{height}:r=30:d={seconds},\
+             drawbox=x={}:y={}:w={box_width}:h={box_height}:color=white:t=fill",
+            (width - box_width) / 2,
+            (height - box_height) / 2,
+        );
+
+        let mut command = std::process::Command::new(ffmpeg);
+        crate::core::process::configure_std_command(&mut command);
+        let built = command
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                &source,
+                "-pix_fmt",
+                "yuv420p",
+            ])
+            .arg(&path)
+            .output()
+            .ok()?;
+
+        (built.status.success() && path.exists()).then_some(path)
+    }
+
+    /// Renders `graph` over `input` and hands back its frames as single-plane luma.
+    fn motion_luma_frames(
+        ffmpeg: &std::path::Path,
+        input: &std::path::Path,
+        graph: &str,
+        canvas: (u32, u32),
+    ) -> Vec<Vec<u8>> {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let graph_file = dir.path().join("graph.txt");
+        std::fs::write(&graph_file, graph.trim_end_matches(';')).expect("write filtergraph");
+
+        let mut command = std::process::Command::new(ffmpeg);
+        crate::core::process::configure_std_command(&mut command);
+        let render = command
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
+            .arg(input)
+            .arg("-/filter_complex")
+            .arg(&graph_file)
+            .args(["-map", "[out]", "-pix_fmt", "gray", "-f", "rawvideo", "-"])
+            .output()
+            .expect("run ffmpeg");
+
+        assert!(
+            render.status.success(),
+            "ffmpeg refused the animated graph: {}\n{graph}",
+            String::from_utf8_lossy(&render.stderr)
+        );
+
+        let frame_bytes = (canvas.0 * canvas.1) as usize;
+        render
+            .stdout
+            .chunks_exact(frame_bytes)
+            .map(<[u8]>::to_vec)
+            .collect()
+    }
+
+    /// Lit-pixel count and centroid of one luma frame.
+    fn motion_white_region(frame: &[u8], width: u32) -> Option<(usize, f64, f64)> {
+        let lit: Vec<(usize, usize)> = frame
+            .iter()
+            .enumerate()
+            .filter(|(_, luma)| **luma > 127)
+            .map(|(index, _)| (index % width as usize, index / width as usize))
+            .collect();
+        if lit.is_empty() {
+            return None;
+        }
+        let area = lit.len();
+        let sum_x: usize = lit.iter().map(|(x, _)| *x).sum();
+        let sum_y: usize = lit.iter().map(|(_, y)| *y).sum();
+        Some((area, sum_x as f64 / area as f64, sum_y as f64 / area as f64))
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: the rendered pixels actually move
+    ///
+    /// The string assertions above encode a belief about what `scale=eval=frame`
+    /// and an expression `overlay` do. This one hands real FFmpeg the graph the
+    /// export builds and measures the frames that come back: a zoom must grow the
+    /// white region, a pan must move its centroid while holding its area, a
+    /// `hold` must step rather than ramp, and a clip whose keyframes agree must
+    /// not move a single pixel.
+    ///
+    /// The last of those is the control that makes the rest mean something: it
+    /// runs the same animated code path and must still come out bit-constant.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary. Run with:
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib --features dev-full -- --ignored motion
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn animated_motion_moves_the_rendered_pixels() {
+        use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
+
+        const CANVAS: (u32, u32) = (320, 180);
+        const SOURCE: (u32, u32) = (320, 180);
+        const FPS: f64 = 30.0;
+        const SLOT_SEC: f64 = 2.0;
+
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(input) = motion_white_box_clip(&ffmpeg, dir.path(), SOURCE, (160, 90), SLOT_SEC)
+        else {
+            skip_without_ffmpeg("the white-box fixture could not be encoded");
+            return;
+        };
+
+        let render = |clip: &Clip| {
+            let graph = animated_motion_graph(clip, SOURCE, CANVAS, FPS, SLOT_SEC, 0.0);
+            motion_luma_frames(&ffmpeg, &input, &graph, CANVAS)
+        };
+
+        // --- zoom in: the white region has to grow ---------------------------
+        let zooming = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.4, 0.4), 0.0), false),
+            (2.0, motion_transform((0.5, 0.5), (0.9, 0.9), 0.0), false),
+        ]);
+        let frames = render(&zooming);
+        assert_eq!(frames.len(), 60, "the slot must render every frame");
+        let areas: Vec<usize> = frames
+            .iter()
+            .map(|frame| motion_white_region(frame, CANVAS.0).expect("lit pixels").0)
+            .collect();
+        assert!(
+            areas.last().unwrap() > &(areas[0] * 4),
+            "a 0.4x -> 0.9x zoom must grow the white region several fold: {} -> {}",
+            areas[0],
+            areas.last().unwrap()
+        );
+        assert!(
+            areas.windows(2).all(|pair| pair[1] >= pair[0]),
+            "a monotonic zoom must never shrink between frames: {areas:?}"
+        );
+        assert!(
+            areas.iter().collect::<std::collections::HashSet<_>>().len() > 20,
+            "a zoom must resize continuously, not in a couple of jumps: {areas:?}"
+        );
+
+        // --- pan: the centroid has to travel, the area must not --------------
+        let panning = motion_clip(&[
+            (0.0, motion_transform((0.3, 0.5), (0.5, 0.5), 0.0), false),
+            (2.0, motion_transform((0.7, 0.5), (0.5, 0.5), 0.0), false),
+        ]);
+        let frames = render(&panning);
+        let measured: Vec<(usize, f64, f64)> = frames
+            .iter()
+            .map(|frame| motion_white_region(frame, CANVAS.0).expect("lit pixels"))
+            .collect();
+        let (first_area, first_x, first_y) = measured[0];
+        let (last_area, last_x, last_y) = *measured.last().unwrap();
+        assert!(
+            last_x - first_x > 90.0,
+            "a 0.3 -> 0.7 pan across a 320px canvas must move the centroid ~128px: {first_x} -> {last_x}"
+        );
+        assert!(
+            (last_y - first_y).abs() < 2.0,
+            "a horizontal pan must not drift vertically: {first_y} -> {last_y}"
+        );
+        assert!(
+            (last_area as f64 - first_area as f64).abs() / (first_area as f64) < 0.02,
+            "a pan must not resize the picture: {first_area} -> {last_area}"
+        );
+
+        // --- hold: two states, not a ramp ------------------------------------
+        let held = motion_clip(&[
+            (0.0, motion_transform((0.5, 0.5), (0.4, 0.4), 0.0), true),
+            (1.0, motion_transform((0.5, 0.5), (0.9, 0.9), 0.0), false),
+            (2.0, motion_transform((0.5, 0.5), (0.9, 0.9), 0.0), false),
+        ]);
+        let frames = render(&held);
+        let held_areas: std::collections::BTreeSet<usize> = frames
+            .iter()
+            .map(|frame| motion_white_region(frame, CANVAS.0).expect("lit pixels").0)
+            .collect();
+        assert_eq!(
+            held_areas.len(),
+            2,
+            "a held segment then a flat one must render exactly two sizes: {held_areas:?}"
+        );
+
+        // --- negative control: keyframes that agree must not move a pixel ----
+        let still = motion_clip(&[
+            (0.0, motion_transform((0.4, 0.6), (0.7, 0.7), 0.0), false),
+            (1.0, motion_transform((0.4, 0.6), (0.7, 0.7), 0.0), false),
+            (2.0, motion_transform((0.6, 0.6), (0.7, 0.7), 0.0), false),
+        ]);
+        // Only the last segment moves, so the first second is the control: every
+        // frame of it must be byte-identical to the one before.
+        let frames = render(&still);
+        let held_frames = &frames[..30];
+        assert!(
+            held_frames.windows(2).all(|pair| pair[0] == pair[1]),
+            "frames inside a segment whose endpoints agree must be bit-identical"
+        );
+        let (start_area, start_x, _) = motion_white_region(&frames[0], CANVAS.0).expect("lit");
+        let (end_area, end_x, _) =
+            motion_white_region(frames.last().unwrap(), CANVAS.0).expect("lit");
+        assert_eq!(
+            start_area, end_area,
+            "the moving segment only pans, so the area must hold"
+        );
+        assert!(
+            end_x - start_x > 40.0,
+            "the clip must still move once its moving segment starts: {start_x} -> {end_x}"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: the whole builder routes an animated clip to the animated path
+    ///
+    /// The composition gate, the routing branch and the emitter are three
+    /// separate decisions, and a clip only animates if all three agree. This
+    /// drives the real argument builder rather than the emitter alone, so a gate
+    /// that never opens shows up here instead of shipping.
+    #[test]
+    fn the_argument_builder_animates_a_clip_that_carries_motion() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::timeline::{SequenceFormat, TransformKeyframe};
+
+        let build = |keyframes: Vec<TransformKeyframe>, transform: Transform| {
+            let mut sequence = Sequence::new("Motion", SequenceFormat::youtube_1080());
+            let mut track = Track::new_video("Video 1");
+            let mut clip = Clip::new("video_asset")
+                .with_source_range(0.0, 3.0)
+                .place_at(0.0);
+            clip.transform = transform;
+            clip.motion_keyframes = keyframes;
+            track.add_clip(clip);
+            sequence.add_track(track);
+
+            let video_path = create_temp_media_file("motion_source.mp4");
+            let mut video_asset = Asset::new_video(
+                "motion_source.mp4",
+                &video_path,
+                VideoInfo {
+                    width: 1280,
+                    height: 720,
+                    ..VideoInfo::default()
+                },
+            )
+            .with_duration(3.0)
+            .with_file_size(3_000_000);
+            video_asset.id = "video_asset".to_string();
+            let mut assets = HashMap::new();
+            assets.insert(video_asset.id.clone(), video_asset);
+
+            let args = build_complex_filter_args_with_audio_info(
+                &sequence,
+                &assets,
+                &HashMap::new(),
+                &HashMap::new(),
+                &ExportSettings::default(),
+            )
+            .expect("a clip with motion should build a filtergraph");
+            filter_complex_of(&args).to_string()
+        };
+
+        let panning = vec![
+            TransformKeyframe {
+                time_offset: 0.0,
+                transform: motion_transform((0.3, 0.5), (0.5, 0.5), 0.0),
+                interpolation: Default::default(),
+            },
+            TransformKeyframe {
+                time_offset: 3.0,
+                transform: motion_transform((0.7, 0.5), (1.0, 1.0), 0.0),
+                interpolation: Default::default(),
+            },
+        ];
+
+        // The clip's own transform is the identity, so only the keyframes can
+        // have pulled the composition in at all.
+        let animated = build(panning.clone(), Transform::default());
+        assert!(
+            animated.contains(":eval=frame"),
+            "an identity-transform clip with motion must still animate: {animated}"
+        );
+        assert!(
+            animated.contains("overlay=x='"),
+            "the overlay corner must be an expression: {animated}"
+        );
+
+        // The same move, but turning: still one static composite.
+        let mut rotating = panning;
+        rotating[1].transform.rotation_deg = 20.0;
+        let stilled = build(rotating, Transform::default());
+        assert!(
+            !stilled.contains(":eval=frame"),
+            "rotating motion must not reach the animated path: {stilled}"
+        );
+
+        // And a clip with no motion at all is untouched by any of this.
+        let plain = build(Vec::new(), Transform::default());
+        assert!(
+            !plain.contains(":eval=frame") && !plain.contains("overlay=x='"),
+            "a clip without motion must build exactly as it always did: {plain}"
+        );
     }
 }

--- a/src-tauri/src/core/render/ffmpeg_graph.rs
+++ b/src-tauri/src/core/render/ffmpeg_graph.rs
@@ -49,27 +49,50 @@ const FILTER_SCRIPT_MINIMUM_MAJOR: u32 = 7;
 /// Whether a reported FFmpeg version can read a filtergraph from a file.
 ///
 /// [`crate::core::ffmpeg::FFmpegInfo::version`] is whatever `get_ffmpeg_version`
-/// scraped off the banner, which is only loosely a version number: releases give
-/// `8.0.1` or `8.0.1-essentials_build-www.gyan.dev`, distributions give `n6.1`,
-/// git builds give `N-109421-g1b2c3d4`, and a banner that did not parse at all
-/// yields the whole first line.
+/// scraped off the banner, which is only loosely a version number. Three shapes
+/// turn up in practice:
 ///
-/// So this reads a major version only from the unambiguous shape — leading ASCII
-/// digits terminated by `.`, `-`, or the end of the string — and answers `false`
-/// for everything else. That conservative default is the point: a `false` here
-/// routes the graph inline, which is what every FFmpeg has always accepted, so an
+/// * Releases: `8.0.1`, or `8.0.1-essentials_build-www.gyan.dev` from the Gyan
+///   builds this project downloads first.
+/// * Distribution builds, which prefix the git tag: `n6.1`, `n7.1`.
+/// * Master builds, which report git-describe against no tag at all:
+///   `N-119421-g1b2c3d4`. This one matters because
+///   `ffmpeg-master-latest-*-gpl` from BtbN is the project's own configured
+///   fallback download (`scripts/ffmpeg-sources.json`), so the binary most
+///   likely to be handed a huge graph is also the one with no readable major
+///   version. BtbN publishes only recent masters, all well past 7.0.
+///
+/// Anything else — including a banner line that never parsed into a version at
+/// all — answers `false`, which routes the graph inline. That conservative
+/// default is the point: inline is what every FFmpeg has always accepted, so an
 /// unrecognised version keeps behaving exactly as it did before the script-file
-/// path existed. Guessing the other way would break every export on that binary.
+/// path existed. Guessing the other way breaks every export on that binary.
+///
+/// Note there is deliberately no `-filter_complex_script` fallback for older
+/// builds: that option was removed in FFmpeg 9, so it trades one broken set of
+/// versions for another. A major-version gate is the only shape that holds.
 pub fn ffmpeg_supports_filter_script(version: &str) -> bool {
     let version = version.trim();
-    let digits: String = version.chars().take_while(char::is_ascii_digit).collect();
+
+    if is_git_master_build(version) {
+        return true;
+    }
+
+    // A distribution build prefixes the git tag with `n`, and `v` shows up in
+    // hand-rolled builds; neither changes the number that follows.
+    let number = version
+        .strip_prefix(['n', 'v', 'N', 'V'])
+        .filter(|rest| rest.starts_with(|first: char| first.is_ascii_digit()))
+        .unwrap_or(version);
+
+    let digits: String = number.chars().take_while(char::is_ascii_digit).collect();
     if digits.is_empty() {
         return false;
     }
 
     // Anything other than a version separator after the digits means this was
     // never a version number, so it is not evidence of anything.
-    match version[digits.len()..].chars().next() {
+    match number[digits.len()..].chars().next() {
         None | Some('.') | Some('-') => {}
         Some(_) => return false,
     }
@@ -77,6 +100,35 @@ pub fn ffmpeg_supports_filter_script(version: &str) -> bool {
     digits
         .parse::<u32>()
         .is_ok_and(|major| major >= FILTER_SCRIPT_MINIMUM_MAJOR)
+}
+
+/// Whether a version string is FFmpeg's untagged git-describe form.
+///
+/// `N-<build>-g<hash>`, optionally with a trailing date or flavour suffix. The
+/// build counter is not a version, so it is checked for shape only.
+fn is_git_master_build(version: &str) -> bool {
+    let Some(rest) = version
+        .strip_prefix("N-")
+        .or_else(|| version.strip_prefix("n-"))
+    else {
+        return false;
+    };
+
+    let build: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    if build.is_empty() {
+        return false;
+    }
+
+    let Some(hash) = rest[build.len()..]
+        .strip_prefix("-g")
+        .or_else(|| rest[build.len()..].strip_prefix("-G"))
+    else {
+        return false;
+    };
+
+    // At least one hex digit of commit hash, then anything (a date suffix, a
+    // flavour tag) may follow.
+    hash.starts_with(|first: char| first.is_ascii_hexdigit())
 }
 
 /// Moves an argument list's filtergraph out of the argv and into a script file.
@@ -325,6 +377,66 @@ mod tests {
     }
 
     /// Feature: Filtergraph delivery
+    /// Scenario: tagged distribution builds are read through their prefix
+    ///
+    /// Distributions report the git tag, `n7.1` rather than `7.1`. Reading the
+    /// `n` as "unparseable" would push a perfectly capable binary onto the inline
+    /// path — while still, correctly, rejecting `n6.1`.
+    #[test]
+    fn a_tag_prefixed_version_is_read_through_its_prefix() {
+        for version in ["n7.1", "n8.0.1", "v7.0", "N7.1"] {
+            assert!(
+                ffmpeg_supports_filter_script(version),
+                "{version} is a tagged 7.0-or-later build"
+            );
+        }
+
+        for version in ["n6.1", "n6.1.1", "v6.0", "n0.11"] {
+            assert!(
+                !ffmpeg_supports_filter_script(version),
+                "{version} is a tagged build that still predates the -/option form"
+            );
+        }
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: an untagged master build is trusted
+    ///
+    /// `ffmpeg-master-latest-*-gpl` from BtbN is this project's own fallback
+    /// download, and it reports git-describe against no tag: `N-119421-g1b2c3d4`.
+    /// There is no major version to read, so the shape itself is the evidence —
+    /// BtbN publishes only recent masters. Without this the binary most likely to
+    /// be handed a motion-heavy graph is the one denied the script file.
+    #[test]
+    fn an_untagged_master_build_is_treated_as_current() {
+        for version in [
+            "N-119421-g1b2c3d4",
+            "N-6-gabc",
+            "N-119421-g1b2c3d4c3-20250101",
+            "n-119421-gdeadbeef",
+        ] {
+            assert!(
+                ffmpeg_supports_filter_script(version),
+                "{version} is a git master build and reads a filtergraph from a file"
+            );
+        }
+
+        // The shape has to be the whole shape; a lookalike is not evidence.
+        for version in [
+            "N-",
+            "N-abc-g1b2",
+            "N-119421",
+            "N-119421-x1b2",
+            "N-119421-g",
+        ] {
+            assert!(
+                !ffmpeg_supports_filter_script(version),
+                "{version:?} only resembles a git-describe build, so it must stay inline"
+            );
+        }
+    }
+
+    /// Feature: Filtergraph delivery
     /// Scenario: a version string nobody can read means inline
     ///
     /// `get_ffmpeg_version` hands back whatever it scraped off the banner, and
@@ -337,13 +449,11 @@ mod tests {
         for version in [
             "",
             "   ",
-            "n6.1",
-            "n7.1",
-            "N-109421-g1b2c3d4",
             "unknown",
             "ffmpeg version 8.0.1 Copyright (c) 2000-2025",
             "7x",
-            "v7.0",
+            "nightly",
+            "next",
             "-7.0",
             "99999999999999999999.0",
         ] {

--- a/src-tauri/src/core/render/ffmpeg_graph.rs
+++ b/src-tauri/src/core/render/ffmpeg_graph.rs
@@ -34,6 +34,117 @@ impl std::fmt::Display for FfmpegInvocationError {
 
 impl std::error::Error for FfmpegInvocationError {}
 
+/// The option whose value is a filtergraph written straight into the argv.
+const FILTER_COMPLEX_OPTION: &str = "-filter_complex";
+
+/// The option whose value is the *path* of a file holding the filtergraph.
+///
+/// FFmpeg's `-/name value` form reads "set option `name` to the contents of the
+/// file `value`", and has done since FFmpeg 7.0.
+const FILTER_SCRIPT_OPTION: &str = "-/filter_complex";
+
+/// The first FFmpeg major release that understands the `-/option file` form.
+const FILTER_SCRIPT_MINIMUM_MAJOR: u32 = 7;
+
+/// Whether a reported FFmpeg version can read a filtergraph from a file.
+///
+/// [`crate::core::ffmpeg::FFmpegInfo::version`] is whatever `get_ffmpeg_version`
+/// scraped off the banner, which is only loosely a version number: releases give
+/// `8.0.1` or `8.0.1-essentials_build-www.gyan.dev`, distributions give `n6.1`,
+/// git builds give `N-109421-g1b2c3d4`, and a banner that did not parse at all
+/// yields the whole first line.
+///
+/// So this reads a major version only from the unambiguous shape — leading ASCII
+/// digits terminated by `.`, `-`, or the end of the string — and answers `false`
+/// for everything else. That conservative default is the point: a `false` here
+/// routes the graph inline, which is what every FFmpeg has always accepted, so an
+/// unrecognised version keeps behaving exactly as it did before the script-file
+/// path existed. Guessing the other way would break every export on that binary.
+pub fn ffmpeg_supports_filter_script(version: &str) -> bool {
+    let version = version.trim();
+    let digits: String = version.chars().take_while(char::is_ascii_digit).collect();
+    if digits.is_empty() {
+        return false;
+    }
+
+    // Anything other than a version separator after the digits means this was
+    // never a version number, so it is not evidence of anything.
+    match version[digits.len()..].chars().next() {
+        None | Some('.') | Some('-') => {}
+        Some(_) => return false,
+    }
+
+    digits
+        .parse::<u32>()
+        .is_ok_and(|major| major >= FILTER_SCRIPT_MINIMUM_MAJOR)
+}
+
+/// Moves an argument list's filtergraph out of the argv and into a script file.
+///
+/// Windows caps a command line at 32,767 characters, and the graph is by far the
+/// largest argument: one clip animated through a dozen motion keyframes carries
+/// kilobytes of `scale`/`overlay` expressions on its own, so a timeline with a
+/// handful of them overflows the limit and the export dies before FFmpeg starts.
+/// Handing the graph over as a file keeps the command line a constant size no
+/// matter how big the graph gets.
+///
+/// `use_script_file` is [`ffmpeg_supports_filter_script`] for the binary this
+/// export will actually run. When it is `false` the arguments are returned
+/// untouched and nothing is written: FFmpeg releases before 7.0 have no `-/`
+/// form, and handing them one would break every export rather than only the
+/// oversized ones. Those binaries keep the inline graph they have always had —
+/// command-line limit included, which is no worse than before this path existed.
+///
+/// Nothing about the graph's *content* changes — the bytes written here are the
+/// bytes the builders produced. Unlike the ASS overlay path, which interpolates a
+/// filename into the filtergraph grammar and so has to escape it, this path is a
+/// plain argv value handed to `Command::arg`, so no quoting is involved and a
+/// temp directory containing spaces or apostrophes is harmless.
+///
+/// The returned [`tempfile::TempDir`] owns the script: dropping it deletes the
+/// file, so the caller must keep it alive until FFmpeg has exited. Returns
+/// `None` for an argument list with no filtergraph, which is left untouched.
+pub fn materialize_filter_script(
+    mut args: Vec<String>,
+    use_script_file: bool,
+) -> std::io::Result<(Vec<String>, Option<tempfile::TempDir>)> {
+    if !use_script_file {
+        return Ok((args, None));
+    }
+
+    let Some(option_index) = args.iter().position(|arg| arg == FILTER_COMPLEX_OPTION) else {
+        return Ok((args, None));
+    };
+    let Some(graph_index) = option_index
+        .checked_add(1)
+        .filter(|index| *index < args.len())
+    else {
+        return Ok((args, None));
+    };
+
+    let directory = tempfile::Builder::new()
+        .prefix("openreelio-filtergraph-")
+        .tempdir()?;
+    let script_path = directory.path().join("filter_complex.txt");
+    std::fs::write(&script_path, args[graph_index].as_bytes())?;
+
+    // Every downstream argument is a `String`, so a path that is not valid UTF-8
+    // has to fail loudly here rather than be silently mangled into one.
+    let script_arg = script_path
+        .to_str()
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Filtergraph script path is not valid UTF-8: {script_path:?}"),
+            )
+        })?
+        .to_string();
+
+    args[option_index] = FILTER_SCRIPT_OPTION.to_string();
+    args[graph_index] = script_arg;
+    Ok((args, Some(directory)))
+}
+
 pub fn build_ffmpeg_invocation_from_args(
     args: Vec<String>,
     estimated_frames: u64,
@@ -128,5 +239,191 @@ mod tests {
 
         assert_eq!(invocation.estimated_frames, 120);
         assert_eq!(invocation.plan_hash.as_deref(), Some("render-plan-hash"));
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: the graph travels as a file, byte for byte
+    ///
+    /// The command line is capped — 32,767 characters on Windows — and the graph
+    /// is the one argument with no upper bound on its size. Moving it to a file
+    /// must change nothing about its content, or every existing render changes
+    /// with it.
+    #[test]
+    fn filter_script_moves_the_graph_into_a_file_unchanged() {
+        // Commas, quotes, colons and backslashes all mean something to one
+        // grammar or another on the way to FFmpeg; none may be rewritten here.
+        let graph = "[0:v]scale=w='if(lt(t,1),640,720)':h=360:eval=frame[v];\
+                     [v]drawtext=text='a\\,b':x=3[out]";
+        let args = vec![
+            "-i".to_string(),
+            "in.mp4".to_string(),
+            "-filter_complex".to_string(),
+            graph.to_string(),
+            "-map".to_string(),
+            "[out]".to_string(),
+            "out.mp4".to_string(),
+        ];
+
+        let (rewritten, directory) = materialize_filter_script(args, true).expect("materialize");
+        let directory = directory.expect("a graph must produce a script");
+
+        assert_eq!(rewritten[2], "-/filter_complex");
+        assert_eq!(
+            std::fs::read_to_string(&rewritten[3]).expect("read script"),
+            graph,
+            "the script must hold exactly the bytes the builder produced"
+        );
+        assert_eq!(
+            rewritten.last().map(String::as_str),
+            Some("out.mp4"),
+            "the output path must stay last so the invocation can still find it"
+        );
+        assert_eq!(
+            rewritten.len(),
+            7,
+            "the rewrite must stay a one-for-one swap of the option and its value"
+        );
+
+        // The script only has to outlive FFmpeg, and the handle is what keeps it.
+        let script_path = std::path::PathBuf::from(&rewritten[3]);
+        assert!(script_path.exists());
+        drop(directory);
+        assert!(
+            !script_path.exists(),
+            "dropping the handle must clean the script up"
+        );
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: only FFmpeg 7.0 and later is offered a script file
+    ///
+    /// The `-/option file` form arrived in FFmpeg 7.0. Handing it to an older
+    /// binary does not degrade the export, it kills it — and it would kill every
+    /// export, not just the oversized graphs the script file exists for.
+    #[test]
+    fn filter_script_support_is_decided_by_the_major_version() {
+        for version in [
+            "7.0",
+            "7.1.1",
+            "8.0.1",
+            "8.0.1-essentials_build-www.gyan.dev",
+            "10.2",
+            "8",
+        ] {
+            assert!(
+                ffmpeg_supports_filter_script(version),
+                "{version} is 7.0 or later and can read a filtergraph from a file"
+            );
+        }
+
+        for version in ["6.1.1", "6.1.1-static", "5.0", "4.4", "0.11"] {
+            assert!(
+                !ffmpeg_supports_filter_script(version),
+                "{version} predates the -/option form"
+            );
+        }
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: a version string nobody can read means inline
+    ///
+    /// `get_ffmpeg_version` hands back whatever it scraped off the banner, and
+    /// falls back to the entire first line when even that fails. Every one of
+    /// these has to land on the inline path, because inline is what every FFmpeg
+    /// has always accepted: guessing "probably new enough" and guessing wrong
+    /// breaks the user's export outright.
+    #[test]
+    fn an_unreadable_ffmpeg_version_falls_back_to_the_inline_graph() {
+        for version in [
+            "",
+            "   ",
+            "n6.1",
+            "n7.1",
+            "N-109421-g1b2c3d4",
+            "unknown",
+            "ffmpeg version 8.0.1 Copyright (c) 2000-2025",
+            "7x",
+            "v7.0",
+            "-7.0",
+            "99999999999999999999.0",
+        ] {
+            assert!(
+                !ffmpeg_supports_filter_script(version),
+                "{version:?} is not a legible major version, so it must stay inline"
+            );
+        }
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: an unsupported FFmpeg keeps the arguments it always had
+    ///
+    /// This is the no-regression guarantee: on the inline branch the argument
+    /// list must come back byte-identical, with no temp directory and no file
+    /// written anywhere.
+    #[test]
+    fn filter_script_leaves_the_graph_inline_when_ffmpeg_is_too_old() {
+        let graph = "[0:v]scale=w='if(lt(t,1),640,720)':h=360:eval=frame[out]";
+        let args = vec![
+            "-i".to_string(),
+            "in.mp4".to_string(),
+            "-filter_complex".to_string(),
+            graph.to_string(),
+            "-map".to_string(),
+            "[out]".to_string(),
+            "out.mp4".to_string(),
+        ];
+
+        let (rewritten, directory) =
+            materialize_filter_script(args.clone(), false).expect("materialize");
+
+        assert_eq!(
+            rewritten, args,
+            "an unsupported FFmpeg must be handed exactly the arguments it always was"
+        );
+        assert!(
+            directory.is_none(),
+            "the inline path must not create a temp directory"
+        );
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: an argument list with no graph is left alone
+    ///
+    /// Still-frame extraction and the codec probes share this boundary and carry
+    /// no filtergraph; they must not pay for a temp directory.
+    #[test]
+    fn filter_script_leaves_a_graphless_command_untouched() {
+        let args = vec![
+            "-i".to_string(),
+            "in.mp4".to_string(),
+            "-frames:v".to_string(),
+            "1".to_string(),
+            "out.png".to_string(),
+        ];
+
+        let (rewritten, directory) =
+            materialize_filter_script(args.clone(), true).expect("materialize");
+
+        assert_eq!(rewritten, args);
+        assert!(
+            directory.is_none(),
+            "no graph means no script and no temp directory"
+        );
+    }
+
+    /// Feature: Filtergraph delivery
+    /// Scenario: a truncated command cannot be rewritten into nonsense
+    ///
+    /// `-filter_complex` as the final argument has no value to move. Rewriting
+    /// the option anyway would hand FFmpeg a script path that is not there.
+    #[test]
+    fn filter_script_ignores_a_dangling_filter_complex_option() {
+        let args = vec!["-i".to_string(), "-filter_complex".to_string()];
+
+        let (rewritten, directory) =
+            materialize_filter_script(args.clone(), true).expect("materialize");
+
+        assert_eq!(rewritten, args);
+        assert!(directory.is_none());
     }
 }

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -16,8 +16,9 @@ use crate::core::{
 
 use super::{
     export::{
-        append_ass_text_overlay, append_black_video_gap, append_drawtext_text_overlays,
-        append_master_audio_output, append_output_time_range_args, append_timeline_video_output,
+        append_animated_video_transform_composition, append_ass_text_overlay,
+        append_black_video_gap, append_drawtext_text_overlays, append_master_audio_output,
+        append_output_time_range_args, append_timeline_video_output,
         append_video_stream_normalization, append_video_transform_composition,
         apply_audio_mix_settings, asset_has_playable_audio, build_audio_trim_filter,
         build_video_trim_filter, clip_audio_is_suppressed_by_companion,
@@ -30,7 +31,10 @@ use super::{
         AssetAudioInfo, ExportEngine, ExportError, ExportSettings, SourceFrameCountCache,
         VideoCodec, VideoTimelineSegment, TIMELINE_EPSILON_SEC,
     },
-    transform_layout::compute_clip_transform_layout,
+    transform_layout::{
+        clip_motion_renders_animated, compute_clip_transform_layout, render_opacity,
+        resolve_clip_motion_track,
+    },
     transition_stitch::{
         clip_stream_frames, plan_sequence_transitions, stitch_transition_groups, ClipHandles,
     },
@@ -276,26 +280,55 @@ pub(super) fn build_sequence_ffmpeg_args(
                                     ))
                                 })?;
 
-                        let layout = compute_clip_transform_layout(
+                        // Keyframed motion animates the composite; everything
+                        // else — including motion that turns the picture, which
+                        // FFmpeg cannot animate alongside a changing frame size
+                        // — composites once at the clip's base transform.
+                        let motion_track = resolve_clip_motion_track(
                             source_width,
                             source_height,
                             output_width,
                             output_height,
-                            &clip.transform,
-                            clip.opacity,
-                        );
+                            clip,
+                            handles.head_sec,
+                        )
+                        .filter(|_| clip_motion_renders_animated(clip));
 
-                        append_video_transform_composition(
-                            &mut filter_complex,
-                            &video_out_label,
-                            &normalized_video_label,
-                            &layout,
-                            segment_duration_sec,
-                            output_width,
-                            output_height,
-                            output_fps,
-                            output_pixel_format,
-                        );
+                        if let Some(motion_track) = motion_track {
+                            append_animated_video_transform_composition(
+                                &mut filter_complex,
+                                &video_out_label,
+                                &normalized_video_label,
+                                &motion_track,
+                                render_opacity(clip.opacity),
+                                segment_duration_sec,
+                                output_width,
+                                output_height,
+                                output_fps,
+                                output_pixel_format,
+                            );
+                        } else {
+                            let layout = compute_clip_transform_layout(
+                                source_width,
+                                source_height,
+                                output_width,
+                                output_height,
+                                &clip.transform,
+                                clip.opacity,
+                            );
+
+                            append_video_transform_composition(
+                                &mut filter_complex,
+                                &video_out_label,
+                                &normalized_video_label,
+                                &layout,
+                                segment_duration_sec,
+                                output_width,
+                                output_height,
+                                output_fps,
+                                output_pixel_format,
+                            );
+                        }
                     } else {
                         append_video_stream_normalization(
                             &mut filter_complex,

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -22,10 +22,10 @@ use super::{
         append_video_stream_normalization, append_video_transform_composition,
         apply_audio_mix_settings, asset_has_playable_audio, build_audio_trim_filter,
         build_video_trim_filter, clip_audio_is_suppressed_by_companion,
-        clip_needs_transform_composition, collect_audio_companion_keys,
-        collect_drawtext_text_overlays, collect_enabled_clips_sorted, effective_source_dimensions,
-        generated_text_visual_end_sec, hdr_metadata_for_asset, is_text_clip,
-        output_video_dimensions, output_video_fps, output_video_pixel_format,
+        clip_composition_is_motion_only, clip_needs_transform_composition,
+        collect_audio_companion_keys, collect_drawtext_text_overlays, collect_enabled_clips_sorted,
+        effective_source_dimensions, generated_text_visual_end_sec, hdr_metadata_for_asset,
+        is_text_clip, output_video_dimensions, output_video_fps, output_video_pixel_format,
         resolve_asset_source_dimensions, resolve_asset_source_duration, resolve_trim_source_kind,
         seed_source_dimension_cache, seed_source_duration_cache, unmeasurable_effect_message,
         AssetAudioInfo, ExportEngine, ExportError, ExportSettings, SourceFrameCountCache,
@@ -254,32 +254,46 @@ pub(super) fn build_sequence_ffmpeg_args(
                         ));
                     }
 
-                    if clip_needs_transform_composition(clip) {
-                        // A moved, scaled, rotated or translucent clip has to be
-                        // drawn onto the canvas rather than fitted to it. The
-                        // placement follows the source's real pixel dimensions,
-                        // which is also what the preview measures.
-                        let probed_dimensions =
-                            resolve_asset_source_dimensions(asset, &mut source_dimensions)
-                                .ok_or_else(|| {
-                                    ExportError::InvalidSettings(format!(
+                    // A moved, scaled, rotated or translucent clip has to be
+                    // drawn onto the canvas rather than fitted to it. The
+                    // placement follows the source's real pixel dimensions,
+                    // which is also what the preview measures.
+                    //
+                    // A clip composited *only* for its motion is the exception:
+                    // it rendered as a plain canvas fit before motion animated,
+                    // so an unmeasurable source degrades it back to that fit
+                    // instead of failing the export over it. Validation raises
+                    // the matching warning.
+                    let composite_dimensions = if clip_needs_transform_composition(clip) {
+                        let motion_only = clip_composition_is_motion_only(clip);
+                        match resolve_asset_source_dimensions(asset, &mut source_dimensions) {
+                            // The transform scales to an absolute size, so it has
+                            // to be measured against the frame the effect chain
+                            // hands it rather than against the file on disk.
+                            Some(probed) => {
+                                match effective_source_dimensions(probed, &clip_filter_graph) {
+                                    Ok(dimensions) => Some(dimensions),
+                                    Err(_) if motion_only => None,
+                                    Err(effect_label) => {
+                                        return Err(ExportError::InvalidSettings(
+                                            unmeasurable_effect_message(&effect_label, &clip.id),
+                                        ))
+                                    }
+                                }
+                            }
+                            None if motion_only => None,
+                            None => {
+                                return Err(ExportError::InvalidSettings(format!(
                                     "Could not determine source dimensions of asset '{}' needed to place transformed clip '{}'",
                                     asset.id, clip.id
-                                ))
-                                })?;
+                                )))
+                            }
+                        }
+                    } else {
+                        None
+                    };
 
-                        // The transform scales to an absolute size, so it has to
-                        // be measured against the frame the effect chain hands
-                        // it rather than against the file on disk.
-                        let (source_width, source_height) =
-                            effective_source_dimensions(probed_dimensions, &clip_filter_graph)
-                                .map_err(|effect_label| {
-                                    ExportError::InvalidSettings(unmeasurable_effect_message(
-                                        &effect_label,
-                                        &clip.id,
-                                    ))
-                                })?;
-
+                    if let Some((source_width, source_height)) = composite_dimensions {
                         // Keyframed motion animates the composite; everything
                         // else — including motion that turns the picture, which
                         // FFmpeg cannot animate alongside a changing frame size

--- a/src-tauri/src/core/render/transform_layout.rs
+++ b/src-tauri/src/core/render/transform_layout.rs
@@ -34,7 +34,8 @@
 //! R(t) * (x, y) = (x*cos(t) - y*sin(t), x*sin(t) + y*cos(t))
 //! ```
 
-use crate::core::timeline::Transform;
+use crate::core::timeline::{Clip, KeyframeInterpolation, Transform};
+use crate::core::Point2D;
 
 /// Smallest scale factor a clip may render at.
 ///
@@ -142,29 +143,20 @@ pub(super) fn compute_clip_transform_layout(
 
     // The preview fits the source inside the canvas before applying the clip's
     // own scale, so an identity transform is a letterboxed fit and nothing else.
-    let base_scale = (canvas_width / source_width).min(canvas_height / source_height);
-    let base_scale = if base_scale.is_finite() && base_scale > 0.0 {
-        base_scale
-    } else {
-        warn_fallback("base scale", base_scale);
-        1.0
-    };
+    let base_scale = contain_fit_scale(source_width, source_height, canvas_width, canvas_height);
 
     let scale_x = sanitize_scale(transform.scale.x, "scale.x");
     let scale_y = sanitize_scale(transform.scale.y, "scale.y");
 
-    // Both axes shrink by the same factor when the frame is too big to render,
-    // because clamping them independently would silently restretch the picture:
-    // a 100x scale on 16:9 would come out square.
-    let ideal_width = source_width * base_scale * scale_x;
-    let ideal_height = source_height * base_scale * scale_y;
-    let shrink = uniform_shrink(
-        ideal_width,
-        ideal_height,
-        frame_dimension_limit(canvas_width, canvas_height),
+    let (scaled_width, scaled_height) = scaled_frame_dimensions(
+        source_width,
+        source_height,
+        canvas_width,
+        canvas_height,
+        base_scale,
+        scale_x,
+        scale_y,
     );
-    let scaled_width = align_dimension(ideal_width * shrink);
-    let scaled_height = align_dimension(ideal_height * shrink);
 
     let rotation_deg = sanitize_finite(transform.rotation_deg, 0.0, "rotation");
     let rotation_rad = rotation_deg.to_radians();
@@ -222,6 +214,52 @@ pub(super) fn compute_clip_transform_layout(
         overlay_y,
         opacity: sanitize_opacity(opacity),
     }
+}
+
+/// The contain-fit factor that maps the source onto the canvas at scale 1.
+///
+/// Shared by the static layout and the animated one so an identity transform is
+/// a letterboxed fit in both.
+fn contain_fit_scale(
+    source_width: f64,
+    source_height: f64,
+    canvas_width: f64,
+    canvas_height: f64,
+) -> f64 {
+    let base_scale = (canvas_width / source_width).min(canvas_height / source_height);
+    if base_scale.is_finite() && base_scale > 0.0 {
+        base_scale
+    } else {
+        warn_fallback("base scale", base_scale);
+        1.0
+    }
+}
+
+/// The even pixel dimensions a clip's picture is scaled to before rotation.
+///
+/// Both axes shrink by the same factor when the frame is too big to render,
+/// because clamping them independently would silently restretch the picture: a
+/// 100x scale on 16:9 would come out square.
+fn scaled_frame_dimensions(
+    source_width: f64,
+    source_height: f64,
+    canvas_width: f64,
+    canvas_height: f64,
+    base_scale: f64,
+    scale_x: f64,
+    scale_y: f64,
+) -> (u32, u32) {
+    let ideal_width = source_width * base_scale * scale_x;
+    let ideal_height = source_height * base_scale * scale_y;
+    let shrink = uniform_shrink(
+        ideal_width,
+        ideal_height,
+        frame_dimension_limit(canvas_width, canvas_height),
+    );
+    (
+        align_dimension(ideal_width * shrink),
+        align_dimension(ideal_height * shrink),
+    )
 }
 
 fn sanitize_scale(value: f64, field: &str) -> f64 {
@@ -324,6 +362,300 @@ fn round_to_even_i32(value: f64) -> i32 {
     }
     let even = (value / DIMENSION_ALIGNMENT).round() * DIMENSION_ALIGNMENT;
     even.clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32
+}
+
+// =============================================================================
+// Animated motion
+// =============================================================================
+
+/// One motion keyframe resolved to the geometry the graph animates through.
+///
+/// The frame dimensions are the *same* numbers [`compute_clip_transform_layout`]
+/// would emit for this keyframe's transform, so an animated clip and a clip
+/// pinned at one of its keyframes agree exactly at that instant.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct MotionKeyframeLayout {
+    /// Seconds from the start of the clip's *branch*, head handle included.
+    pub time_sec: f64,
+    /// Width the source is scaled to at this keyframe (even, >= 2).
+    pub scaled_width: u32,
+    /// Height the source is scaled to at this keyframe (even, >= 2).
+    pub scaled_height: u32,
+    /// Sanitised normalised position the anchor is pinned to.
+    pub position_x: f64,
+    pub position_y: f64,
+    /// Sanitised normalised anchor point.
+    pub anchor_x: f64,
+    pub anchor_y: f64,
+    /// Clockwise rotation in radians at this keyframe.
+    pub rotation_rad: f64,
+    /// Whether the segment that *starts* here holds instead of interpolating.
+    pub hold: bool,
+}
+
+/// A clip's motion keyframes resolved against one canvas.
+///
+/// Empty-keyframe clips never produce one of these: they are static by
+/// definition and take the ordinary layout path.
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct ClipMotionTrack {
+    pub keyframes: Vec<MotionKeyframeLayout>,
+}
+
+/// Whether a clip's motion keyframes are motion this render can animate.
+///
+/// This is the single predicate behind all three decisions that have to agree:
+/// whether the clip is composited at all, whether the composite is the animated
+/// one, and whether the export warns that the motion is not rendered. It reads
+/// only the stored transforms, so it needs no canvas or source dimensions and
+/// validation can ask it as cheaply as the graph builder can.
+///
+/// Motion qualifies when it has at least two usable keyframes, those keyframes
+/// actually move the picture, and none of them turns it. Rotation is excluded
+/// because `rotate` never re-configures when its input size changes: an animated
+/// `scale` feeding it freezes the picture at its first frame's size, silently.
+/// Such a clip keeps the static composite and the warning that goes with it.
+pub(super) fn clip_motion_renders_animated(clip: &Clip) -> bool {
+    let keyframes = sorted_valid_motion_keyframes(clip);
+    let Some((_, first, _)) = keyframes.first() else {
+        return false;
+    };
+    if keyframes.len() < 2 {
+        return false;
+    }
+    if keyframes
+        .iter()
+        .any(|(_, transform, _)| transform.rotation_deg.abs() > f64::EPSILON)
+    {
+        return false;
+    }
+    keyframes.iter().any(|(_, transform, _)| {
+        (transform.position.x - first.position.x).abs() > f64::EPSILON
+            || (transform.position.y - first.position.y).abs() > f64::EPSILON
+            || (transform.scale.x - first.scale.x).abs() > f64::EPSILON
+            || (transform.scale.y - first.scale.y).abs() > f64::EPSILON
+            || (transform.anchor.x - first.anchor.x).abs() > f64::EPSILON
+            || (transform.anchor.y - first.anchor.y).abs() > f64::EPSILON
+    })
+}
+
+/// The alpha a clip composites with, sanitised the way the static layout does.
+///
+/// The animated path has no [`ClipTransformLayout`] to read `opacity` off, but it
+/// still has to attenuate on exactly the same terms, so both go through this.
+pub(super) fn render_opacity(opacity: f32) -> f64 {
+    sanitize_opacity(opacity)
+}
+
+/// Whether that alpha is far enough from opaque to be worth a filter.
+pub(super) fn opacity_needs_alpha_filter(opacity: f64) -> bool {
+    opacity < 1.0 - OPACITY_EPSILON
+}
+
+/// Normalises a keyframe transform the way the preview does.
+///
+/// Mirrors `normalizeTransform` in `src/utils/clipMotion.ts`: every component
+/// falls back to its identity when it is not finite, and scale additionally has
+/// a lower clamp. Deliberately *not* the export's own sanitiser — this is the
+/// transform the preview shows, and the export's clamps are applied afterwards
+/// by the layout stage, exactly as they are for a static `clip.transform`.
+fn normalize_motion_transform(transform: &Transform) -> Transform {
+    Transform {
+        position: Point2D {
+            x: finite_or(transform.position.x, 0.5),
+            y: finite_or(transform.position.y, 0.5),
+        },
+        scale: Point2D {
+            x: finite_or(transform.scale.x, 1.0).max(MIN_SCALE),
+            y: finite_or(transform.scale.y, 1.0).max(MIN_SCALE),
+        },
+        rotation_deg: finite_or(transform.rotation_deg, 0.0),
+        anchor: Point2D {
+            x: finite_or(transform.anchor.x, 0.5),
+            y: finite_or(transform.anchor.y, 0.5),
+        },
+    }
+}
+
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        fallback
+    }
+}
+
+/// A clip's motion keyframes, filtered and ordered the way the preview reads them.
+///
+/// Mirrors `sortedValidKeyframes` in `src/utils/clipMotion.ts`: a keyframe with a
+/// non-finite or negative `timeOffset` is dropped, and the rest are sorted by
+/// time. The sort is stable, so keyframes sharing a time keep their stored order
+/// just as `Array.prototype.sort` keeps it.
+fn sorted_valid_motion_keyframes(clip: &Clip) -> Vec<(f64, Transform, bool)> {
+    let mut keyframes: Vec<(f64, Transform, bool)> = clip
+        .motion_keyframes
+        .iter()
+        .filter(|keyframe| keyframe.time_offset.is_finite() && keyframe.time_offset >= 0.0)
+        .map(|keyframe| {
+            (
+                keyframe.time_offset,
+                normalize_motion_transform(&keyframe.transform),
+                matches!(keyframe.interpolation, KeyframeInterpolation::Hold),
+            )
+        })
+        .collect();
+    keyframes.sort_by(|left, right| {
+        left.0
+            .partial_cmp(&right.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    keyframes
+}
+
+/// The transform the preview shows for a clip at `clip_time_sec` into it.
+///
+/// This is the executable specification the emitted FFmpeg expression is checked
+/// against, not a step the render itself takes: the graph carries a closed-form
+/// piecewise-linear expression instead of sampling per frame. It exists so the
+/// two can be compared at arbitrary times — see
+/// `the_emitted_curve_tracks_the_preview_sampler`.
+///
+/// The Rust twin of `getClipMotionTransformAtTime` in `src/utils/clipMotion.ts`,
+/// down to the clamp-hold outside the keyframe range and the linear blend
+/// between them. `clip_time_sec` is clip-relative *timeline* seconds — the
+/// preview computes it as `max(0, timelineTime - clip.place.timelineInSec)`.
+///
+/// Note that only `Hold` short-circuits: a `Bezier` keyframe interpolates
+/// linearly, because the preview compares against the literal string `'hold'`
+/// and lets every other interpolation fall through to `interpolateTransform`.
+#[cfg(test)]
+pub(super) fn clip_motion_transform_at(clip: &Clip, clip_time_sec: f64) -> Transform {
+    let keyframes = sorted_valid_motion_keyframes(clip);
+    let Some((first_time, first_transform, _)) = keyframes.first() else {
+        return normalize_motion_transform(&clip.transform);
+    };
+
+    let clip_time = clip_time_sec.max(0.0);
+    if clip_time <= *first_time {
+        return first_transform.clone();
+    }
+
+    let (last_time, last_transform, _) = &keyframes[keyframes.len() - 1];
+    if clip_time >= *last_time {
+        return last_transform.clone();
+    }
+
+    for window in keyframes.windows(2) {
+        let (start_time, start_transform, hold) = &window[0];
+        let (end_time, end_transform, _) = &window[1];
+        if clip_time < *start_time || clip_time > *end_time {
+            continue;
+        }
+        if *hold {
+            return start_transform.clone();
+        }
+        let duration = end_time - start_time;
+        let progress = if duration > 0.0 {
+            (clip_time - start_time) / duration
+        } else {
+            0.0
+        };
+        return interpolate_transform(start_transform, end_transform, progress);
+    }
+
+    normalize_motion_transform(&clip.transform)
+}
+
+/// Blends two transforms component-wise.
+///
+/// Mirrors `interpolateTransform`: every scalar is a plain linear blend and the
+/// progress is clamped to `0..=1`. Rotation blends in degrees without taking the
+/// shortest way round, so 350 -> 10 sweeps backwards through zero in the export
+/// exactly as it does in the preview.
+#[cfg(test)]
+fn interpolate_transform(start: &Transform, end: &Transform, progress: f64) -> Transform {
+    let progress = progress.clamp(0.0, 1.0);
+    let lerp = |from: f64, to: f64| from + (to - from) * progress;
+    Transform {
+        position: Point2D {
+            x: lerp(start.position.x, end.position.x),
+            y: lerp(start.position.y, end.position.y),
+        },
+        scale: Point2D {
+            x: lerp(start.scale.x, end.scale.x),
+            y: lerp(start.scale.y, end.scale.y),
+        },
+        rotation_deg: lerp(start.rotation_deg, end.rotation_deg),
+        anchor: Point2D {
+            x: lerp(start.anchor.x, end.anchor.x),
+            y: lerp(start.anchor.y, end.anchor.y),
+        },
+    }
+}
+
+/// Resolves a clip's motion keyframes into per-keyframe render geometry.
+///
+/// `head_sec` is the transition handle in front of the clip. The graph measures
+/// time from the start of the *branch* — `build_video_trim_filter` ends every
+/// branch with `setpts=PTS-STARTPTS` — and the branch starts `head_sec` before
+/// the clip does, so every keyframe time shifts by it. This is the same move
+/// `anchor_auto_reframe_keyframes` makes for the auto-reframe crop expression.
+///
+/// Returns `None` for a clip with no usable keyframes, which is the signal to
+/// take the ordinary static layout path.
+pub(super) fn resolve_clip_motion_track(
+    source_width: u32,
+    source_height: u32,
+    canvas_width: u32,
+    canvas_height: u32,
+    clip: &Clip,
+    head_sec: f64,
+) -> Option<ClipMotionTrack> {
+    let keyframes = sorted_valid_motion_keyframes(clip);
+    if keyframes.is_empty() {
+        return None;
+    }
+
+    let source_width = f64::from(source_width.max(1));
+    let source_height = f64::from(source_height.max(1));
+    let canvas_width = f64::from(canvas_width.max(1));
+    let canvas_height = f64::from(canvas_height.max(1));
+    let base_scale = contain_fit_scale(source_width, source_height, canvas_width, canvas_height);
+    let head_sec = if head_sec.is_finite() && head_sec > 0.0 {
+        head_sec
+    } else {
+        0.0
+    };
+
+    let resolved = keyframes
+        .into_iter()
+        .map(|(time_offset, transform, hold)| {
+            let (scaled_width, scaled_height) = scaled_frame_dimensions(
+                source_width,
+                source_height,
+                canvas_width,
+                canvas_height,
+                base_scale,
+                sanitize_scale(transform.scale.x, "scale.x"),
+                sanitize_scale(transform.scale.y, "scale.y"),
+            );
+            MotionKeyframeLayout {
+                time_sec: time_offset + head_sec,
+                scaled_width,
+                scaled_height,
+                position_x: sanitize_normalized(transform.position.x, "position.x"),
+                position_y: sanitize_normalized(transform.position.y, "position.y"),
+                anchor_x: sanitize_normalized(transform.anchor.x, "anchor.x"),
+                anchor_y: sanitize_normalized(transform.anchor.y, "anchor.y"),
+                rotation_rad: sanitize_finite(transform.rotation_deg, 0.0, "rotation").to_radians(),
+                hold,
+            }
+        })
+        .collect();
+
+    Some(ClipMotionTrack {
+        keyframes: resolved,
+    })
 }
 
 #[cfg(test)]
@@ -648,5 +980,299 @@ mod tests {
 
         assert_eq!(result.scaled_width, 20); // 1920 * 0.01, the command's floor
         assert_eq!(result.scaled_height, 10); // 1080 * 0.01 = 10.8 -> nearest even
+    }
+
+    // -------------------------------------------------------------------------
+    // Motion keyframes: parity with the preview's sampler
+    // -------------------------------------------------------------------------
+
+    fn keyframe(
+        time_offset: f64,
+        transform: Transform,
+        interpolation: KeyframeInterpolation,
+    ) -> crate::core::timeline::TransformKeyframe {
+        crate::core::timeline::TransformKeyframe {
+            time_offset,
+            transform,
+            interpolation,
+        }
+    }
+
+    fn moved(position: (f64, f64), scale: (f64, f64), rotation_deg: f64) -> Transform {
+        Transform {
+            position: Point2D::new(position.0, position.1),
+            scale: Point2D::new(scale.0, scale.1),
+            rotation_deg,
+            anchor: Point2D::center(),
+        }
+    }
+
+    fn clip_with_motion(keyframes: Vec<crate::core::timeline::TransformKeyframe>) -> Clip {
+        let mut clip = Clip::new("asset").with_source_range(0.0, 4.0).place_at(0.0);
+        clip.motion_keyframes = keyframes;
+        clip
+    }
+
+    /// Feature: Keyframed motion semantics
+    /// Scenario: the export samples the curve the preview drew
+    ///
+    /// `getClipMotionTransformAtTime` holds the first value before the first
+    /// keyframe and the last value after the last, blends linearly in between,
+    /// and short-circuits a `hold` segment to its start value. Diverging on any
+    /// of those would export a move the editor never watched.
+    #[test]
+    fn motion_sampling_matches_the_preview_semantics() {
+        let clip = clip_with_motion(vec![
+            keyframe(
+                1.0,
+                moved((0.2, 0.5), (0.5, 0.5), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                3.0,
+                moved((0.6, 0.5), (1.5, 1.5), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+        ]);
+
+        // Clamp-hold before the first keyframe, including at negative times.
+        for time in [-5.0, 0.0, 0.999, 1.0] {
+            let sampled = clip_motion_transform_at(&clip, time);
+            assert!(
+                (sampled.position.x - 0.2).abs() < 1e-12 && (sampled.scale.x - 0.5).abs() < 1e-12,
+                "before the first keyframe the first value holds, at t={time}"
+            );
+        }
+
+        // Clamp-hold after the last keyframe.
+        for time in [3.0, 9.0] {
+            let sampled = clip_motion_transform_at(&clip, time);
+            assert!(
+                (sampled.position.x - 0.6).abs() < 1e-12 && (sampled.scale.x - 1.5).abs() < 1e-12,
+                "after the last keyframe the last value holds, at t={time}"
+            );
+        }
+
+        // Linear in between: halfway is the midpoint of both components.
+        let middle = clip_motion_transform_at(&clip, 2.0);
+        assert!(
+            (middle.position.x - 0.4).abs() < 1e-12,
+            "position must blend linearly: {}",
+            middle.position.x
+        );
+        assert!(
+            (middle.scale.x - 1.0).abs() < 1e-12,
+            "scale must blend linearly: {}",
+            middle.scale.x
+        );
+    }
+
+    /// Feature: Keyframed motion semantics
+    /// Scenario: only `hold` short-circuits; bezier still blends linearly
+    ///
+    /// The preview compares the interpolation against the literal `'hold'` and
+    /// lets everything else fall through to `interpolateTransform`, so a bezier
+    /// keyframe blends linearly there. The export has to agree, or a project
+    /// carrying bezier motion would render a curve the preview never showed.
+    #[test]
+    fn only_hold_interpolation_freezes_a_motion_segment() {
+        let held = clip_with_motion(vec![
+            keyframe(
+                0.0,
+                moved((0.2, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Hold,
+            ),
+            keyframe(
+                2.0,
+                moved((0.8, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+        ]);
+        assert!(
+            (clip_motion_transform_at(&held, 1.0).position.x - 0.2).abs() < 1e-12,
+            "a hold segment must stay at its start value"
+        );
+
+        let bezier = clip_with_motion(vec![
+            keyframe(
+                0.0,
+                moved((0.2, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Bezier {
+                    cp1x: 0.4,
+                    cp1y: 0.0,
+                    cp2x: 0.6,
+                    cp2y: 1.0,
+                },
+            ),
+            keyframe(
+                2.0,
+                moved((0.8, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+        ]);
+        assert!(
+            (clip_motion_transform_at(&bezier, 1.0).position.x - 0.5).abs() < 1e-12,
+            "a bezier segment blends linearly, exactly as the preview does"
+        );
+    }
+
+    /// Feature: Keyframed motion semantics
+    /// Scenario: unusable keyframes are dropped and the rest are ordered
+    ///
+    /// Mirrors `sortedValidKeyframes`: a non-finite or negative `timeOffset` is
+    /// not a keyframe, and stored order is not sort order.
+    #[test]
+    fn motion_keyframes_are_filtered_and_sorted_like_the_preview() {
+        let clip = clip_with_motion(vec![
+            keyframe(
+                3.0,
+                moved((0.9, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                -1.0,
+                moved((0.0, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                f64::NAN,
+                moved((0.1, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                1.0,
+                moved((0.1, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+        ]);
+
+        let track = resolve_clip_motion_track(1280, 720, 1920, 1080, &clip, 0.0).expect("track");
+        assert_eq!(
+            track.keyframes.len(),
+            2,
+            "the negative and non-finite keyframes must be dropped"
+        );
+        assert!(
+            track.keyframes[0].time_sec < track.keyframes[1].time_sec,
+            "the surviving keyframes must be in time order"
+        );
+        assert!(
+            (clip_motion_transform_at(&clip, 0.0).position.x - 0.1).abs() < 1e-12,
+            "the earliest surviving keyframe is what holds before the curve starts"
+        );
+    }
+
+    /// Feature: Keyframed motion in the export
+    /// Scenario: the emitted curve tracks the preview's sampler
+    ///
+    /// The graph carries a closed-form piecewise-linear expression, while the
+    /// preview samples per frame. This pins the two together: at a spread of
+    /// times, linearly interpolating the *keyframe frame sizes* the graph
+    /// animates through must land on the size the static layout would give the
+    /// transform the preview shows at that instant.
+    #[test]
+    fn the_emitted_curve_tracks_the_preview_sampler() {
+        const SOURCE: (u32, u32) = (1280, 720);
+        const CANVAS: (u32, u32) = (1920, 1080);
+
+        let clip = clip_with_motion(vec![
+            keyframe(
+                0.0,
+                moved((0.3, 0.4), (0.5, 0.5), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                2.0,
+                moved((0.5, 0.5), (1.2, 0.9), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                4.0,
+                moved((0.8, 0.6), (0.7, 1.4), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+        ]);
+        let track = resolve_clip_motion_track(SOURCE.0, SOURCE.1, CANVAS.0, CANVAS.1, &clip, 0.0)
+            .expect("track");
+
+        for step in 0..=40 {
+            let time = f64::from(step) * 0.1;
+
+            // What the graph computes: a linear blend of the keyframe sizes.
+            let curve = track
+                .keyframes
+                .windows(2)
+                .find(|pair| time >= pair[0].time_sec && time <= pair[1].time_sec)
+                .map(|pair| {
+                    let span = pair[1].time_sec - pair[0].time_sec;
+                    let progress = if span > 0.0 {
+                        (time - pair[0].time_sec) / span
+                    } else {
+                        0.0
+                    };
+                    let blend = |from: u32, to: u32| {
+                        f64::from(from) + (f64::from(to) - f64::from(from)) * progress
+                    };
+                    (
+                        blend(pair[0].scaled_width, pair[1].scaled_width),
+                        blend(pair[0].scaled_height, pair[1].scaled_height),
+                    )
+                })
+                .expect("a segment covers every sampled time");
+
+            // What the preview shows, put through the ordinary static layout.
+            let sampled = clip_motion_transform_at(&clip, time);
+            let layout = compute_clip_transform_layout(
+                SOURCE.0, SOURCE.1, CANVAS.0, CANVAS.1, &sampled, 1.0,
+            );
+
+            // The only gap is the static layout's even-pixel alignment, which
+            // rounds each endpoint before the blend rather than after it.
+            assert!(
+                (curve.0 - f64::from(layout.scaled_width)).abs() <= 2.0,
+                "width diverges from the preview at t={time}: curve {} vs preview {}",
+                curve.0,
+                layout.scaled_width
+            );
+            assert!(
+                (curve.1 - f64::from(layout.scaled_height)).abs() <= 2.0,
+                "height diverges from the preview at t={time}: curve {} vs preview {}",
+                curve.1,
+                layout.scaled_height
+            );
+        }
+    }
+
+    /// Feature: Keyframed motion across a transition handle
+    /// Scenario: the head handle shifts every keyframe into branch time
+    #[test]
+    fn a_head_handle_shifts_every_motion_keyframe() {
+        let clip = clip_with_motion(vec![
+            keyframe(
+                0.0,
+                moved((0.3, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+            keyframe(
+                2.0,
+                moved((0.7, 0.5), (1.0, 1.0), 0.0),
+                KeyframeInterpolation::Linear,
+            ),
+        ]);
+
+        let bare = resolve_clip_motion_track(1280, 720, 1920, 1080, &clip, 0.0).expect("track");
+        assert_eq!(bare.keyframes[0].time_sec, 0.0);
+        assert_eq!(bare.keyframes[1].time_sec, 2.0);
+
+        let handled = resolve_clip_motion_track(1280, 720, 1920, 1080, &clip, 0.75).expect("track");
+        assert_eq!(handled.keyframes[0].time_sec, 0.75);
+        assert_eq!(handled.keyframes[1].time_sec, 2.75);
+
+        let negative =
+            resolve_clip_motion_track(1280, 720, 1920, 1080, &clip, -1.0).expect("track");
+        assert_eq!(
+            negative.keyframes[0].time_sec, 0.0,
+            "a nonsensical handle must not drag the curve backwards"
+        );
     }
 }


### PR DESCRIPTION
### **User description**
## What (Batch 2, Phase A1 — WYSIWYG capability)

Motion keyframes (pan / zoom / anchor — the one-click Ken Burns preset) were stored, round-tripped, and **animated in the preview**, but the final render **ignored them** and composited the clip once at its base transform. The export silently disagreed with what the user saw. This is the first of the essential "make the export actually render what the timeline shows" gaps.

## How

- Per-clip composition emits time-varying filters when a clip has animatable motion: `scale=w='…':h='…':eval=frame` (zoom) + a `t`-expression `overlay` (pan/anchor), from a piecewise-linear keyframe interpolation that **mirrors the preview's `clipMotion.ts` sampler exactly** (linear lerp, `hold` segments, clamp-hold, full-snapshot keyframes, no shortest-path rotation).
- The animated layer stages through a planar **alpha** format so the overlay tracks per-frame size changes (verified: `rgba` staging re-freezes).
- **No regression:** a clip with no animatable motion keeps its previous static composition **byte-for-byte** (proven by an exact-string test against the real builder).
- **Script-file delivery:** an animated graph runs kilobytes per clip and would overflow the OS command-line limit, so the filtergraph is delivered via `-/filter_complex <script file>` — **gated on ffmpeg major ≥ 7**; on older/unrecognized ffmpeg it falls back to the inline argument exactly as before (conservative default), so **no export regresses** on any ffmpeg.

## Scope

Rotation keyframes are deferred (they still render static + warn; the `pad→rotate` mechanism is proven but needs a perf pass — it's +157–228% vs +12% for the non-rotated path). The motion warning is narrowed so it no longer fires for the pan/zoom/anchor motion the export now renders.

## Evidence

- Design was a pixel-verified spike: static negative control bit-constant across frames; zoom grows the region, pan moves the centroid with area held, `hold` steps not ramps — all vs analytic prediction, on real ffmpeg + a real 1080p mp4.
- Rust suite **4139 passed, 0 failed**; fmt + clippy clean.
- **ffmpeg-backed** `#[ignore]` tests run against the bundled binary (per the #831 CI setup): `animated_motion_moves_the_rendered_pixels` asserts zoom-grows / pan-moves / hold-steps / **static-stays-bit-identical** (negative control) — 16 ignored tests pass with `REQUIRE_FFMPEG_TESTS=1`.
- Cost: +12% render time for the non-rotated path.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements animated motion keyframe rendering in exports.

- Adds support for pan, zoom, and anchor animations.

- Introduces script-file delivery for complex filtergraphs.

- Gates script-file usage on FFmpeg version 7.0+.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Clip["Clip with Motion Keyframes"] -- "Interpolate" --> Expr["FFmpeg Expressions"]
  Expr -- "Build Graph" --> FilterGraph["Filtergraph Script File"]
  FilterGraph -- "Execute (FFmpeg 7+)" --> RenderedVideo["Animated Export"]
  Expr -- "Fallback (FFmpeg <7)" --> InlineGraph["Inline Filtergraph"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Implement animated motion rendering and script-file delivery</code></dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Added <code>append_animated_video_transform_composition</code> to generate <br>time-varying FFmpeg filters for zoom and pan.<br> <li> Implemented <code>build_motion_lerp_expression</code> to create piecewise-linear <br>expressions in <code>t</code> for FFmpeg.<br> <li> Updated export logic to use script-file delivery for filtergraphs to <br>avoid command-line length limits.<br> <li> Refined validation warnings to allow supported motion animations while <br>still flagging rotation.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/838/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+863/-10</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ffmpeg_graph.rs</strong><dd><code>Add FFmpeg version gating and filtergraph script materialization</code></dd></summary>
<hr>

src-tauri/src/core/render/ffmpeg_graph.rs

<ul><li>Added <code>ffmpeg_supports_filter_script</code> to detect if the FFmpeg binary <br>supports the <code>-/filter_complex</code> file input (version 7.0+).<br> <li> Implemented <code>materialize_filter_script</code> to write large filtergraphs to <br>temporary files.<br> <li> Added comprehensive tests for version detection and script <br>materialization.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/838/files#diff-a777e8fb2f82d0ea3d2f5b992a3547241a998ab28c48fa86db4d623c9f2a5746">+297/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ffmpeg_plan.rs</strong><dd><code>Integrate animated motion into the FFmpeg render plan</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/ffmpeg_plan.rs

<ul><li>Updated the sequence argument builder to route clips with valid motion <br>keyframes to the new animated composition path.<br> <li> Integrated transition handle offsets into motion keyframe timing.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/838/files#diff-7f93452cf29faaec41eb667dd7d07cf667603dace2d8f99aba49ae2e38c3e2df">+52/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transform_layout.rs</strong><dd><code>Add motion keyframe resolution and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/transform_layout.rs

<ul><li>Added <code>clip_motion_renders_animated</code> predicate to determine if motion <br>can be rendered (excludes rotation).<br> <li> Implemented <code>resolve_clip_motion_track</code> to map timeline keyframes to <br>render-space geometry.<br> <li> Added a Rust-based motion sampler for parity testing with the <br>frontend's TypeScript implementation.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/838/files#diff-99d4e6cb34b516190bd48a31e7d102c53fbc516f4ab3c74be11f44ea00043801">+645/-19</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated pan, zoom, anchor, opacity, and motion keyframes to video exports.
  * Preserved hold interpolation and improved motion timing around transitions.
  * Added support for FFmpeg filter scripts in compatible versions, improving complex export handling.

* **Bug Fixes**
  * Improved fallback behavior for unsupported FFmpeg versions and non-animated clips.
  * Added validation warnings for unsupported rotating or degenerate motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->