### PR TITLE
perf(preview): resident streaming decoder (kill per-frame ffmpeg spawn)

### DIFF
--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -33,6 +33,7 @@ pub mod managed_runtime;
 pub mod masks;
 pub mod performance;
 pub mod plugin;
+pub mod preview;
 pub mod process;
 pub mod project;
 pub mod qc;

--- a/src-tauri/src/core/preview/commands.rs
+++ b/src-tauri/src/core/preview/commands.rs
@@ -1,0 +1,62 @@
+//! IPC surface for the resident preview decoder.
+//!
+//! `get_preview_frame` returns raw RGBA through [`tauri::ipc::Response`], which
+//! reaches the webview as an `ArrayBuffer`. Returning `Vec<u8>` from a plain
+//! command would serialise every pixel as a JSON number, which costs more than
+//! the decode it replaced.
+
+use tauri::ipc::Response;
+use tauri::State;
+
+use super::state::SharedPreviewDecoders;
+use crate::core::ffmpeg::SharedFFmpegState;
+use crate::core::fs::validate_local_input_path;
+
+/// Decodes the preview frame nearest `time_sec` and returns it as raw RGBA.
+///
+/// The frame is downscaled to fit inside `max_width` by `max_height` without
+/// changing its aspect ratio, because the canvas composites with a contain-fit
+/// that reads the drawable's own dimensions.
+///
+/// The reply is a 32-byte little-endian header followed by
+/// `width * height * 4` bytes of pixels: `u32` version (2), `u32` width, `u32`
+/// height, `u32` frame index, `f64` source time, `u32` flags, `u32` reserved.
+///
+/// Bit 0 of the flags word (`PreviewFrame::FLAG_INDEXED`) says whether the frame
+/// index means anything. It is clear for a variable-rate source, whose
+/// presentation times are not `index / fps`; such a frame can only be addressed
+/// by the source time it answers for.
+#[tauri::command]
+pub async fn get_preview_frame(
+    input_path: String,
+    time_sec: f64,
+    max_width: u32,
+    max_height: u32,
+    decoders: State<'_, SharedPreviewDecoders>,
+    ffmpeg_state: State<'_, SharedFFmpegState>,
+) -> Result<Response, String> {
+    let input_path = validate_local_input_path(&input_path, "inputPath")?;
+    let pool = decoders.pool(&ffmpeg_state).await?;
+
+    // The decode blocks on a pipe read, so it must not run on an async worker.
+    let frame = tokio::task::spawn_blocking(move || {
+        pool.frame_at(&input_path, time_sec, max_width, max_height)
+    })
+    .await
+    .map_err(|error| format!("Preview decode task failed: {error}"))?
+    .map_err(|error| error.to_string())?;
+
+    Ok(Response::new(frame.into_wire_bytes()))
+}
+
+/// Kills every resident preview decoder.
+///
+/// The frontend calls this when the canvas preview goes away, so an idle
+/// project does not keep FFmpeg processes alive.
+#[tauri::command]
+pub async fn release_preview_decoders(
+    decoders: State<'_, SharedPreviewDecoders>,
+) -> Result<(), String> {
+    decoders.release_all().await;
+    Ok(())
+}

--- a/src-tauri/src/core/preview/decoder.rs
+++ b/src-tauri/src/core/preview/decoder.rs
@@ -1,0 +1,2286 @@
+//! Resident streaming decoder for the canvas timeline preview.
+//!
+//! The canvas preview used to pay a full FFmpeg process spawn, a JPEG encode, a
+//! disk write, an asset-protocol read and a JPEG decode for every displayed
+//! frame. This module replaces that with a small pool of long-lived FFmpeg
+//! children that stream raw RGBA down a pipe, so advancing one frame during
+//! playback costs a single `read_exact`.
+//!
+//! ## Seeking
+//!
+//! FFmpeg's accurate seek discards every frame whose presentation time is below
+//! `-ss`, so a seek argument even slightly *ahead* of the wanted frame lands on
+//! the following one. The seek argument is therefore the frame's exact
+//! presentation time `frame_index / fps`, *truncated* (never rounded) to
+//! nanoseconds so it can only ever be at or below that time. Measured against a
+//! sequential oracle this lands on the requested frame every time, while a
+//! forward-biased argument misses roughly a third of the time.
+//!
+//! ## Constant versus variable frame rate
+//!
+//! Reading the pipe forward only addresses the right picture when a frame's
+//! presentation time is `index / fps`. That holds for a constant-rate source and
+//! is false for a variable-rate one — a screen recording that idles at 5 fps and
+//! bursts to 30 has no such mapping, and its `avg_frame_rate` is a fiction that
+//! puts every requested time on the wrong frame and then *accumulates* the error
+//! as the pipe advances one frame per request while the timeline advances by a
+//! nominal frame duration.
+//!
+//! Variable-rate sources therefore do not use the resident stream at all: every
+//! request is its own accurate seek to the requested time, which is exactly what
+//! the per-frame extraction this module replaced always did. The fast path is
+//! kept for constant-rate sources, which is the overwhelming majority of edited
+//! footage.
+//!
+//! ## Lifecycle
+//!
+//! Every child is owned by exactly one [`ResidentDecoder`], whose `Drop` kills
+//! it, reaps it with `wait`, and joins the stderr drain thread. The pool keeps
+//! at most [`DEFAULT_MAX_RESIDENT_DECODERS`] of them and evicts the
+//! least-recently-used one on overflow, which runs that `Drop`. A read that
+//! hangs is bounded by [`READ_TIMEOUT`]: a watchdog kills the child, which
+//! closes the pipe and unblocks the read rather than leaking the thread.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdout, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::core::ffmpeg::rotation::rotation_from_probe_stream;
+use crate::core::ffmpeg::{display_dimensions, FFmpegError, FFmpegResult};
+use crate::core::process::configure_std_command;
+
+/// Bytes per pixel in the `rgba` raw frames the decoder streams.
+const BYTES_PER_PIXEL: usize = 4;
+
+/// How many decoders may stay resident before the least-recently-used one is
+/// evicted. Each one is a live FFmpeg process, so this is the ceiling on how
+/// much the preview costs while idle.
+pub const DEFAULT_MAX_RESIDENT_DECODERS: usize = 4;
+
+/// How far ahead of the pipe cursor a request may be before the decoder is
+/// respawned instead of read forward.
+///
+/// Reading forward costs one decode per skipped frame (~3 ms at 1080p) while a
+/// respawn costs a process spawn plus an accurate seek (~78 ms measured), so
+/// skipping stays cheaper well past this bound. It is kept deliberately short
+/// so a scrub that jumps a second does not sit decoding frames nobody sees.
+const MAX_FORWARD_SKIP_FRAMES: u64 = 12;
+
+/// Upper bound on reading the next frame off an already-running pipe.
+///
+/// A decode that has not produced its frame by now is wedged; killing the child
+/// closes the pipe, which is what unblocks the read.
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on the first read after a respawn.
+///
+/// That read waits for process start, an accurate seek, and a decode from the
+/// preceding keyframe, which on 4K long-GOP footage over slow storage can take
+/// far longer than a steady-state read. Sharing the steady-state budget would
+/// let the watchdog kill a perfectly healthy child and leave the decoder
+/// respawning into the same timeout forever.
+const FIRST_READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Upper bound on the FFprobe call that resolves a source's frame rate.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How much of a child's stderr is kept for error reporting.
+const MAX_STDERR_TAIL_BYTES: usize = 4096;
+
+/// How long a child that has closed its output is given to finish exiting.
+///
+/// Only used to distinguish a clean end of stream from a failed decode, so a
+/// child still running when this elapses simply counts as the latter.
+const CLEAN_EXIT_GRACE: Duration = Duration::from_millis(500);
+
+/// Largest frame the decoder will allocate for, as a guard against a bad
+/// request turning into a multi-gigabyte allocation.
+const MAX_FRAME_PIXELS: u64 = 8192 * 8192;
+
+/// Highest frame rate accepted from a probe. Anything above this is a container
+/// artefact (some remuxers advertise 1000/1) rather than a real picture rate.
+const MAX_PLAUSIBLE_FPS: f64 = 1000.0;
+
+/// A decoded preview frame in straight `rgba`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreviewFrame {
+    /// Width of `pixels`, after aspect-preserving downscale and rotation.
+    pub width: u32,
+    /// Height of `pixels`, after aspect-preserving downscale and rotation.
+    pub height: u32,
+    /// Index of this frame in the source's frame sequence.
+    ///
+    /// `None` for a variable-rate source, where a frame's presentation time is
+    /// not `index / fps` and an index would be a number the caller could only
+    /// misuse.
+    pub frame_index: Option<u64>,
+    /// Presentation time this frame answers for, in seconds.
+    pub source_time: f64,
+    /// `width * height * 4` bytes of straight-alpha RGBA.
+    pub pixels: Vec<u8>,
+}
+
+impl PreviewFrame {
+    /// Size of the header [`PreviewFrame::into_wire_bytes`] prepends.
+    pub const HEADER_BYTES: usize = 32;
+
+    /// Version tag the frontend checks before reading the rest of the header.
+    pub const WIRE_VERSION: u32 = 2;
+
+    /// Header flag: the frame index is meaningful, so the caller may address
+    /// this source by frame.
+    pub const FLAG_INDEXED: u32 = 1;
+
+    /// The frame as one buffer: a fixed 32-byte little-endian header followed
+    /// by the pixels.
+    ///
+    /// Layout: `u32` version, `u32` width, `u32` height, `u32` frame index,
+    /// `f64` source time, `u32` flags, `u32` reserved, then
+    /// `width * height * 4` bytes. The `f64` sits at offset 16 and the pixels
+    /// start at 32, so both are naturally aligned for a
+    /// `DataView`/`Uint8ClampedArray` on the other side.
+    pub fn into_wire_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(Self::HEADER_BYTES + self.pixels.len());
+        bytes.extend_from_slice(&Self::WIRE_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&self.width.to_le_bytes());
+        bytes.extend_from_slice(&self.height.to_le_bytes());
+        // Saturating: a u32 frame index covers 4.5 years of 30 fps footage, and
+        // a wrapped index would be a silent lie about which frame this is.
+        let index = self
+            .frame_index
+            .map(|index| u32::try_from(index).unwrap_or(u32::MAX))
+            .unwrap_or(0);
+        bytes.extend_from_slice(&index.to_le_bytes());
+        bytes.extend_from_slice(&self.source_time.to_le_bytes());
+        let flags = if self.frame_index.is_some() {
+            Self::FLAG_INDEXED
+        } else {
+            0
+        };
+        bytes.extend_from_slice(&flags.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&self.pixels);
+        bytes
+    }
+}
+
+/// How a source's presentation times relate to its frame numbers.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SourceTiming {
+    /// Frame `n` is shown at `n / fps`, so the pipe can be read forward and a
+    /// requested time can be snapped to a frame index.
+    ConstantRate {
+        /// The rate both `avg_frame_rate` and `r_frame_rate` agree on.
+        fps: f64,
+    },
+    /// Presentation times are not derivable from a frame number. Every request
+    /// is its own accurate seek to the time asked for.
+    VariableRate,
+}
+
+impl SourceTiming {
+    /// The rate frames can be addressed by, when there is one.
+    pub fn constant_fps(&self) -> Option<f64> {
+        match self {
+            Self::ConstantRate { fps } => Some(*fps),
+            Self::VariableRate => None,
+        }
+    }
+}
+
+/// What the pool needs to know about a source file to answer a request.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceInfo {
+    /// Whether frames can be addressed by index, and at what rate.
+    pub timing: SourceTiming,
+    /// Width after the display matrix is applied, as FFmpeg will output it.
+    pub display_width: u32,
+    /// Height after the display matrix is applied, as FFmpeg will output it.
+    pub display_height: u32,
+}
+
+/// Where a respawned child should start decoding.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SeekTarget {
+    /// A constant-rate source: seek to frame `index`'s exact presentation time
+    /// and keep the pipe, because the frames after it are addressable.
+    Frame(u64),
+    /// A variable-rate source: seek to the requested time. The pipe is not kept,
+    /// because nothing downstream can say which picture its next frame is.
+    Time(f64),
+}
+
+/// Identity of a resident decoder: one source at one output size.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DecoderKey {
+    source: PathBuf,
+    width: u32,
+    height: u32,
+}
+
+/// The child process handle, reachable without holding the decoder lock so a
+/// watchdog or a cancellation can kill a child that a read is blocked on.
+type ChildSlot = Arc<Mutex<Option<Child>>>;
+
+/// Locks a mutex, taking the value back after a panic elsewhere rather than
+/// propagating the poison: every piece of state behind these locks is either
+/// re-derived or explicitly reset before use.
+fn lock_recovering<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The seek argument for `frame_index` at `fps`, in `S.NNNNNNNNN` form.
+///
+/// Truncated rather than rounded: FFmpeg's accurate seek drops frames whose
+/// presentation time is below `-ss`, so an argument above the frame's own time
+/// lands on the *next* frame. Truncation can only ever undershoot, which the
+/// seek absorbs by decoding one extra frame.
+pub fn seek_argument(frame_index: u64, fps: f64) -> String {
+    if !fps.is_finite() || fps <= 0.0 {
+        return "0.000000000".to_string();
+    }
+
+    seek_argument_seconds(frame_index as f64 / fps)
+}
+
+/// The seek argument for `seconds`, truncated to nanoseconds.
+///
+/// Truncation is what keeps the argument at or below the time asked for, which
+/// is the difference between landing on a frame and landing on the one after it.
+pub fn seek_argument_seconds(seconds: f64) -> String {
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return "0.000000000".to_string();
+    }
+
+    let nanos = (seconds * 1e9).floor().max(0.0) as u64;
+    format!("{}.{:09}", nanos / 1_000_000_000, nanos % 1_000_000_000)
+}
+
+/// The frame index whose presentation time is closest to `time_sec`.
+///
+/// Only meaningful for a constant-rate source; see [`SourceTiming`].
+pub fn frame_index_for_time(time_sec: f64, fps: f64) -> u64 {
+    if !time_sec.is_finite() || time_sec <= 0.0 || !fps.is_finite() || fps <= 0.0 {
+        return 0;
+    }
+
+    (time_sec * fps).round().max(0.0) as u64
+}
+
+/// How far apart two reported rates may be and still count as the same rate.
+const RATE_AGREEMENT_TOLERANCE: f64 = 1e-3;
+
+/// Decides whether frames can be addressed by index.
+///
+/// A stream is treated as constant-rate only when its average rate and its base
+/// rate agree. Anything else — including the field-rate doubling some encoders
+/// report for otherwise constant footage — falls back to per-request seeking.
+/// That costs speed on a file that did not need it; the opposite mistake shows
+/// the wrong picture and then drifts further with every frame.
+pub fn classify_timing(avg_frame_rate: Option<f64>, base_frame_rate: Option<f64>) -> SourceTiming {
+    match (avg_frame_rate, base_frame_rate) {
+        (Some(avg), Some(base)) if avg > 0.0 && base > 0.0 => {
+            if ((avg / base) - 1.0).abs() <= RATE_AGREEMENT_TOLERANCE {
+                SourceTiming::ConstantRate { fps: avg }
+            } else {
+                SourceTiming::VariableRate
+            }
+        }
+        // Only one rate is usable, so there is nothing to corroborate it with.
+        _ => SourceTiming::VariableRate,
+    }
+}
+
+/// The output size for a source of `display` dimensions inside a `max` box.
+///
+/// Downscale only: the preview canvas composites with a contain-fit that reads
+/// the drawable's intrinsic size, so upscaling here would only waste bandwidth
+/// to produce pixels the canvas would draw at the same size anyway.
+pub fn fitted_output_size(
+    display_width: u32,
+    display_height: u32,
+    max_width: u32,
+    max_height: u32,
+) -> (u32, u32) {
+    if display_width == 0 || display_height == 0 {
+        return (1, 1);
+    }
+    if max_width == 0 || max_height == 0 {
+        return (display_width.max(1), display_height.max(1));
+    }
+
+    let scale = f64::min(
+        max_width as f64 / display_width as f64,
+        max_height as f64 / display_height as f64,
+    )
+    .min(1.0);
+
+    let width = ((display_width as f64 * scale).round() as u32).max(1);
+    let height = ((display_height as f64 * scale).round() as u32).max(1);
+    (width, height)
+}
+
+/// Parses an FFprobe rational such as `30000/1001` into a frame rate.
+///
+/// Returns `None` for the placeholders FFprobe uses when a stream has no usable
+/// rate (`0/0`, `N/A`) and for rates outside what a picture stream can be.
+fn parse_frame_rate(raw: &str) -> Option<f64> {
+    let (numerator, denominator) = raw.trim().split_once('/')?;
+    let numerator: f64 = numerator.trim().parse().ok()?;
+    let denominator: f64 = denominator.trim().parse().ok()?;
+    if denominator == 0.0 {
+        return None;
+    }
+
+    let fps = numerator / denominator;
+    if !fps.is_finite() || fps <= 0.0 || fps > MAX_PLAUSIBLE_FPS {
+        return None;
+    }
+
+    Some(fps)
+}
+
+/// Reads the timing and display size of a source's first video stream.
+pub fn probe_source(ffprobe: &Path, source: &Path) -> FFmpegResult<SourceInfo> {
+    if !source.exists() {
+        return Err(FFmpegError::InvalidInput(format!(
+            "Input file does not exist: {}",
+            source.display()
+        )));
+    }
+
+    let mut command = std::process::Command::new(ffprobe);
+    configure_std_command(&mut command);
+    command
+        .args([
+            "-v",
+            "error",
+            "-print_format",
+            "json",
+            "-select_streams",
+            "v:0",
+            "-show_streams",
+        ])
+        .arg(source.as_os_str())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let (status, stdout, stderr) = run_with_timeout(command, PROBE_TIMEOUT)?;
+    if !status.success() {
+        return Err(FFmpegError::ProbeError(format!(
+            "FFprobe failed for {}: {}",
+            source.display(),
+            String::from_utf8_lossy(&stderr).trim()
+        )));
+    }
+
+    let parsed: serde_json::Value = serde_json::from_slice(&stdout).map_err(|error| {
+        FFmpegError::ParseError(format!("FFprobe output was not JSON: {error}"))
+    })?;
+
+    let stream = parsed
+        .get("streams")
+        .and_then(|streams| streams.as_array())
+        .and_then(|streams| streams.first())
+        .ok_or_else(|| {
+            FFmpegError::ProbeError(format!(
+                "No video stream in {} to preview",
+                source.display()
+            ))
+        })?;
+
+    let coded_width = stream.get("width").and_then(serde_json::Value::as_u64);
+    let coded_height = stream.get("height").and_then(serde_json::Value::as_u64);
+    let (Some(coded_width), Some(coded_height)) = (coded_width, coded_height) else {
+        return Err(FFmpegError::ProbeError(format!(
+            "Video stream in {} reports no dimensions",
+            source.display()
+        )));
+    };
+
+    let rotation = rotation_from_probe_stream(stream);
+    let (display_width, display_height) =
+        display_dimensions(coded_width as u32, coded_height as u32, rotation);
+
+    let reported_rate = |field: &str| {
+        stream
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .and_then(parse_frame_rate)
+    };
+    let average_rate = reported_rate("avg_frame_rate");
+    let base_rate = reported_rate("r_frame_rate");
+    if average_rate.is_none() && base_rate.is_none() {
+        return Err(FFmpegError::ProbeError(format!(
+            "Video stream in {} reports no usable frame rate",
+            source.display()
+        )));
+    }
+
+    Ok(SourceInfo {
+        timing: classify_timing(average_rate, base_rate),
+        display_width: display_width.max(1),
+        display_height: display_height.max(1),
+    })
+}
+
+/// How often a watchdogged one-shot child is checked for having exited.
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Runs a one-shot child, killing it if it outlives `timeout`.
+///
+/// `Command::output` has no deadline, and the input is untrusted, so a file that
+/// wedges FFprobe would otherwise wedge a preview thread with it. The pipes are
+/// drained on their own threads because a child that fills one would never reach
+/// the exit this waits for.
+fn run_with_timeout(
+    mut command: std::process::Command,
+    timeout: Duration,
+) -> FFmpegResult<(std::process::ExitStatus, Vec<u8>, Vec<u8>)> {
+    let mut child = command.spawn().map_err(FFmpegError::ProcessError)?;
+    let stdout_reader = child.stdout.take().map(spawn_pipe_drain);
+    let stderr_reader = child.stderr.take().map(spawn_pipe_drain);
+
+    let deadline = Instant::now() + timeout;
+    let mut killed = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(error) => return Err(FFmpegError::ProcessError(error)),
+        }
+
+        if !killed && Instant::now() >= deadline {
+            let _ = child.kill();
+            killed = true;
+        }
+
+        std::thread::sleep(CHILD_POLL_INTERVAL);
+    };
+
+    if killed {
+        return Err(FFmpegError::Timeout);
+    }
+
+    let stdout = stdout_reader.map(join_pipe_drain).unwrap_or_default();
+    let stderr = stderr_reader.map(join_pipe_drain).unwrap_or_default();
+    Ok((status, stdout, stderr))
+}
+
+/// Reads a pipe to end on its own thread.
+fn spawn_pipe_drain<R: Read + Send + 'static>(mut pipe: R) -> JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        let mut collected = Vec::new();
+        let _ = pipe.read_to_end(&mut collected);
+        collected
+    })
+}
+
+/// Collects what a pipe drain read, treating a panicked reader as no output.
+fn join_pipe_drain(handle: JoinHandle<Vec<u8>>) -> Vec<u8> {
+    handle.join().unwrap_or_default()
+}
+
+/// The deadline a read must finish by, shared with the watchdog thread.
+#[derive(Debug, Default)]
+struct WatchdogState {
+    /// When the running read must be killed, or `None` when none is running.
+    deadline: Option<Instant>,
+    /// Set once the owning decoder is going away, to end the thread.
+    stopped: bool,
+}
+
+/// Kills a decoder's child when a read overruns the budget it was armed with.
+///
+/// One thread per decoder, rearmed per read, rather than one thread per read: a
+/// thread spawn and join for every displayed frame — and up to thirteen when the
+/// decoder skips forward — is real overhead on the path this module exists to
+/// make cheap.
+struct ReadWatchdog {
+    shared: Arc<(Mutex<WatchdogState>, Condvar)>,
+    /// Set by the thread when it actually killed a child, so a read failure
+    /// caused by the watchdog can be told apart from a genuine end of stream.
+    fired: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl ReadWatchdog {
+    /// Starts the watchdog for `child`. It idles until a read arms it.
+    fn new(child: ChildSlot) -> Self {
+        let shared = Arc::new((Mutex::new(WatchdogState::default()), Condvar::new()));
+        let fired = Arc::new(AtomicBool::new(false));
+
+        let thread_shared = Arc::clone(&shared);
+        let thread_fired = Arc::clone(&fired);
+        let thread = std::thread::spawn(move || {
+            let (lock, condvar) = &*thread_shared;
+            let mut state = lock_recovering(lock);
+            loop {
+                if state.stopped {
+                    return;
+                }
+
+                let Some(deadline) = state.deadline else {
+                    state = condvar
+                        .wait(state)
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    continue;
+                };
+
+                let now = Instant::now();
+                if now >= deadline {
+                    if let Some(child) = lock_recovering(&child).as_mut() {
+                        let _ = child.kill();
+                    }
+                    thread_fired.store(true, Ordering::SeqCst);
+                    state.deadline = None;
+                    continue;
+                }
+
+                let (next, _) = condvar
+                    .wait_timeout(state, deadline - now)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                state = next;
+            }
+        });
+
+        Self {
+            shared,
+            fired,
+            thread: Some(thread),
+        }
+    }
+
+    /// Starts counting down `budget` against the running read.
+    fn arm(&self, budget: Duration) {
+        self.fired.store(false, Ordering::SeqCst);
+        let (lock, condvar) = &*self.shared;
+        lock_recovering(lock).deadline = Some(Instant::now() + budget);
+        condvar.notify_all();
+    }
+
+    /// Stops the countdown once the read has returned.
+    fn disarm(&self) {
+        let (lock, condvar) = &*self.shared;
+        lock_recovering(lock).deadline = None;
+        condvar.notify_all();
+    }
+
+    /// Whether the last armed read was ended by the watchdog rather than by the
+    /// source running out of frames.
+    fn fired(&self) -> bool {
+        self.fired.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for ReadWatchdog {
+    fn drop(&mut self) {
+        {
+            let (lock, condvar) = &*self.shared;
+            let mut state = lock_recovering(lock);
+            state.stopped = true;
+            state.deadline = None;
+            condvar.notify_all();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Drains a child's stderr into a bounded tail so a failure can be reported.
+///
+/// The child would otherwise block once the stderr pipe filled, and the tail is
+/// capped so a chatty decoder cannot grow it without bound.
+fn spawn_stderr_drain(mut stderr: ChildStderr, tail: Arc<Mutex<String>>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut chunk = [0u8; 1024];
+        loop {
+            match stderr.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => {
+                    let mut tail = lock_recovering(&tail);
+                    tail.push_str(&String::from_utf8_lossy(&chunk[..read]));
+                    if tail.len() > MAX_STDERR_TAIL_BYTES {
+                        let mut cut = tail.len() - MAX_STDERR_TAIL_BYTES;
+                        while cut < tail.len() && !tail.is_char_boundary(cut) {
+                            cut += 1;
+                        }
+                        let trimmed = tail[cut..].to_string();
+                        *tail = trimmed;
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// One long-lived FFmpeg child streaming a single source at a single size.
+struct ResidentDecoder {
+    ffmpeg: PathBuf,
+    source: PathBuf,
+    info: SourceInfo,
+    output_width: u32,
+    output_height: u32,
+    frame_bytes: usize,
+    child: ChildSlot,
+    stdout: Option<ChildStdout>,
+    stderr_tail: Arc<Mutex<String>>,
+    stderr_drain: Option<JoinHandle<()>>,
+    /// Index of the frame the pipe will yield next, or `None` when no child is
+    /// running.
+    next_frame_index: Option<u64>,
+    /// PID of the running child, kept so tests can prove it was reaped.
+    child_pid: Option<u32>,
+    /// Set once the pool has released this decoder.
+    ///
+    /// Releasing kills the child, which makes an in-flight read fail; without
+    /// this flag that failure would be recovered from by respawning, and a
+    /// decoder the pool had already let go would start a fresh FFmpeg.
+    released: Arc<AtomicBool>,
+    /// Kills a child whose read has overrun its budget.
+    watchdog: ReadWatchdog,
+    /// The first address the source was found to have no frame at.
+    ///
+    /// Requests at or past it are refused without spawning anything, so a clip
+    /// whose source range runs off the end of its media does not pay a process
+    /// spawn per rendered frame. Cleared by any successful read, and never set
+    /// from a watchdog kill, so a slow decode cannot wall off a healthy source.
+    first_missing: Option<SeekTarget>,
+}
+
+impl ResidentDecoder {
+    fn new(
+        ffmpeg: PathBuf,
+        source: PathBuf,
+        info: SourceInfo,
+        output_width: u32,
+        output_height: u32,
+    ) -> FFmpegResult<Self> {
+        let pixels = u64::from(output_width) * u64::from(output_height);
+        if pixels == 0 || pixels > MAX_FRAME_PIXELS {
+            return Err(FFmpegError::InvalidInput(format!(
+                "Preview frame size {output_width}x{output_height} is out of range"
+            )));
+        }
+
+        let child: ChildSlot = Arc::new(Mutex::new(None));
+        Ok(Self {
+            ffmpeg,
+            source,
+            info,
+            output_width,
+            output_height,
+            frame_bytes: pixels as usize * BYTES_PER_PIXEL,
+            watchdog: ReadWatchdog::new(Arc::clone(&child)),
+            child,
+            stdout: None,
+            stderr_tail: Arc::new(Mutex::new(String::new())),
+            stderr_drain: None,
+            next_frame_index: None,
+            child_pid: None,
+            released: Arc::new(AtomicBool::new(false)),
+            first_missing: None,
+        })
+    }
+
+    /// Kills the child, reaps it, and joins the stderr drain thread.
+    ///
+    /// Killing before dropping the pipes is what guarantees no orphan: on
+    /// Windows a child that is merely disconnected from its pipes keeps running.
+    fn shutdown(&mut self) {
+        if let Some(mut child) = lock_recovering(&self.child).take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        self.child_pid = None;
+        // Dropping stdout after the kill closes our end of the pipe; the drain
+        // thread's read then returns 0 and it exits, so the join cannot hang.
+        self.stdout = None;
+        if let Some(drain) = self.stderr_drain.take() {
+            let _ = drain.join();
+        }
+        self.next_frame_index = None;
+    }
+
+    /// Restarts the child so the pipe's next frame is the one `target` names.
+    fn respawn_at(&mut self, target: SeekTarget) -> FFmpegResult<()> {
+        if self.released.load(Ordering::SeqCst) {
+            return Err(FFmpegError::ExecutionFailed(
+                "The preview decoder was released while this frame was decoding".to_string(),
+            ));
+        }
+
+        self.shutdown();
+        lock_recovering(&self.stderr_tail).clear();
+
+        let seek = match target {
+            SeekTarget::Frame(index) => {
+                seek_argument(index, self.info.timing.constant_fps().unwrap_or(0.0))
+            }
+            SeekTarget::Time(seconds) => seek_argument_seconds(seconds),
+        };
+        let scale = format!("scale={}:{}", self.output_width, self.output_height);
+
+        let mut command = std::process::Command::new(&self.ffmpeg);
+        configure_std_command(&mut command);
+        command
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin"])
+            .args(["-ss", &seek])
+            .arg("-i")
+            .arg(self.source.as_os_str())
+            .args(["-an", "-sn", "-dn"])
+            // Passthrough keeps one output frame per decoded frame; the default
+            // rate conversion would duplicate or drop frames on a
+            // variable-rate source and desynchronise the pipe cursor.
+            //
+            // `-vsync 0` rather than the newer `-fps_mode passthrough` it is an
+            // alias for: the resolver can land on a system FFmpeg older than
+            // 5.1, which does not know `-fps_mode` and would refuse to start.
+            .args(["-vsync", "0"])
+            .args(["-vf", &scale])
+            .args(["-f", "rawvideo", "-pix_fmt", "rgba"])
+            .arg("-")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = command.spawn().map_err(FFmpegError::ProcessError)?;
+        self.child_pid = Some(child.id());
+        self.stdout = child.stdout.take();
+        if let Some(stderr) = child.stderr.take() {
+            self.stderr_drain = Some(spawn_stderr_drain(stderr, Arc::clone(&self.stderr_tail)));
+        }
+        *lock_recovering(&self.child) = Some(child);
+        self.next_frame_index = match target {
+            SeekTarget::Frame(index) => Some(index),
+            // Nothing downstream can say which picture the pipe's next frame is,
+            // so there is no cursor to advance.
+            SeekTarget::Time(_) => None,
+        };
+        Ok(())
+    }
+
+    /// Reads exactly `buffer.len()` bytes off the pipe, killing the child if the
+    /// read has not finished within `budget`.
+    ///
+    /// A read the watchdog ended is reported as [`std::io::ErrorKind::TimedOut`]
+    /// so callers can tell "this source has no such frame" from "this decode was
+    /// too slow", which are handled very differently.
+    fn read_exact_bounded(&mut self, buffer: &mut [u8], budget: Duration) -> std::io::Result<()> {
+        let Self {
+            stdout, watchdog, ..
+        } = self;
+        let Some(stdout) = stdout.as_mut() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "preview decoder is not running",
+            ));
+        };
+
+        watchdog.arm(budget);
+        let result = stdout.read_exact(buffer);
+        watchdog.disarm();
+
+        match result {
+            Err(error) if watchdog.fired() => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("preview decode exceeded {budget:?}: {error}"),
+            )),
+            other => other,
+        }
+    }
+
+    /// Reads and discards `count` frames so the cursor lands on the wanted one.
+    fn skip_frames(&mut self, count: u64) -> std::io::Result<()> {
+        let mut scratch = vec![0u8; self.frame_bytes];
+        for _ in 0..count {
+            self.read_exact_bounded(&mut scratch, READ_TIMEOUT)?;
+            self.next_frame_index = self.next_frame_index.map(|index| index + 1);
+        }
+        Ok(())
+    }
+
+    /// Reads the frame the pipe is positioned on.
+    fn read_current_frame(&mut self, budget: Duration) -> std::io::Result<Vec<u8>> {
+        let mut pixels = vec![0u8; self.frame_bytes];
+        self.read_exact_bounded(&mut pixels, budget)?;
+        self.next_frame_index = self.next_frame_index.map(|index| index + 1);
+        Ok(pixels)
+    }
+
+    /// The failure to report when a read came up short, with the child's own
+    /// diagnosis when it produced one.
+    fn read_failure(&self, target: SeekTarget, error: &std::io::Error) -> FFmpegError {
+        let where_ = match target {
+            SeekTarget::Frame(index) => format!("index {index}"),
+            SeekTarget::Time(seconds) => format!("{seconds:.3}s"),
+        };
+        let tail = lock_recovering(&self.stderr_tail).trim().to_string();
+        if tail.is_empty() {
+            FFmpegError::ExecutionFailed(format!(
+                "No preview frame at {where_} of {}: {error}",
+                self.source.display()
+            ))
+        } else {
+            FFmpegError::ExecutionFailed(format!(
+                "No preview frame at {where_} of {}: {error}. FFmpeg said: {tail}",
+                self.source.display()
+            ))
+        }
+    }
+
+    /// Whether the source is already known to have nothing at `target`.
+    fn is_past_end(&self, target: SeekTarget) -> bool {
+        match (self.first_missing, target) {
+            (Some(SeekTarget::Frame(missing)), SeekTarget::Frame(index)) => index >= missing,
+            (Some(SeekTarget::Time(missing)), SeekTarget::Time(seconds)) => seconds >= missing,
+            _ => false,
+        }
+    }
+
+    /// Whether the running child has already exited reporting success.
+    ///
+    /// Used to tell "this source ends here" from "this decode went wrong". At a
+    /// clean end of stream FFmpeg has closed stdout and is on its way out, so
+    /// the wait resolves almost immediately; the poll is bounded anyway so a
+    /// child that is doing something else cannot stall the caller.
+    fn child_finished_successfully(&self) -> bool {
+        let deadline = Instant::now() + CLEAN_EXIT_GRACE;
+        loop {
+            {
+                let mut child = lock_recovering(&self.child);
+                let Some(child) = child.as_mut() else {
+                    return false;
+                };
+                match child.try_wait() {
+                    Ok(Some(status)) => return status.success(),
+                    Ok(None) => {}
+                    Err(_) => return false,
+                }
+            }
+
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(CHILD_POLL_INTERVAL);
+        }
+    }
+
+    /// Seeks to `target` and reads the one frame it names.
+    ///
+    /// On failure the child is reaped rather than left for the next respawn.
+    ///
+    /// Only a *clean* end of stream is remembered as the end of the source. A
+    /// decode that went wrong part-way through a file — a corrupt GOP, say —
+    /// leaves FFmpeg exiting non-zero, and treating that as the end would wall
+    /// off every later address until something below it succeeded, so a forward
+    /// sweep past one bad frame would report "no frame" for the whole rest of
+    /// the sweep. A watchdog kill is excluded for the same reason.
+    fn seek_and_read(&mut self, target: SeekTarget) -> FFmpegResult<Vec<u8>> {
+        self.respawn_at(target)?;
+        match self.read_current_frame(FIRST_READ_TIMEOUT) {
+            Ok(pixels) => {
+                self.first_missing = None;
+                Ok(pixels)
+            }
+            Err(error) => {
+                if error.kind() == std::io::ErrorKind::UnexpectedEof
+                    && self.child_finished_successfully()
+                {
+                    self.first_missing = Some(target);
+                }
+                let failure = self.read_failure(target, &error);
+                self.shutdown();
+                Err(failure)
+            }
+        }
+    }
+
+    /// The frame at `frame_index` of a constant-rate source, read forward from
+    /// the resident pipe when it is close enough and from a fresh seek otherwise.
+    fn frame_at_index(&mut self, frame_index: u64) -> FFmpegResult<PreviewFrame> {
+        let target = SeekTarget::Frame(frame_index);
+        if self.is_past_end(target) {
+            return Err(FFmpegError::ExecutionFailed(format!(
+                "{} has no frame at index {frame_index}",
+                self.source.display()
+            )));
+        }
+
+        let contiguous = match self.next_frame_index {
+            Some(next) if next == frame_index => true,
+            Some(next) if frame_index > next && frame_index - next <= MAX_FORWARD_SKIP_FRAMES => {
+                let skip = frame_index - next;
+                match self.skip_frames(skip) {
+                    Ok(()) => true,
+                    // A child that died mid-skip is indistinguishable from one
+                    // that ran out of frames; the seek below decides which.
+                    Err(_) => false,
+                }
+            }
+            _ => false,
+        };
+
+        // A failed read here means the resident child died or ran out of
+        // frames. Re-seeking is the recovery for the first and what turns the
+        // second into a clear error, so both fall through to the seek below.
+        if contiguous {
+            if let Ok(pixels) = self.read_current_frame(READ_TIMEOUT) {
+                self.first_missing = None;
+                return Ok(self.finish_frame(target, pixels));
+            }
+        }
+
+        let pixels = self.seek_and_read(target)?;
+        Ok(self.finish_frame(target, pixels))
+    }
+
+    /// The frame a variable-rate source shows from `time_sec`, by accurate seek.
+    ///
+    /// Never read forward: on a variable-rate source the pipe's next frame is at
+    /// an unknown time, so advancing the cursor per request would walk away from
+    /// the timeline without bound. The pipe is closed straight after the read for
+    /// the same reason — there is nothing addressable left in it.
+    fn frame_at_time(&mut self, time_sec: f64) -> FFmpegResult<PreviewFrame> {
+        let time_sec = if time_sec.is_finite() {
+            time_sec.max(0.0)
+        } else {
+            0.0
+        };
+        let target = SeekTarget::Time(time_sec);
+        if self.is_past_end(target) {
+            return Err(FFmpegError::ExecutionFailed(format!(
+                "{} has no frame at {time_sec:.3}s",
+                self.source.display()
+            )));
+        }
+
+        let pixels = self.seek_and_read(target)?;
+        let frame = self.finish_frame(target, pixels);
+        self.shutdown();
+        Ok(frame)
+    }
+
+    fn finish_frame(&self, target: SeekTarget, pixels: Vec<u8>) -> PreviewFrame {
+        let (frame_index, source_time) = match target {
+            SeekTarget::Frame(index) => (
+                Some(index),
+                index as f64 / self.info.timing.constant_fps().unwrap_or(1.0),
+            ),
+            // The accurate seek landed on the first frame at or after this time,
+            // which is the frame this request stands for.
+            SeekTarget::Time(seconds) => (None, seconds),
+        };
+
+        PreviewFrame {
+            width: self.output_width,
+            height: self.output_height,
+            frame_index,
+            source_time,
+            pixels,
+        }
+    }
+}
+
+impl Drop for ResidentDecoder {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// A decoder plus the handle needed to kill its child from outside the lock a
+/// blocked read is holding.
+struct DecoderSlot {
+    key: DecoderKey,
+    child: ChildSlot,
+    released: Arc<AtomicBool>,
+    decoder: Mutex<ResidentDecoder>,
+    last_used: Mutex<Instant>,
+}
+
+/// A bounded pool of resident decoders, keyed by source and output size.
+pub struct PreviewDecoderPool {
+    ffmpeg: PathBuf,
+    ffprobe: PathBuf,
+    max_resident: usize,
+    slots: Mutex<Vec<Arc<DecoderSlot>>>,
+    sources: Mutex<HashMap<PathBuf, SourceInfo>>,
+}
+
+impl PreviewDecoderPool {
+    /// A pool that spawns `ffmpeg` and probes with `ffprobe`.
+    pub fn new(ffmpeg: PathBuf, ffprobe: PathBuf) -> Self {
+        Self::with_capacity(ffmpeg, ffprobe, DEFAULT_MAX_RESIDENT_DECODERS)
+    }
+
+    /// A pool holding at most `max_resident` live children.
+    pub fn with_capacity(ffmpeg: PathBuf, ffprobe: PathBuf, max_resident: usize) -> Self {
+        Self {
+            ffmpeg,
+            ffprobe,
+            max_resident: max_resident.max(1),
+            slots: Mutex::new(Vec::new()),
+            sources: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// How many decoders are currently resident.
+    pub fn resident_count(&self) -> usize {
+        lock_recovering(&self.slots).len()
+    }
+
+    /// The frame nearest `time_sec`, downscaled to fit inside `max_width` by
+    /// `max_height` without changing its aspect ratio.
+    ///
+    /// This blocks on a pipe read and must be called off the async runtime.
+    pub fn frame_at(
+        &self,
+        source: &Path,
+        time_sec: f64,
+        max_width: u32,
+        max_height: u32,
+    ) -> FFmpegResult<PreviewFrame> {
+        let info = self.source_info(source)?;
+        let (output_width, output_height) = fitted_output_size(
+            info.display_width,
+            info.display_height,
+            max_width,
+            max_height,
+        );
+        let key = DecoderKey {
+            source: source.to_path_buf(),
+            width: output_width,
+            height: output_height,
+        };
+        let slot = self.slot_for(key, source, &info, output_width, output_height)?;
+
+        // The pool lock is released before the decode so a slow frame on one
+        // asset cannot stall a request for another.
+        let mut decoder = lock_recovering(&slot.decoder);
+        match info.timing {
+            SourceTiming::ConstantRate { fps } => {
+                decoder.frame_at_index(frame_index_for_time(time_sec, fps))
+            }
+            // No index maps onto this source's presentation times, so the
+            // request is answered by seeking to the time it asked for.
+            SourceTiming::VariableRate => decoder.frame_at_time(time_sec),
+        }
+    }
+
+    /// Kills every resident child and forgets every probe.
+    ///
+    /// Children are killed through the slot handles rather than by dropping the
+    /// decoders, so this also unblocks a read that is in flight.
+    pub fn release_all(&self) {
+        let slots: Vec<Arc<DecoderSlot>> = std::mem::take(&mut *lock_recovering(&self.slots));
+        for slot in &slots {
+            // Flag first, kill second: an in-flight read sees the flag when its
+            // read fails and gives up instead of spawning a replacement.
+            slot.released.store(true, Ordering::SeqCst);
+            if let Some(child) = lock_recovering(&slot.child).as_mut() {
+                let _ = child.kill();
+            }
+        }
+        // Reap only once the in-flight reads have unblocked and released the
+        // decoder locks. Shutting each one down here rather than leaving it to
+        // `Drop` means every child is waited on by the time this returns, even
+        // though a caller mid-decode still holds its `Arc`.
+        for slot in slots {
+            lock_recovering(&slot.decoder).shutdown();
+        }
+        lock_recovering(&self.sources).clear();
+    }
+
+    /// The cached probe for `source`, probing it on first use.
+    fn source_info(&self, source: &Path) -> FFmpegResult<SourceInfo> {
+        if let Some(info) = lock_recovering(&self.sources).get(source) {
+            return Ok(info.clone());
+        }
+
+        let info = probe_source(&self.ffprobe, source)?;
+        lock_recovering(&self.sources).insert(source.to_path_buf(), info.clone());
+        Ok(info)
+    }
+
+    /// The slot for `key`, creating it and evicting the least-recently-used
+    /// decoder when the pool is already full.
+    fn slot_for(
+        &self,
+        key: DecoderKey,
+        source: &Path,
+        info: &SourceInfo,
+        output_width: u32,
+        output_height: u32,
+    ) -> FFmpegResult<Arc<DecoderSlot>> {
+        let mut slots = lock_recovering(&self.slots);
+
+        if let Some(slot) = slots.iter().find(|slot| slot.key == key) {
+            *lock_recovering(&slot.last_used) = Instant::now();
+            return Ok(Arc::clone(slot));
+        }
+
+        let decoder = ResidentDecoder::new(
+            self.ffmpeg.clone(),
+            source.to_path_buf(),
+            info.clone(),
+            output_width,
+            output_height,
+        )?;
+        let slot = Arc::new(DecoderSlot {
+            key,
+            child: Arc::clone(&decoder.child),
+            released: Arc::clone(&decoder.released),
+            decoder: Mutex::new(decoder),
+            last_used: Mutex::new(Instant::now()),
+        });
+        slots.push(Arc::clone(&slot));
+
+        while slots.len() > self.max_resident {
+            let Some(oldest) = slots
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, slot)| *lock_recovering(&slot.last_used))
+                .map(|(index, _)| index)
+            else {
+                break;
+            };
+            // Dropping the last `Arc` runs `ResidentDecoder::drop`, which kills
+            // and reaps the child.
+            let evicted = slots.remove(oldest);
+            drop(evicted);
+        }
+
+        Ok(slot)
+    }
+}
+
+impl Drop for PreviewDecoderPool {
+    fn drop(&mut self) {
+        self.release_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feature: preview seek accuracy
+    /// Scenario: the seek argument is the frame's own presentation time
+    #[test]
+    fn seek_argument_is_the_exact_frame_time_for_integer_rates() {
+        assert_eq!(seek_argument(0, 30.0), "0.000000000");
+        assert_eq!(seek_argument(1, 30.0), "0.033333333");
+        assert_eq!(seek_argument(60, 30.0), "2.000000000");
+        assert_eq!(seek_argument(119, 30.0), "3.966666666");
+    }
+
+    /// Feature: preview seek accuracy
+    /// Scenario: the seek argument never lands past the frame it names
+    ///
+    /// FFmpeg drops frames whose presentation time is below `-ss`, so an
+    /// argument even one nanosecond above the frame's time returns the next
+    /// frame instead. Rounding would do exactly that on fractional rates.
+    #[test]
+    fn seek_argument_never_exceeds_the_frame_presentation_time() {
+        let rates = [
+            23.976023976023978,
+            29.97002997002997,
+            30.0,
+            59.94005994005994,
+        ];
+        for fps in rates {
+            for frame_index in [0u64, 1, 7, 59, 100, 1001, 100_000] {
+                let argument = seek_argument(frame_index, fps);
+                let parsed: f64 = argument
+                    .parse()
+                    .unwrap_or_else(|error| panic!("`{argument}` must parse: {error}"));
+                let exact = frame_index as f64 / fps;
+                assert!(
+                    parsed <= exact,
+                    "seek {argument} for frame {frame_index} at {fps} fps is ahead of {exact}"
+                );
+                assert!(
+                    exact - parsed < 1e-8,
+                    "seek {argument} for frame {frame_index} at {fps} fps undershoots by too much"
+                );
+            }
+        }
+    }
+
+    /// Feature: preview seek accuracy
+    /// Scenario: a nonsensical rate cannot produce a nonsensical seek
+    #[test]
+    fn seek_argument_is_zero_for_unusable_rates() {
+        assert_eq!(seek_argument(10, 0.0), "0.000000000");
+        assert_eq!(seek_argument(10, f64::NAN), "0.000000000");
+        assert_eq!(seek_argument(10, -30.0), "0.000000000");
+    }
+
+    /// Feature: preview frame addressing
+    /// Scenario: a source time snaps to the nearest frame
+    #[test]
+    fn frame_index_snaps_to_the_nearest_frame() {
+        assert_eq!(frame_index_for_time(0.0, 30.0), 0);
+        assert_eq!(frame_index_for_time(0.016, 30.0), 0);
+        assert_eq!(frame_index_for_time(0.017, 30.0), 1);
+        assert_eq!(frame_index_for_time(2.0, 30.0), 60);
+        assert_eq!(frame_index_for_time(-5.0, 30.0), 0);
+        assert_eq!(frame_index_for_time(f64::NAN, 30.0), 0);
+    }
+
+    /// Feature: preview frame sizing
+    /// Scenario: the frame keeps its aspect ratio inside the canvas box
+    ///
+    /// The canvas composites with a contain-fit that reads the drawable's
+    /// intrinsic size, so a frame stretched to the canvas box would make that
+    /// fit a no-op and silently change how every transformed clip is drawn.
+    #[test]
+    fn fitted_output_preserves_aspect_ratio() {
+        assert_eq!(fitted_output_size(1920, 1080, 960, 540), (960, 540));
+        assert_eq!(fitted_output_size(1920, 1080, 960, 960), (960, 540));
+        assert_eq!(fitted_output_size(1080, 1920, 960, 540), (304, 540));
+    }
+
+    /// Feature: preview frame sizing
+    /// Scenario: a small source is never upscaled
+    #[test]
+    fn fitted_output_never_upscales() {
+        assert_eq!(fitted_output_size(320, 180, 1920, 1080), (320, 180));
+    }
+
+    /// Feature: preview frame sizing
+    /// Scenario: degenerate sizes still produce a decodable frame
+    #[test]
+    fn fitted_output_stays_at_least_one_pixel() {
+        assert_eq!(fitted_output_size(1920, 1080, 1, 1), (1, 1));
+        assert_eq!(fitted_output_size(0, 0, 960, 540), (1, 1));
+        assert_eq!(fitted_output_size(1920, 1080, 0, 0), (1920, 1080));
+    }
+
+    /// Feature: preview frame rate resolution
+    /// Scenario: FFprobe rationals become frame rates, placeholders do not
+    #[test]
+    fn frame_rate_parsing_rejects_probe_placeholders() {
+        assert_eq!(parse_frame_rate("30/1"), Some(30.0));
+        assert_eq!(parse_frame_rate("30000/1001"), Some(30000.0 / 1001.0));
+        assert_eq!(parse_frame_rate("0/0"), None);
+        assert_eq!(parse_frame_rate("N/A"), None);
+        assert_eq!(parse_frame_rate("0/1"), None);
+        assert_eq!(parse_frame_rate("90000/1"), None);
+        assert_eq!(parse_frame_rate("30"), None);
+    }
+
+    /// Reads a little-endian `u32` out of a wire header.
+    fn header_u32(bytes: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ])
+    }
+
+    /// Feature: preview frame transport
+    /// Scenario: the wire header describes the pixels that follow it
+    #[test]
+    fn wire_bytes_carry_a_readable_header() {
+        let frame = PreviewFrame {
+            width: 2,
+            height: 1,
+            frame_index: Some(7),
+            source_time: 0.25,
+            pixels: vec![1, 2, 3, 4, 5, 6, 7, 8],
+        };
+        let bytes = frame.into_wire_bytes();
+
+        assert_eq!(bytes.len(), PreviewFrame::HEADER_BYTES + 8);
+        assert_eq!(header_u32(&bytes, 0), PreviewFrame::WIRE_VERSION);
+        assert_eq!(header_u32(&bytes, 4), 2);
+        assert_eq!(header_u32(&bytes, 8), 1);
+        assert_eq!(header_u32(&bytes, 12), 7);
+        assert_eq!(
+            f64::from_le_bytes([
+                bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22],
+                bytes[23],
+            ]),
+            0.25
+        );
+        assert_eq!(header_u32(&bytes, 24), PreviewFrame::FLAG_INDEXED);
+        assert_eq!(
+            &bytes[PreviewFrame::HEADER_BYTES..],
+            &[1, 2, 3, 4, 5, 6, 7, 8]
+        );
+    }
+
+    /// Feature: preview frame transport
+    /// Scenario: an unindexable frame says so rather than shipping a made-up index
+    ///
+    /// A variable-rate source has no index the frontend could cache or seek by,
+    /// and a zero here would be read as "frame zero" if the flag did not say
+    /// otherwise.
+    #[test]
+    fn wire_bytes_mark_a_variable_rate_frame_as_unindexed() {
+        let frame = PreviewFrame {
+            width: 1,
+            height: 1,
+            frame_index: None,
+            source_time: 1.5,
+            pixels: vec![9, 9, 9, 9],
+        };
+        let bytes = frame.into_wire_bytes();
+
+        assert_eq!(header_u32(&bytes, 12), 0);
+        assert_eq!(header_u32(&bytes, 24) & PreviewFrame::FLAG_INDEXED, 0);
+    }
+
+    /// Feature: variable frame rate handling
+    /// Scenario: a source is only read forward when its two rates agree
+    ///
+    /// Reading the pipe forward assumes frame `n` is shown at `n / fps`. That is
+    /// false for a variable-rate source, and believing it there shows the wrong
+    /// picture and then drifts further with every frame.
+    #[test]
+    fn timing_is_constant_only_when_both_reported_rates_agree() {
+        assert_eq!(
+            classify_timing(Some(30.0), Some(30.0)),
+            SourceTiming::ConstantRate { fps: 30.0 }
+        );
+        assert_eq!(
+            classify_timing(Some(30000.0 / 1001.0), Some(30000.0 / 1001.0)),
+            SourceTiming::ConstantRate {
+                fps: 30000.0 / 1001.0
+            }
+        );
+
+        // The screen-recording shape: an average far below the base rate.
+        assert_eq!(
+            classify_timing(Some(6.0), Some(30.0)),
+            SourceTiming::VariableRate
+        );
+        assert_eq!(
+            classify_timing(Some(10.3), Some(30.0)),
+            SourceTiming::VariableRate
+        );
+        // Field-rate doubling: constant footage, but not provably so.
+        assert_eq!(
+            classify_timing(Some(30.0), Some(60.0)),
+            SourceTiming::VariableRate
+        );
+    }
+
+    /// Feature: variable frame rate handling
+    /// Scenario: a rate nothing corroborates is not trusted for indexing
+    #[test]
+    fn timing_is_variable_when_a_rate_is_missing() {
+        assert_eq!(
+            classify_timing(Some(30.0), None),
+            SourceTiming::VariableRate
+        );
+        assert_eq!(
+            classify_timing(None, Some(30.0)),
+            SourceTiming::VariableRate
+        );
+        assert_eq!(classify_timing(None, None), SourceTiming::VariableRate);
+    }
+
+    /// Feature: variable frame rate handling
+    /// Scenario: a time seek is truncated the same way a frame seek is
+    #[test]
+    fn seconds_seek_argument_never_exceeds_the_time_asked_for() {
+        for seconds in [0.0, 0.1, 1.0 / 3.0, 2.5, 123.456789012] {
+            let argument = seek_argument_seconds(seconds);
+            let parsed: f64 = argument
+                .parse()
+                .unwrap_or_else(|error| panic!("`{argument}` must parse: {error}"));
+            assert!(
+                parsed <= seconds,
+                "seek {argument} is ahead of the requested {seconds}"
+            );
+            assert!(
+                seconds - parsed < 1e-8,
+                "seek {argument} undershoots too far"
+            );
+        }
+        assert_eq!(seek_argument_seconds(-1.0), "0.000000000");
+        assert_eq!(seek_argument_seconds(f64::NAN), "0.000000000");
+    }
+}
+
+#[cfg(test)]
+mod ffmpeg_backed_tests {
+    //! Tests that put a real FFmpeg behind the pool.
+    //!
+    //! They are `#[ignore]`d because they need a binary the machine may not
+    //! have; `require_or_skip_ffmpeg` turns the skip into a failure when
+    //! `REQUIRE_FFMPEG_TESTS` is set, so a CI job that installs FFmpeg cannot
+    //! report green without having run them.
+
+    use super::*;
+    use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
+
+    const TEST_FPS: f64 = 30.0;
+    const TEST_WIDTH: u32 = 160;
+    const TEST_HEIGHT: u32 = 90;
+    const TEST_FRAMES: u64 = 120;
+
+    /// The FFprobe beside the FFmpeg the tests resolved.
+    fn ffprobe_beside(ffmpeg: &Path) -> Option<PathBuf> {
+        if let Some(explicit) = std::env::var_os("OPENREELIO_FFPROBE_PATH") {
+            return Some(PathBuf::from(explicit));
+        }
+
+        let sibling = ffmpeg.with_file_name(if cfg!(windows) {
+            "ffprobe.exe"
+        } else {
+            "ffprobe"
+        });
+        if sibling.exists() {
+            return Some(sibling);
+        }
+
+        skip_without_ffmpeg("no FFprobe beside the resolved FFmpeg");
+        None
+    }
+
+    /// A scratch directory that removes itself.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(label: &str) -> std::io::Result<Self> {
+            let path = std::env::temp_dir().join(format!(
+                "openreelio-preview-{label}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path)?;
+            Ok(Self(path))
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A variable-rate clip shaped like a screen recording: a burst at 30 fps
+    /// for half a second, then a long idle stretch at 5 fps.
+    ///
+    /// FFprobe reports `r_frame_rate` 30 and `avg_frame_rate` 6 for this, which
+    /// is exactly the shape that makes an index-based mapping wrong.
+    fn write_variable_rate_source(ffmpeg: &Path, directory: &Path) -> Option<PathBuf> {
+        let source = directory.join("variable.mp4");
+        let mut command = std::process::Command::new(ffmpeg);
+        configure_std_command(&mut command);
+        let output = command
+            .args(["-y", "-hide_banner", "-loglevel", "error"])
+            .args(["-f", "lavfi", "-i"])
+            .arg(format!(
+                "testsrc2=size={TEST_WIDTH}x{TEST_HEIGHT}:rate=30:duration=3"
+            ))
+            .args(["-vf", "setpts='(if(lt(N,15),N/30,0.5+(N-15)/5))/TB'"])
+            .args(["-vsync", "passthrough"])
+            .args(["-c:v", "libx264", "-g", "250", "-pix_fmt", "yuv420p"])
+            .arg(&source)
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            skip_without_ffmpeg(&format!(
+                "could not synthesise a variable-rate source: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+            return None;
+        }
+
+        Some(source)
+    }
+
+    /// The frame a plain per-request accurate seek returns for `time_sec`.
+    ///
+    /// This is what the extraction path this module replaced does, so it is the
+    /// definition of "no worse than before" for a source the resident stream
+    /// cannot address.
+    fn seek_oracle(ffmpeg: &Path, source: &Path, time_sec: f64) -> Option<Vec<u8>> {
+        let mut command = std::process::Command::new(ffmpeg);
+        configure_std_command(&mut command);
+        let output = command
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin"])
+            .args(["-ss", &format!("{time_sec}")])
+            .arg("-i")
+            .arg(source)
+            .args(["-frames:v", "1", "-an", "-sn", "-dn"])
+            .args(["-vf", &format!("scale={TEST_WIDTH}:{TEST_HEIGHT}")])
+            .args(["-f", "rawvideo", "-pix_fmt", "rgba", "-"])
+            .output()
+            .ok()?;
+
+        if !output.status.success() || output.stdout.is_empty() {
+            return None;
+        }
+
+        Some(output.stdout)
+    }
+
+    /// A four-second 30 fps clip whose frames all differ from one another.
+    fn write_source(ffmpeg: &Path, directory: &Path) -> Option<PathBuf> {
+        let source = directory.join("source.mp4");
+        let mut command = std::process::Command::new(ffmpeg);
+        configure_std_command(&mut command);
+        let output = command
+            .args(["-y", "-hide_banner", "-loglevel", "error"])
+            .args(["-f", "lavfi", "-i"])
+            .arg(format!(
+                "testsrc2=size={TEST_WIDTH}x{TEST_HEIGHT}:rate={}:duration={}",
+                TEST_FPS as u32,
+                TEST_FRAMES as f64 / TEST_FPS
+            ))
+            .args(["-c:v", "libx264", "-g", "250", "-pix_fmt", "yuv420p"])
+            .arg(&source)
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            skip_without_ffmpeg(&format!(
+                "could not synthesise a preview source: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+            return None;
+        }
+
+        Some(source)
+    }
+
+    /// Every frame of the source, decoded in one sequential pass, as the oracle
+    /// a seek is checked against.
+    fn decode_all_frames(ffmpeg: &Path, source: &Path) -> Option<Vec<Vec<u8>>> {
+        let mut command = std::process::Command::new(ffmpeg);
+        configure_std_command(&mut command);
+        let output = command
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin"])
+            .arg("-i")
+            .arg(source)
+            .args(["-an", "-sn", "-dn", "-vsync", "0"])
+            .args(["-vf", &format!("scale={TEST_WIDTH}:{TEST_HEIGHT}")])
+            .args(["-f", "rawvideo", "-pix_fmt", "rgba", "-"])
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        let frame_bytes = TEST_WIDTH as usize * TEST_HEIGHT as usize * BYTES_PER_PIXEL;
+        Some(
+            output
+                .stdout
+                .chunks_exact(frame_bytes)
+                .map(<[u8]>::to_vec)
+                .collect(),
+        )
+    }
+
+    /// Whether a process id is still alive.
+    fn process_is_alive(pid: u32) -> bool {
+        let pid = sysinfo::Pid::from_u32(pid);
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
+        system.process(pid).is_some()
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: sequential frames come off one resident pipe at the exact size
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn resident_decoding_streams_exact_sized_frames_in_order() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("sequential") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+        let Some(oracle) = decode_all_frames(&ffmpeg, &source) else {
+            panic!("the oracle decode must succeed once FFmpeg is available");
+        };
+
+        let pool = PreviewDecoderPool::new(ffmpeg, ffprobe);
+        let expected_bytes = TEST_WIDTH as usize * TEST_HEIGHT as usize * BYTES_PER_PIXEL;
+
+        for index in 0..20u64 {
+            let frame = pool
+                .frame_at(&source, index as f64 / TEST_FPS, TEST_WIDTH, TEST_HEIGHT)
+                .unwrap_or_else(|error| panic!("frame {index} must decode: {error}"));
+
+            assert_eq!(frame.width, TEST_WIDTH);
+            assert_eq!(frame.height, TEST_HEIGHT);
+            assert_eq!(frame.frame_index, Some(index));
+            assert_eq!(
+                frame.pixels.len(),
+                expected_bytes,
+                "frame {index} must be exactly width * height * 4 bytes"
+            );
+            assert_eq!(
+                frame.pixels, oracle[index as usize],
+                "frame {index} must match the sequential oracle"
+            );
+        }
+
+        assert_eq!(
+            pool.resident_count(),
+            1,
+            "a sequential pass must reuse a single resident decoder"
+        );
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: a seek lands on the frame it was asked for
+    ///
+    /// This is the assertion the whole seek design turns on: `-ss` is the
+    /// frame's own presentation time, truncated, and a forward-biased argument
+    /// would land on the following frame instead.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn seeking_lands_on_the_requested_frame() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("seek") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+        let Some(oracle) = decode_all_frames(&ffmpeg, &source) else {
+            panic!("the oracle decode must succeed once FFmpeg is available");
+        };
+
+        let pool = PreviewDecoderPool::new(ffmpeg, ffprobe);
+        // Deliberately non-contiguous and far enough apart to force a respawn.
+        for index in [97u64, 13, 60, 0, 118, 44, 91, 7, 105, 31] {
+            let frame = pool
+                .frame_at(&source, index as f64 / TEST_FPS, TEST_WIDTH, TEST_HEIGHT)
+                .unwrap_or_else(|error| panic!("frame {index} must decode: {error}"));
+
+            assert_eq!(frame.frame_index, Some(index));
+            assert_eq!(
+                frame.pixels, oracle[index as usize],
+                "seeking to frame {index} returned a different frame"
+            );
+        }
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: rapid seeking leaves no FFmpeg behind
+    ///
+    /// This is the risk the whole design lives or dies on: every respawn kills
+    /// and reaps its predecessor, and releasing the pool kills what is left.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn rapid_seeking_leaves_no_orphaned_ffmpeg() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("orphans") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let pool = PreviewDecoderPool::new(ffmpeg, ffprobe);
+        let mut seen_pids = Vec::new();
+
+        for step in 0..30u64 {
+            // Alternating far-apart targets so every request forces a respawn.
+            let index = if step % 2 == 0 {
+                step * 3
+            } else {
+                TEST_FRAMES - 1 - step * 3
+            };
+            pool.frame_at(&source, index as f64 / TEST_FPS, TEST_WIDTH, TEST_HEIGHT)
+                .unwrap_or_else(|error| panic!("seek {step} must decode: {error}"));
+
+            let slots = lock_recovering(&pool.slots);
+            for slot in slots.iter() {
+                if let Some(pid) = lock_recovering(&slot.decoder).child_pid {
+                    if !seen_pids.contains(&pid) {
+                        seen_pids.push(pid);
+                    }
+                }
+            }
+        }
+
+        assert!(
+            seen_pids.len() > 1,
+            "the seeks must have respawned the decoder at least once"
+        );
+
+        pool.release_all();
+        assert_eq!(pool.resident_count(), 0);
+
+        let alive: Vec<u32> = seen_pids
+            .into_iter()
+            .filter(|pid| process_is_alive(*pid))
+            .collect();
+        assert!(
+            alive.is_empty(),
+            "every decoder FFmpeg must be dead after release, but {alive:?} are alive"
+        );
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: the pool stays bounded and evicts the least recently used
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn the_pool_evicts_the_least_recently_used_decoder() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("eviction") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let pool = PreviewDecoderPool::with_capacity(ffmpeg, ffprobe, 2);
+
+        // Three distinct output sizes are three distinct decoders for one source.
+        let sizes = [(160u32, 90u32), (80, 45), (40, 23)];
+        let mut first_pid = None;
+        for (index, (width, height)) in sizes.iter().enumerate() {
+            pool.frame_at(&source, 0.0, *width, *height)
+                .unwrap_or_else(|error| panic!("size {index} must decode: {error}"));
+
+            assert!(
+                pool.resident_count() <= 2,
+                "the pool must never hold more than its capacity"
+            );
+
+            if index == 0 {
+                let slots = lock_recovering(&pool.slots);
+                first_pid = slots
+                    .first()
+                    .and_then(|slot| lock_recovering(&slot.decoder).child_pid);
+            }
+        }
+
+        assert_eq!(pool.resident_count(), 2);
+
+        let Some(first_pid) = first_pid else {
+            panic!("the first decoder must have spawned a child");
+        };
+        assert!(
+            !process_is_alive(first_pid),
+            "the evicted decoder's FFmpeg must have been killed"
+        );
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: dropping a decoder kills its child and closes the pipe
+    ///
+    /// On Windows a child that is merely disconnected from its pipes keeps
+    /// running, so the kill has to come first and the read has to unblock.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn dropping_the_pool_kills_the_child_and_closes_the_pipe() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("drop") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let info = probe_source(&ffprobe, &source)
+            .unwrap_or_else(|error| panic!("the source must probe: {error}"));
+        let mut decoder =
+            ResidentDecoder::new(ffmpeg, source.clone(), info, TEST_WIDTH, TEST_HEIGHT)
+                .unwrap_or_else(|error| panic!("the decoder must build: {error}"));
+
+        decoder
+            .frame_at_index(0)
+            .unwrap_or_else(|error| panic!("the first frame must decode: {error}"));
+        let Some(pid) = decoder.child_pid else {
+            panic!("a running decoder must report a child pid");
+        };
+        assert!(process_is_alive(pid), "the child must be running");
+
+        drop(decoder);
+
+        assert!(
+            !process_is_alive(pid),
+            "dropping the decoder must kill its FFmpeg"
+        );
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: killing a child unblocks a read that is waiting on its pipe
+    ///
+    /// This is the assumption the read watchdog rests on, and the one most
+    /// likely to differ on Windows: a blocking pipe read has no timeout of its
+    /// own, so if killing the child did not close the pipe, a wedged decode
+    /// would strand a blocking thread forever.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn killing_a_child_unblocks_a_read_waiting_on_its_pipe() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+
+        // `-re` paces the source at its own frame rate, so one frame a second
+        // arrives and a request for twenty of them is guaranteed to be waiting.
+        let mut command = std::process::Command::new(&ffmpeg);
+        configure_std_command(&mut command);
+        let spawned = command
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-re"])
+            .args(["-f", "lavfi", "-i", "testsrc2=size=64x64:rate=1"])
+            .args(["-f", "rawvideo", "-pix_fmt", "rgba", "-"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn();
+
+        let Ok(mut child) = spawned else {
+            skip_without_ffmpeg("could not start a paced FFmpeg for the pipe test");
+            return;
+        };
+        let Some(mut stdout) = child.stdout.take() else {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("a piped child must expose stdout");
+        };
+
+        let pid = child.id();
+        let slot: ChildSlot = Arc::new(Mutex::new(Some(child)));
+        let watchdog = ReadWatchdog::new(Arc::clone(&slot));
+
+        // Twenty seconds of paced frames: the read cannot complete on its own.
+        let mut buffer = vec![0u8; 64 * 64 * BYTES_PER_PIXEL * 20];
+        watchdog.arm(Duration::from_millis(500));
+        let started = Instant::now();
+        let result = stdout.read_exact(&mut buffer);
+        let elapsed = started.elapsed();
+        watchdog.disarm();
+
+        assert!(
+            result.is_err(),
+            "the read must have been cut short by the kill, not satisfied"
+        );
+        assert!(
+            watchdog.fired(),
+            "the watchdog must report that it was the one that ended the read"
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "killing the child must unblock the read promptly, but it took {elapsed:?}"
+        );
+        assert!(
+            !process_is_alive(pid),
+            "the watchdog's kill must have taken effect"
+        );
+
+        drop(watchdog);
+        let reaped = lock_recovering(&slot).take();
+        if let Some(mut child) = reaped {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: one watchdog thread serves every read of a decoder
+    ///
+    /// A thread spawned and joined per read costs two thread operations for
+    /// every displayed frame on the path this module exists to make cheap.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn the_watchdog_is_rearmed_rather_than_respawned_per_read() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("rearm") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let info = probe_source(&ffprobe, &source)
+            .unwrap_or_else(|error| panic!("the source must probe: {error}"));
+        let mut decoder = ResidentDecoder::new(ffmpeg, source, info, TEST_WIDTH, TEST_HEIGHT)
+            .unwrap_or_else(|error| panic!("the decoder must build: {error}"));
+
+        let thread_id = decoder
+            .watchdog
+            .thread
+            .as_ref()
+            .map(|thread| thread.thread().id());
+        assert!(
+            thread_id.is_some(),
+            "a decoder must start with a watchdog thread"
+        );
+
+        for index in 0..10u64 {
+            decoder
+                .frame_at_index(index)
+                .unwrap_or_else(|error| panic!("frame {index} must decode: {error}"));
+        }
+
+        let after = decoder
+            .watchdog
+            .thread
+            .as_ref()
+            .map(|thread| thread.thread().id());
+        assert_eq!(
+            thread_id, after,
+            "ten reads must have shared one watchdog thread"
+        );
+        assert!(
+            !decoder.watchdog.fired(),
+            "a healthy decode must not have tripped the watchdog"
+        );
+    }
+
+    /// Feature: variable frame rate handling
+    /// Scenario: a variable-rate source is recognised rather than averaged
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn a_variable_rate_source_is_probed_as_variable() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("vfr-probe") else {
+            return;
+        };
+        let Some(variable) = write_variable_rate_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+        let Some(constant) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let variable_info = probe_source(&ffprobe, &variable)
+            .unwrap_or_else(|error| panic!("the variable source must probe: {error}"));
+        assert_eq!(
+            variable_info.timing,
+            SourceTiming::VariableRate,
+            "a source whose average and base rates disagree must not be indexed by frame"
+        );
+
+        let constant_info = probe_source(&ffprobe, &constant)
+            .unwrap_or_else(|error| panic!("the constant source must probe: {error}"));
+        assert_eq!(
+            constant_info.timing,
+            SourceTiming::ConstantRate { fps: TEST_FPS },
+            "an ordinary constant-rate source must keep the fast path"
+        );
+    }
+
+    /// Feature: variable frame rate handling
+    /// Scenario: a requested time returns the picture that time shows
+    ///
+    /// Reading the resident pipe forward on a variable-rate source shows the
+    /// wrong frame immediately and then drifts further with every request, so
+    /// these requests are compared against a plain per-request accurate seek —
+    /// the extraction this module replaced — at increasing times, which is the
+    /// pattern that made the drift unbounded.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn a_variable_rate_source_does_not_drift_across_a_playback_sweep() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("vfr-sweep") else {
+            return;
+        };
+        let Some(source) = write_variable_rate_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let pool = PreviewDecoderPool::new(ffmpeg.clone(), ffprobe);
+
+        // Through the 30 fps burst, across the rate change, and into the idle
+        // stretch. Under the index mapping the average rate implies, the very
+        // first of these already lands almost two seconds late.
+        let times = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.7, 0.9, 1.1, 1.5, 2.1];
+        for time in times {
+            let frame = pool
+                .frame_at(&source, time, TEST_WIDTH, TEST_HEIGHT)
+                .unwrap_or_else(|error| panic!("frame at {time}s must decode: {error}"));
+
+            let Some(expected) = seek_oracle(&ffmpeg, &source, time) else {
+                panic!("the per-request seek oracle must produce a frame at {time}s");
+            };
+
+            assert_eq!(
+                frame.pixels, expected,
+                "the frame returned for {time}s is not the one an accurate seek returns"
+            );
+            assert_eq!(
+                frame.frame_index, None,
+                "a variable-rate source must not report a frame index"
+            );
+            assert!(
+                (frame.source_time - time).abs() < 1e-6,
+                "a variable-rate frame must answer for the time it was asked for, \
+                 but {time}s came back as {}s",
+                frame.source_time
+            );
+        }
+    }
+
+    /// Feature: variable frame rate handling
+    /// Scenario: a variable-rate decode leaves no FFmpeg running behind it
+    ///
+    /// The per-request seek closes its pipe as soon as the frame is read,
+    /// because nothing addressable is left in it.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn a_variable_rate_decode_leaves_no_live_child() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("vfr-lifecycle") else {
+            return;
+        };
+        let Some(source) = write_variable_rate_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let pool = PreviewDecoderPool::new(ffmpeg, ffprobe);
+        for time in [0.0, 0.2, 0.9, 1.5] {
+            pool.frame_at(&source, time, TEST_WIDTH, TEST_HEIGHT)
+                .unwrap_or_else(|error| panic!("frame at {time}s must decode: {error}"));
+
+            let slots = lock_recovering(&pool.slots);
+            for slot in slots.iter() {
+                assert!(
+                    lock_recovering(&slot.decoder).child_pid.is_none(),
+                    "a variable-rate decode must not leave a child running between requests"
+                );
+            }
+        }
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: requests past the end of a source stop spawning children
+    ///
+    /// A clip whose source range runs off the end of its media would otherwise
+    /// pay a process spawn and an accurate seek for every rendered frame in the
+    /// dead zone.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn requests_past_the_end_stop_respawning() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("past-end") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let info = probe_source(&ffprobe, &source)
+            .unwrap_or_else(|error| panic!("the source must probe: {error}"));
+        let mut decoder = ResidentDecoder::new(ffmpeg, source, info, TEST_WIDTH, TEST_HEIGHT)
+            .unwrap_or_else(|error| panic!("the decoder must build: {error}"));
+
+        // Well past the 120 frames the source holds.
+        let beyond = TEST_FRAMES + 500;
+        assert!(
+            decoder.frame_at_index(beyond).is_err(),
+            "there is no frame that far past the end"
+        );
+        assert_eq!(
+            decoder.first_missing,
+            Some(SeekTarget::Frame(beyond)),
+            "the end of the source must be remembered"
+        );
+        assert!(
+            decoder.child_pid.is_none(),
+            "the failed decode's child must have been reaped, not left behind"
+        );
+
+        let started = Instant::now();
+        assert!(decoder.frame_at_index(beyond + 10).is_err());
+        assert!(
+            started.elapsed() < Duration::from_millis(50),
+            "a request past a known end must be refused without spawning anything"
+        );
+
+        // A frame that does exist proves the decoder is not walled off.
+        decoder
+            .frame_at_index(0)
+            .unwrap_or_else(|error| panic!("frame 0 must still decode: {error}"));
+        assert_eq!(
+            decoder.first_missing, None,
+            "a successful read must clear the remembered end"
+        );
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: a decode that fails for a reason other than the end of the
+    /// source does not wall off the addresses after it
+    ///
+    /// Only a clean end of stream means "there is nothing here". A child that
+    /// died, was killed, or hit a bad frame must fail that one request; treating
+    /// it as the end would make a forward sweep past a single bad frame report
+    /// "no frame" for everything after it.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn a_failed_decode_that_is_not_the_end_does_not_wall_off_later_frames() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("mid-stream-failure") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let info = probe_source(&ffprobe, &source)
+            .unwrap_or_else(|error| panic!("the source must probe: {error}"));
+        let mut decoder = ResidentDecoder::new(ffmpeg, source, info, TEST_WIDTH, TEST_HEIGHT)
+            .unwrap_or_else(|error| panic!("the decoder must build: {error}"));
+
+        decoder
+            .frame_at_index(10)
+            .unwrap_or_else(|error| panic!("frame 10 must decode: {error}"));
+
+        // A child that died mid-file — killed here, but a fatal decode error
+        // ends it the same way — exits non-zero, which is what separates it from
+        // a source that simply ran out of pictures.
+        if let Some(child) = lock_recovering(&decoder.child).as_mut() {
+            let _ = child.kill();
+        }
+        assert!(
+            !decoder.child_finished_successfully(),
+            "a child that died must not be read as a clean end of stream"
+        );
+        assert_eq!(
+            decoder.first_missing, None,
+            "nothing so far has proved the source ends anywhere"
+        );
+
+        // Reading past the actual end is the case that *is* the end: FFmpeg runs
+        // out of pictures and exits reporting success.
+        assert!(decoder.frame_at_index(TEST_FRAMES + 500).is_err());
+        assert_eq!(
+            decoder.first_missing,
+            Some(SeekTarget::Frame(TEST_FRAMES + 500)),
+            "a clean end of stream is the one failure worth remembering"
+        );
+
+        // And the addresses that do exist still work afterwards.
+        decoder
+            .frame_at_index(11)
+            .unwrap_or_else(|error| panic!("frame 11 must still decode: {error}"));
+        assert_eq!(decoder.first_missing, None);
+    }
+
+    /// Feature: resident preview decoding
+    /// Scenario: releasing the pool does not let an in-flight read respawn
+    ///
+    /// Recovering from a dead child by re-seeking is what makes a crashed
+    /// decoder self-healing, and it is exactly the wrong response to a
+    /// deliberate release: it would start an FFmpeg the pool no longer tracks.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn a_released_decoder_refuses_to_respawn() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let Some(ffprobe) = ffprobe_beside(&ffmpeg) else {
+            return;
+        };
+        let Ok(directory) = TempDir::new("released") else {
+            return;
+        };
+        let Some(source) = write_source(&ffmpeg, directory.path()) else {
+            return;
+        };
+
+        let pool = PreviewDecoderPool::new(ffmpeg, ffprobe);
+        pool.frame_at(&source, 0.0, TEST_WIDTH, TEST_HEIGHT)
+            .unwrap_or_else(|error| panic!("the first frame must decode: {error}"));
+
+        let slot = {
+            let slots = lock_recovering(&pool.slots);
+            let Some(slot) = slots.first() else {
+                panic!("a decoded frame must have left a resident decoder");
+            };
+            Arc::clone(slot)
+        };
+
+        pool.release_all();
+
+        let mut decoder = lock_recovering(&slot.decoder);
+        let outcome = decoder.frame_at_index(90);
+        let child_pid = decoder.child_pid;
+        drop(decoder);
+
+        assert!(
+            outcome.is_err(),
+            "a released decoder must refuse the frame rather than start a new FFmpeg"
+        );
+        assert!(
+            child_pid.is_none(),
+            "a released decoder must not be holding a child"
+        );
+    }
+}

--- a/src-tauri/src/core/preview/mod.rs
+++ b/src-tauri/src/core/preview/mod.rs
@@ -1,0 +1,20 @@
+//! Canvas preview decoding.
+//!
+//! The canvas preview player composites one drawable per active clip per
+//! displayed frame. This module supplies those drawables from a small pool of
+//! long-lived FFmpeg processes streaming raw RGBA, replacing the previous
+//! spawn-encode-write-read-decode round trip per frame.
+
+#[cfg(all(not(test), feature = "gui"))]
+mod commands;
+pub mod decoder;
+mod state;
+
+#[cfg(all(not(test), feature = "gui"))]
+pub use commands::*;
+pub use decoder::{
+    classify_timing, fitted_output_size, frame_index_for_time, seek_argument,
+    seek_argument_seconds, PreviewDecoderPool, PreviewFrame, SourceInfo, SourceTiming,
+    DEFAULT_MAX_RESIDENT_DECODERS,
+};
+pub use state::{create_preview_decoder_state, PreviewDecoderState, SharedPreviewDecoders};

--- a/src-tauri/src/core/preview/state.rs
+++ b/src-tauri/src/core/preview/state.rs
@@ -1,0 +1,112 @@
+//! Managed state holding the resident preview decoder pool.
+//!
+//! The pool is built lazily rather than at startup because FFmpeg detection is
+//! itself asynchronous and may not have finished by the time the first preview
+//! frame is asked for.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use super::decoder::PreviewDecoderPool;
+use crate::core::ffmpeg::SharedFFmpegState;
+
+/// The lazily built pool behind the preview frame command.
+#[derive(Default)]
+pub struct PreviewDecoderState {
+    pool: RwLock<Option<Arc<PreviewDecoderPool>>>,
+}
+
+/// The managed-state handle registered with the application.
+pub type SharedPreviewDecoders = Arc<PreviewDecoderState>;
+
+/// Creates the preview decoder state to register with `manage`.
+pub fn create_preview_decoder_state() -> SharedPreviewDecoders {
+    Arc::new(PreviewDecoderState::default())
+}
+
+impl PreviewDecoderState {
+    /// The pool, building it from the resolved FFmpeg binaries on first use.
+    ///
+    /// Uses whatever FFmpeg detection resolved rather than a path of its own, so
+    /// the preview cannot end up on a different binary from the rest of the app.
+    pub async fn pool(
+        &self,
+        ffmpeg_state: &SharedFFmpegState,
+    ) -> Result<Arc<PreviewDecoderPool>, String> {
+        if let Some(pool) = self.pool.read().await.as_ref() {
+            return Ok(Arc::clone(pool));
+        }
+
+        let (ffmpeg_path, ffprobe_path) = {
+            let ffmpeg_state = ffmpeg_state.read().await;
+            let info = ffmpeg_state
+                .runner()
+                .ok_or_else(|| "FFmpeg not available".to_string())?
+                .info();
+            (info.ffmpeg_path.clone(), info.ffprobe_path.clone())
+        };
+
+        let mut guard = self.pool.write().await;
+        // Another caller may have won the race between the two locks.
+        if let Some(pool) = guard.as_ref() {
+            return Ok(Arc::clone(pool));
+        }
+
+        let pool = Arc::new(PreviewDecoderPool::new(ffmpeg_path, ffprobe_path));
+        *guard = Some(Arc::clone(&pool));
+        Ok(pool)
+    }
+
+    /// Kills every resident decoder and forgets the pool.
+    ///
+    /// Called when the preview goes away (unmount, project close, app exit) so
+    /// no FFmpeg outlives the thing that was displaying its frames.
+    ///
+    /// The teardown kills, waits and joins, and can block for as long as an
+    /// in-flight read, so it runs on a blocking thread rather than on an async
+    /// worker.
+    pub async fn release_all(&self) {
+        let pool = self.pool.write().await.take();
+        let Some(pool) = pool else {
+            return;
+        };
+
+        if tokio::task::spawn_blocking(move || pool.release_all())
+            .await
+            .is_err()
+        {
+            tracing::warn!("Preview decoder teardown task failed to run to completion");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feature: preview decoder lifecycle
+    /// Scenario: releasing an unused state is harmless
+    #[tokio::test]
+    async fn releasing_before_any_frame_is_a_no_op() {
+        let state = create_preview_decoder_state();
+        state.release_all().await;
+        state.release_all().await;
+    }
+
+    /// Feature: preview decoder lifecycle
+    /// Scenario: no pool is built while FFmpeg is still unresolved
+    #[tokio::test]
+    async fn the_pool_is_refused_until_ffmpeg_resolves() {
+        let state = create_preview_decoder_state();
+        let ffmpeg_state = crate::core::ffmpeg::create_ffmpeg_state();
+
+        match state.pool(&ffmpeg_state).await {
+            Ok(_) => panic!("an unresolved FFmpeg must not produce a pool"),
+            Err(error) => assert!(
+                error.contains("FFmpeg not available"),
+                "the error must say FFmpeg is missing, got: {error}"
+            ),
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1906,10 +1906,14 @@ mod tauri_app {
     pub fn run() {
         // Create shared FFmpeg state
         let ffmpeg_state = create_ffmpeg_state();
+        // Resident preview decoders. Built lazily on the first preview frame,
+        // because FFmpeg detection has not necessarily finished by now.
+        let preview_decoders = crate::core::preview::create_preview_decoder_state();
 
         let builder = tauri::Builder::default()
             .manage(AppState::new())
             .manage(ffmpeg_state.clone())
+            .manage(preview_decoders.clone())
             .plugin(tauri_plugin_dialog::init());
 
         // Enable updater for release builds by default. Development builds can
@@ -2287,6 +2291,11 @@ mod tauri_app {
             crate::core::ffmpeg::generate_thumbnail,
             crate::core::ffmpeg::probe_media,
             crate::core::ffmpeg::generate_waveform,
+            // Resident preview decoder. Deliberately outside `collect_commands!`:
+            // it answers with raw bytes (`tauri::ipc::Response`), which Specta
+            // cannot describe, and the frontend calls it through `invoke`.
+            crate::core::preview::get_preview_frame,
+            crate::core::preview::release_preview_decoders,
             // Performance/Memory commands
             ipc::get_memory_stats,
             ipc::trigger_memory_cleanup,
@@ -2456,11 +2465,26 @@ mod tauri_app {
                 // Defensive: ignore individual teardown errors so exit always
                 // proceeds. `block_on` is safe here — the run callback executes
                 // on the main thread, not a tokio worker.
+                let preview_decoders =
+                    app_handle.state::<crate::core::preview::SharedPreviewDecoders>();
                 tauri::async_runtime::block_on(async {
                     crate::ipc::shutdown_all_claude_headless_sessions(&state).await;
                     crate::ipc::shutdown_all_claude_login_sessions(&state).await;
                     crate::ipc::shutdown_all_codex_login_sessions(&state).await;
                     crate::ipc::shutdown_all_codex_app_servers(&state).await;
+                    // Resident FFmpeg decoders are not reaped by `std::process::exit`
+                    // either, so they are killed explicitly alongside the agents.
+                    // Bounded: a decoder wedged on a pipe read must not be able
+                    // to hold the whole application open.
+                    if tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        preview_decoders.release_all(),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        tracing::warn!("Preview decoder teardown timed out during exit");
+                    }
                 });
             }
         });

--- a/src/components/preview/TimelinePreviewPlayer.test.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.test.tsx
@@ -8,7 +8,15 @@ import type { Asset, Clip, Sequence, Track } from '@/types';
 
 const frameBufferMock = vi.hoisted(() => ({
   getFrame: vi.fn(),
+  beginRenderPass: vi.fn(),
+  clearAll: vi.fn().mockResolvedValue(undefined),
 }));
+
+/**
+ * The box the resident decoder fits a frame inside: the offscreen compositing
+ * canvas, which mirrors the visible canvas' backing store.
+ */
+const FRAME_TARGET = { maxWidth: 640, maxHeight: 360 };
 
 vi.mock('@/services/videoFrameBuffer', () => ({
   videoFrameBuffer: frameBufferMock,
@@ -183,7 +191,7 @@ function createSequence(): Sequence {
 describe('TimelinePreviewPlayer', () => {
   beforeEach(() => {
     installCanvasMock();
-    frameBufferMock.getFrame.mockReturnValue(new Promise<string | null>(() => {}));
+    frameBufferMock.getFrame.mockReturnValue(new Promise<ImageBitmap | null>(() => {}));
     usePlaybackStore.getState().reset();
     usePlaybackStore.setState({
       currentTime: 2,
@@ -211,7 +219,12 @@ describe('TimelinePreviewPlayer', () => {
     render(<TimelinePreviewPlayer showControls={false} />);
 
     await waitFor(() => {
-      expect(frameBufferMock.getFrame).toHaveBeenCalledWith('asset-1', '/tmp/asset-1.mp4', 2);
+      expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+        'asset-1',
+        '/tmp/asset-1.mp4',
+        2,
+        FRAME_TARGET,
+      );
     });
 
     const visibleCanvas = screen.getByTestId('preview-canvas') as HTMLCanvasElement;
@@ -221,6 +234,78 @@ describe('TimelinePreviewPlayer', () => {
     expect(visibleContext!.fillRect).not.toHaveBeenCalled();
     expect(visibleContext!.clearRect).not.toHaveBeenCalled();
     expect(visibleContext!.drawImage).not.toHaveBeenCalled();
+  });
+
+  it('asks for a larger frame when a clip is zoomed so the preview stays sharp', async () => {
+    // A clip scaled to 2x draws its frame at twice the canvas size. Decoding at
+    // canvas size would upscale it on screen, which is softer than the
+    // full-resolution extraction this path replaced.
+    const clip = createClip('clip-1', 'asset-1');
+    clip.transform.scale = { x: 2, y: 2 };
+    const sequence = createSequence();
+    sequence.tracks = [createVideoTrack('track-1', clip)];
+    useProjectStore.setState({
+      activeSequenceId: sequence.id,
+      sequences: new Map([[sequence.id, sequence]]),
+      stateVersion: 1,
+    });
+
+    render(<TimelinePreviewPlayer showControls={false} />);
+
+    await waitFor(() => {
+      expect(frameBufferMock.getFrame).toHaveBeenCalledWith('asset-1', '/tmp/asset-1.mp4', 2, {
+        maxWidth: 1280,
+        maxHeight: 720,
+      });
+    });
+  });
+
+  it('sizes a zoom animation by its widest keyframe so one decoder serves the whole move', async () => {
+    // Sizing by the instantaneous scale would ask for a different frame size
+    // every rendered frame, which thrashes both the frame cache and the pool of
+    // resident decoders behind it.
+    const clip = createClip('clip-1', 'asset-1');
+    clip.motionKeyframes = [
+      {
+        timeOffset: 0,
+        interpolation: 'linear',
+        transform: {
+          position: { x: 0.5, y: 0.5 },
+          scale: { x: 1, y: 1 },
+          rotationDeg: 0,
+          anchor: { x: 0.5, y: 0.5 },
+        },
+      },
+      {
+        timeOffset: 8,
+        interpolation: 'linear',
+        transform: {
+          position: { x: 0.5, y: 0.5 },
+          scale: { x: 1.5, y: 1.5 },
+          rotationDeg: 0,
+          anchor: { x: 0.5, y: 0.5 },
+        },
+      },
+    ];
+    const sequence = createSequence();
+    sequence.tracks = [createVideoTrack('track-1', clip)];
+    useProjectStore.setState({
+      activeSequenceId: sequence.id,
+      sequences: new Map([[sequence.id, sequence]]),
+      stateVersion: 1,
+    });
+
+    render(<TimelinePreviewPlayer showControls={false} />);
+
+    await waitFor(() => {
+      expect(frameBufferMock.getFrame).toHaveBeenCalled();
+    });
+
+    // At t=2 the interpolated scale is 1.125, but the box is the clip's widest.
+    const targets = frameBufferMock.getFrame.mock.calls.map((call) => call[3]);
+    for (const target of targets) {
+      expect(target).toEqual({ maxWidth: 960, maxHeight: 540 });
+    }
   });
 
   it('reports the visible preview canvas lifecycle for finishing tools', async () => {
@@ -254,26 +339,37 @@ describe('TimelinePreviewPlayer', () => {
     render(<TimelinePreviewPlayer showControls={false} />);
 
     await waitFor(() => {
-      expect(frameBufferMock.getFrame).toHaveBeenCalledWith('asset-1', '/tmp/asset-1.mp4', 2);
+      expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+        'asset-1',
+        '/tmp/asset-1.mp4',
+        2,
+        FRAME_TARGET,
+      );
     });
 
     expect(frameBufferMock.getFrame).not.toHaveBeenCalledWith(
       '__text__title',
       expect.anything(),
       expect.anything(),
+      expect.anything(),
     );
   });
 
   it('coalesces rapid render requests while frame extraction is pending', async () => {
-    const firstExtraction = createDeferred<string | null>();
+    const firstExtraction = createDeferred<ImageBitmap | null>();
     frameBufferMock.getFrame
       .mockImplementationOnce(() => firstExtraction.promise)
-      .mockReturnValue(new Promise<string | null>(() => {}));
+      .mockReturnValue(new Promise<ImageBitmap | null>(() => {}));
 
     render(<TimelinePreviewPlayer showControls={false} />);
 
     await waitFor(() => {
-      expect(frameBufferMock.getFrame).toHaveBeenCalledWith('asset-1', '/tmp/asset-1.mp4', 2);
+      expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+        'asset-1',
+        '/tmp/asset-1.mp4',
+        2,
+        FRAME_TARGET,
+      );
     });
 
     act(() => {
@@ -294,8 +390,18 @@ describe('TimelinePreviewPlayer', () => {
       expect(frameBufferMock.getFrame).toHaveBeenCalledTimes(2);
     });
 
-    expect(frameBufferMock.getFrame).toHaveBeenLastCalledWith('asset-1', '/tmp/asset-1.mp4', 4);
-    expect(frameBufferMock.getFrame).not.toHaveBeenCalledWith('asset-1', '/tmp/asset-1.mp4', 3);
+    expect(frameBufferMock.getFrame).toHaveBeenLastCalledWith(
+      'asset-1',
+      '/tmp/asset-1.mp4',
+      4,
+      FRAME_TARGET,
+    );
+    expect(frameBufferMock.getFrame).not.toHaveBeenCalledWith(
+      'asset-1',
+      '/tmp/asset-1.mp4',
+      3,
+      FRAME_TARGET,
+    );
   });
   it('renders the transform overlay for a single selected clip', () => {
     useTimelineStore.setState({ selectedClipIds: ['clip-1'] });

--- a/src/components/preview/TimelinePreviewPlayer.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.tsx
@@ -23,13 +23,14 @@ import { usePlaybackLoop } from '@/hooks/usePlaybackLoop';
 import { useSequenceRenderGraph } from '@/hooks/useSequenceRenderGraph';
 import { useSequenceTextClipData } from '@/hooks/useSequenceTextClipData';
 import { videoFrameBuffer } from '@/services/videoFrameBuffer';
+import type { PreviewFrameTarget } from '@/services/videoFrameBuffer';
 import {
   applyClipTransformToRenderedTextData,
   extractTextDataFromClipWithMap,
   renderTextToCanvas,
 } from '@/utils/textRenderer';
 import { getClipSourceTimeAtTimelineTime, isClipActiveAtTime } from '@/utils/clipTiming';
-import { getClipMotionTransformAtTime } from '@/utils/clipMotion';
+import { getClipMaxMotionScale, getClipMotionTransformAtTime } from '@/utils/clipMotion';
 import { computeContainFit, scaleFontSizeToCanvas } from '@/utils/previewCoords';
 import { getActiveVisualLayers } from '@/utils/renderGraphLayers';
 import { isCaptionLikeClip } from '@/utils/captionClip';
@@ -96,7 +97,7 @@ interface ActiveClipInfo {
   asset: Asset | undefined;
 }
 
-type DrawableVisual = HTMLImageElement | HTMLCanvasElement;
+type DrawableVisual = HTMLImageElement | HTMLCanvasElement | ImageBitmap;
 
 // =============================================================================
 // Constants
@@ -106,6 +107,44 @@ const DEFAULT_ASPECT_RATIO = 16 / 9;
 const DEFAULT_WIDTH = 640;
 const DEFAULT_HEIGHT = 360;
 const MAX_COMPOUND_RENDER_DEPTH = 6;
+
+/** How long the render pump waits before retrying a frame that threw. */
+const RENDER_RETRY_DELAY_MS = 50;
+
+/**
+ * The most a clip's zoom may enlarge its decode box beyond the canvas.
+ *
+ * A clip scaled past 1 draws its frame larger than the canvas, so decoding at
+ * canvas size would show a soft picture where the old full-resolution extraction
+ * showed a sharp one. The cap keeps an extreme zoom from asking for a frame
+ * whose pixels dwarf everything else on screen; the decoder never upscales past
+ * the source's own resolution either way.
+ */
+const MAX_PREVIEW_DECODE_SCALE = 4;
+
+/**
+ * The decode box for a clip: the canvas, enlarged by the most this clip's
+ * transform ever magnifies its frame.
+ *
+ * Uses the clip's maximum scale rather than its scale at this instant so an
+ * animated zoom keeps asking for one size, which is what lets a single resident
+ * decoder and a single set of cache entries serve the whole move.
+ */
+function frameTargetForClip(
+  clip: Clip,
+  canvasWidth: number,
+  canvasHeight: number,
+): PreviewFrameTarget {
+  const zoom = Math.min(
+    MAX_PREVIEW_DECODE_SCALE,
+    Math.max(1, getClipMaxMotionScale(clip)),
+  );
+
+  return {
+    maxWidth: Math.max(1, Math.round(canvasWidth * zoom)),
+    maxHeight: Math.max(1, Math.round(canvasHeight * zoom)),
+  };
+}
 
 /** Map BlendMode to Canvas globalCompositeOperation.
  * Canvas 2D only supports a subset of blend modes natively.
@@ -343,20 +382,21 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 
   /**
    * Extract a frame for a specific asset at a given time.
-   * Uses the VideoFrameBuffer for optimized dual-frame buffering and smart seeking.
    *
-   * Features:
-   * - Dual-frame buffer (current + next frame prefetch)
-   * - Smart seeking: iterate forward for small jumps
-   * - Automatic deduplication of pending requests
+   * Frames come from the resident decoder through the VideoFrameBuffer, which
+   * handles caching and deduplication. `target` is the canvas the frame will be
+   * composited into: the decoder fits the frame inside it without changing its
+   * aspect ratio, so the contain-fit below still sees the source's own shape.
    */
   const extractFrameForAsset = useCallback(
-    async (assetId: string, assetPath: string, timeSec: number): Promise<string | null> => {
-      // Use the advanced VideoFrameBuffer for optimized frame fetching
-      // It handles caching, deduplication, and prefetching internally
+    async (
+      assetId: string,
+      assetPath: string,
+      timeSec: number,
+      target: PreviewFrameTarget,
+    ): Promise<ImageBitmap | null> => {
       try {
-        const frameUrl = await videoFrameBuffer.getFrame(assetId, assetPath, timeSec);
-        return frameUrl;
+        return await videoFrameBuffer.getFrame(assetId, assetPath, timeSec, target);
       } catch (error) {
         // Log extraction failure with structured data for debugging
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -428,26 +468,33 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
           );
         });
 
+        // Video frames arrive as drawables straight from the resident decoder;
+        // stills still go through an <img>, which is what decodes them.
+        const canvasWidth = targetCtx.canvas.width;
+        const canvasHeight = targetCtx.canvas.height;
+
         const frameResults = await Promise.all(
           mediaClips.map(async (clipInfo) => {
             if (!clipInfo.asset) {
-              return { clipInfo, imgUrl: null as string | null };
+              return { clipInfo, imgUrl: null as string | null, frame: null as DrawableVisual | null };
             }
 
             if (clipInfo.asset.kind === 'image') {
               return {
                 clipInfo,
                 imgUrl: convertFileSrc(clipInfo.asset.uri),
+                frame: null as DrawableVisual | null,
               };
             }
 
-            const frameUrl = await extractFrameForAsset(
+            const frame = await extractFrameForAsset(
               clipInfo.asset.id,
               clipInfo.asset.uri,
               clipInfo.sourceTime,
+              frameTargetForClip(clipInfo.clip, canvasWidth, canvasHeight),
             );
 
-            return { clipInfo, imgUrl: frameUrl };
+            return { clipInfo, imgUrl: null as string | null, frame: frame as DrawableVisual | null };
           }),
         );
 
@@ -456,12 +503,12 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         }
 
         const loadedFrames = await Promise.all(
-          frameResults.map(async ({ clipInfo, imgUrl }) => {
+          frameResults.map(async ({ clipInfo, imgUrl, frame }) => {
             if (!imgUrl) {
-              return { clipInfo, img: null as HTMLImageElement | null };
+              return { clipInfo, img: frame };
             }
 
-            return new Promise<{ clipInfo: ActiveClipInfo; img: HTMLImageElement | null }>(
+            return new Promise<{ clipInfo: ActiveClipInfo; img: DrawableVisual | null }>(
               (resolve) => {
                 const img = new Image();
                 img.crossOrigin = 'anonymous';
@@ -477,7 +524,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
           return false;
         }
 
-        const mediaFrameByClipId = new Map<string, HTMLImageElement>();
+        const mediaFrameByClipId = new Map<string, DrawableVisual>();
         for (const { clipInfo, img } of loadedFrames) {
           if (img) {
             mediaFrameByClipId.set(clipInfo.clip.id, img);
@@ -509,6 +556,14 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
             const nestedCtx = nestedCanvas.getContext('2d');
             if (!nestedCtx) {
               continue;
+            }
+
+            // A nested sequence issues a whole new batch of frame requests.
+            // Staleness alone does not cover an unmount: the player can be gone
+            // by the time the outer batch resolves, and its frame buffer may be
+            // midway through releasing the decoders.
+            if (!isMountedRef.current) {
+              return false;
             }
 
             const nestedTime = getClipSourceTimeAtTimelineTime(clip, timelineTime);
@@ -631,6 +686,11 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         return;
       }
 
+      // Every frame handed out from here until the next pass is protected from
+      // cache eviction, so a sequence with more clips than the cache's byte
+      // budget holds cannot have a frame closed under it mid-composite.
+      videoFrameBuffer.beginRenderPass();
+
       // Track loading state via ref to avoid re-renders during playback
       // Only update React state when transitioning between loading/not-loading
       const wasLoading = isLoadingRef.current;
@@ -699,7 +759,26 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
             }
 
             queuedRenderTimeRef.current = null;
-            await renderFrame(nextTime);
+            try {
+              await renderFrame(nextTime);
+            } catch (error) {
+              // A render can throw on a transient drawable failure — a cached
+              // frame released mid-composite, for instance. Dropping the pump
+              // here would leave the last good picture on a paused or scrubbing
+              // screen with nothing to replace it, so the time is re-queued and
+              // the next pass redraws it from a fresh frame.
+              console.error('[TimelinePreviewPlayer] Frame render failed:', {
+                timeSec: nextTime.toFixed(3),
+                error: error instanceof Error ? error.message : String(error),
+              });
+              if (queuedRenderTimeRef.current === null && isMountedRef.current) {
+                queuedRenderTimeRef.current = nextTime;
+                // Yield so a failure that repeats cannot spin the pump.
+                await new Promise((resolve) => {
+                  setTimeout(resolve, RENDER_RETRY_DELAY_MS);
+                });
+              }
+            }
           }
         } finally {
           renderPumpActiveRef.current = false;
@@ -746,6 +825,15 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
       requestRenderFrame(currentTime);
     }
   }, [currentTime, requestRenderFrame]);
+
+  // Release the decoded frames and the FFmpeg processes behind them when the
+  // canvas preview goes away, so nothing keeps decoding for a player that is no
+  // longer on screen.
+  useEffect(() => {
+    return () => {
+      videoFrameBuffer.clearAll();
+    };
+  }, []);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/services/playbackMonitor.ts
+++ b/src/services/playbackMonitor.ts
@@ -13,7 +13,10 @@
  */
 
 import { SYNC_THRESHOLDS } from '@/constants/precision';
-import { frameCache } from '@/services/frameCache';
+import {
+  PREVIEW_FRAME_CACHE_MAX_ENTRIES,
+  previewFrameCache,
+} from '@/services/previewFrameCache';
 import { videoFrameBuffer } from '@/services/videoFrameBuffer';
 import { createLogger } from '@/services/logger';
 
@@ -73,6 +76,7 @@ const SAMPLE_WINDOW_SIZE = 60; // ~2 seconds at 30fps
 
 /** Memory pressure threshold (% of cache full) */
 const MEMORY_PRESSURE_THRESHOLD = 0.9;
+
 
 // =============================================================================
 // PlaybackMonitor Class
@@ -251,17 +255,19 @@ export class PlaybackMonitor {
   checkMemoryPressure(): void {
     if (!this.isActive) return;
 
-    const cacheStats = frameCache.getStats();
-    const maxEntries = 100; // Should match FRAME_EXTRACTION.MAX_CACHE_ENTRIES
+    // The preview cache holds decoded RGBA frames, whose memory lives outside
+    // the JS heap, so its occupancy is what "memory pressure" means here.
+    const bufferStats = videoFrameBuffer.getStats();
+    const maxEntries = PREVIEW_FRAME_CACHE_MAX_ENTRIES;
 
-    const fillRatio = cacheStats.entryCount / maxEntries;
+    const fillRatio = bufferStats.bufferedFrames / maxEntries;
     if (fillRatio > MEMORY_PRESSURE_THRESHOLD) {
       this.memoryPressureEvents++;
 
       logger.warn('Frame cache memory pressure', {
         fillRatio: (fillRatio * 100).toFixed(1) + '%',
-        entries: cacheStats.entryCount,
-        sizeMB: (cacheStats.totalSizeBytes / 1024 / 1024).toFixed(2),
+        entries: bufferStats.bufferedFrames,
+        sizeMB: (bufferStats.bufferedBytes / 1024 / 1024).toFixed(2),
       });
     }
   }
@@ -270,7 +276,7 @@ export class PlaybackMonitor {
    * Get current session statistics.
    */
   getStats(): SessionStats {
-    const cacheStats = frameCache.getStats();
+    const cacheStats = previewFrameCache.getStats();
     const bufferStats = videoFrameBuffer.getStats();
 
     // Calculate frame stats

--- a/src/services/previewFrameCache.test.ts
+++ b/src/services/previewFrameCache.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Feature: bounded preview frame cache
+ *
+ * Decoded preview frames are `ImageBitmap`s whose memory lives outside the JS
+ * heap and is only released by `close()`. A cache that forgets an entry without
+ * closing it leaks that memory for the life of the process, so every path that
+ * drops a frame has to close it.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createPreviewFrameKey,
+  createPreviewTimeKey,
+  PreviewFrameCache,
+  type ClosablePreviewFrame,
+} from '@/services/previewFrameCache';
+
+interface FakeFrame extends ClosablePreviewFrame {
+  close: ReturnType<typeof vi.fn>;
+}
+
+/** A stand-in for an `ImageBitmap` that records whether it was released. */
+function createFrame(width: number, height: number): FakeFrame {
+  return { width, height, close: vi.fn() };
+}
+
+describe('PreviewFrameCache', () => {
+  it('should return the frame it stored when the key is read back', () => {
+    const cache = new PreviewFrameCache<FakeFrame>();
+    const frame = createFrame(4, 4);
+
+    cache.set('a', frame);
+
+    expect(cache.get('a')).toBe(frame);
+    expect(cache.has('a')).toBe(true);
+  });
+
+  it('should report a miss as null rather than throwing', () => {
+    const cache = new PreviewFrameCache<FakeFrame>();
+
+    expect(cache.get('absent')).toBeNull();
+    expect(cache.getStats().misses).toBe(1);
+  });
+
+  it('should close the least recently used frame when the entry bound is exceeded', () => {
+    const cache = new PreviewFrameCache<FakeFrame>({ maxEntries: 2 });
+    const first = createFrame(2, 2);
+    const second = createFrame(2, 2);
+    const third = createFrame(2, 2);
+
+    cache.set('first', first);
+    cache.set('second', second);
+    cache.set('third', third);
+
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(cache.has('first')).toBe(false);
+    expect(cache.has('second')).toBe(true);
+    expect(cache.has('third')).toBe(true);
+    expect(cache.getStats().entries).toBe(2);
+  });
+
+  it('should treat a read as use so the least recently used frame is the one evicted', () => {
+    const cache = new PreviewFrameCache<FakeFrame>({ maxEntries: 2 });
+    const first = createFrame(2, 2);
+    const second = createFrame(2, 2);
+    const third = createFrame(2, 2);
+
+    cache.set('first', first);
+    cache.set('second', second);
+    // Reading `first` makes `second` the oldest.
+    cache.get('first');
+    cache.set('third', third);
+
+    expect(second.close).toHaveBeenCalledTimes(1);
+    expect(first.close).not.toHaveBeenCalled();
+    expect(cache.has('first')).toBe(true);
+  });
+
+  it('should evict by real frame bytes rather than a per-entry guess', () => {
+    // Two 100x100 RGBA frames are 40000 bytes each.
+    const cache = new PreviewFrameCache<FakeFrame>({
+      maxEntries: 100,
+      maxBytes: 50_000,
+      minEntries: 1,
+    });
+    const first = createFrame(100, 100);
+    const second = createFrame(100, 100);
+
+    cache.set('first', first);
+    expect(cache.getStats().bytes).toBe(40_000);
+
+    cache.set('second', second);
+
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(cache.getStats().entries).toBe(1);
+    expect(cache.getStats().bytes).toBe(40_000);
+  });
+
+  it('should keep the frame it just stored even when that frame alone is over budget', () => {
+    const cache = new PreviewFrameCache<FakeFrame>({
+      maxEntries: 4,
+      maxBytes: 1_000,
+      minEntries: 1,
+    });
+    const oversized = createFrame(100, 100);
+
+    cache.set('oversized', oversized);
+
+    expect(oversized.close).not.toHaveBeenCalled();
+    expect(cache.get('oversized')).toBe(oversized);
+  });
+
+  it('should close the frame it replaces when a key is written twice', () => {
+    const cache = new PreviewFrameCache<FakeFrame>();
+    const original = createFrame(2, 2);
+    const replacement = createFrame(2, 2);
+
+    cache.set('key', original);
+    cache.set('key', replacement);
+
+    expect(original.close).toHaveBeenCalledTimes(1);
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(cache.get('key')).toBe(replacement);
+  });
+
+  it('should let a pass exceed the byte budget rather than close what it is drawing', () => {
+    // The compositor gathers every visible clip's frame and only then draws
+    // them, so a later frame in the same pass must not be able to evict — and
+    // therefore close — an earlier one it is still holding. Twenty 100x100
+    // frames are 800 KB against a 1 KB budget.
+    const cache = new PreviewFrameCache<FakeFrame>({
+      maxEntries: 50,
+      maxBytes: 1_000,
+      minEntries: 1,
+    });
+
+    cache.beginPass();
+    const frames = Array.from({ length: 20 }, () => createFrame(100, 100));
+    frames.forEach((frame, index) => {
+      cache.set(`frame-${index}`, frame);
+      cache.pin(frame);
+    });
+
+    for (const frame of frames) {
+      expect(frame.close).not.toHaveBeenCalled();
+    }
+    expect(cache.getStats().entries).toBe(20);
+    expect(cache.getStats().bytes).toBeGreaterThan(1_000);
+  });
+
+  it('should evict the previous pass once a new one begins', () => {
+    const cache = new PreviewFrameCache<FakeFrame>({
+      maxEntries: 10,
+      maxBytes: 50_000,
+      minEntries: 1,
+    });
+    const first = createFrame(100, 100);
+    const second = createFrame(100, 100);
+
+    cache.beginPass();
+    cache.set('first', first);
+    cache.pin(first);
+    expect(first.close).not.toHaveBeenCalled();
+
+    // A new pass releases the last one's protection, so the budget applies again.
+    cache.beginPass();
+    cache.set('second', second);
+    cache.pin(second);
+
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(second.close).not.toHaveBeenCalled();
+  });
+
+  it('should stop pinning once a pass reaches the entry ceiling', () => {
+    // Otherwise a pass that pinned everything would stop eviction outright and
+    // let the cache grow without bound.
+    const cache = new PreviewFrameCache<FakeFrame>({ maxEntries: 3 });
+
+    cache.beginPass();
+    for (let index = 0; index < 10; index += 1) {
+      cache.pin(createFrame(2, 2));
+    }
+
+    expect(cache.pinnedCount()).toBe(3);
+  });
+
+  it('should close every frame when the cache is cleared', () => {
+    const cache = new PreviewFrameCache<FakeFrame>();
+    const first = createFrame(2, 2);
+    const second = createFrame(2, 2);
+
+    cache.set('first', first);
+    cache.set('second', second);
+    cache.clear();
+
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(second.close).toHaveBeenCalledTimes(1);
+    expect(cache.getStats().entries).toBe(0);
+    expect(cache.getStats().bytes).toBe(0);
+  });
+
+  it('should survive a frame whose close throws', () => {
+    const cache = new PreviewFrameCache<FakeFrame>();
+    const frame: FakeFrame = {
+      width: 2,
+      height: 2,
+      close: vi.fn(() => {
+        throw new Error('already detached');
+      }),
+    };
+
+    cache.set('key', frame);
+
+    expect(() => cache.clear()).not.toThrow();
+  });
+});
+
+describe('preview frame cache keys', () => {
+  it('should separate the same frame decoded for different canvas sizes', () => {
+    expect(createPreviewFrameKey('asset-1', 12, 960, 540)).not.toBe(
+      createPreviewFrameKey('asset-1', 12, 480, 270),
+    );
+  });
+
+  it('should separate the same frame index across assets', () => {
+    expect(createPreviewFrameKey('asset-1', 12, 960, 540)).not.toBe(
+      createPreviewFrameKey('asset-2', 12, 960, 540),
+    );
+  });
+
+  it('should not collide a time key with a frame-index key', () => {
+    expect(createPreviewTimeKey('asset-1', 12, 960, 540)).not.toBe(
+      createPreviewFrameKey('asset-1', 12, 960, 540),
+    );
+  });
+});

--- a/src/services/previewFrameCache.ts
+++ b/src/services/previewFrameCache.ts
@@ -1,0 +1,315 @@
+/**
+ * PreviewFrameCache
+ *
+ * Bounded LRU cache of decoded preview frames.
+ *
+ * The frames it holds are `ImageBitmap`s, which own memory outside the JS heap
+ * and are only released by `close()`. Every eviction therefore closes the
+ * bitmap it drops, and the cache is bounded by real bytes (`width * height * 4`)
+ * rather than by a per-entry guess, because a 960x540 frame and a 1920x1080 one
+ * differ by 4x.
+ */
+
+import { createLogger } from '@/services/logger';
+
+const logger = createLogger('PreviewFrameCache');
+
+/** Bytes an RGBA pixel occupies. */
+const BYTES_PER_PIXEL = 4;
+
+/** Default ceiling on cached frames. */
+export const PREVIEW_FRAME_CACHE_MAX_ENTRIES = 96;
+
+/**
+ * Default ceiling on cached frame bytes.
+ *
+ * Which of the two bounds binds depends entirely on the footage: a 960x540
+ * frame is 2 MB, so the entry count runs out first, while a full-resolution
+ * 1080p frame is 8.3 MB and roughly twenty-three of them exhaust this instead.
+ * That is the intended behaviour — the budget is about memory, not about frames.
+ */
+const DEFAULT_MAX_BYTES = 192 * 1024 * 1024;
+
+/**
+ * Frames the cache keeps regardless of the byte budget.
+ *
+ * A compositing pass draws every visible clip, so a cache that cannot hold a
+ * whole pass would evict frames the very next pass asks for again. This floor
+ * keeps a working set alive even when the frames are large enough that the byte
+ * budget alone would not.
+ */
+const DEFAULT_MIN_ENTRIES = 12;
+
+/**
+ * What the cache stores: anything with intrinsic pixel dimensions that can be
+ * released. `ImageBitmap` satisfies this.
+ */
+export interface ClosablePreviewFrame {
+  readonly width: number;
+  readonly height: number;
+  close(): void;
+}
+
+export interface PreviewFrameCacheOptions {
+  /** Maximum number of frames held at once. */
+  maxEntries?: number;
+  /** Maximum total bytes held at once. */
+  maxBytes?: number;
+  /** Frames kept even when they exceed the byte budget between them. */
+  minEntries?: number;
+}
+
+export interface PreviewFrameCacheStats {
+  /** Frames currently held. */
+  entries: number;
+  /** Bytes currently held. */
+  bytes: number;
+  /** Fraction of lookups that found a frame (0-1). */
+  hitRate: number;
+  /** Lookups that found a frame. */
+  hits: number;
+  /** Lookups that did not. */
+  misses: number;
+  /** Frames closed to stay inside the bounds. */
+  evictions: number;
+}
+
+interface CacheEntry<T extends ClosablePreviewFrame> {
+  frame: T;
+  bytes: number;
+}
+
+/**
+ * The cache key for one decoded frame.
+ *
+ * The output size is part of the key because a frame decoded for a 960x540
+ * canvas is not the frame a 480x270 canvas wants.
+ */
+export function createPreviewFrameKey(
+  assetId: string,
+  frameIndex: number,
+  width: number,
+  height: number,
+): string {
+  return `${assetId}|${width}x${height}|#${frameIndex}`;
+}
+
+/**
+ * The cache key for a frame that can only be named by the time it answers for.
+ *
+ * Used before the first reply has said how a source is addressed, and for the
+ * whole life of a variable-rate source, whose presentation times are not a
+ * multiple of any frame duration. Keyed to the millisecond.
+ */
+export function createPreviewTimeKey(
+  assetId: string,
+  timeSec: number,
+  width: number,
+  height: number,
+): string {
+  return `${assetId}|${width}x${height}|@${timeSec.toFixed(3)}`;
+}
+
+/**
+ * An LRU cache of decoded frames that closes what it drops.
+ */
+export class PreviewFrameCache<T extends ClosablePreviewFrame = ImageBitmap> {
+  /** Insertion order is the LRU order; a hit re-inserts to mark it recent. */
+  private readonly entries = new Map<string, CacheEntry<T>>();
+
+  /**
+   * Frames the current compositing pass has been handed and is about to draw.
+   *
+   * A pass gathers every visible clip's frame and only then draws them, so a
+   * later frame in the same pass can push the cache over budget and evict — and
+   * therefore `close()` — one the compositor is still holding. Drawing a
+   * detached bitmap throws, and retrying the pass hits the same eviction, so the
+   * preview thrashes instead of recovering. Pinned frames are skipped by
+   * eviction, which is what makes a pass safe no matter how many clips it draws.
+   */
+  private readonly pinned = new Set<T>();
+
+  private readonly maxEntries: number;
+  private readonly maxBytes: number;
+  private readonly minEntries: number;
+
+  private totalBytes = 0;
+  private hits = 0;
+  private misses = 0;
+  private evictions = 0;
+
+  constructor(options: PreviewFrameCacheOptions = {}) {
+    this.maxEntries = Math.max(1, options.maxEntries ?? PREVIEW_FRAME_CACHE_MAX_ENTRIES);
+    this.maxBytes = Math.max(1, options.maxBytes ?? DEFAULT_MAX_BYTES);
+    this.minEntries = Math.min(
+      this.maxEntries,
+      Math.max(1, options.minEntries ?? DEFAULT_MIN_ENTRIES),
+    );
+  }
+
+  /** The frame stored under `key`, or `null`. */
+  get(key: string): T | null {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+
+    // Re-insert so this key becomes the most recently used.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    this.hits++;
+    return entry.frame;
+  }
+
+  /** Whether a frame is stored under `key`, without affecting recency. */
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  /**
+   * Stores `frame` under `key`, closing whatever it replaces and evicting the
+   * least recently used frames until the cache is back inside its bounds.
+   *
+   * The frame just stored is never the one evicted, so a caller can always draw
+   * what it just put in.
+   */
+  set(key: string, frame: T): void {
+    const existing = this.entries.get(key);
+    if (existing) {
+      this.entries.delete(key);
+      this.totalBytes -= existing.bytes;
+      if (existing.frame !== frame) {
+        closeFrame(existing.frame);
+      }
+    }
+
+    const bytes = frame.width * frame.height * BYTES_PER_PIXEL;
+    this.entries.set(key, { frame, bytes });
+    this.totalBytes += bytes;
+
+    this.evictUntilWithinBounds(key);
+  }
+
+  /** Drops and closes the frame stored under `key`, if any. */
+  delete(key: string): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+
+    this.entries.delete(key);
+    this.totalBytes -= entry.bytes;
+    closeFrame(entry.frame);
+  }
+
+  /**
+   * Starts a compositing pass: releases the previous pass's pins.
+   *
+   * Pins are released at the *start* of a pass rather than the end so a pass
+   * that throws part-way cannot strand them and stop the cache evicting.
+   */
+  beginPass(): void {
+    this.pinned.clear();
+  }
+
+  /**
+   * Protects `frame` from eviction until the next {@link beginPass}.
+   *
+   * Ignored once the pinned set has grown to the entry ceiling, because a pass
+   * that pins everything would stop eviction altogether and let the cache grow
+   * without bound. A pass with that many clips is already past what the preview
+   * can composite.
+   */
+  pin(frame: T): void {
+    if (this.pinned.size >= this.maxEntries) {
+      return;
+    }
+
+    this.pinned.add(frame);
+  }
+
+  /** Frames currently protected from eviction. */
+  pinnedCount(): number {
+    return this.pinned.size;
+  }
+
+  /** Drops and closes every frame. */
+  clear(): void {
+    this.pinned.clear();
+    for (const entry of this.entries.values()) {
+      closeFrame(entry.frame);
+    }
+    this.entries.clear();
+    this.totalBytes = 0;
+  }
+
+  /** Current occupancy and hit rate. */
+  getStats(): PreviewFrameCacheStats {
+    const lookups = this.hits + this.misses;
+    return {
+      entries: this.entries.size,
+      bytes: this.totalBytes,
+      hitRate: lookups > 0 ? this.hits / lookups : 0,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+    };
+  }
+
+  /** Forgets hit/miss/eviction counters without touching the frames. */
+  resetStats(): void {
+    this.hits = 0;
+    this.misses = 0;
+    this.evictions = 0;
+  }
+
+  /**
+   * Evicts the oldest unpinned frames until both bounds hold, never evicting
+   * `keepKey`.
+   *
+   * The byte budget stops applying once the cache is down to `minEntries`, so
+   * large frames shrink the working set rather than emptying it. That floor is a
+   * thrash-avoidance heuristic, though — what actually guarantees the current
+   * pass keeps every frame it is drawing is the pinned set.
+   */
+  private evictUntilWithinBounds(keepKey: string): void {
+    while (
+      this.entries.size > this.maxEntries ||
+      (this.totalBytes > this.maxBytes && this.entries.size > this.minEntries)
+    ) {
+      let oldestKey: string | null = null;
+      for (const [key, entry] of this.entries) {
+        if (key !== keepKey && !this.pinned.has(entry.frame)) {
+          oldestKey = key;
+          break;
+        }
+      }
+
+      // Everything left is either the frame just stored or in use by the pass
+      // being composited. Dropping either would hand a caller a closed bitmap,
+      // so the budget is allowed to overshoot until the pass ends.
+      if (oldestKey === null) return;
+
+      const entry = this.entries.get(oldestKey);
+      this.entries.delete(oldestKey);
+      if (entry) {
+        this.totalBytes -= entry.bytes;
+        closeFrame(entry.frame);
+      }
+      this.evictions++;
+    }
+  }
+}
+
+/** Releases a frame's off-heap memory, tolerating an already-closed bitmap. */
+function closeFrame(frame: ClosablePreviewFrame): void {
+  try {
+    frame.close();
+  } catch (error) {
+    logger.debug('Closing a cached preview frame failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Cache shared by the canvas preview path. */
+export const previewFrameCache = new PreviewFrameCache();

--- a/src/services/videoFrameBuffer.test.ts
+++ b/src/services/videoFrameBuffer.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Feature: canvas preview frames from the resident decoder
+ *
+ * The canvas preview no longer reads JPEGs off disk: the Rust core streams raw
+ * RGBA from a long-lived FFmpeg and this service turns the reply into something
+ * the canvas can draw. Only the Tauri IPC boundary is mocked; the cache, the key
+ * derivation and the bitmap creation are the real ones.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { previewFrameCache } from '@/services/previewFrameCache';
+import { videoFrameBuffer } from '@/services/videoFrameBuffer';
+
+const invokeMock = vi.mocked(invoke);
+
+const TARGET = { maxWidth: 320, maxHeight: 180 };
+
+/** Size of the decoder's wire header. */
+const HEADER_BYTES = 32;
+
+/**
+ * The bytes the resident decoder puts on the wire: a 32-byte little-endian
+ * header followed by `width * height * 4` bytes of RGBA.
+ *
+ * A `frameIndex` of `null` is what a variable-rate source sends: a zero index
+ * with the indexed flag clear.
+ */
+function encodeFrameReply(options: {
+  width: number;
+  height: number;
+  frameIndex: number | null;
+  sourceTime: number;
+  fill?: number;
+}): ArrayBuffer {
+  const { width, height, frameIndex, sourceTime, fill = 0 } = options;
+  const pixelBytes = width * height * 4;
+  const buffer = new ArrayBuffer(HEADER_BYTES + pixelBytes);
+  const view = new DataView(buffer);
+
+  view.setUint32(0, 2, true);
+  view.setUint32(4, width, true);
+  view.setUint32(8, height, true);
+  view.setUint32(12, frameIndex ?? 0, true);
+  view.setFloat64(16, sourceTime, true);
+  view.setUint32(24, frameIndex === null ? 0 : 1, true);
+  view.setUint32(28, 0, true);
+  new Uint8Array(buffer, HEADER_BYTES).fill(fill);
+
+  return buffer;
+}
+
+/** An IPC reply the test releases by hand. */
+function createDeferredReply(): {
+  promise: Promise<ArrayBuffer>;
+  resolve: (value: ArrayBuffer) => void;
+} {
+  let resolve: (value: ArrayBuffer) => void = () => {};
+  const promise = new Promise<ArrayBuffer>((settle) => {
+    resolve = settle;
+  });
+
+  return { promise, resolve };
+}
+
+/** A void IPC reply the test releases by hand. */
+function createDeferredVoid(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((settle) => {
+    resolve = () => settle();
+  });
+
+  return { promise, resolve };
+}
+
+interface StubBitmap {
+  width: number;
+  height: number;
+  close: ReturnType<typeof vi.fn>;
+}
+
+const createdBitmaps: StubBitmap[] = [];
+
+beforeEach(() => {
+  createdBitmaps.length = 0;
+  invokeMock.mockReset();
+
+  // jsdom ships neither, and they are the browser boundary rather than our code.
+  vi.stubGlobal(
+    'ImageData',
+    class {
+      constructor(
+        public readonly data: Uint8ClampedArray,
+        public readonly width: number,
+        public readonly height: number,
+      ) {}
+    },
+  );
+  vi.stubGlobal('createImageBitmap', (source: { width: number; height: number }) => {
+    const bitmap: StubBitmap = { width: source.width, height: source.height, close: vi.fn() };
+    createdBitmaps.push(bitmap);
+    return Promise.resolve(bitmap);
+  });
+});
+
+afterEach(async () => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
+  await videoFrameBuffer.clearAll();
+  vi.unstubAllGlobals();
+});
+
+describe('VideoFrameBuffer', () => {
+  it('should return a drawable carrying the decoded frame size when the decoder replies', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    const frame = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+
+    expect(frame).not.toBeNull();
+    expect(frame?.width).toBe(320);
+    expect(frame?.height).toBe(180);
+  });
+
+  it('should ask the decoder for the canvas box rather than the full source size', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+
+    expect(invokeMock).toHaveBeenCalledWith('get_preview_frame', {
+      inputPath: '/tmp/a.mp4',
+      timeSec: 0.5,
+      maxWidth: 320,
+      maxHeight: 180,
+    });
+  });
+
+  it('should decode once when two nearby times resolve to the same frame', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    const first = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+    // 0.501 s at the 30 fps the first reply implies is still frame 15.
+    const second = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.501, TARGET);
+
+    expect(second).toBe(first);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(createdBitmaps).toHaveLength(1);
+  });
+
+  it('should decode again for a different frame of the same asset', async () => {
+    invokeMock
+      .mockResolvedValueOnce(
+        encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+      )
+      .mockResolvedValueOnce(
+        encodeFrameReply({ width: 320, height: 180, frameIndex: 30, sourceTime: 1 }),
+      );
+
+    const first = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+    const second = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 1, TARGET);
+
+    expect(second).not.toBe(first);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should share a single decode between concurrent requests for the same frame', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    const [first, second] = await Promise.all([
+      videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET),
+      videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET),
+    ]);
+
+    expect(second).toBe(first);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should resolve to null rather than reject when the decoder fails', async () => {
+    invokeMock.mockRejectedValue(new Error('No preview frame at index 900'));
+
+    const frame = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 30, TARGET);
+
+    expect(frame).toBeNull();
+    expect(videoFrameBuffer.getStats().failedRequests).toBe(1);
+  });
+
+  it('should resolve to null rather than reject when the reply is malformed', async () => {
+    invokeMock.mockResolvedValue(new ArrayBuffer(8));
+
+    const frame = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+
+    expect(frame).toBeNull();
+  });
+
+  it('should resolve to null when the reply carries fewer pixels than its header claims', async () => {
+    const truncated = encodeFrameReply({
+      width: 320,
+      height: 180,
+      frameIndex: 15,
+      sourceTime: 0.5,
+    }).slice(0, HEADER_BYTES + 16);
+    invokeMock.mockResolvedValue(truncated);
+
+    const frame = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+
+    expect(frame).toBeNull();
+  });
+
+  it('should close every cached frame and release the decoders when cleared', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+    await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+    expect(previewFrameCache.getStats().entries).toBe(1);
+
+    await videoFrameBuffer.clearAll();
+
+    expect(createdBitmaps[0]?.close).toHaveBeenCalledTimes(1);
+    expect(previewFrameCache.getStats().entries).toBe(0);
+    expect(invokeMock).toHaveBeenCalledWith('release_preview_decoders');
+  });
+
+  it('should not hand back a frame it has closed when two clips ask for one picture', async () => {
+    // The crossfade shape: the same asset visible twice at times a millisecond
+    // apart, on the very first render, before any reply has said how the source
+    // is addressed. Both requests converge on one cache entry, and closing the
+    // frame the other caller is about to draw is a detached-bitmap crash.
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    const [first, second] = await Promise.all([
+      videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET),
+      videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.501, TARGET),
+    ]);
+
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+    for (const bitmap of createdBitmaps) {
+      if (bitmap === first) {
+        expect(bitmap.close).not.toHaveBeenCalled();
+      }
+    }
+    expect(previewFrameCache.getStats().entries).toBe(1);
+  });
+
+  it('should not reach the decoder for work queued before a teardown', async () => {
+    // The leak this whole mechanism exists to stop: a request that arrives after
+    // the pool has been released rebuilds it, and nothing is left to tear the
+    // rebuilt one down.
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    const queued = [
+      videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 1, TARGET),
+      videoFrameBuffer.getFrame('asset-2', '/tmp/b.mp4', 2, TARGET),
+      videoFrameBuffer.getFrame('asset-3', '/tmp/c.mp4', 3, TARGET),
+      videoFrameBuffer.getFrame('asset-4', '/tmp/d.mp4', 4, TARGET),
+      videoFrameBuffer.getFrame('asset-5', '/tmp/e.mp4', 5, TARGET),
+    ];
+
+    await videoFrameBuffer.clearAll();
+    const results = await Promise.all(queued);
+
+    const frameCalls = invokeMock.mock.calls.filter(([command]) => command === 'get_preview_frame');
+    const releaseIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === 'release_preview_decoders',
+    );
+
+    expect(releaseIndex).toBeGreaterThanOrEqual(0);
+    expect(invokeMock.mock.calls.slice(releaseIndex + 1)).toEqual([]);
+    expect(frameCalls.length).toBeLessThanOrEqual(2);
+    expect(results.some((frame) => frame === null)).toBe(true);
+  });
+
+  it('should discard a frame that arrives after a teardown rather than caching it', async () => {
+    const held = createDeferredReply();
+    invokeMock.mockImplementation((command: string) =>
+      command === 'get_preview_frame' ? held.promise : Promise.resolve(undefined),
+    );
+
+    const pending = videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+    const cleared = videoFrameBuffer.clearAll();
+
+    held.resolve(encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }));
+
+    expect(await pending).toBeNull();
+    await cleared;
+    expect(previewFrameCache.getStats().entries).toBe(0);
+  });
+
+  it('should not reach the decoder for a request that starts during a teardown', async () => {
+    // The residual window: a request entering while clearAll is suspended
+    // captures the *new* epoch, so every epoch check passes, and it can still
+    // invoke after the release — which lazily rebuilds a pool of FFmpeg children
+    // with nothing left to reap them.
+    const heldRelease = createDeferredVoid();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'release_preview_decoders') {
+        return heldRelease.promise;
+      }
+      return Promise.resolve(
+        encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+      );
+    });
+
+    const countCalls = (command: string): number =>
+      invokeMock.mock.calls.filter(([name]) => name === command).length;
+
+    const cleared = videoFrameBuffer.clearAll();
+    // Run out the microtasks until the teardown has actually asked the backend
+    // to let go, so the request below is unambiguously inside the window.
+    for (let tick = 0; tick < 20 && countCalls('release_preview_decoders') === 0; tick += 1) {
+      await Promise.resolve();
+    }
+    expect(countCalls('release_preview_decoders')).toBe(1);
+
+    const framesBefore = countCalls('get_preview_frame');
+    const during = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+    const framesAfter = countCalls('get_preview_frame');
+
+    heldRelease.resolve();
+    await cleared;
+
+    expect(during).toBeNull();
+    expect(framesAfter).toBe(framesBefore);
+  });
+
+  it('should serve requests again once a teardown has finished', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    await videoFrameBuffer.clearAll();
+    const frame = await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+
+    expect(frame).not.toBeNull();
+  });
+
+  it('should keep the semaphore exact across a teardown', async () => {
+    // Zeroing the permit counter while permits are still held would double-count
+    // the returns and leave the buffer permanently over-permissive.
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    const queued = Array.from({ length: 6 }, (_, index) =>
+      videoFrameBuffer.getFrame(`asset-${index}`, `/tmp/${index}.mp4`, index, TARGET),
+    );
+    await videoFrameBuffer.clearAll();
+    await Promise.all(queued);
+
+    // The counter is private; its effect is observable — a fresh request must
+    // still be able to take a permit and complete.
+    const after = await videoFrameBuffer.getFrame('asset-9', '/tmp/9.mp4', 1, TARGET);
+    expect(after).not.toBeNull();
+  });
+
+  it('should pin the frames of one pass so none is closed while it is still drawing', async () => {
+    // A pass drawing more clips than the byte budget holds must still get every
+    // bitmap it asked for; closing one mid-composite throws on drawImage and the
+    // retry hits the same eviction.
+    invokeMock.mockImplementation(() =>
+      Promise.resolve(
+        encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+      ),
+    );
+
+    videoFrameBuffer.beginRenderPass();
+    const frames = await Promise.all(
+      Array.from({ length: 40 }, (_, index) =>
+        videoFrameBuffer.getFrame(`asset-${index}`, `/tmp/${index}.mp4`, 0.5, TARGET),
+      ),
+    );
+
+    expect(frames.every((frame) => frame !== null)).toBe(true);
+    for (const bitmap of createdBitmaps) {
+      expect(bitmap.close).not.toHaveBeenCalled();
+    }
+  });
+
+  it('should address a variable-rate source by time rather than inventing a frame rate', async () => {
+    // A reply with no frame index means the source has no index/time mapping.
+    // Keying it by a made-up rate would serve one picture for every time.
+    invokeMock
+      .mockResolvedValueOnce(
+        encodeFrameReply({ width: 320, height: 180, frameIndex: null, sourceTime: 0.1 }),
+      )
+      .mockResolvedValueOnce(
+        encodeFrameReply({ width: 320, height: 180, frameIndex: null, sourceTime: 0.2 }),
+      );
+
+    const first = await videoFrameBuffer.getFrame('asset-1', '/tmp/vfr.mp4', 0.1, TARGET);
+    const second = await videoFrameBuffer.getFrame('asset-1', '/tmp/vfr.mp4', 0.2, TARGET);
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBe(first);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(previewFrameCache.getStats().entries).toBe(2);
+  });
+
+  it('should still serve a variable-rate source from cache for a repeated time', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: null, sourceTime: 0.1 }),
+    );
+
+    const first = await videoFrameBuffer.getFrame('asset-1', '/tmp/vfr.mp4', 0.1, TARGET);
+    const second = await videoFrameBuffer.getFrame('asset-1', '/tmp/vfr.mp4', 0.1, TARGET);
+
+    expect(second).toBe(first);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should report the frames it is holding', async () => {
+    invokeMock.mockResolvedValue(
+      encodeFrameReply({ width: 320, height: 180, frameIndex: 15, sourceTime: 0.5 }),
+    );
+
+    await videoFrameBuffer.getFrame('asset-1', '/tmp/a.mp4', 0.5, TARGET);
+    const stats = videoFrameBuffer.getStats();
+
+    expect(stats.activeAssets).toBe(1);
+    expect(stats.bufferedFrames).toBe(1);
+    expect(stats.bufferedBytes).toBe(320 * 180 * 4);
+  });
+});

--- a/src/services/videoFrameBuffer.ts
+++ b/src/services/videoFrameBuffer.ts
@@ -1,23 +1,28 @@
 /**
  * VideoFrameBuffer Service
  *
- * Advanced frame buffering system inspired by OpenCut's video-cache.ts.
- * Implements dual-frame buffer pattern with smart seeking optimization.
+ * Supplies the canvas preview player with decoded frames.
  *
- * Features:
- * - Dual-frame buffer (currentFrame + nextFrame) for smooth playback
- * - Smart seeking: iterate forward for small jumps (<2s), full seek otherwise
- * - Per-asset frame pools to reduce memory allocation pressure
- * - Prefetch pipeline with non-blocking background loading
- * - Performance monitoring and drift detection
+ * Frames come from the resident decoder in the Rust core: one long-lived FFmpeg
+ * per source streaming raw RGBA, so an in-order request costs a pipe read rather
+ * than a process spawn, a JPEG encode, a disk write and a JPEG decode. This
+ * service turns those bytes into `ImageBitmap`s, caches them under a bounded
+ * budget, and never lets two requests for the same frame decode twice.
+ *
+ * The old smart-seek and prefetch machinery is gone on purpose: it existed to
+ * amortise a ~100 ms per-frame spawn by speculatively extracting up to thirty
+ * neighbouring frames, and against a resident decoder those speculative reads
+ * only move the pipe cursor away from the frame that is actually wanted.
  */
 
-import { convertFileSrc } from '@tauri-apps/api/core';
-import { extractFrame as extractFrameIPC } from '@/utils/ffmpeg';
-import { buildFrameOutputPath } from '@/services/framePaths';
-import { createFrameCacheKey, FRAME_EXTRACTION } from '@/constants/preview';
-import { frameCache } from '@/services/frameCache';
+import { getPreviewFrame, releasePreviewDecoders } from '@/utils/ffmpeg';
+import type { PreviewFrameData } from '@/utils/ffmpeg';
 import { createLogger } from '@/services/logger';
+import {
+  createPreviewFrameKey,
+  createPreviewTimeKey,
+  previewFrameCache,
+} from '@/services/previewFrameCache';
 
 const logger = createLogger('VideoFrameBuffer');
 
@@ -25,107 +30,129 @@ const logger = createLogger('VideoFrameBuffer');
 // Types
 // =============================================================================
 
-/**
- * Frame data with metadata for buffer management.
- */
-export interface BufferedFrame {
-  /** Cache key for this frame */
-  key: string;
-  /** Asset URL for rendering */
-  url: string;
-  /** Source timestamp in seconds */
-  timestamp: number;
-  /** When this frame was loaded */
-  loadedAt: number;
-  /** Estimated size in bytes */
-  sizeBytes: number;
+/** The box a decoded frame is fitted inside, in canvas pixels. */
+export interface PreviewFrameTarget {
+  maxWidth: number;
+  maxHeight: number;
 }
 
 /**
- * Per-asset frame buffer state.
+ * How an asset's frames can be looked up, learned from the decoder's first
+ * reply for it.
  */
-interface AssetBufferState {
-  /** Asset identifier */
-  assetId: string;
-  /** Path to the asset file */
-  assetPath: string;
-  /** Currently displayed frame */
-  currentFrame: BufferedFrame | null;
-  /** Prefetched next frame */
-  nextFrame: BufferedFrame | null;
-  /** Last time we fetched a frame for this asset */
-  lastFetchTime: number;
-  /** Whether prefetch is in progress */
-  isPrefetching: boolean;
-  /** Pending prefetch promise (for deduplication) */
-  prefetchPromise: Promise<void> | null;
-  /** Seek iteration position (for smart seeking) */
-  iterationPosition: number;
-}
+type AssetAddressing =
+  /** Constant-rate: a requested time maps onto a frame index. */
+  | { kind: 'indexed'; fps: number }
+  /** Variable-rate: only the requested time itself identifies a frame. */
+  | { kind: 'timed' };
 
 /**
  * Performance statistics for monitoring.
  */
 export interface BufferStats {
-  /** Number of assets being tracked */
+  /** Number of assets a frame has been requested for. */
   activeAssets: number;
-  /** Total frames in buffer */
+  /** Decoded frames currently held in the cache. */
   bufferedFrames: number;
+  /** Bytes those frames occupy. */
+  bufferedBytes: number;
   /** Cache hit rate (0-1) */
   cacheHitRate: number;
   /** Average frame fetch latency (ms) */
   avgFetchLatencyMs: number;
-  /** Number of smart seeks (iterate) vs full seeks */
-  smartSeekCount: number;
-  /** Number of full seeks */
-  fullSeekCount: number;
-  /** Number of prefetch hits (next frame was ready) */
-  prefetchHits: number;
-  /** Number of prefetch misses */
-  prefetchMisses: number;
+  /** Requests dropped because the fetch queue was full. */
+  droppedRequests: number;
+  /** Requests that failed to decode. */
+  failedRequests: number;
 }
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-/** Maximum time jump for iterate-forward optimization (seconds) */
-const ITERATE_FORWARD_THRESHOLD = 2.0;
+/**
+ * Backstop for an IPC reply that never arrives (ms).
+ *
+ * This is deliberately longer than the decoder's own read budget rather than
+ * shorter. Giving up here does not cancel the decode — the Rust watchdog is the
+ * only thing that can kill the process — so a shorter deadline would abandon
+ * work that was about to succeed and then decode it again, which is how a slow
+ * first read on long-GOP footage turns into a loop.
+ */
+const FRAME_FETCH_TIMEOUT_MS = 70_000;
 
-/** Frame fetch timeout (ms) */
-const FRAME_FETCH_TIMEOUT_MS = 5000;
-
-/** Maximum concurrent fetch operations per asset */
+/** Maximum concurrent decode requests in flight */
 const MAX_CONCURRENT_FETCHES = 2;
 
 /** Maximum queued frame fetches waiting for a concurrency slot */
 const MAX_FETCH_QUEUE_SIZE = 64;
 
-/** How far ahead to prefetch the next frame (seconds) */
-const NEXT_FRAME_OFFSET = FRAME_EXTRACTION.PREFETCH_INTERVAL_SEC;
+/** Highest frame rate accepted when learning a source's rate from a reply. */
+const MAX_PLAUSIBLE_FPS = 1000;
 
 // =============================================================================
 // VideoFrameBuffer Class
 // =============================================================================
 
 /**
- * Advanced frame buffer with dual-frame caching and smart seeking.
+ * Frame supplier for the canvas preview, backed by the resident decoder.
  */
 export class VideoFrameBuffer {
-  /** Per-asset buffer states */
-  private assetBuffers: Map<string, AssetBufferState> = new Map();
+  /** Assets a frame has been requested for. */
+  private readonly seenAssets = new Set<string>();
 
-  /** Pending fetch operations (for deduplication) */
-  private pendingFetches: Map<string, Promise<string | null>> = new Map();
+  /**
+   * How each asset's frames can be addressed, learned from the first reply.
+   *
+   * A constant-rate source reports a frame index, which lets a requested time be
+   * snapped to the same frame the decoder would snap it to — so two requests a
+   * few milliseconds apart resolve to one cache entry instead of two decodes of
+   * the same picture. A variable-rate source reports no index and is addressed
+   * by time.
+   */
+  private readonly assetAddressing = new Map<string, AssetAddressing>();
+
+  /**
+   * The first request for an asset, which later requests wait behind.
+   *
+   * Until a reply says how the asset is addressed there is no canonical cache
+   * key, so a burst of first requests (the same asset on two tracks, or the two
+   * halves of a crossfade) would each pick a different provisional key, decode
+   * separately, and then collide on the key they converge to.
+   */
+  private readonly addressingProbes = new Map<string, Promise<void>>();
+
+  /** In-flight decodes, keyed by cache key, so duplicates share one request. */
+  private readonly pendingFetches = new Map<string, Promise<ImageBitmap | null>>();
+
+  /**
+   * Bumped by {@link VideoFrameBuffer.clearAll}; captured by every fetch.
+   *
+   * A fetch whose epoch is stale must not reach the backend: the teardown kills
+   * the resident decoders, and a request arriving after it would build a fresh
+   * pool of FFmpeg processes with nothing left to release them.
+   */
+  private epoch = 0;
+
+  /**
+   * True from the first line of {@link VideoFrameBuffer.clearAll} until the
+   * backend has actually let go.
+   *
+   * The epoch alone cannot close the window: a request that *starts* during the
+   * teardown captures the new epoch, so it passes every epoch check and can
+   * still reach the backend after the release, which lazily rebuilds the pool
+   * and leaves FFmpeg children holding media files open with nothing left to
+   * reap them. A compound clip's nested render and a fast unmount/remount both
+   * reach this. Nothing is fetched while it is set.
+   */
+  private tearingDown = false;
 
   /** Performance statistics */
   private stats = {
-    smartSeekCount: 0,
-    fullSeekCount: 0,
-    prefetchHits: 0,
-    prefetchMisses: 0,
     totalFetchLatencyMs: 0,
     fetchCount: 0,
+    droppedRequests: 0,
+    failedRequests: 0,
   };
 
   /** Semaphore for concurrent fetch limiting */
@@ -137,130 +164,170 @@ export class VideoFrameBuffer {
   // ===========================================================================
 
   /**
-   * Get a frame for the given asset at the specified time.
-   * Uses smart seeking and dual-frame buffer for performance.
+   * Get a drawable frame for the given asset at the specified source time.
+   *
+   * Resolves to `null` — never rejects — when the frame cannot be produced, so
+   * the caller can leave the previous pixels on screen.
    *
    * @param assetId - Asset identifier
-   * @param assetPath - Path to the asset file
-   * @param timestamp - Desired frame time in seconds
-   * @returns Frame URL or null if unavailable
+   * @param assetPath - Path (or file URI) of the asset file
+   * @param timestamp - Desired source time in seconds
+   * @param target - Box the frame is fitted inside, in canvas pixels
+   * @returns A drawable frame, or null if unavailable
    */
-  async getFrame(assetId: string, assetPath: string, timestamp: number): Promise<string | null> {
+  async getFrame(
+    assetId: string,
+    assetPath: string,
+    timestamp: number,
+    target: PreviewFrameTarget,
+  ): Promise<ImageBitmap | null> {
+    // A teardown is in progress and the backend is about to be told to let go.
+    // Anything started now would arrive after that and rebuild the pool.
+    if (this.tearingDown) {
+      return null;
+    }
+
     const startTime = performance.now();
+    const epoch = this.epoch;
+    this.seenAssets.add(assetId);
 
-    // Get or create buffer state for this asset
-    const state = this.getOrCreateAssetState(assetId, assetPath);
+    const width = Math.max(1, Math.round(target.maxWidth));
+    const height = Math.max(1, Math.round(target.maxHeight));
 
-    // Check if we already have the frame
-    const cacheKey = createFrameCacheKey(assetId, timestamp);
-    const cached = frameCache.get(cacheKey);
+    // Wait behind the first request for this asset so every later one keys on
+    // the frame the decoder actually returns rather than a provisional guess.
+    await this.awaitAddressing(assetId);
+    if (epoch !== this.epoch || this.tearingDown) {
+      return null;
+    }
+
+    const cacheKey = this.cacheKeyFor(assetId, timestamp, width, height);
+    const cached = previewFrameCache.get(cacheKey);
     if (cached) {
-      this.updateCurrentFrame(state, {
-        key: cacheKey,
-        url: cached,
-        timestamp,
-        loadedAt: Date.now(),
-        sizeBytes: 0,
-      });
-      this.triggerPrefetch(state, timestamp);
+      previewFrameCache.pin(cached);
       return cached;
     }
 
-    // Check if nextFrame matches
-    if (state.nextFrame && Math.abs(state.nextFrame.timestamp - timestamp) < 0.001) {
-      this.stats.prefetchHits++;
-      this.updateCurrentFrame(state, state.nextFrame);
-      state.nextFrame = null;
-      this.triggerPrefetch(state, timestamp);
-      return state.currentFrame!.url;
-    } else if (state.nextFrame) {
-      this.stats.prefetchMisses++;
+    const frame = await this.fetchFrame(
+      assetId,
+      assetPath,
+      timestamp,
+      width,
+      height,
+      cacheKey,
+      epoch,
+    );
+
+    if (frame) {
+      // The caller is about to draw this; eviction must not close it first.
+      previewFrameCache.pin(frame);
     }
 
-    // Decide: iterate forward or full seek?
-    const timeDelta = timestamp - state.lastFetchTime;
-    const shouldIterateForward = timeDelta > 0 && timeDelta < ITERATE_FORWARD_THRESHOLD;
-
-    let frameUrl: string | null = null;
-
-    if (shouldIterateForward && state.currentFrame) {
-      // Smart seek: iterate forward from current position
-      this.stats.smartSeekCount++;
-      frameUrl = await this.iterateToTime(state, timestamp);
-    } else {
-      // Full seek: fetch frame directly
-      this.stats.fullSeekCount++;
-      frameUrl = await this.fetchFrame(assetId, assetPath, timestamp);
-    }
-
-    if (frameUrl) {
-      this.updateCurrentFrame(state, {
-        key: cacheKey,
-        url: frameUrl,
-        timestamp,
-        loadedAt: Date.now(),
-        sizeBytes: 100 * 1024, // Estimate
-      });
-      state.lastFetchTime = timestamp;
-      this.triggerPrefetch(state, timestamp);
-    }
-
-    // Track latency
     const latency = performance.now() - startTime;
     this.stats.totalFetchLatencyMs += latency;
     this.stats.fetchCount++;
 
-    // Log if latency is high
     if (latency > 100) {
       logger.debug('High frame fetch latency', {
         assetId,
         timestamp: timestamp.toFixed(3),
         latencyMs: latency.toFixed(1),
-        seekType: shouldIterateForward ? 'iterate' : 'full',
       });
     }
 
-    return frameUrl;
+    return frame;
   }
 
   /**
-   * Clear buffer for a specific asset.
+   * Marks the start of a compositing pass.
+   *
+   * Frames handed out from here until the next call are protected from
+   * eviction, so a pass drawing more clips than the cache's byte budget holds
+   * cannot close a bitmap it is still about to draw.
    */
-  clearAsset(assetId: string): void {
-    this.assetBuffers.delete(assetId);
+  beginRenderPass(): void {
+    previewFrameCache.beginPass();
   }
 
   /**
-   * Clear all buffers.
+   * Drop every cached frame and kill the resident decoders behind them.
+   *
+   * Called when the canvas preview goes away (unmount, project close) so no
+   * FFmpeg outlives the thing that was displaying its frames.
+   *
+   * The order matters and is the whole point of the method. Releasing first and
+   * letting queued work drain afterwards would have every parked request reach a
+   * backend that has just thrown its pool away, which rebuilds it — leaving
+   * exactly the orphaned FFmpeg processes this is supposed to prevent. So: stop
+   * new work, release everything parked, let what is already on the wire settle,
+   * and only then tell the backend to let go.
    */
-  clearAll(): void {
-    this.assetBuffers.clear();
+  async clearAll(): Promise<void> {
+    this.tearingDown = true;
+    this.epoch += 1;
+    const epoch = this.epoch;
+
+    // Everything parked for a permit wakes up, sees the new epoch, and returns
+    // without reaching the backend.
+    //
+    // `activeFetchCount` is deliberately not zeroed: a parked request bails out
+    // before it takes a permit, and one already holding a permit gives it back
+    // in its own `finally`. Forcing the counter to zero here would double-count
+    // those returns and leave the semaphore permanently over-permissive.
+    const parked = this.fetchQueue;
+    this.fetchQueue = [];
+    for (const release of parked) {
+      release();
+    }
+
+    const inFlight = [...this.pendingFetches.values()];
     this.pendingFetches.clear();
+    this.addressingProbes.clear();
+
+    previewFrameCache.clear();
+    this.seenAssets.clear();
+    this.assetAddressing.clear();
     this.resetStats();
+
+    // Requests already on the wire will still be answered by the pool, so the
+    // release has to come after them or it would tear down a pool that is about
+    // to be rebuilt.
+    await Promise.allSettled(inFlight);
+
+    if (epoch !== this.epoch) {
+      // A later teardown superseded this one and owns both the release and the
+      // clearing of `tearingDown`.
+      return;
+    }
+
+    try {
+      await releasePreviewDecoders();
+    } catch (error: unknown) {
+      logger.debug('Releasing the resident preview decoders failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      if (epoch === this.epoch) {
+        this.tearingDown = false;
+      }
+    }
   }
 
   /**
    * Get performance statistics.
    */
   getStats(): BufferStats {
-    let bufferedFrames = 0;
-    for (const state of this.assetBuffers.values()) {
-      if (state.currentFrame) bufferedFrames++;
-      if (state.nextFrame) bufferedFrames++;
-    }
-
-    const cacheStats = frameCache.getStats();
+    const cacheStats = previewFrameCache.getStats();
 
     return {
-      activeAssets: this.assetBuffers.size,
-      bufferedFrames,
+      activeAssets: this.seenAssets.size,
+      bufferedFrames: cacheStats.entries,
+      bufferedBytes: cacheStats.bytes,
       cacheHitRate: cacheStats.hitRate,
       avgFetchLatencyMs:
         this.stats.fetchCount > 0 ? this.stats.totalFetchLatencyMs / this.stats.fetchCount : 0,
-      smartSeekCount: this.stats.smartSeekCount,
-      fullSeekCount: this.stats.fullSeekCount,
-      prefetchHits: this.stats.prefetchHits,
-      prefetchMisses: this.stats.prefetchMisses,
+      droppedRequests: this.stats.droppedRequests,
+      failedRequests: this.stats.failedRequests,
     };
   }
 
@@ -269,13 +336,12 @@ export class VideoFrameBuffer {
    */
   resetStats(): void {
     this.stats = {
-      smartSeekCount: 0,
-      fullSeekCount: 0,
-      prefetchHits: 0,
-      prefetchMisses: 0,
       totalFetchLatencyMs: 0,
       fetchCount: 0,
+      droppedRequests: 0,
+      failedRequests: 0,
     };
+    previewFrameCache.resetStats();
   }
 
   // ===========================================================================
@@ -283,108 +349,120 @@ export class VideoFrameBuffer {
   // ===========================================================================
 
   /**
-   * Get or create buffer state for an asset.
+   * Blocks until the first reply for `assetId` has said how it is addressed.
+   *
+   * Only the very first request for an asset waits on nothing; the rest of that
+   * opening burst wait here so they all key on the same thing.
    */
-  private getOrCreateAssetState(assetId: string, assetPath: string): AssetBufferState {
-    let state = this.assetBuffers.get(assetId);
-    if (!state) {
-      state = {
-        assetId,
-        assetPath,
-        currentFrame: null,
-        nextFrame: null,
-        lastFetchTime: 0,
-        isPrefetching: false,
-        prefetchPromise: null,
-        iterationPosition: 0,
-      };
-      this.assetBuffers.set(assetId, state);
-    }
-    return state;
-  }
-
-  /**
-   * Update current frame and manage buffer.
-   */
-  private updateCurrentFrame(state: AssetBufferState, frame: BufferedFrame): void {
-    state.currentFrame = frame;
-  }
-
-  /**
-   * Iterate forward from current position to target time.
-   * More efficient for small time jumps during scrubbing.
-   */
-  private async iterateToTime(state: AssetBufferState, targetTime: number): Promise<string | null> {
-    const interval = FRAME_EXTRACTION.PREFETCH_INTERVAL_SEC;
-    let currentTime = state.iterationPosition || state.lastFetchTime;
-
-    // Iterate forward, checking cache at each step
-    while (currentTime < targetTime) {
-      currentTime += interval;
-
-      // Check if we overshoot
-      if (currentTime >= targetTime) {
-        break;
-      }
-
-      // Check cache for intermediate frames (warming cache)
-      const cacheKey = createFrameCacheKey(state.assetId, currentTime);
-      if (!frameCache.has(cacheKey)) {
-        // Pre-warm cache for this position (fire and forget)
-        this.fetchFrame(state.assetId, state.assetPath, currentTime).catch(() => {});
-      }
+  private async awaitAddressing(assetId: string): Promise<void> {
+    const probe = this.addressingProbes.get(assetId);
+    if (!probe || this.assetAddressing.has(assetId)) {
+      return;
     }
 
-    // Fetch the actual target frame
-    state.iterationPosition = targetTime;
-    return this.fetchFrame(state.assetId, state.assetPath, targetTime);
+    await probe;
   }
 
   /**
-   * Fetch a single frame (with deduplication and concurrency control).
+   * The cache key for a request: the frame's index for a constant-rate source,
+   * and the requested time for a variable-rate one or before the first reply.
+   */
+  private cacheKeyFor(assetId: string, timestamp: number, width: number, height: number): string {
+    const addressing = this.assetAddressing.get(assetId);
+    if (addressing?.kind !== 'indexed') {
+      return createPreviewTimeKey(assetId, timestamp, width, height);
+    }
+
+    const frameIndex = Math.max(0, Math.round(Math.max(0, timestamp) * addressing.fps));
+    return createPreviewFrameKey(assetId, frameIndex, width, height);
+  }
+
+  /**
+   * Records how a reply says its source is addressed.
+   *
+   * A reply carrying no frame index comes from a variable-rate source, whose
+   * presentation times are not a multiple of any frame duration; inventing a
+   * rate for it would put every later request on the wrong picture.
+   */
+  private learnAddressing(assetId: string, frame: PreviewFrameData): void {
+    if (this.assetAddressing.has(assetId)) {
+      return;
+    }
+
+    if (frame.frameIndex === null) {
+      this.assetAddressing.set(assetId, { kind: 'timed' });
+      return;
+    }
+
+    if (frame.frameIndex <= 0 || frame.sourceTime <= 0) {
+      // Frame zero says nothing about the rate; leave it for the next reply.
+      return;
+    }
+
+    const fps = frame.frameIndex / frame.sourceTime;
+    if (!Number.isFinite(fps) || fps <= 0 || fps > MAX_PLAUSIBLE_FPS) {
+      return;
+    }
+
+    this.assetAddressing.set(assetId, { kind: 'indexed', fps });
+  }
+
+  /**
+   * Fetch a single frame, sharing one request between duplicate callers.
    */
   private async fetchFrame(
     assetId: string,
     assetPath: string,
     timestamp: number,
-  ): Promise<string | null> {
-    const cacheKey = createFrameCacheKey(assetId, timestamp);
-
-    // Check cache first
-    const cached = frameCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    // Check pending fetches (deduplication)
+    width: number,
+    height: number,
+    cacheKey: string,
+    epoch: number,
+  ): Promise<ImageBitmap | null> {
     const pending = this.pendingFetches.get(cacheKey);
     if (pending) {
       return pending;
     }
 
-    // Create fetch promise
-    const fetchPromise = this.executeFetch(assetId, assetPath, timestamp, cacheKey);
+    const fetchPromise = this.executeFetch(assetId, assetPath, timestamp, width, height, epoch);
     this.pendingFetches.set(cacheKey, fetchPromise);
+
+    if (!this.assetAddressing.has(assetId) && !this.addressingProbes.has(assetId)) {
+      const probe = fetchPromise.then(
+        () => {
+          this.addressingProbes.delete(assetId);
+        },
+        () => {
+          this.addressingProbes.delete(assetId);
+        },
+      );
+      this.addressingProbes.set(assetId, probe);
+    }
 
     try {
       return await fetchPromise;
     } finally {
-      this.pendingFetches.delete(cacheKey);
+      if (this.pendingFetches.get(cacheKey) === fetchPromise) {
+        this.pendingFetches.delete(cacheKey);
+      }
     }
   }
 
   /**
-   * Execute frame extraction with concurrency control.
+   * Decode one frame, under the concurrency limit, and cache the result.
    */
   private async executeFetch(
     assetId: string,
     assetPath: string,
     timestamp: number,
-    cacheKey: string,
-  ): Promise<string | null> {
+    width: number,
+    height: number,
+    epoch: number,
+  ): Promise<ImageBitmap | null> {
     // Wait for permit if at capacity
     if (this.activeFetchCount >= MAX_CONCURRENT_FETCHES) {
       if (this.fetchQueue.length >= MAX_FETCH_QUEUE_SIZE) {
+        this.stats.droppedRequests++;
         logger.warn('Frame fetch queue full, dropping request', {
           assetId,
           timestamp: timestamp.toFixed(3),
@@ -398,49 +476,53 @@ export class VideoFrameBuffer {
       });
     }
 
+    // The preview was torn down while this sat in the queue. Reaching the
+    // backend now would rebuild the pool of FFmpeg processes the teardown is in
+    // the middle of releasing.
+    if (epoch !== this.epoch) {
+      return null;
+    }
+
     this.activeFetchCount++;
 
     try {
-      const safeAssetName = assetId.replace(/[^a-zA-Z0-9]/g, '_').substring(0, 50);
-      const timeMs = Math.floor(timestamp * 1000);
-      const outputPath = await buildFrameOutputPath(
-        safeAssetName,
-        timeMs,
-        FRAME_EXTRACTION.OUTPUT_FORMAT,
-      );
-
-      // Create timeout promise
-      let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error('Frame fetch timeout')),
-          FRAME_FETCH_TIMEOUT_MS,
-        );
-      });
-
-      // Race extraction against timeout
-      try {
-        await Promise.race([
-          extractFrameIPC({
-            inputPath: assetPath,
-            timeSec: timestamp,
-            outputPath,
-          }),
-          timeoutPromise,
-        ]);
-      } finally {
-        if (timeoutId !== null) {
-          clearTimeout(timeoutId);
-        }
+      const frame = await requestFrameWithTimeout(assetPath, timestamp, width, height);
+      if (epoch !== this.epoch) {
+        return null;
       }
 
-      const frameUrl = convertFileSrc(outputPath);
+      this.learnAddressing(assetId, frame);
 
-      // Store in cache
-      frameCache.set(cacheKey, frameUrl, 100 * 1024);
+      // Re-derive the key now the addressing is known: for a constant-rate
+      // source it becomes the frame's index, which is what later requests for
+      // this picture will look up.
+      const canonicalKey = this.cacheKeyFor(assetId, timestamp, width, height);
+      const alreadyCached = previewFrameCache.get(canonicalKey);
+      if (alreadyCached) {
+        return alreadyCached;
+      }
 
-      return frameUrl;
+      const bitmap = await createFrameBitmap(frame.pixels, frame.width, frame.height);
+
+      // Re-check across the decode: another request for a nearby time may have
+      // converged on this same key while the bitmap was being built. Handing
+      // back the entry that already exists — and closing the one nobody has seen
+      // — is what keeps a cached frame from being closed under a caller that is
+      // still drawing it.
+      const raced = previewFrameCache.get(canonicalKey);
+      if (raced) {
+        bitmap.close();
+        return raced;
+      }
+      if (epoch !== this.epoch) {
+        bitmap.close();
+        return null;
+      }
+
+      previewFrameCache.set(canonicalKey, bitmap);
+      return bitmap;
     } catch (error) {
+      this.stats.failedRequests++;
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error('Frame fetch failed', {
         assetId,
@@ -449,7 +531,7 @@ export class VideoFrameBuffer {
       });
       return null;
     } finally {
-      this.activeFetchCount--;
+      this.activeFetchCount = Math.max(0, this.activeFetchCount - 1);
 
       // Release next waiter if any
       const next = this.fetchQueue.shift();
@@ -458,58 +540,65 @@ export class VideoFrameBuffer {
       }
     }
   }
+}
 
-  /**
-   * Trigger prefetch for the next frame (non-blocking).
-   */
-  private triggerPrefetch(state: AssetBufferState, currentTime: number): void {
-    // Don't prefetch if already in progress
-    if (state.isPrefetching) {
-      return;
-    }
+/**
+ * Asks the resident decoder for one frame, giving up after
+ * {@link FRAME_FETCH_TIMEOUT_MS} so a wedged decode cannot hold a fetch permit
+ * forever.
+ */
+async function requestFrameWithTimeout(
+  assetPath: string,
+  timestamp: number,
+  width: number,
+  height: number,
+): Promise<PreviewFrameData> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error('Frame fetch timeout')), FRAME_FETCH_TIMEOUT_MS);
+  });
 
-    const nextTime = currentTime + NEXT_FRAME_OFFSET;
-    const cacheKey = createFrameCacheKey(state.assetId, nextTime);
-
-    // Don't prefetch if already cached or if we already have it
-    if (frameCache.has(cacheKey) || this.pendingFetches.has(cacheKey)) {
-      return;
-    }
-
-    if (state.nextFrame && Math.abs(state.nextFrame.timestamp - nextTime) < 0.001) {
-      return;
-    }
-
-    state.isPrefetching = true;
-    state.prefetchPromise = this.prefetchNextFrame(state, nextTime);
-  }
-
-  /**
-   * Prefetch the next frame in background.
-   */
-  private async prefetchNextFrame(state: AssetBufferState, nextTime: number): Promise<void> {
-    try {
-      const frameUrl = await this.fetchFrame(state.assetId, state.assetPath, nextTime);
-      if (frameUrl) {
-        state.nextFrame = {
-          key: createFrameCacheKey(state.assetId, nextTime),
-          url: frameUrl,
-          timestamp: nextTime,
-          loadedAt: Date.now(),
-          sizeBytes: 100 * 1024,
-        };
-      }
-    } catch (error) {
-      logger.debug('Prefetch failed (ignored)', {
-        assetId: state.assetId,
-        nextTime: nextTime.toFixed(3),
-        error: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      state.isPrefetching = false;
-      state.prefetchPromise = null;
+  try {
+    return await Promise.race([
+      getPreviewFrame({
+        inputPath: assetPath,
+        timeSec: timestamp,
+        maxWidth: width,
+        maxHeight: height,
+      }),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
     }
   }
+}
+
+/**
+ * Turns raw RGBA into a drawable the canvas can composite.
+ *
+ * `ImageBitmap` is used rather than `putImageData` because the preview draws
+ * every clip through `drawImage` under a transform, an alpha and a blend mode,
+ * none of which `putImageData` honours.
+ */
+async function createFrameBitmap(
+  pixels: Uint8ClampedArray<ArrayBuffer>,
+  width: number,
+  height: number,
+): Promise<ImageBitmap> {
+  if (typeof createImageBitmap !== 'function') {
+    throw new Error('This runtime cannot decode preview frames: createImageBitmap is unavailable');
+  }
+
+  const imageData = new ImageData(pixels, width, height);
+  return createImageBitmap(imageData, {
+    // The decoder emits straight alpha in the sRGB the canvas already works in;
+    // letting the browser convert either would shift the preview away from what
+    // the export renders.
+    premultiplyAlpha: 'none',
+    colorSpaceConversion: 'none',
+  });
 }
 
 // =============================================================================

--- a/src/utils/clipMotion.test.ts
+++ b/src/utils/clipMotion.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { Clip } from '@/types';
-import { getClipMotionTransformAtTime, hasActiveMotionKeyframes } from './clipMotion';
+import {
+  getClipMaxMotionScale,
+  getClipMotionTransformAtTime,
+  hasActiveMotionKeyframes,
+} from './clipMotion';
 
 function createClip(): Clip {
   return {
@@ -86,5 +90,64 @@ describe('clipMotion', () => {
       expect(getClipMotionTransformAtTime(clip, 7)).toEqual(clip.transform);
     });
   });
-});
+  describe('getClipMaxMotionScale', () => {
+    it('should report the static transform scale when the clip has no keyframes', () => {
+      const clip = createClip();
+      clip.transform.scale = { x: 1.75, y: 1.25 };
 
+      expect(getClipMaxMotionScale(clip)).toBe(1.75);
+    });
+
+    it('should report the widest keyframe rather than the scale at any instant', () => {
+      // Callers size a decode box off this, and a box that tracked the
+      // instantaneous scale would change on every rendered frame.
+      const clip = createClip();
+      clip.motionKeyframes = [
+        {
+          timeOffset: 0,
+          interpolation: 'linear',
+          transform: { ...clip.transform, scale: { x: 1, y: 1 } },
+        },
+        {
+          timeOffset: 5,
+          interpolation: 'linear',
+          transform: { ...clip.transform, scale: { x: 2.5, y: 2.5 } },
+        },
+        {
+          timeOffset: 10,
+          interpolation: 'linear',
+          transform: { ...clip.transform, scale: { x: 1.2, y: 1.2 } },
+        },
+      ];
+
+      expect(getClipMaxMotionScale(clip)).toBe(2.5);
+    });
+
+    it('should take the larger of the two axes', () => {
+      const clip = createClip();
+      clip.motionKeyframes = [
+        {
+          timeOffset: 0,
+          interpolation: 'linear',
+          transform: { ...clip.transform, scale: { x: 1, y: 3 } },
+        },
+      ];
+
+      expect(getClipMaxMotionScale(clip)).toBe(3);
+    });
+
+    it('should fall back to the static transform when every keyframe is discarded', () => {
+      const clip = createClip();
+      clip.transform.scale = { x: 1.5, y: 1.5 };
+      clip.motionKeyframes = [
+        {
+          timeOffset: Number.NaN,
+          interpolation: 'linear',
+          transform: { ...clip.transform, scale: { x: 9, y: 9 } },
+        },
+      ];
+
+      expect(getClipMaxMotionScale(clip)).toBe(1.5);
+    });
+  });
+});

--- a/src/utils/clipMotion.ts
+++ b/src/utils/clipMotion.ts
@@ -81,6 +81,31 @@ export function hasActiveMotionKeyframes(clip: Clip): boolean {
   return sortedValidKeyframes(clip.motionKeyframes).length > 0;
 }
 
+/**
+ * The largest scale factor a clip's transform reaches anywhere in its range.
+ *
+ * Keyframes are interpolated linearly (or held), so the extreme is always at a
+ * keyframe and this needs no sampling. Callers use it to decide how many source
+ * pixels a clip actually needs: a clip zoomed to 2x draws its frame at twice the
+ * canvas size, and decoding it at canvas size would show a soft picture.
+ *
+ * @param clip - The clip to inspect.
+ * @returns The maximum of every keyframe's horizontal and vertical scale, or the
+ *   static transform's when the clip has no keyframes.
+ */
+export function getClipMaxMotionScale(clip: Clip): number {
+  const keyframes = sortedValidKeyframes(clip.motionKeyframes);
+  const transforms =
+    keyframes.length > 0
+      ? keyframes.map((keyframe) => keyframe.transform)
+      : [normalizeTransform(clip.transform)];
+
+  return transforms.reduce(
+    (largest, transform) => Math.max(largest, transform.scale.x, transform.scale.y),
+    0,
+  );
+}
+
 export function getClipMotionTransformAtTime(clip: Clip, timelineTimeSec: number): Transform {
   const keyframes = sortedValidKeyframes(clip.motionKeyframes);
   if (keyframes.length === 0) {

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -18,6 +18,36 @@ export interface ExtractFrameOptions {
   outputPath: string;
 }
 
+export interface PreviewFrameOptions {
+  /** Path (or file URI) of the media the frame is decoded from. */
+  inputPath: string;
+  /** Source time of the wanted frame, in seconds. */
+  timeSec: number;
+  /** Width of the box the frame is fitted inside, in pixels. */
+  maxWidth: number;
+  /** Height of the box the frame is fitted inside, in pixels. */
+  maxHeight: number;
+}
+
+export interface PreviewFrameData {
+  /** Width of the decoded frame, after aspect-preserving downscale. */
+  width: number;
+  /** Height of the decoded frame, after aspect-preserving downscale. */
+  height: number;
+  /**
+   * Index of this frame in the source's frame sequence.
+   *
+   * `null` for a variable-rate source, whose presentation times are not
+   * `index / fps`; such a frame can only be addressed by the time it answers
+   * for.
+   */
+  frameIndex: number | null;
+  /** The source time this frame answers for, in seconds. */
+  sourceTime: number;
+  /** `width * height * 4` bytes of straight-alpha RGBA. */
+  pixels: Uint8ClampedArray<ArrayBuffer>;
+}
+
 export interface GenerateThumbnailOptions {
   inputPath: string;
   outputPath: string;
@@ -60,6 +90,110 @@ export async function extractFrame(options: ExtractFrameOptions): Promise<void> 
     timeSec: options.timeSec,
     outputPath: options.outputPath,
   });
+}
+
+/** Size of the header the resident preview decoder prepends to its pixels. */
+const PREVIEW_FRAME_HEADER_BYTES = 32;
+
+/** Wire version this build knows how to read. */
+const PREVIEW_FRAME_WIRE_VERSION = 2;
+
+/** Header flag: the frame index is meaningful for this source. */
+const PREVIEW_FRAME_FLAG_INDEXED = 1;
+
+/** Bytes per pixel in the decoder's `rgba` output. */
+const PREVIEW_FRAME_BYTES_PER_PIXEL = 4;
+
+/** The IPC reply as bytes, whichever shape the runtime handed back. */
+function toFrameBytes(payload: ArrayBuffer | Uint8Array | number[]): Uint8Array {
+  if (payload instanceof Uint8Array) return payload;
+  if (Array.isArray(payload)) return Uint8Array.from(payload);
+  return new Uint8Array(payload);
+}
+
+/**
+ * Reads the resident decoder's reply: a 32-byte little-endian header
+ * (version, width, height, frame index, source time, flags, reserved) followed
+ * by raw RGBA.
+ *
+ * Exported so the frame path can be tested without a live decoder.
+ */
+export function decodePreviewFrameReply(
+  payload: ArrayBuffer | Uint8Array | number[],
+): PreviewFrameData {
+  const bytes = toFrameBytes(payload);
+  if (bytes.byteLength < PREVIEW_FRAME_HEADER_BYTES) {
+    throw new Error('Preview frame reply is shorter than its header');
+  }
+
+  const header = new DataView(bytes.buffer, bytes.byteOffset, PREVIEW_FRAME_HEADER_BYTES);
+  const version = header.getUint32(0, true);
+  if (version !== PREVIEW_FRAME_WIRE_VERSION) {
+    throw new Error(`Unsupported preview frame version ${version}`);
+  }
+
+  const width = header.getUint32(4, true);
+  const height = header.getUint32(8, true);
+  const rawFrameIndex = header.getUint32(12, true);
+  const sourceTime = header.getFloat64(16, true);
+  const flags = header.getUint32(24, true);
+  // A variable-rate source ships a zero index with the flag clear; reading that
+  // zero as "frame zero" would key every one of its frames to the same picture.
+  const frameIndex = (flags & PREVIEW_FRAME_FLAG_INDEXED) !== 0 ? rawFrameIndex : null;
+
+  const pixels = bytes.subarray(PREVIEW_FRAME_HEADER_BYTES);
+  const expected = width * height * PREVIEW_FRAME_BYTES_PER_PIXEL;
+  if (pixels.byteLength !== expected) {
+    throw new Error(
+      `Preview frame carries ${pixels.byteLength} bytes but ${width}x${height} needs ${expected}`,
+    );
+  }
+
+  return {
+    width,
+    height,
+    frameIndex,
+    sourceTime,
+    // A view rather than a copy: the reply's buffer is ours alone, and a 1080p
+    // frame is 8 MB that nobody needs a second time. The cast is safe because
+    // the preview path never uses `SharedArrayBuffer` (which would need
+    // cross-origin isolation the app does not enable).
+    pixels: new Uint8ClampedArray(
+      pixels.buffer as ArrayBuffer,
+      pixels.byteOffset,
+      pixels.byteLength,
+    ),
+  };
+}
+
+/**
+ * Decode the frame nearest `timeSec` through the resident preview decoder.
+ *
+ * The decoder keeps a live FFmpeg per source and streams raw RGBA, so an
+ * in-order request costs one pipe read rather than a process spawn. The frame is
+ * fitted inside `maxWidth` by `maxHeight` with its aspect ratio intact, because
+ * the preview canvas composites with a contain-fit that reads the drawable's own
+ * dimensions.
+ */
+export async function getPreviewFrame(options: PreviewFrameOptions): Promise<PreviewFrameData> {
+  const payload = await invoke<ArrayBuffer | Uint8Array | number[]>('get_preview_frame', {
+    inputPath: normalizeLocalMediaInputPath(options.inputPath),
+    timeSec: options.timeSec,
+    maxWidth: Math.max(1, Math.round(options.maxWidth)),
+    maxHeight: Math.max(1, Math.round(options.maxHeight)),
+  });
+
+  return decodePreviewFrameReply(payload);
+}
+
+/**
+ * Kill every resident preview decoder.
+ *
+ * Called when the canvas preview goes away so no FFmpeg outlives the thing that
+ * was displaying its frames.
+ */
+export async function releasePreviewDecoders(): Promise<void> {
+  return invoke<void>('release_preview_decoders');
 }
 
 /**


### PR DESCRIPTION
### **User description**
placeholder


___

### **PR Type**
Enhancement, Performance, Tests


___

### **Description**
- Replaces per-frame FFmpeg spawning with long-lived resident decoders.

- Streams raw RGBA over pipes to eliminate disk I/O and JPEG overhead.

- Implements a bounded LRU `ImageBitmap` cache with byte-budgeting.

- Adds a frame-pinning mechanism to prevent eviction during compositing passes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
    TP["TimelinePreviewPlayer"] -- "getFrame" --> VFB["VideoFrameBuffer"]
    VFB -- "LRU Cache" --> PFC["PreviewFrameCache"]
  end
  subgraph Backend
    VFB -- "IPC (raw bytes)" --> GPF["get_preview_frame"]
    GPF -- "Pipe Read" --> PDP["PreviewDecoderPool"]
    PDP -- "Resident" --> FF["FFmpeg Process"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>videoFrameBuffer.ts</strong><dd><code>Refactor frame buffer to use resident decoders and ImageBitmaps</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-ab964fcb60a84721b1d6c872e0387fd9ae2a410c588e7fb0e19c651a89ac852e">+384/-295</a></td>

</tr>

<tr>
  <td><strong>previewFrameCache.ts</strong><dd><code>New bounded LRU cache for off-heap ImageBitmap frames</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-6972183f29529d11e1466f6dd613f21fefbc09bc5034c80c88bdf8cbd4c8d80c">+315/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TimelinePreviewPlayer.tsx</strong><dd><code>Update preview player to handle ImageBitmaps and dynamic scaling</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-4d288d619dc53b5be764a00b666c542c6daa5d478e6fd1e7e1a6d6e4c9cf90c0">+108/-20</a></td>

</tr>

<tr>
  <td><strong>decoder.rs</strong><dd><code>Core logic for managing resident FFmpeg process pool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-88c593d7177b81997286310ca70669ae3e15f7db2400bcc78ecb433d9e69d65e">+2286/-0</a></td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>IPC commands for raw byte frame delivery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-68f64a2c7ec94f74a22c567dcc589f12e5866e98f403df35b5c14a1af444daba">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>state.rs</strong><dd><code>Managed state for lazy decoder pool initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-78f4b198bd57504019b9524f106d5e152f44ca6f9f89542f8e42a8987b6b8dd9">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ffmpeg.ts</strong><dd><code>Add binary protocol decoding for preview frame replies</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-6076bb24ce52bcff01adaad13fe60e08c769a1be9d94c2f603e24c1d1d023977">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>clipMotion.ts</strong><dd><code>Add utility to calculate maximum motion scale for clips</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-c9f4e3ff4223f2ef692e651227fd315b6a68bd8575f13e810ac6386465de8495">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>videoFrameBuffer.test.ts</strong><dd><code>Comprehensive tests for the new resident decoder service</code>&nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-ca277ea8cf37dc16c132de300f03028ccd389d9183bbc596c9648b7ab5e321c6">+435/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>playbackMonitor.ts</strong><dd><code>Update memory pressure monitoring for new cache system</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-2ea08cd5dae5896313e18f233b00dfd54cdb3f3872ea58984560e74f8c450bc3">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-2e54fa69a6cc2c4a47431aaa1543f7324a2e84beb82f894757985d0e63b93662">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-352d1d5a97fbbcf9f921ca01f6cea6fd6df09145faf504976d040f7eaf9fe89d">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimelinePreviewPlayer.test.tsx</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-1d323dfd0f9ee6f59ec0c8894eaadedfc0db4647f07cbcc16019ffe23c9f7955">+114/-8</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>previewFrameCache.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-e4d74f538b3556c9f06020f63c1e725c3406350e6a631c67f310ee5f366e05c5">+237/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>clipMotion.test.ts</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/842/files#diff-f155cda62d2a335fed46558d1d2b13180023466710327b0b9b357ccdf07e9b88">+65/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

