### PR TITLE
fix(render): kill the FFmpeg a superseded preview-cache render leaves behind

### DIFF
--- a/src-tauri/src/core/process.rs
+++ b/src-tauri/src/core/process.rs
@@ -20,12 +20,18 @@ pub fn configure_std_command(cmd: &mut std::process::Command) {
 
 /// Apply platform-specific flags to a tokio process command.
 pub fn configure_tokio_command(cmd: &mut tokio::process::Command) {
+    // Kill the child if the future awaiting it is dropped. Every caller here
+    // awaits the process's own output, so a dropped future means the result is
+    // being abandoned — leaving FFmpeg running would orphan a process that holds
+    // its output file open (blocking its later removal on Windows) and burns CPU
+    // on work nobody will read. This is the backstop that makes a superseded
+    // preview-cache render safe even if it is cancelled by dropping its task.
+    cmd.kill_on_drop(true);
+
     #[cfg(target_os = "windows")]
     {
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
-    #[cfg(not(target_os = "windows"))]
-    let _ = cmd;
 }
 
 #[cfg(test)]

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -40,6 +40,7 @@ pub mod hardware;
 pub mod hdr;
 mod pip_stitch;
 pub mod plan;
+pub(crate) mod preview_cancel;
 mod render_window;
 pub mod smart;
 mod transform_layout;

--- a/src-tauri/src/core/render/preview_cancel.rs
+++ b/src-tauri/src/core/render/preview_cancel.rs
@@ -1,0 +1,138 @@
+//! Cooperative cancellation for a preview-cache fill.
+//!
+//! Superseding a fill has to stop it *and* kill the FFmpeg it currently has in
+//! flight — dropping the task alone leaves the process orphaned. Aborting the
+//! task races the graceful cleanup (the abort drops the task before its cancel
+//! arm can remove the partial file and report the segment as no longer
+//! rendering), so the fill is cancelled cooperatively instead: the loop checks
+//! [`PreviewCacheCancel::is_superseded`] between segments, and the segment
+//! currently rendering is cancelled through its own oneshot so the exporter
+//! kills FFmpeg, deletes the partial output and returns `ExportError::Cancelled`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use tokio::sync::oneshot;
+
+/// Cancellation shared between a preview-cache fill task and the call that
+/// supersedes it.
+#[derive(Default)]
+pub struct PreviewCacheCancel {
+    superseded: AtomicBool,
+    segment: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl PreviewCacheCancel {
+    /// Marks the fill superseded and cancels the segment in flight, if any.
+    pub fn trigger(&self) {
+        self.superseded.store(true, Ordering::Release);
+        if let Some(sender) = self.segment.lock().ok().and_then(|mut slot| slot.take()) {
+            let _ = sender.send(());
+        }
+    }
+
+    /// Whether a newer fill has taken over.
+    pub fn is_superseded(&self) -> bool {
+        self.superseded.load(Ordering::Acquire)
+    }
+
+    /// Arms cancellation for the segment about to render, returning its receiver.
+    ///
+    /// If the fill was superseded before the sender is armed, the returned
+    /// receiver is already cancelled so the render is skipped rather than run.
+    /// The flag is read *inside* the lock and [`trigger`](Self::trigger) sets the
+    /// flag *before* taking the lock, so the two cannot interleave into a state
+    /// where the flag is set yet a live sender sits in the slot that nothing will
+    /// ever fire — which would leave the segment rendering uncancellably.
+    pub fn arm_segment(&self) -> oneshot::Receiver<()> {
+        let (sender, receiver) = oneshot::channel();
+        match self.segment.lock() {
+            Ok(mut slot) => {
+                if self.is_superseded() {
+                    *slot = None;
+                    let _ = sender.send(());
+                } else {
+                    *slot = Some(sender);
+                }
+            }
+            // Fail safe: an unusable lock must cancel the segment, never leave it
+            // rendering with no way to stop it.
+            Err(_) => {
+                let _ = sender.send(());
+            }
+        }
+        receiver
+    }
+
+    /// Clears the armed segment sender once its render has returned.
+    pub fn disarm_segment(&self) {
+        if let Ok(mut slot) = self.segment.lock() {
+            *slot = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: triggering marks the fill superseded
+    #[test]
+    fn should_report_superseded_after_trigger() {
+        let cancel = PreviewCacheCancel::default();
+        assert!(!cancel.is_superseded());
+        cancel.trigger();
+        assert!(cancel.is_superseded());
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: triggering cancels the segment currently armed
+    #[test]
+    fn should_cancel_the_armed_segment_when_triggered() {
+        let cancel = PreviewCacheCancel::default();
+        let mut receiver = cancel.arm_segment();
+        assert_eq!(
+            receiver.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        );
+
+        cancel.trigger();
+
+        assert_eq!(receiver.try_recv(), Ok(()));
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: arming after a supersede yields an already-cancelled receiver
+    ///
+    /// Covers the race where the fill is superseded between the loop's
+    /// `is_superseded` check and arming the next segment: the segment must not
+    /// render.
+    #[test]
+    fn should_arm_a_pre_cancelled_receiver_after_a_supersede() {
+        let cancel = PreviewCacheCancel::default();
+        cancel.trigger();
+
+        let mut receiver = cancel.arm_segment();
+
+        assert_eq!(receiver.try_recv(), Ok(()));
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: disarming drops the sender so a later trigger sends nothing
+    #[test]
+    fn should_drop_the_sender_on_disarm() {
+        let cancel = PreviewCacheCancel::default();
+        let mut receiver = cancel.arm_segment();
+        cancel.disarm_segment();
+
+        cancel.trigger();
+
+        // The receiver's sender was dropped by disarm, so the channel is closed
+        // rather than delivering a cancellation.
+        assert_eq!(
+            receiver.try_recv(),
+            Err(oneshot::error::TryRecvError::Closed)
+        );
+    }
+}

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -2696,14 +2696,16 @@ fn reconcile_cache_manifest(
     Ok(())
 }
 
-/// Abort handle and identity for the active cache render task.
+use crate::core::render::preview_cancel::PreviewCacheCancel;
+
+/// Cancellation handle and identity for the active cache render task.
 ///
-/// Starting a new cache render aborts any in-flight background task so that
+/// Starting a new cache render supersedes any in-flight background task so that
 /// only one cache render is active at a time.
 struct ActiveCacheRender {
     job_id: String,
     sequence_id: String,
-    abort_handle: tokio::task::AbortHandle,
+    cancel: std::sync::Arc<PreviewCacheCancel>,
 }
 
 static ACTIVE_CACHE_RENDER: std::sync::LazyLock<std::sync::Mutex<Option<ActiveCacheRender>>> =
@@ -2895,29 +2897,48 @@ pub async fn render_preview_cache(
     let job_profile_hash = profile_hash.clone();
     let cache_config = config.clone();
 
-    // Cancel any in-flight cache render before starting a new one.
-    if let Ok(mut handle) = ACTIVE_CACHE_RENDER.lock() {
-        if let Some(previous) = handle.take() {
-            previous.abort_handle.abort();
-            tracing::info!("Aborted previous cache render task");
-            emit_render_lifecycle(
-                &app_handle,
-                RenderLifecycleEvent {
-                    job_id: previous.job_id,
-                    sequence_id: Some(previous.sequence_id),
-                    kind: RenderLifecycleKind::PreviewCache,
-                    state: RenderLifecycleState::Cancelled,
-                    progress: None,
-                    message: Some("Preview cache render was replaced by a newer job".to_string()),
-                    output_path: None,
-                    plan_hash: None,
-                },
-            );
+    let cache_job_id_for_task = cache_job_id.clone();
+    let cancel = std::sync::Arc::new(PreviewCacheCancel::default());
+    let task_cancel = cancel.clone();
+
+    // Supersede any in-flight fill and register this one in a single critical
+    // section, so two concurrent calls cannot both end up running: if the take
+    // and the register were separate locks, a second call could take (finding
+    // nothing yet registered) and register over this one, leaving this fill with
+    // no one able to cancel it. A supersede that lands before the task spawns is
+    // still caught by the loop-top `is_superseded()`.
+    let superseded = if let Ok(mut handle) = ACTIVE_CACHE_RENDER.lock() {
+        let previous = handle.take();
+        if let Some(previous) = &previous {
+            previous.cancel.trigger();
         }
+        *handle = Some(ActiveCacheRender {
+            job_id: cache_job_id.clone(),
+            sequence_id: seq_id.clone(),
+            cancel,
+        });
+        previous
+    } else {
+        None
+    };
+    if let Some(previous) = superseded {
+        tracing::info!("Superseded previous cache render task");
+        emit_render_lifecycle(
+            &app_handle,
+            RenderLifecycleEvent {
+                job_id: previous.job_id,
+                sequence_id: Some(previous.sequence_id),
+                kind: RenderLifecycleKind::PreviewCache,
+                state: RenderLifecycleState::Cancelled,
+                progress: None,
+                message: Some("Preview cache render was replaced by a newer job".to_string()),
+                output_path: None,
+                plan_hash: None,
+            },
+        );
     }
 
-    let cache_job_id_for_task = cache_job_id.clone();
-    let join_handle = tokio::spawn(async move {
+    tokio::spawn(async move {
         use tauri::Manager;
 
         let engine = ExportEngine::new(ffmpeg_runner);
@@ -2938,6 +2959,13 @@ pub async fn render_preview_cache(
         );
 
         for (completed, (idx, start_sec, end_sec)) in segment_ranges.iter().enumerate() {
+            // A newer fill has taken over: stop before starting another segment
+            // rather than render work no one will read.
+            if task_cancel.is_superseded() {
+                completed_normally = false;
+                break;
+            }
+
             // Re-load manifest to get latest state
             let mut current_manifest = match load_manifest(&project_path, &job_seq_id) {
                 Ok(Some(m)) => m,
@@ -3193,7 +3221,9 @@ pub async fn render_preview_cache(
             }
             let segment_plan_hash = render_plan.plan_hash.clone();
 
-            // Render with fresh data
+            // Render with fresh data. The segment cancel lets a superseding fill
+            // kill this FFmpeg mid-encode instead of orphaning it.
+            let segment_cancel_rx = task_cancel.arm_segment();
             let result = engine
                 .export_sequence_with_effects_for_plan(
                     &fresh_sequence,
@@ -3202,9 +3232,10 @@ pub async fn render_preview_cache(
                     &seg_settings,
                     &render_plan,
                     None,
-                    None,
+                    Some(segment_cancel_rx),
                 )
                 .await;
+            task_cancel.disarm_segment();
 
             // Update manifest
             let mut updated_manifest = match load_manifest(&project_path, &job_seq_id) {
@@ -3268,6 +3299,40 @@ pub async fn render_preview_cache(
                         &mut updated_manifest,
                         cache_config.max_cache_bytes,
                     );
+                }
+                Err(crate::core::render::ExportError::Cancelled) => {
+                    // A newer fill superseded this one mid-segment. The exporter
+                    // already killed FFmpeg and removed the partial file; leave
+                    // the segment renderable (not failed) so the timeline shows
+                    // work still to do, not a permanent error, and stop the loop.
+                    if let Some(seg) = updated_manifest
+                        .segments
+                        .iter_mut()
+                        .find(|s| s.index == *idx)
+                    {
+                        seg.state = crate::core::render::CacheSegmentState::Empty;
+                        seg.cached_file = None;
+                        seg.file_size_bytes = 0;
+                    }
+                    let _ = save_manifest(&project_path, &updated_manifest);
+                    emit_render_lifecycle(
+                        &app_handle,
+                        RenderLifecycleEvent {
+                            job_id: cache_job_id_for_task.clone(),
+                            sequence_id: Some(job_seq_id.clone()),
+                            kind: RenderLifecycleKind::PreviewCache,
+                            state: RenderLifecycleState::Cancelled,
+                            progress: None,
+                            message: Some(format!(
+                                "Preview cache segment {} superseded by a newer render",
+                                idx
+                            )),
+                            output_path: None,
+                            plan_hash: Some(segment_plan_hash.clone()),
+                        },
+                    );
+                    completed_normally = false;
+                    break;
                 }
                 Err(error) => {
                     if let Some(seg) = updated_manifest
@@ -3362,15 +3427,6 @@ pub async fn render_preview_cache(
             }
         }
     });
-
-    // Store the abort handle so the next render call can cancel this one.
-    if let Ok(mut handle) = ACTIVE_CACHE_RENDER.lock() {
-        *handle = Some(ActiveCacheRender {
-            job_id: cache_job_id.clone(),
-            sequence_id: seq_id.clone(),
-            abort_handle: join_handle.abort_handle(),
-        });
-    }
 
     Ok(RenderCacheJobResult {
         job_id: cache_job_id,


### PR DESCRIPTION
### **User description**
## Bug

Superseding an in-flight preview-cache fill `abort()`ed its task but passed **no cancel receiver** to the exporter, and the spawned FFmpeg had no `kill_on_drop`. Dropping the task therefore **orphaned the process**: it kept the partial segment file open (blocking its removal on Windows), burned CPU on a render no one would read, and left the manifest segment stuck at `Rendering` — a cache bar that stayed blue until the next render reconciled it. `ensure_preview_window` (a later PR) makes this per-scrub, so it must be fixed first.

## Fix

Cancel the fill **cooperatively** instead of aborting:

- `PreviewCacheCancel` (a Tauri-free primitive in `core::render`) carries a `superseded` flag the fill loop checks between segments and a oneshot for the segment currently rendering. Superseding sets the flag and fires the oneshot; the exporter's existing cancel arm then `child.kill()`s FFmpeg, deletes the partial output and returns `ExportError::Cancelled`.
- The fill records a cancelled segment as **`Empty`** (ordinary pending work) — not the `Error` that an interrupted-render `Reset` would produce, and not a stuck `Rendering`.
- The flag is read **inside** the segment lock while `trigger` sets it **before** taking that lock, so they cannot interleave into a set-but-uncancellable state (a real TOCTOU an adversarial review caught).
- Supersede + register of the new fill now happen in **one critical section**, so two concurrent calls cannot both end up running.
- `configure_tokio_command` sets `kill_on_drop(true)` as a backstop for **every** export path — a task dropped without a graceful cancel still kills its FFmpeg.

## Verification

- `cargo fmt` / `clippy -p openreelio --features gui --lib` / `clippy --all-targets --features dev-full -- -D warnings` clean.
- `cargo test -p openreelio --features gui --lib` → **4232 passed**; `PreviewCacheCancel` has 4 unit tests (trigger, cancel-armed-segment, arm-after-supersede, disarm).
- `cargo test -p openreelio-cli` → 231 + 164 passed (`kill_on_drop` blast radius checked: all 22 `configure_tokio_command` callers await their child; nothing detaches). `bindings.ts` unchanged.
- Adversarial review: confirmed the orphan is genuinely fixed, `Empty` is the correct state, and `kill_on_drop` is safe everywhere; two findings (the TOCTOU and the supersede/register race) fixed in this PR.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implements cooperative cancellation for preview-cache renders.

- Ensures FFmpeg processes are killed when superseded.

- Prevents orphaned processes from locking files on Windows.

- Fixes cache manifest state for cancelled segments.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["render_preview_cache"] -- "trigger()" --> B["PreviewCacheCancel"]
  B -- "send(msg)" --> C["ExportEngine"]
  C -- "kill()" --> D["FFmpeg Process"]
  B -- "is_superseded()" --> E["Fill Loop"]
  E -- "break" --> F["Task Exit"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>process.rs</strong><dd><code>Enable kill-on-drop for tokio child processes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/process.rs

<ul><li>Added <code>cmd.kill_on_drop(true)</code> to <code>configure_tokio_command</code>.<br> <li> Ensures child processes are terminated if the parent task is dropped.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/847/files#diff-4f373c222071aca3b32e8ff9e58b2a0db2501b3842313942b8ec1f5c51f6f487">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>preview_cancel.rs</strong><dd><code>New cooperative cancellation primitive for preview renders</code></dd></summary>
<hr>

src-tauri/src/core/render/preview_cancel.rs

<ul><li>Created <code>PreviewCacheCancel</code> primitive using <code>AtomicBool</code> and <code>oneshot</code> <br>channels.<br> <li> Provides thread-safe methods to trigger, arm, and check cancellation <br>status.<br> <li> Includes unit tests for various cancellation scenarios.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/847/files#diff-c6ba5a23a51d915b18055176444a6064028daa7ae5c5f0cb472869a60c41aa3c">+138/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose preview_cancel module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/mod.rs

- Registered the new `preview_cancel` module.


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/847/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>render.rs</strong><dd><code>Integrate cooperative cancellation into preview render IPC</code></dd></summary>
<hr>

src-tauri/src/ipc/commands/render.rs

<ul><li>Replaced <code>AbortHandle</code> with <code>PreviewCacheCancel</code> in <code>ActiveCacheRender</code>.<br> <li> Updated <code>render_preview_cache</code> to use cooperative cancellation instead <br>of task aborting.<br> <li> Added logic to handle <code>ExportError::Cancelled</code> by resetting segment <br>state to <code>Empty</code>.<br> <li> Unified superseding and registration into a single critical section.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/847/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+90/-34</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cooperative cancellation for preview-cache rendering.
  - Starting a new preview render now cancels the previous render and reports its cancellation status.
  - Interrupted segments are reset so they can be rendered again.

- **Bug Fixes**
  - Prevented orphaned FFmpeg processes from keeping output files open after rendering is cancelled.
  - Improved cancellation of segments currently being encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->