### PR TITLE
refactor(render): extract the preview-cache fill, add an ensure_preview_window scaffold

### DIFF
--- a/src-tauri/src/core/render/cache.rs
+++ b/src-tauri/src/core/render/cache.rs
@@ -1129,6 +1129,164 @@ impl RenderCacheStatus {
 }
 
 // =============================================================================
+// Preview Window Availability (for a cache-first preview)
+// =============================================================================
+
+/// What the preview cache holds for the segments covering a playhead window.
+///
+/// A cache-first preview parks on a time and needs to know two things: which
+/// segment file backs that time right now, and whether a fill was started to
+/// produce the ones that are missing. Everything here is a projection of the
+/// manifest — no filesystem work beyond resolving a cached segment's path.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewWindowAvailability {
+    /// Sequence the window belongs to
+    pub sequence_id: SequenceId,
+    /// Segment duration the manifest is laid out with, in seconds
+    pub segment_duration_sec: f64,
+    /// Segments covering the requested window, ordered by `start_sec`
+    pub segments: Vec<PreviewWindowSegment>,
+    /// `Some` when this call started a fill for the window's missing segments,
+    /// `None` when every window segment was already current and nothing ran.
+    pub job_id: Option<String>,
+}
+
+/// One segment of a [`PreviewWindowAvailability`].
+///
+/// Mirrors [`CacheSegmentStatusDto`] — same fields, same path-resolution rules —
+/// but scoped to a window instead of the whole timeline.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewWindowSegment {
+    /// Segment index (0-based)
+    pub index: u32,
+    /// Start time in seconds
+    pub start_sec: f64,
+    /// End time in seconds
+    pub end_sec: f64,
+    /// Segment state at the moment the window was projected
+    pub state: CacheSegmentState,
+    /// The segment's render+content fingerprint, as a decimal string.
+    ///
+    /// Carried as text because a `u64` loses precision crossing JSON; a
+    /// cache-first preview keys its frame cache on it.
+    pub fingerprint: String,
+    /// Absolute path to the cached segment file — `Some` only when the segment is
+    /// [`Cached`](CacheSegmentState::Cached) and its manifest-named file resolves
+    /// through the segment-name allowlist, `None` otherwise.
+    ///
+    /// The manifest is attacker-controlled whenever the project directory is, so
+    /// the path comes from [`resolve_cached_segment_path`], never from joining
+    /// the raw recorded name.
+    pub cached_path: Option<String>,
+}
+
+/// Selects the segments whose `[start_sec, end_sec)` overlaps the playhead window
+/// `[playhead_sec, playhead_sec + lookahead_sec)`.
+///
+/// The playhead is clamped to `0.0` (a negative or NaN time selects from the
+/// start of the timeline) and a negative lookahead is treated as zero. A
+/// zero-length window still selects the segment the playhead sits inside, so
+/// "just render where I am" is expressible.
+///
+/// Returned indices are in manifest order, which is start-time order.
+pub fn select_window_indices(
+    manifest: &RenderCacheManifest,
+    playhead_sec: f64,
+    lookahead_sec: f64,
+) -> Vec<u32> {
+    let window_start = playhead_sec.max(0.0);
+    let window_end = window_start + lookahead_sec.max(0.0);
+
+    manifest
+        .segments
+        .iter()
+        .filter(|segment| {
+            // Half-open on both sides, so a segment that merely touches the
+            // window's edge is not pulled in. The `start_sec <= window_start`
+            // arm keeps the segment containing the playhead selected when the
+            // window has zero length.
+            segment.end_sec > window_start
+                && (segment.start_sec < window_end || segment.start_sec <= window_start)
+        })
+        .map(|segment| segment.index)
+        .collect()
+}
+
+/// Narrows `indices` to the segments that still need rendering.
+///
+/// Indices with no matching segment are dropped rather than reported as
+/// pending: they name nothing this manifest can render.
+pub fn window_pending_indices(manifest: &RenderCacheManifest, indices: &[u32]) -> Vec<u32> {
+    indices
+        .iter()
+        .filter(|index| {
+            manifest
+                .segments
+                .iter()
+                .any(|segment| segment.index == **index && segment.needs_render())
+        })
+        .copied()
+        .collect()
+}
+
+/// Projects the named segments of a manifest into a [`PreviewWindowAvailability`].
+///
+/// `job_id` is left `None`; the caller sets it when it starts a fill. Segment
+/// paths are resolved exactly as [`RenderCacheStatus::from_manifest`] resolves
+/// them, so a window and the full status never disagree about which file backs
+/// a segment.
+pub fn window_availability(
+    manifest: &RenderCacheManifest,
+    project_dir: &Path,
+    indices: &[u32],
+) -> PreviewWindowAvailability {
+    // Resolve the profile directory once; a bad sequence id or profile hash
+    // simply leaves every path `None` rather than failing the whole projection.
+    let profile_dir =
+        profile_cache_dir(project_dir, &manifest.sequence_id, &manifest.profile_hash).ok();
+
+    let segments = indices
+        .iter()
+        .filter_map(|index| {
+            let segment = manifest
+                .segments
+                .iter()
+                .find(|segment| segment.index == *index)?;
+
+            // A path is offered only for a segment that actually has a current
+            // file on disk, and only when the name clears the allowlist.
+            let cached_path = if segment.state == CacheSegmentState::Cached {
+                profile_dir
+                    .as_ref()
+                    .zip(segment.cached_file.as_ref())
+                    .and_then(|(dir, file)| resolve_cached_segment_path(dir, file))
+                    .map(|path| path.to_string_lossy().to_string())
+            } else {
+                None
+            };
+
+            Some(PreviewWindowSegment {
+                index: segment.index,
+                start_sec: segment.start_sec,
+                end_sec: segment.end_sec,
+                state: segment.state.clone(),
+                fingerprint: segment.fingerprint.to_string(),
+                cached_path,
+            })
+        })
+        .collect();
+
+    PreviewWindowAvailability {
+        sequence_id: manifest.sequence_id.clone(),
+        segment_duration_sec: manifest.segment_duration_sec,
+        segments,
+        job_id: None,
+    }
+}
+
+// =============================================================================
 // Cache Directory Helpers
 // =============================================================================
 
@@ -3275,5 +3433,150 @@ mod tests {
         // Then nothing should be evicted
         assert_eq!(evicted, 0);
         assert_eq!(manifest.segments[0].state, CacheSegmentState::Cached);
+    }
+
+    // -----------------------------------------------------------------------
+    // Preview Window Availability
+    // -----------------------------------------------------------------------
+
+    /// A 20-second manifest laid out in four 5-second segments:
+    /// `[0,5) [5,10) [10,15) [15,20)`.
+    fn window_test_manifest() -> RenderCacheManifest {
+        RenderCacheManifest::new("seq1", &preview_profile_hash(&test_canvas()), 20.0, 5.0)
+    }
+
+    #[test]
+    fn should_report_no_pending_segments_when_whole_window_is_cached() {
+        // Given a window whose every segment is cached
+        let mut manifest = window_test_manifest();
+        for index in 0..2 {
+            manifest.mark_segment_cached(index, format!("segment_{index:04}.mp4"), 100);
+        }
+
+        // When selecting the window around the playhead: [1, 10) covers 0 and 1
+        let indices = select_window_indices(&manifest, 1.0, 9.0);
+
+        // Then it covers both segments and nothing needs rendering
+        assert_eq!(indices, vec![0, 1]);
+        assert!(window_pending_indices(&manifest, &indices).is_empty());
+    }
+
+    #[test]
+    fn should_select_stale_and_empty_segments_within_the_window() {
+        // Given a window whose first segment is cached, second stale, third empty
+        let mut manifest = window_test_manifest();
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
+        manifest.mark_segment_cached(1, "segment_0001.mp4".to_string(), 100);
+        manifest.segments[1].state = CacheSegmentState::Stale;
+
+        // When selecting the window spanning all three
+        let indices = select_window_indices(&manifest, 0.0, 15.0);
+
+        // Then only the stale and empty segments are pending
+        assert_eq!(indices, vec![0, 1, 2]);
+        assert_eq!(window_pending_indices(&manifest, &indices), vec![1, 2]);
+    }
+
+    #[test]
+    fn should_pull_in_the_next_segment_when_lookahead_crosses_the_boundary() {
+        // Given a manifest of 5-second segments and a playhead late in segment 0
+        let manifest = window_test_manifest();
+
+        // When the lookahead stays inside segment 0
+        let inside = select_window_indices(&manifest, 4.0, 0.5);
+
+        // Then only segment 0 is selected
+        assert_eq!(inside, vec![0]);
+
+        // When the lookahead reaches past the boundary
+        let across = select_window_indices(&manifest, 4.0, 2.0);
+
+        // Then the next segment comes with it
+        assert_eq!(across, vec![0, 1]);
+    }
+
+    #[test]
+    fn should_treat_the_window_as_half_open_at_both_edges() {
+        // Given segments laid out as [0,5) [5,10) [10,15) [15,20)
+        let manifest = window_test_manifest();
+
+        // When the playhead sits exactly on a boundary
+        // Then the segment starting there is selected, not the one ending there
+        assert_eq!(select_window_indices(&manifest, 5.0, 1.0), vec![1]);
+
+        // When the window ends exactly on a boundary
+        // Then the segment starting there is not pulled in
+        assert_eq!(select_window_indices(&manifest, 1.0, 4.0), vec![0]);
+
+        // When the window has zero length
+        // Then the segment containing the playhead is still selected
+        assert_eq!(select_window_indices(&manifest, 7.0, 0.0), vec![1]);
+
+        // When the playhead is negative it clamps to the start of the timeline
+        assert_eq!(select_window_indices(&manifest, -3.0, 1.0), vec![0]);
+
+        // When the playhead is past the end nothing is selected
+        assert!(select_window_indices(&manifest, 25.0, 5.0).is_empty());
+    }
+
+    #[test]
+    fn should_offer_a_cached_path_only_for_a_segment_name_we_could_have_written() {
+        // Given a cached segment with a real name and one with a traversing name
+        let tmp = tempfile::tempdir().unwrap();
+        let profile_hash = preview_profile_hash(&test_canvas());
+        let mut manifest = window_test_manifest();
+        manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
+        manifest.mark_segment_cached(1, "../../../escape.mp4".to_string(), 100);
+
+        // When projecting the window covering both
+        let availability = window_availability(&manifest, tmp.path(), &[0, 1, 2]);
+
+        // Then the real name resolves inside the profile cache directory
+        let expected = profile_cache_dir(tmp.path(), "seq1", &profile_hash)
+            .unwrap()
+            .join("segment_0000.mp4");
+        assert_eq!(
+            availability.segments[0].cached_path.as_deref(),
+            Some(expected.to_string_lossy().as_ref())
+        );
+
+        // And the traversing name is refused
+        assert_eq!(availability.segments[1].cached_path, None);
+
+        // And a segment that is not cached offers no path at all
+        assert_eq!(availability.segments[2].state, CacheSegmentState::Empty);
+        assert_eq!(availability.segments[2].cached_path, None);
+    }
+
+    #[test]
+    fn should_project_window_segments_in_start_order_with_manifest_metadata() {
+        // Given a manifest whose fingerprints have been set
+        let mut manifest = window_test_manifest();
+        manifest.segments[1].fingerprint = 18_446_744_073_709_551_615;
+
+        // When projecting a window
+        let availability = window_availability(&manifest, Path::new("."), &[1, 2]);
+
+        // Then the projection carries the manifest's layout and identity
+        assert_eq!(availability.sequence_id, "seq1");
+        assert_eq!(availability.segment_duration_sec, 5.0);
+        assert_eq!(availability.job_id, None);
+        let starts: Vec<f64> = availability.segments.iter().map(|s| s.start_sec).collect();
+        assert_eq!(starts, vec![5.0, 10.0]);
+        // And the u64 fingerprint survives as text rather than losing precision
+        assert_eq!(availability.segments[0].fingerprint, "18446744073709551615");
+    }
+
+    #[test]
+    fn should_ignore_window_indices_that_name_no_segment() {
+        // Given a manifest of four segments
+        let manifest = window_test_manifest();
+
+        // When asked about an index beyond the timeline
+        // Then it is neither pending nor projected
+        assert!(window_pending_indices(&manifest, &[99]).is_empty());
+        assert!(window_availability(&manifest, Path::new("."), &[99])
+            .segments
+            .is_empty());
     }
 }

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -75,10 +75,11 @@ pub use cache::{
     enforce_cache_limit, is_cached_segment_name, load_manifest, manifest_for_profile,
     manifest_path, preview_profile_hash, profile_cache_dir, prune_other_profile_caches,
     refresh_manifest_plan_fingerprints, render_cache_dir, resolve_cached_segment_path,
-    save_manifest, segment_cache_file, sequence_cache_dir, CacheSegmentState,
-    CacheSegmentStatusDto, InterruptedRenderPolicy, ManifestForProfile, RenderCacheConfig,
-    RenderCacheManifest, RenderCacheSegment, RenderCacheStatus, SegmentFingerprint,
-    SEGMENT_FINGERPRINT_UNSET,
+    save_manifest, segment_cache_file, select_window_indices, sequence_cache_dir,
+    window_availability, window_pending_indices, CacheSegmentState, CacheSegmentStatusDto,
+    InterruptedRenderPolicy, ManifestForProfile, PreviewWindowAvailability, PreviewWindowSegment,
+    RenderCacheConfig, RenderCacheManifest, RenderCacheSegment, RenderCacheStatus,
+    SegmentFingerprint, SEGMENT_FINGERPRINT_UNSET,
 };
 
 // Smart render re-exports

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -2711,6 +2711,131 @@ struct ActiveCacheRender {
 static ACTIVE_CACHE_RENDER: std::sync::LazyLock<std::sync::Mutex<Option<ActiveCacheRender>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
 
+/// Everything a preview cache command needs from the open project, copied out
+/// from under the project lock so nothing downstream holds it.
+struct CacheRenderInputs {
+    sequence: crate::core::timeline::Sequence,
+    assets: std::collections::HashMap<String, crate::core::assets::Asset>,
+    effects: std::collections::HashMap<String, crate::core::effects::Effect>,
+    render_graph: crate::core::render::RenderGraph,
+    project_path: std::path::PathBuf,
+    seq_id: String,
+}
+
+/// Copies the active sequence and its render inputs out of the open project.
+async fn gather_cache_render_inputs(
+    state: &State<'_, AppState>,
+) -> Result<CacheRenderInputs, String> {
+    let guard = state.project.lock().await;
+    let project = guard
+        .as_ref()
+        .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+
+    let seq_id = project
+        .state
+        .active_sequence_id
+        .as_ref()
+        .ok_or_else(|| "No active sequence".to_string())?
+        .clone();
+
+    let sequence = project
+        .state
+        .sequences
+        .get(&seq_id)
+        .ok_or_else(|| format!("Sequence not found: {seq_id}"))?
+        .clone();
+
+    let render_graph = crate::core::render::build_render_graph(&project.state, &seq_id)
+        .map_err(|error| format!("Failed to build render graph: {error}"))?;
+
+    let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
+        .state
+        .assets
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    let effects: std::collections::HashMap<String, crate::core::effects::Effect> = project
+        .state
+        .effects
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    Ok(CacheRenderInputs {
+        sequence,
+        assets,
+        effects,
+        render_graph,
+        project_path: project.path.clone(),
+        seq_id,
+    })
+}
+
+/// Loads the preview cache manifest for a sequence and brings its freshness
+/// verdict up to date.
+///
+/// A manifest left by another encode profile describes files in a different
+/// directory that were encoded to different settings, so it is discarded along
+/// with those files. What survives is then reconciled against the sequence
+/// layout, re-fingerprinted against the current render plan, and stripped of
+/// segments whose files have gone missing.
+///
+/// This may persist the manifest — it resets segments an interrupted run left in
+/// [`CacheSegmentState::Rendering`](crate::core::render::CacheSegmentState) — so
+/// only a caller that is about to own the render may call it. Read-only callers
+/// use [`crate::core::render::cache_status_snapshot`].
+#[allow(clippy::too_many_arguments)]
+fn prepare_cache_manifest(
+    project_path: &std::path::Path,
+    seq_id: &str,
+    profile_hash: &str,
+    sequence: &crate::core::timeline::Sequence,
+    render_graph: &crate::core::render::RenderGraph,
+    assets: &std::collections::HashMap<String, crate::core::assets::Asset>,
+    effects: &std::collections::HashMap<String, crate::core::effects::Effect>,
+    config: &crate::core::render::RenderCacheConfig,
+) -> Result<crate::core::render::RenderCacheManifest, String> {
+    use crate::core::render::cache::{
+        cleanup_stale_files, manifest_for_profile, prune_other_profile_caches, save_manifest,
+    };
+
+    let loaded = manifest_for_profile(
+        project_path,
+        seq_id,
+        profile_hash,
+        sequence.duration(),
+        config.segment_duration_sec,
+    )
+    .map_err(|e| format!("Failed to load cache manifest: {e}"))?;
+    if let Some(discarded) = loaded.discarded_profile {
+        tracing::info!(
+            "Discarding preview cache for sequence {seq_id} written with render profile \
+             {discarded:?}; current profile is {profile_hash:?}"
+        );
+        if let Err(error) = prune_other_profile_caches(project_path, seq_id, profile_hash) {
+            tracing::warn!("Failed to prune stale render profile caches: {error}");
+        }
+    }
+    let mut manifest = loaded.manifest;
+
+    reconcile_cache_manifest(&mut manifest, project_path, sequence, config)?;
+    if crate::core::render::refresh_manifest_plan_fingerprints(
+        &mut manifest,
+        project_path,
+        sequence,
+        render_graph,
+        assets,
+        effects,
+    )? {
+        save_manifest(project_path, &manifest)
+            .map_err(|error| format!("Failed to save cache manifest: {error}"))?;
+    }
+    cleanup_stale_files(project_path, &mut manifest);
+
+    Ok(manifest)
+}
+
 /// Render preview cache for the active sequence.
 ///
 /// Triggers background rendering of uncached segments. Returns the cache
@@ -2723,100 +2848,31 @@ pub async fn render_preview_cache(
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
 ) -> Result<RenderCacheJobResult, String> {
-    use crate::core::render::cache::{
-        cleanup_stale_files, enforce_cache_limit, load_manifest, manifest_for_profile,
-        preview_profile_hash, prune_other_profile_caches, save_manifest,
-    };
-    use crate::core::render::ExportEngine;
-    use tauri::Emitter;
+    use crate::core::render::cache::preview_profile_hash;
 
     let config = resolve_cache_config(&app_handle);
 
     // Gather project data
-    let (sequence, assets, effects, render_graph, project_path, seq_id) = {
-        let guard = state.project.lock().await;
-        let project = guard
-            .as_ref()
-            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+    let CacheRenderInputs {
+        sequence,
+        assets,
+        effects,
+        render_graph,
+        project_path,
+        seq_id,
+    } = gather_cache_render_inputs(&state).await?;
 
-        let seq_id = project
-            .state
-            .active_sequence_id
-            .as_ref()
-            .ok_or_else(|| "No active sequence".to_string())?
-            .clone();
-
-        let sequence = project
-            .state
-            .sequences
-            .get(&seq_id)
-            .ok_or_else(|| format!("Sequence not found: {seq_id}"))?
-            .clone();
-
-        let render_graph = crate::core::render::build_render_graph(&project.state, &seq_id)
-            .map_err(|error| format!("Failed to build render graph: {error}"))?;
-
-        let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
-            .state
-            .assets
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-
-        let effects: std::collections::HashMap<String, crate::core::effects::Effect> = project
-            .state
-            .effects
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-
-        (
-            sequence,
-            assets,
-            effects,
-            render_graph,
-            project.path.clone(),
-            seq_id,
-        )
-    };
-
-    // Load or create the manifest for the preview encode profile. A manifest left
-    // by another profile describes files in a different directory that were encoded
-    // to different settings, so it is discarded along with those files.
-    let cache_job_id = ulid::Ulid::new().to_string();
     let profile_hash = preview_profile_hash(&sequence.format.canvas);
-    let loaded = manifest_for_profile(
+    let manifest = prepare_cache_manifest(
         &project_path,
         &seq_id,
         &profile_hash,
-        sequence.duration(),
-        config.segment_duration_sec,
-    )
-    .map_err(|e| format!("Failed to load cache manifest: {e}"))?;
-    if let Some(discarded) = loaded.discarded_profile {
-        tracing::info!(
-            "Discarding preview cache for sequence {seq_id} written with render profile \
-             {discarded:?}; current profile is {profile_hash:?}"
-        );
-        if let Err(error) = prune_other_profile_caches(&project_path, &seq_id, &profile_hash) {
-            tracing::warn!("Failed to prune stale render profile caches: {error}");
-        }
-    }
-    let mut manifest = loaded.manifest;
-
-    reconcile_cache_manifest(&mut manifest, &project_path, &sequence, &config)?;
-    if crate::core::render::refresh_manifest_plan_fingerprints(
-        &mut manifest,
-        &project_path,
         &sequence,
         &render_graph,
         &assets,
         &effects,
-    )? {
-        save_manifest(&project_path, &manifest)
-            .map_err(|error| format!("Failed to save cache manifest: {error}"))?;
-    }
-    cleanup_stale_files(&project_path, &mut manifest);
+        &config,
+    )?;
 
     // Find segments that need rendering
     let pending_indices: Vec<u32> = manifest
@@ -2826,6 +2882,54 @@ pub async fn render_preview_cache(
         .map(|s| s.index)
         .collect();
 
+    // `State<'_>` cannot be moved into the spawned task, so the runner is cloned
+    // out here. It stays optional so that an already-current cache still reports
+    // `AlreadyCached` when FFmpeg is missing, exactly as it did while the fill
+    // was inlined: the "FFmpeg not initialized" error is only raised on the path
+    // that actually spawns.
+    let ffmpeg_runner = ffmpeg_state.read().await.runner().cloned();
+
+    spawn_cache_fill(
+        app_handle,
+        ffmpeg_runner,
+        project_path,
+        seq_id,
+        profile_hash,
+        config,
+        manifest,
+        pending_indices,
+    )
+}
+
+/// Fills the named segments of a sequence's preview cache in the background.
+///
+/// Shared by every command that wants cache segments produced: the caller
+/// decides *which* segments (the whole timeline for
+/// [`render_preview_cache`], just the playhead window for
+/// [`ensure_preview_window`]) and this owns the rest — the already-current
+/// early return, persisting the manifest, and the background fill task.
+///
+/// `manifest` must already be reconciled and re-fingerprinted; this function
+/// trusts `pending_indices` and does not recompute freshness.
+///
+/// Starting a fill supersedes any fill already in flight, so at most one cache
+/// render is running at a time.
+#[allow(clippy::too_many_arguments)]
+fn spawn_cache_fill(
+    app_handle: tauri::AppHandle,
+    ffmpeg_runner: Option<crate::core::ffmpeg::FFmpegRunner>,
+    project_path: std::path::PathBuf,
+    seq_id: String,
+    profile_hash: String,
+    config: crate::core::render::RenderCacheConfig,
+    manifest: crate::core::render::RenderCacheManifest,
+    pending_indices: Vec<u32>,
+) -> Result<RenderCacheJobResult, String> {
+    use crate::core::render::cache::{enforce_cache_limit, load_manifest, save_manifest};
+    use crate::core::render::ExportEngine;
+    use tauri::Emitter;
+
+    let cache_job_id = ulid::Ulid::new().to_string();
     let total_pending = pending_indices.len() as u32;
 
     if total_pending == 0 {
@@ -2884,18 +2988,11 @@ pub async fn render_preview_cache(
         },
     );
 
-    // Clone FFmpegRunner before spawning (State<'_> cannot be moved into spawn)
-    let ffmpeg_runner = {
-        let ffmpeg_guard = ffmpeg_state.read().await;
-        ffmpeg_guard
-            .runner()
-            .ok_or("FFmpeg not initialized")?
-            .clone()
-    };
+    let ffmpeg_runner = ffmpeg_runner.ok_or("FFmpeg not initialized")?;
 
     let job_seq_id = seq_id.clone();
     let job_profile_hash = profile_hash.clone();
-    let cache_config = config.clone();
+    let cache_config = config;
 
     let cache_job_id_for_task = cache_job_id.clone();
     let cancel = std::sync::Arc::new(PreviewCacheCancel::default());
@@ -3435,6 +3532,114 @@ pub async fn render_preview_cache(
         segments_to_render: total_pending,
         status: RenderCacheJobStatus::Started,
     })
+}
+
+/// Default lookahead, as a multiple of the cache segment duration, when the
+/// caller does not name one: the segment the playhead sits in plus roughly one
+/// more, so a preview parked on a time has somewhere to run to.
+const DEFAULT_PREVIEW_LOOKAHEAD_SEGMENTS: f64 = 2.0;
+
+/// Ensures the preview cache covers the segments around a playhead.
+///
+/// This is the cache-first preview's hot path: it reports which segment file
+/// backs each time in `[playhead_sec, playhead_sec + lookahead_sec)` and, only
+/// when some of those segments are missing or stale, starts a fill for exactly
+/// those segments. Unlike [`render_preview_cache`] it never renders the whole
+/// timeline, so parking on a time costs one window, not one project.
+///
+/// When every window segment is already current, nothing is rendered and
+/// `job_id` is `None`. Otherwise a background fill is started (superseding any
+/// fill already running) and `job_id` names it; the returned segment states are
+/// the pre-render snapshot, so the ones being filled still read `Empty` or
+/// `Stale` — callers refresh on the `render-cache-*` events.
+///
+/// `lookahead_sec` defaults to twice the configured segment duration. A
+/// negative playhead is clamped to the start of the timeline.
+///
+/// # Not yet convergent — do not wire to per-scrub UI without the fixes below
+///
+/// This command is registered but has no caller yet, and it is **not** correct
+/// under its intended per-playhead call pattern. Fix these before wiring it:
+/// 1. It reconciles with [`InterruptedRenderPolicy::Reset`], which flips the
+///    segment a running fill is mid-encode on to `Error` and then supersedes and
+///    restarts it — so a window overlapping the in-flight segment kills and
+///    restarts it on every call and it never completes. The active fill's
+///    segment set must be consulted so a window already being produced is not
+///    superseded (and a live `Rendering` segment is not reset).
+/// 2. Its background fill emits the unfiltered `render-cache-*` events, which a
+///    whole-timeline cache UI reads as its own completion. The events (or the
+///    consumer) must be scoped by job.
+/// 3. On a subset window, [`cleanup_stale_files`] can delete an out-of-window
+///    stale file without persisting, and [`enforce_cache_limit`]'s
+///    highest-index-first eviction can drop the very window segment just
+///    rendered — an eviction loop on a full cache. The active window must be
+///    pinned against eviction and the cleanup persisted.
+#[tauri::command]
+#[specta::specta]
+pub async fn ensure_preview_window(
+    playhead_sec: f64,
+    lookahead_sec: Option<f64>,
+    state: State<'_, AppState>,
+    ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
+    app: tauri::AppHandle,
+) -> Result<crate::core::render::PreviewWindowAvailability, String> {
+    use crate::core::render::cache::{
+        preview_profile_hash, select_window_indices, window_availability, window_pending_indices,
+    };
+
+    let config = resolve_cache_config(&app);
+
+    let CacheRenderInputs {
+        sequence,
+        assets,
+        effects,
+        render_graph,
+        project_path,
+        seq_id,
+    } = gather_cache_render_inputs(&state).await?;
+
+    let profile_hash = preview_profile_hash(&sequence.format.canvas);
+    let manifest = prepare_cache_manifest(
+        &project_path,
+        &seq_id,
+        &profile_hash,
+        &sequence,
+        &render_graph,
+        &assets,
+        &effects,
+        &config,
+    )?;
+
+    let lookahead =
+        lookahead_sec.unwrap_or(DEFAULT_PREVIEW_LOOKAHEAD_SEGMENTS * config.segment_duration_sec);
+    let window_indices = select_window_indices(&manifest, playhead_sec, lookahead);
+    let window_pending = window_pending_indices(&manifest, &window_indices);
+
+    // Project the window before any fill starts, so the reported states are the
+    // snapshot the caller can act on right now.
+    let mut availability = window_availability(&manifest, &project_path, &window_indices);
+
+    if window_pending.is_empty() {
+        // Everything the playhead needs is already current: do not spawn, do not
+        // emit, do not supersede a fill that is usefully running elsewhere.
+        return Ok(availability);
+    }
+
+    let ffmpeg_runner = ffmpeg_state.read().await.runner().cloned();
+
+    let result = spawn_cache_fill(
+        app,
+        ffmpeg_runner,
+        project_path,
+        seq_id,
+        profile_hash,
+        config,
+        manifest,
+        window_pending,
+    )?;
+
+    availability.job_id = Some(result.job_id);
+    Ok(availability)
 }
 
 /// Status of a render cache job

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1656,6 +1656,7 @@ mod tauri_app {
                 $crate::ipc::get_cache_status,
                 $crate::ipc::clear_render_cache,
                 $crate::ipc::render_preview_cache,
+                $crate::ipc::ensure_preview_window,
                 // Stabilization command
                 $crate::ipc::stabilize_clip,
                 // Smart reframe command
@@ -2192,6 +2193,7 @@ mod tauri_app {
             ipc::get_cache_status,
             ipc::clear_render_cache,
             ipc::render_preview_cache,
+            ipc::ensure_preview_window,
             // Stabilization command
             ipc::stabilize_clip,
             // Smart reframe command

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -719,6 +719,50 @@ async renderPreviewCache() : Promise<Result<RenderCacheJobResult, string>> {
 }
 },
 /**
+ * Ensures the preview cache covers the segments around a playhead.
+ * 
+ * This is the cache-first preview's hot path: it reports which segment file
+ * backs each time in `[playhead_sec, playhead_sec + lookahead_sec)` and, only
+ * when some of those segments are missing or stale, starts a fill for exactly
+ * those segments. Unlike [`render_preview_cache`] it never renders the whole
+ * timeline, so parking on a time costs one window, not one project.
+ * 
+ * When every window segment is already current, nothing is rendered and
+ * `job_id` is `None`. Otherwise a background fill is started (superseding any
+ * fill already running) and `job_id` names it; the returned segment states are
+ * the pre-render snapshot, so the ones being filled still read `Empty` or
+ * `Stale` — callers refresh on the `render-cache-*` events.
+ * 
+ * `lookahead_sec` defaults to twice the configured segment duration. A
+ * negative playhead is clamped to the start of the timeline.
+ * 
+ * # Not yet convergent — do not wire to per-scrub UI without the fixes below
+ * 
+ * This command is registered but has no caller yet, and it is **not** correct
+ * under its intended per-playhead call pattern. Fix these before wiring it:
+ * 1. It reconciles with [`InterruptedRenderPolicy::Reset`], which flips the
+ * segment a running fill is mid-encode on to `Error` and then supersedes and
+ * restarts it — so a window overlapping the in-flight segment kills and
+ * restarts it on every call and it never completes. The active fill's
+ * segment set must be consulted so a window already being produced is not
+ * superseded (and a live `Rendering` segment is not reset).
+ * 2. Its background fill emits the unfiltered `render-cache-*` events, which a
+ * whole-timeline cache UI reads as its own completion. The events (or the
+ * consumer) must be scoped by job.
+ * 3. On a subset window, [`cleanup_stale_files`] can delete an out-of-window
+ * stale file without persisting, and [`enforce_cache_limit`]'s
+ * highest-index-first eviction can drop the very window segment just
+ * rendered — an eviction loop on a full cache. The active window must be
+ * pinned against eviction and the cleanup persisted.
+ */
+async ensurePreviewWindow(playheadSec: number, lookaheadSec: number | null) : Promise<Result<PreviewWindowAvailability, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ensure_preview_window", { playheadSec, lookaheadSec }) };
+} catch (e) {
+    return { status: "error", error: e  as any };
+}
+},
+/**
  * Run video stabilization analysis on a clip.
  * 
  * This performs the analysis pass only:
@@ -6794,6 +6838,72 @@ startSec: number;
  * End time in seconds
  */
 endSec: number }
+/**
+ * What the preview cache holds for the segments covering a playhead window.
+ * 
+ * A cache-first preview parks on a time and needs to know two things: which
+ * segment file backs that time right now, and whether a fill was started to
+ * produce the ones that are missing. Everything here is a projection of the
+ * manifest — no filesystem work beyond resolving a cached segment's path.
+ */
+export type PreviewWindowAvailability = { 
+/**
+ * Sequence the window belongs to
+ */
+sequenceId: string; 
+/**
+ * Segment duration the manifest is laid out with, in seconds
+ */
+segmentDurationSec: number; 
+/**
+ * Segments covering the requested window, ordered by `start_sec`
+ */
+segments: PreviewWindowSegment[]; 
+/**
+ * `Some` when this call started a fill for the window's missing segments,
+ * `None` when every window segment was already current and nothing ran.
+ */
+jobId: string | null }
+/**
+ * One segment of a [`PreviewWindowAvailability`].
+ * 
+ * Mirrors [`CacheSegmentStatusDto`] — same fields, same path-resolution rules —
+ * but scoped to a window instead of the whole timeline.
+ */
+export type PreviewWindowSegment = { 
+/**
+ * Segment index (0-based)
+ */
+index: number; 
+/**
+ * Start time in seconds
+ */
+startSec: number; 
+/**
+ * End time in seconds
+ */
+endSec: number; 
+/**
+ * Segment state at the moment the window was projected
+ */
+state: CacheSegmentState; 
+/**
+ * The segment's render+content fingerprint, as a decimal string.
+ * 
+ * Carried as text because a `u64` loses precision crossing JSON; a
+ * cache-first preview keys its frame cache on it.
+ */
+fingerprint: string; 
+/**
+ * Absolute path to the cached segment file — `Some` only when the segment is
+ * [`Cached`](CacheSegmentState::Cached) and its manifest-named file resolves
+ * through the segment-name allowlist, `None` otherwise.
+ * 
+ * The manifest is attacker-controlled whenever the project directory is, so
+ * the path comes from [`resolve_cached_segment_path`], never from joining
+ * the raw recorded name.
+ */
+cachedPath: string | null }
 /**
  * Project information returned when creating or opening a project.
  */


### PR DESCRIPTION
### **User description**
## Extraction (behavior-preserving)

`render_preview_cache` inlined everything — gathering project data under the lock, loading/reconciling the manifest, and the background fill task with its cancel wiring. Split into three reusable pieces:

- `gather_cache_render_inputs` — gather under the project lock;
- `prepare_cache_manifest` — load / profile-discard / reconcile / refresh / cleanup;
- `spawn_cache_fill(..., pending_indices)` — the AlreadyCached early return, the manifest save, and the background fill task **including the PR #847 supersede/cancel wiring, moved verbatim** — so a caller can render a chosen subset of segments instead of the whole timeline.

`render_preview_cache` is now a thin orchestration over them. An adversarial review confirmed **zero behavior drift**: event order, the AlreadyCached result, and the cancel wiring are unchanged. The one deliberate subtlety — `ffmpeg_runner: Option` — preserves the old behavior that an already-current cache reports AlreadyCached even when FFmpeg is uninitialised (the "not initialized" error is only raised on the path that actually spawns).

## `ensure_preview_window` scaffold (registered, not yet wired)

Adds the command a cache-first preview will call to render just the segments around the playhead, plus its window helpers (`select_window_indices`, `window_pending_indices`, `window_availability`) and `PreviewWindowAvailability`/`PreviewWindowSegment` DTOs (path resolution via the segment-name allowlist, same rules as `CacheSegmentStatusDto`).

**It has no caller yet, and its doc records that it is not yet convergent under a per-scrub pattern** — it must consult the active fill's segment set (so a window overlapping the in-flight segment doesn't kill and restart it), scope its cache events by job, and pin the active window against eviction, before the UI calls it. Those fixes are tracked as a prerequisite for the wiring PR. This lands the extraction and the scaffold.

## Verification

- `cargo fmt` / `clippy -p openreelio --features gui --lib` / `clippy --all-targets --features dev-full -- -D warnings` clean.
- `cargo test -p openreelio --features gui --lib` → **4240 passed** (7 new pure-helper tests for window selection / availability / the path-traversal guard).
- `cargo test -p openreelio-cli` → 231 + 164 passed. `bindings.ts` regenerated (`ensurePreviewWindow` + DTOs; new types, no existing consumer).


___

### **PR Type**
Enhancement


___

### **Description**
- Refactors `render_preview_cache` into reusable orchestration components.

- Introduces `ensure_preview_window` for targeted playhead-based rendering.

- Implements window-projection logic to identify missing cache segments.

- Adds TypeScript bindings for the new preview window command.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ensure_preview_window"] -- "selects" --> B["Window Indices"]
  B -- "filters" --> C["Pending Indices"]
  C -- "triggers" --> D["spawn_cache_fill"]
  D -- "updates" --> E["Preview Cache"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bindings.ts</strong><dd><code>Update TypeScript bindings for preview window commands</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bindings.ts

<ul><li>Added <code>ensurePreviewWindow</code> async function to invoke the new Tauri <br>command.<br> <li> Defined <code>PreviewWindowAvailability</code> and <code>PreviewWindowSegment</code> types for <br>frontend consumption.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/849/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>Implement preview window selection and projection logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/cache.rs

<ul><li>Implemented <code>PreviewWindowAvailability</code> and <code>PreviewWindowSegment</code> DTOs.<br> <li> Added <code>select_window_indices</code> to find segments overlapping a time range.<br> <li> Added <code>window_pending_indices</code> and <code>window_availability</code> helpers.<br> <li> Included comprehensive unit tests for window selection and path <br>resolution.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/849/files#diff-630fc011e9e6377be668e04305949567349f26fefcf086384602a27b4aaec044">+303/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose new cache window utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/mod.rs

<ul><li>Exported new window-related types and functions from the <code>cache</code> module.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/849/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>render.rs</strong><dd><code>Refactor cache rendering IPC and add window command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/render.rs

<ul><li>Refactored <code>render_preview_cache</code> into <code>gather_cache_render_inputs</code>, <br><code>prepare_cache_manifest</code>, and <code>spawn_cache_fill</code>.<br> <li> Implemented <code>ensure_preview_window</code> command to render only segments near <br>the playhead.<br> <li> Added detailed documentation regarding future convergence requirements <br>for per-scrub UI.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/849/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+288/-83</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Register new preview window command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/lib.rs

<ul><li>Registered the <code>ensure_preview_window</code> command in the Tauri handler.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/849/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cache-aware preview window availability, showing which segments are ready, pending, or require rendering.
  - Added background rendering for missing or outdated preview segments around the current playback position.
  - Added configurable lookahead coverage, with a default based on cache segment duration.
  - Improved preview cache handling to preserve already-cached results when rendering is unavailable.
- **Bug Fixes**
  - Added safeguards against unsafe cached file paths and invalid segment references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->