### PR TITLE
perf(render): skip opening inputs a windowed render does not draw

### DIFF
--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -18968,13 +18968,14 @@ mod tests {
     }
 
     /// Feature: Windowed render
-    /// Scenario: a clip outside the window keeps its input and loses its chain
+    /// Scenario: a clip outside the window is never opened
     ///
-    /// PR 2a deliberately does not prune inputs — that is a later step — so the
-    /// `-i` list stays as long as it was and every `[n:v]` label keeps meaning
-    /// what it says. What a clip outside the window does lose is its filters.
+    /// A clip that shares no frame with the window gets neither an `-i` nor a
+    /// chain, so FFmpeg never opens or probes it. The one surviving clip
+    /// renumbers to input 0 — the label suffix follows the emitted-input count,
+    /// not the clip's position on the timeline.
     #[test]
-    fn a_clip_outside_the_window_keeps_its_input_but_builds_no_chain() {
+    fn a_clip_outside_the_window_gets_neither_an_input_nor_a_chain() {
         let (sequence, assets, audio_info) = windowed_audio_fixture(
             "window_pruned_chain.mp4",
             &[(0.0, 2.0), (2.0, 2.0), (4.0, 2.0)],
@@ -18985,16 +18986,16 @@ mod tests {
 
         assert_eq!(
             args.iter().filter(|arg| *arg == "-i").count(),
-            3,
-            "every clip keeps its input in PR 2a. Got: {args:?}"
+            1,
+            "only the clip inside the window is opened. Got: {args:?}"
         );
         assert!(
-            !filter_complex.contains("[0:v]") && !filter_complex.contains("[1:v]"),
-            "the two clips in front of the window must build no chain: {filter_complex}"
+            filter_complex.contains("[0:v]"),
+            "the surviving clip renumbers to input 0: {filter_complex}"
         );
         assert!(
-            filter_complex.contains("[2:v]"),
-            "the clip inside the window must still build one: {filter_complex}"
+            !filter_complex.contains("[1:v]") && !filter_complex.contains("[2:v]"),
+            "the two clips in front of the window must never be opened: {filter_complex}"
         );
     }
 
@@ -19337,6 +19338,48 @@ mod tests {
                     ("b-on-a-cut", 2.0, 4.0),
                     ("h-off-grid", 2.017, 4.004),
                 ],
+            );
+        }
+
+        // Input pruning: a window over the last of six clips opens only that one
+        // clip's file, and the result is still byte-identical to the full render.
+        {
+            let mut sequence = Sequence::new("Pruned", square_canvas());
+            sequence.tracks.clear();
+            let mut track = Track::new_video("V1");
+            for i in 0..6u32 {
+                track.add_clip(placed(&format!("prune{i}"), 0.0, 2.0, 2.0 * f64::from(i)));
+            }
+            sequence.add_track(track);
+
+            // The window sits inside the sixth clip (10.0-12.0), so the five in
+            // front of it must never be opened.
+            let probe_args = build_complex_filter_args_with_audio_info(
+                &sequence,
+                &assets,
+                &no_effects,
+                &HashMap::new(),
+                &windowed_render_settings(
+                    dir.path().join("prune-probe.mp4"),
+                    Some(10.0),
+                    Some(11.0),
+                ),
+            )
+            .expect("the pruning fixture must build");
+            assert_eq!(
+                probe_args.iter().filter(|arg| *arg == "-i").count(),
+                1,
+                "only the clip inside the window is opened: {probe_args:?}"
+            );
+
+            assert_windows_slice_the_full_render(
+                &ffmpeg,
+                dir.path(),
+                "pruned",
+                &sequence,
+                &assets,
+                &no_effects,
+                &[("last-of-six", 10.0, 11.0)],
             );
         }
 

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -252,17 +252,21 @@ pub(super) fn build_sequence_ffmpeg_args(
             continue;
         }
 
-        args.push("-i".to_string());
-        args.push(validated_path.to_string_lossy().to_string());
-
         // A clip that shares no frame with the window contributes no picture and
-        // no sound, so it gets no filter chain. The input stays: FFmpeg reads
-        // nothing from an input no filter references, and keeping the list
-        // intact keeps every input label in the graph meaning what it says.
+        // no sound, so FFmpeg is never told to open it: an input it opens is an
+        // input it probes, and a windowed render must not pay for the timeline it
+        // is not writing. No `-i` and no label go with it — `input_index` counts
+        // the inputs this command really has, exactly as the audio-only builder
+        // already counts them. The path is still validated above, so a windowed
+        // preview of a project with a broken far-off asset fails just as the full
+        // export would rather than passing as an honest proxy for a render it is
+        // not.
         if !renders_clip(&clip.id) {
-            input_index += 1;
             continue;
         }
+
+        args.push("-i".to_string());
+        args.push(validated_path.to_string_lossy().to_string());
 
         // A clip in a transition renders a little more than its slot: the extra
         // comes out of unused source media, never out of the timeline. The
@@ -550,6 +554,16 @@ pub(super) fn build_sequence_ffmpeg_args(
 
         input_index += 1;
     }
+
+    // Every emitted `-i` advanced `input_index` exactly once, and every filter
+    // label is `{prefix}{input_index}`, so the counter must equal the number of
+    // inputs actually on the command line. A drift here would silently point a
+    // filter at the wrong stream.
+    debug_assert_eq!(
+        input_index,
+        args.iter().filter(|arg| arg.as_str() == "-i").count(),
+        "input_index must count the -i args exactly"
+    );
 
     // Text and caption clips draw onto the composited picture instead of
     // contributing their own video segment. A sequence made only of them has no


### PR DESCRIPTION
### **User description**
## Problem

The window-shaped render (#844) already built no filter chain for a clip outside the window — but it still pushed that clip's `-i`, so FFmpeg opened and probed **every** input the full timeline has (one `avformat_open_input` + `find_stream_info` per clip) on **every** preview-cache segment. For a timeline of many short clips, that open+probe is the dominant cost of rendering a small window.

## Fix

Hoist the retention check above the `-i` push: a clip that shares no frame with the window now gets neither an input nor a label, exactly as the audio-only builder already prunes. Details:

- The input **path is still validated** for every clip, so a windowed preview of a project with a broken far-off asset fails just as the full export would — the preview stays an honest proxy for the render.
- The retention set already closes over transition/composite partners, so a pruned clip is never referenced by a fold (the stitch's orphan/under-populated refusals are structurally unreachable for a pruned clip).
- Input labels stay aligned with the emitted `-i` order (the surviving clip renumbers down), guarded by a new `input_index == -i count` invariant.
- A **full export prunes nothing** (the retention predicate is always true when unranged) and is byte-identical to before.

This is the clip-**count** half of making a windowed render O(window); the clip-**length** half (input-side seek, so a long clip spanning into the window is not decoded from zero) is a separate follow-up that keeps the byte-exact guarantee.

## Verification

- Byte-exact `a_windowed_render_is_byte_identical_to_the_same_frames_of_a_full_render` (managed ffmpeg 9.0.1, whole-frame max_abs=0): **15/15** cases, including a new **pruned/last-of-six** case (window over the last of six clips opens exactly one input, still decodes to the same frames) and **black-tail** (a window past every clip renders from no inputs at all).
- Inverted the former `...keeps_its_input...` arg test to assert the pruned clips are never opened and the survivor renumbers to input 0.
- `cargo fmt`; `clippy -p openreelio --features gui --lib` and `--all-targets --features dev-full -- -D warnings` clean; `cargo test -p openreelio --features gui --lib` → 4225 passed; render-module ignored ffmpeg suite 22 passed; bindings in sync.


___

### **PR Type**
Enhancement


___

### **Description**
- Prunes unused inputs from windowed render commands.

- Skips opening/probing files outside the render window.

- Maintains byte-identical output for full timeline renders.

- Ensures input labels remain aligned with renumbered indices.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Render Request"] -- "Identify Window" --> B["Filter Clips by Window"]
  B -- "Clip Outside" --> C["Skip -i and Filter Chain"]
  B -- "Clip Inside" --> D["Push -i and Build Chain"]
  D -- "Renumber" --> E["Update Input Labels [n:v]"]
  E --> F["FFmpeg Execution"]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ffmpeg_plan.rs</strong><dd><code>Prune unused inputs and rebase labels in FFmpeg plan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/ffmpeg_plan.rs

<ul><li>Hoists the <code>renders_clip</code> check above the <code>-i</code> argument push to skip <br>opening unused assets.<br> <li> Implements input renumbering to ensure filter labels match the actual <br>command-line input order.<br> <li> Adds a debug assertion to verify that <code>input_index</code> stays synchronized <br>with the count of <code>-i</code> arguments.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/845/files#diff-7f93452cf29faaec41eb667dd7d07cf667603dace2d8f99aba49ae2e38c3e2df">+21/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Update render tests for input pruning verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Updates existing tests to reflect that clips outside the window no <br>longer have corresponding <code>-i</code> entries.<br> <li> Adds a new integration test case verifying that a window over the end <br>of a long sequence only opens the relevant clip.<br> <li> Validates that pruned windowed renders remain byte-identical to full <br>renders.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/845/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+54/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windowed exports now process only clips that fall within the selected render range.
  * Clips outside the render window are no longer opened, probed, or included in filter processing.
  * Remaining clips are renumbered correctly, improving export reliability and consistency.

* **Tests**
  * Added coverage confirming that windowed renders match equivalent full renders, including sequences where only the final clip is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->