### PR TITLE
feat(render): expose segment index, fingerprint and file path in cache status

### DIFF
--- a/src-tauri/src/core/render/cache.rs
+++ b/src-tauri/src/core/render/cache.rs
@@ -1009,21 +1009,46 @@ pub struct RenderCacheStatus {
     pub segment_states: Vec<CacheSegmentStatusDto>,
 }
 
-/// Minimal per-segment info for the timeline cache indicator bar
+/// Per-segment info for the timeline cache indicator bar and for a cache-first
+/// preview: which segment file backs a time, and whether it is still current.
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct CacheSegmentStatusDto {
+    /// Segment index (0-based), so a caller can address the segment covering a time
+    pub index: u32,
     /// Start time in seconds
     pub start_sec: f64,
     /// End time in seconds
     pub end_sec: f64,
     /// Segment state
     pub state: CacheSegmentState,
+    /// The segment's render+content fingerprint, as a decimal string.
+    ///
+    /// A `u64` loses precision crossing JSON, so it is carried as text. A
+    /// cache-first preview keys its frame cache on this: when the fingerprint
+    /// changes, the picture the segment holds is stale and must not be reused.
+    pub fingerprint: String,
+    /// Absolute path to the cached segment file — `Some` only when the segment is
+    /// [`Cached`](CacheSegmentState::Cached) and its manifest-named file resolves
+    /// through the segment-name allowlist, `None` otherwise.
+    ///
+    /// The manifest lives inside the project directory and is therefore
+    /// attacker-controlled, so the path is produced by
+    /// [`resolve_cached_segment_path`] rather than by joining the raw name.
+    pub cached_path: Option<String>,
 }
 
 impl RenderCacheStatus {
-    /// Builds a status DTO from a manifest and config
-    pub fn from_manifest(manifest: &RenderCacheManifest, config: &RenderCacheConfig) -> Self {
+    /// Builds a status DTO from a manifest and config.
+    ///
+    /// `project_dir` is needed to resolve each cached segment's file path safely
+    /// (through the segment-name allowlist), so a cache-first preview can decode
+    /// the segment that backs a time without trusting the manifest's raw name.
+    pub fn from_manifest(
+        manifest: &RenderCacheManifest,
+        config: &RenderCacheConfig,
+        project_dir: &Path,
+    ) -> Self {
         let total = manifest.segments.len() as u32;
         let cached = manifest
             .segments
@@ -1041,13 +1066,34 @@ impl RenderCacheStatus {
             .filter(|s| s.state == CacheSegmentState::Rendering)
             .count() as u32;
 
+        // Resolve the profile directory once; a bad sequence id or profile hash
+        // simply leaves every path `None` rather than failing the whole status.
+        let profile_dir =
+            profile_cache_dir(project_dir, &manifest.sequence_id, &manifest.profile_hash).ok();
+
         let segment_states = manifest
             .segments
             .iter()
-            .map(|s| CacheSegmentStatusDto {
-                start_sec: s.start_sec,
-                end_sec: s.end_sec,
-                state: s.state.clone(),
+            .map(|s| {
+                // A path is offered only for a segment that actually has a current
+                // file on disk, and only when the name clears the allowlist.
+                let cached_path = if s.state == CacheSegmentState::Cached {
+                    profile_dir
+                        .as_ref()
+                        .zip(s.cached_file.as_ref())
+                        .and_then(|(dir, file)| resolve_cached_segment_path(dir, file))
+                        .map(|path| path.to_string_lossy().to_string())
+                } else {
+                    None
+                };
+                CacheSegmentStatusDto {
+                    index: s.index,
+                    start_sec: s.start_sec,
+                    end_sec: s.end_sec,
+                    state: s.state.clone(),
+                    fingerprint: s.fingerprint.to_string(),
+                    cached_path,
+                }
             })
             .collect();
 
@@ -1401,7 +1447,7 @@ pub fn cache_status_snapshot(
         );
     }
 
-    Ok(RenderCacheStatus::from_manifest(&view, config))
+    Ok(RenderCacheStatus::from_manifest(&view, config, project_dir))
 }
 
 // =============================================================================
@@ -2451,8 +2497,9 @@ mod tests {
         manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 1000);
         manifest.segments[1].state = CacheSegmentState::Stale;
 
+        let tmp = tempfile::tempdir().unwrap();
         let config = RenderCacheConfig::default();
-        let status = RenderCacheStatus::from_manifest(&manifest, &config);
+        let status = RenderCacheStatus::from_manifest(&manifest, &config, tmp.path());
 
         // Then status should reflect the manifest
         assert_eq!(status.total_segments, 3);
@@ -2463,6 +2510,33 @@ mod tests {
         assert_eq!(status.segment_states[0].state, CacheSegmentState::Cached);
         assert_eq!(status.segment_states[1].state, CacheSegmentState::Stale);
         assert_eq!(status.segment_states[2].state, CacheSegmentState::Empty);
+
+        // The segment identity a cache-first preview needs: index, fingerprint,
+        // and a resolved path for the cached segment (but not for the others).
+        assert_eq!(status.segment_states[0].index, 0);
+        assert_eq!(status.segment_states[2].index, 2);
+        assert!(status.segment_states[0].cached_path.is_some());
+        assert!(status.segment_states[1].cached_path.is_none());
+        assert!(status.segment_states[2].cached_path.is_none());
+    }
+
+    #[test]
+    fn should_not_offer_a_path_for_a_manifest_named_file_outside_the_cache() {
+        // The manifest is inside the project directory and so attacker-controlled;
+        // a status read must never hand back a path escaping the cache directory.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut manifest =
+            RenderCacheManifest::new("seq1", &preview_profile_hash(&test_canvas()), 5.0, 5.0);
+        manifest.mark_segment_cached(0, "../../etc/passwd".to_string(), 1);
+
+        let config = RenderCacheConfig::default();
+        let status = RenderCacheStatus::from_manifest(&manifest, &config, tmp.path());
+
+        assert_eq!(status.segment_states[0].state, CacheSegmentState::Cached);
+        assert!(
+            status.segment_states[0].cached_path.is_none(),
+            "a traversing segment name must not resolve to a path"
+        );
     }
 
     #[test]

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -4213,9 +4213,14 @@ export type CacheSegmentState =
  */
 "error"
 /**
- * Minimal per-segment info for the timeline cache indicator bar
+ * Per-segment info for the timeline cache indicator bar and for a cache-first
+ * preview: which segment file backs a time, and whether it is still current.
  */
 export type CacheSegmentStatusDto = { 
+/**
+ * Segment index (0-based), so a caller can address the segment covering a time
+ */
+index: number; 
 /**
  * Start time in seconds
  */
@@ -4227,7 +4232,25 @@ endSec: number;
 /**
  * Segment state
  */
-state: CacheSegmentState }
+state: CacheSegmentState; 
+/**
+ * The segment's render+content fingerprint, as a decimal string.
+ * 
+ * A `u64` loses precision crossing JSON, so it is carried as text. A
+ * cache-first preview keys its frame cache on this: when the fingerprint
+ * changes, the picture the segment holds is stale and must not be reused.
+ */
+fingerprint: string; 
+/**
+ * Absolute path to the cached segment file — `Some` only when the segment is
+ * [`Cached`](CacheSegmentState::Cached) and its manifest-named file resolves
+ * through the segment-name allowlist, `None` otherwise.
+ * 
+ * The manifest lives inside the project directory and is therefore
+ * attacker-controlled, so the path is produced by
+ * [`resolve_cached_segment_path`] rather than by joining the raw name.
+ */
+cachedPath: string | null }
 /**
  * Cache usage statistics.
  */

--- a/src/components/timeline/CacheStatusBar.test.tsx
+++ b/src/components/timeline/CacheStatusBar.test.tsx
@@ -6,9 +6,12 @@ import type { CacheSegmentStatusDto } from '../../bindings';
 describe('CacheStatusBar', () => {
   const makeSegments = (states: string[]): CacheSegmentStatusDto[] =>
     states.map((state, i) => ({
+      index: i,
       startSec: i * 5,
       endSec: (i + 1) * 5,
       state: state as CacheSegmentStatusDto['state'],
+      fingerprint: '0',
+      cachedPath: null,
     }));
 
   it('should render nothing when duration is zero', () => {


### PR DESCRIPTION
### **User description**
## Why

A cache-first preview needs, for the segment covering a given time, three things `CacheSegmentStatusDto` did not carry: **which** segment it is, whether the picture it holds is **still current**, and **where** to decode it from.

## Change

Add to `CacheSegmentStatusDto` (returned by the existing `get_cache_status` poll):

- `index` — so a caller can address the segment covering a time;
- `fingerprint` — the render+content fingerprint as a **decimal string** (a `u64` loses precision through JSON), which a cache-first preview keys its frame cache on so a stale segment's picture is never reused;
- `cachedPath` — `Some` only when the segment is `Cached` **and** its manifest-named file clears the segment-name allowlist.

**Security:** the manifest lives inside the project directory and is attacker-controlled, so `cachedPath` is produced by `resolve_cached_segment_path` (the same allowlist used for eviction), never by joining the raw name. A traversing name (`../../etc/passwd`) resolves to `None` — covered by a new test alongside the identity-field assertions.

Existing consumers are unaffected. This is the **passive** half of wiring the preview to the render-ahead cache (the active half — `ensure_preview_window` — follows).

## Verification

- `cargo fmt` / `clippy -p openreelio --features gui --lib` / `clippy --all-targets --features dev-full -- -D warnings` clean.
- `cargo test -p openreelio --features gui --lib` → 4233 passed (the DTO test now asserts index/fingerprint/cachedPath; a new test pins the traversal guard).
- `bindings.ts` regenerated (adds `index`, `fingerprint`, `cachedPath`).


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `index`, `fingerprint`, and `cachedPath` to `CacheSegmentStatusDto`.

- Implements secure path resolution for cached segments using an allowlist.

- Converts `u64` fingerprints to decimal strings for JSON compatibility.

- Includes unit tests for path traversal protection and DTO integrity.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Manifest["RenderCacheManifest"] -- "from_manifest(project_dir)" --> DTO["CacheSegmentStatusDto"]
  DTO -- "index" --> UI["Timeline/Preview"]
  DTO -- "fingerprint (string)" --> UI
  DTO -- "cachedPath (validated)" --> UI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bindings.ts</strong><dd><code>Update TypeScript bindings for cache status DTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bindings.ts

<ul><li>Updated <code>CacheSegmentStatusDto</code> type definition to include <code>index</code>, <br><code>fingerprint</code>, and <code>cachedPath</code>.<br> <li> Added documentation comments explaining the purpose of new fields for <br>cache-first previews.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/848/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+25/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>Enhance cache status DTO and implement secure path resolution</code></dd></summary>
<hr>

src-tauri/src/core/render/cache.rs

<ul><li>Modified <code>CacheSegmentStatusDto</code> struct to include <code>index</code>, <code>fingerprint</code>, <br>and <code>cached_path</code>.<br> <li> Updated <code>RenderCacheStatus::from_manifest</code> to require <code>project_dir</code> for <br>safe path resolution.<br> <li> Implemented logic to resolve absolute paths only for valid, cached <br>segments while preventing directory traversal.<br> <li> Added tests to verify correct DTO mapping and security against <br>malicious manifest file names.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/848/files#diff-630fc011e9e6377be668e04305949567349f26fefcf086384602a27b4aaec044">+83/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache status now includes each segment’s index, fingerprint, and resolved cached-file path.
  * Cached paths are only shown when they resolve to an approved segment location.

* **Bug Fixes**
  * Prevented unsafe or invalid manifest paths from being exposed as cached file locations.

* **Tests**
  * Updated cache status coverage for the expanded segment details and path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->