### PR TITLE
feat(render): record the preview cache losslessly so a cached frame is the composite

### DIFF
--- a/src-tauri/src/core/render/cache.rs
+++ b/src-tauri/src/core/render/cache.rs
@@ -41,10 +41,10 @@
 //! cache vs. an export ladder, say) plan identically while producing
 //! incompatible files. The profile hash therefore both feeds the fingerprint
 //! and names the directory segments live in
-//! (`renders/<sequenceId>/<profileHash>/segment_0000.mp4`), so one profile's
+//! (`renders/<sequenceId>/<profileHash>/segment_0000.mov`), so one profile's
 //! files can never be handed to a request for another.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -961,7 +961,7 @@ pub struct RenderCacheConfig {
 impl Default for RenderCacheConfig {
     fn default() -> Self {
         Self {
-            max_cache_bytes: 1024 * 1024 * 1024, // 1 GB
+            max_cache_bytes: 8 * 1024 * 1024 * 1024, // 8 GB (lossless cache is ~45x larger than the old H.264 one)
             segment_duration_sec: DEFAULT_SEGMENT_DURATION_SEC,
             enabled: true,
             smart_render_enabled: true,
@@ -1353,14 +1353,33 @@ pub fn segment_cache_file(
         .join(segment_cache_file_name(index)))
 }
 
+/// Extension segments are written with today.
+///
+/// The preview cache encodes Ut Video, which MP4 cannot carry; see
+/// [`ExportSettings::preview_cache`].
+const SEGMENT_FILE_EXTENSION: &str = "mov";
+
+/// Extensions a segment file may have been written with by *some* build.
+///
+/// Only [`SEGMENT_FILE_EXTENSION`] is ever emitted. `mp4` is the extension the
+/// H.264 preview-cache profile used, and it stays recognized so segments an
+/// older build left on disk are still deletable by
+/// [`prune_other_profile_caches`] and the eviction path — a name we refuse to
+/// recognize is a file we can never clean up.
+const RECOGNIZED_SEGMENT_FILE_EXTENSIONS: [&str; 2] = [SEGMENT_FILE_EXTENSION, "mp4"];
+
 /// Builds the on-disk name for a cached segment.
 ///
 /// This is the sole writer of the naming scheme; [`is_cached_segment_name`] mirrors it.
 fn segment_cache_file_name(index: u32) -> String {
-    format!("segment_{index:04}.mp4")
+    format!("segment_{index:04}.{SEGMENT_FILE_EXTENSION}")
 }
 
 /// Reports whether `name` is a file name this module could have produced.
+///
+/// Accepts every extension in [`RECOGNIZED_SEGMENT_FILE_EXTENSIONS`], not just
+/// the one the writer emits today, because this predicate also gates *deletion*
+/// of files older builds wrote.
 ///
 /// # Security
 /// `RenderCacheSegment::cached_file` is deserialized from `manifest.json` inside the
@@ -1368,12 +1387,20 @@ fn segment_cache_file_name(index: u32) -> String {
 /// joined onto the sequence cache directory and handed to `remove_file` or `fs::copy`.
 /// A value such as `../../../snapshot.json` would escape the cache directory entirely.
 /// Rather than blocklisting traversal, this allowlists exactly what
-/// [`segment_cache_file_name`] emits: a name that does not round-trip through the
-/// writer's own formatting was not written by us and is never touched.
+/// [`segment_cache_file_name`] emits (modulo the legacy extensions above): a name that
+/// does not round-trip through the writer's own formatting was not written by us and is
+/// never touched.
 pub fn is_cached_segment_name(name: &str) -> bool {
+    RECOGNIZED_SEGMENT_FILE_EXTENSIONS
+        .iter()
+        .any(|extension| segment_name_matches_extension(name, extension))
+}
+
+/// Round-trips `name` through the writer's formatting with `extension` substituted.
+fn segment_name_matches_extension(name: &str, extension: &str) -> bool {
     let Some(digits) = name
         .strip_prefix("segment_")
-        .and_then(|rest| rest.strip_suffix(".mp4"))
+        .and_then(|rest| rest.strip_suffix(&format!(".{extension}")))
     else {
         return false;
     };
@@ -1382,7 +1409,7 @@ pub fn is_cached_segment_name(name: &str) -> bool {
     }
     digits
         .parse::<u32>()
-        .is_ok_and(|index| segment_cache_file_name(index) == name)
+        .is_ok_and(|index| format!("segment_{index:04}.{extension}") == name)
 }
 
 /// Resolves a manifest-recorded segment file name to a path inside
@@ -1686,10 +1713,22 @@ pub fn clear_sequence_cache(project_dir: &Path, sequence_id: &str) -> std::io::R
 
 /// Enforces cache size limit by evicting the oldest cached segments (LRU by index).
 /// Returns the number of segments evicted.
+///
+/// `protected` names segments an in-flight fill is currently producing; they are
+/// never evicted. Without that, a fill and the size cap deadlock each other: the
+/// cap evicts highest-index-first, a fill renders low-to-high, and once the
+/// resident set is smaller than the fill's own window the highest cached segment
+/// is always the one the fill just wrote. Every segment would be deleted the
+/// moment it landed and re-requested on the next pass, forever. Callers with no
+/// fill in flight pass an empty set.
+///
+/// This is a guard, not the eviction policy: choosing victims by distance from
+/// the playhead instead of by index is a separate change.
 pub fn enforce_cache_limit(
     project_dir: &Path,
     manifest: &mut RenderCacheManifest,
     max_bytes: u64,
+    protected: &HashSet<u32>,
 ) -> usize {
     if manifest.total_cached_bytes <= max_bytes {
         return 0;
@@ -1711,6 +1750,7 @@ pub fn enforce_cache_limit(
         .segments
         .iter()
         .filter(|s| s.state == CacheSegmentState::Cached)
+        .filter(|s| !protected.contains(&s.index))
         .map(|s| s.index)
         .rev()
         .collect();
@@ -2955,7 +2995,7 @@ mod tests {
             sequence_cache_dir(tmp.path(), "seq1")
                 .unwrap()
                 .join(&preview)
-                .join("segment_0000.mp4")
+                .join("segment_0000.mov")
         );
         assert_eq!(half_path.file_name(), preview_path.file_name());
     }
@@ -3127,7 +3167,7 @@ mod tests {
         assert_eq!(
             seg_file,
             PathBuf::from(format!(
-                "/projects/my_video/.openreelio/cache/renders/seq-001/{profile}/segment_0003.mp4"
+                "/projects/my_video/.openreelio/cache/renders/seq-001/{profile}/segment_0003.mov"
             ))
         );
     }
@@ -3345,6 +3385,26 @@ mod tests {
     }
 
     #[test]
+    fn should_write_segments_as_mov_and_still_recognize_legacy_mp4_for_cleanup() {
+        // Given the writer, which emits only the container the lossless
+        // preview-cache codec needs
+        assert_eq!(segment_cache_file_name(0), "segment_0000.mov");
+        assert!(segment_cache_file_name(7).ends_with(".mov"));
+
+        // Then the predicate accepts what the writer emits
+        assert!(is_cached_segment_name("segment_0000.mov"));
+
+        // And it still accepts the extension older builds wrote, so segments
+        // left behind by the H.264 cache remain deletable rather than becoming
+        // permanently unreachable garbage.
+        assert!(is_cached_segment_name("segment_0000.mp4"));
+
+        // While traversal is refused under either extension.
+        assert!(!is_cached_segment_name("../segment_0000.mov"));
+        assert!(!is_cached_segment_name("../segment_0000.mp4"));
+    }
+
+    #[test]
     fn should_not_remove_a_manifest_named_file_outside_the_cache_dir() {
         // Given a manifest whose `cached_file` traverses out of the cache directory
         let tmp = tempfile::tempdir().unwrap();
@@ -3382,7 +3442,7 @@ mod tests {
         manifest.mark_segment_cached(0, "../victim.mp4".to_string(), 4096);
 
         // When the size limit forces an eviction
-        enforce_cache_limit(tmp.path(), &mut manifest, 0);
+        enforce_cache_limit(tmp.path(), &mut manifest, 0, &HashSet::new());
 
         // Then the file outside the cache directory survives
         assert!(victim.exists());
@@ -3400,14 +3460,14 @@ mod tests {
 
         // Cache all 4 segments (500 bytes each = 2000 total)
         for i in 0..4 {
-            let name = format!("segment_{i:04}.mp4");
+            let name = segment_cache_file_name(i);
             std::fs::write(seg_dir.join(&name), vec![0u8; 500]).unwrap();
             manifest.mark_segment_cached(i, name, 500);
         }
         assert_eq!(manifest.total_cached_bytes, 2000);
 
         // When enforcing a 1000-byte limit
-        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 1000);
+        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 1000, &HashSet::new());
 
         // Then segments should be evicted from the end
         assert_eq!(evicted, 2);
@@ -3428,11 +3488,46 @@ mod tests {
         manifest.mark_segment_cached(0, "segment_0000.mp4".to_string(), 100);
 
         // When enforcing a large limit
-        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 10_000);
+        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 10_000, &HashSet::new());
 
         // Then nothing should be evicted
         assert_eq!(evicted, 0);
         assert_eq!(manifest.segments[0].state, CacheSegmentState::Cached);
+    }
+
+    #[test]
+    fn should_not_evict_segments_the_running_fill_is_producing() {
+        // Given a cache well over its byte cap, where the segments a fill is
+        // currently producing are the highest-index ones — exactly the victims
+        // the index-descending eviction order would pick first.
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = preview_profile_hash(&test_canvas());
+        let seg_dir = profile_cache_dir(tmp.path(), "seq1", &profile).unwrap();
+        std::fs::create_dir_all(&seg_dir).unwrap();
+
+        let mut manifest = RenderCacheManifest::new("seq1", &profile, 20.0, 5.0);
+        for index in 0..4 {
+            let name = segment_cache_file_name(index);
+            std::fs::write(seg_dir.join(&name), vec![0u8; 500]).unwrap();
+            manifest.mark_segment_cached(index, name, 500);
+        }
+
+        // When the cap is enforced while that fill holds indices 2 and 3
+        let protected: HashSet<u32> = [2, 3].into_iter().collect();
+        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 500, &protected);
+
+        // Then the fill's own output survives, files and all, even though the
+        // cache is still over the cap afterwards — a fill that evicted what it
+        // just wrote could never finish.
+        assert_eq!(manifest.segments[2].state, CacheSegmentState::Cached);
+        assert_eq!(manifest.segments[3].state, CacheSegmentState::Cached);
+        assert!(seg_dir.join(segment_cache_file_name(2)).exists());
+        assert!(seg_dir.join(segment_cache_file_name(3)).exists());
+
+        // And the unprotected segments are the ones that were reclaimed.
+        assert_eq!(evicted, 2);
+        assert_eq!(manifest.segments[0].state, CacheSegmentState::Empty);
+        assert_eq!(manifest.segments[1].state, CacheSegmentState::Empty);
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -248,7 +248,7 @@ pub enum ExportPreset {
     Instagram,
     /// WebM (VP9, Opus)
     WebmVp9,
-    /// ProRes (macOS only)
+    /// ProRes
     ProRes,
     /// Custom settings
     Custom,
@@ -290,6 +290,12 @@ pub enum VideoCodec {
     Vp9,
     #[serde(rename = "prores")]
     ProRes,
+    // Ut Video: mathematically lossless, intra-frame, `gbrp`. Records the
+    // compositor's own planes verbatim — no colorspace conversion, no chroma
+    // subsampling, no quantization — and has no quality knob (no CRF). See
+    // `ExportSettings::preview_cache`, its only caller.
+    #[serde(rename = "utvideo")]
+    UtVideo,
     Copy,
 }
 
@@ -852,13 +858,31 @@ impl ExportSettings {
     ///   into a landscape frame, which a fixed 1280x720 profile guarantees.
     /// - **frame rate follows the sequence** (`fps: None`), so cached segments
     ///   carry the sequence's own cadence rather than a fixed 30 fps.
-    /// - **no target bitrate** — quality is CRF-driven. A fixed bitrate cap that
-    ///   is survivable at 720p is catastrophic at full resolution.
-    /// - `ultrafast` x264 preset — render-ahead wants encode speed.
+    /// - **no target bitrate and no CRF** — the codec below is lossless, so
+    ///   there is no quality knob to set. `crf` must stay `None`:
+    ///   [`validate_video_export_request`] rejects a CRF on a codec with no CRF
+    ///   range, and the cache fill validates every segment before rendering it.
+    /// - **`encoder_speed: None`** — the x264 preset ladder does not apply to
+    ///   this encoder, and a value here would only bake a dead string into the
+    ///   profile hash.
     ///
-    /// CRF 28 is the remaining quality/perf knob: it trades cache fidelity for
-    /// render-ahead throughput. Lowering it (or making it configurable) is a
-    /// follow-up, deliberately not bundled with the canvas fix.
+    /// # Fidelity
+    ///
+    /// The picture is encoded with **Ut Video ([`VideoCodec::UtVideo`]) in a
+    /// `.mov`, pixel format `gbrp`** — mathematically lossless. The compositor
+    /// works in `gbrap`; here the alpha plane (opaque everywhere, since every
+    /// layer is overlaid onto an opaque black backdrop) is dropped to `gbrp` and
+    /// the remaining planes are recorded verbatim — no colorspace conversion, no
+    /// chroma subsampling and no quantization — so a decoded cache frame is
+    /// **byte-identical** to the export composite (0/255 error, infinite PSNR). That matters because an agent judges these frames: the
+    /// H.264 4:2:0 profile this replaced measured up to 9/255 error on
+    /// gradients and 155/255 on hard chroma edges such as text and UI, which is
+    /// the difference between reviewing the edit and reviewing the codec. Every
+    /// frame is a keyframe, so any frame is a seek target.
+    ///
+    /// The cost is size: roughly 45x an H.264 draft encode, about 77.5 MB per
+    /// second of 1080p timeline. The default cache budget is sized for that
+    /// (see `PerformanceSettings::cache_size_mb`).
     ///
     /// This is distinct from [`ExportSettings::preview`], which stays a fixed
     /// 720p30 profile for the one-off preview render job and the CLI's frame
@@ -879,14 +903,14 @@ impl ExportSettings {
         Self {
             preset: ExportPreset::Custom,
             output_path,
-            video_codec: VideoCodec::H264,
+            video_codec: VideoCodec::UtVideo,
             audio_codec: AudioCodec::Aac,
             width: Some(canvas.width),
             height: Some(canvas.height),
             video_bitrate: None,
             audio_bitrate: Some("128k".to_string()),
             fps: None,
-            crf: Some(28),
+            crf: None,
             two_pass: false,
             start_time,
             end_time,
@@ -897,7 +921,7 @@ impl ExportSettings {
             tonemap_mode: None,
             hardware_accel: super::hardware::HardwareAccelMode::default(),
             resolved_encoder_name: None,
-            encoder_speed: Some("ultrafast".to_string()),
+            encoder_speed: None,
         }
     }
 
@@ -1192,7 +1216,7 @@ fn crf_range_for_codec(codec: &VideoCodec) -> Option<std::ops::RangeInclusive<u8
     match codec {
         VideoCodec::H264 | VideoCodec::H265 => Some(0..=51),
         VideoCodec::Vp9 => Some(0..=63),
-        VideoCodec::ProRes | VideoCodec::Copy => None,
+        VideoCodec::ProRes | VideoCodec::UtVideo | VideoCodec::Copy => None,
     }
 }
 
@@ -1202,7 +1226,7 @@ fn container_supports_video_codec(container: &ContainerFormat, codec: &VideoCode
         (ContainerFormat::Mp4, VideoCodec::H264 | VideoCodec::H265)
             | (
                 ContainerFormat::Mov,
-                VideoCodec::H264 | VideoCodec::H265 | VideoCodec::ProRes
+                VideoCodec::H264 | VideoCodec::H265 | VideoCodec::ProRes | VideoCodec::UtVideo
             )
             | (ContainerFormat::Webm, VideoCodec::Vp9)
     )
@@ -3116,6 +3140,12 @@ pub(super) fn output_video_pixel_format(settings: &ExportSettings) -> &'static s
 
     match settings.video_codec {
         VideoCodec::ProRes => "yuv422p10le",
+        // Lossless only holds if nothing converts the planes on the way out:
+        // the compositor works in `gbrap`, and `gbrp` keeps its colour planes
+        // verbatim (dropping only the opaque alpha), so no colorspace conversion
+        // and no subsampling happens at all. Anything else here silently gives
+        // back the error this codec was chosen to remove.
+        VideoCodec::UtVideo => "gbrp",
         VideoCodec::H264 | VideoCodec::H265 | VideoCodec::Vp9 | VideoCodec::Copy => {
             if use_10_bit {
                 "yuv420p10le"
@@ -11478,7 +11508,7 @@ mod tests {
     #[test]
     fn preview_cache_settings_should_use_the_sequence_canvas_and_fps() {
         let settings = ExportSettings::preview_cache(
-            PathBuf::from("segment_0000.mp4"),
+            PathBuf::from("segment_0000.mov"),
             &Canvas::new(1920, 1080),
             Some(0.0),
             Some(5.0),
@@ -11490,11 +11520,11 @@ mod tests {
         assert_eq!(settings.height, Some(1080));
         // Follows the sequence fps rather than pinning 30.
         assert_eq!(settings.fps, None);
-        // CRF-driven, no bitrate cap (a 720p-sized cap is ruinous at full res).
+        // Lossless: no bitrate cap and no quality knob at all.
         assert_eq!(settings.video_bitrate, None);
-        assert_eq!(settings.crf, Some(28));
-        assert_eq!(settings.encoder_speed.as_deref(), Some("ultrafast"));
-        assert_eq!(settings.video_codec, VideoCodec::H264);
+        assert_eq!(settings.crf, None);
+        assert_eq!(settings.encoder_speed, None);
+        assert_eq!(settings.video_codec, VideoCodec::UtVideo);
         assert_eq!(settings.audio_codec, AudioCodec::Aac);
         assert_eq!(settings.audio_bitrate.as_deref(), Some("128k"));
         assert_eq!(settings.hdr_mode, HdrMode::Sdr);
@@ -11504,11 +11534,76 @@ mod tests {
     }
 
     /// Feature: Preview render cache profile
+    /// Scenario: should be a lossless profile the segment validator accepts
+    #[test]
+    fn preview_cache_settings_should_be_lossless_and_pass_segment_validation() {
+        let settings = ExportSettings::preview_cache(
+            PathBuf::from("segment_0000.mov"),
+            &Canvas::new(1920, 1080),
+            Some(0.0),
+            Some(5.0),
+        );
+
+        // The codec records the compositor's own planes verbatim: `gbrp` in, no
+        // conversion, no subsampling, no quantization. This is the single place
+        // the output pixel format is stated, so anything else here silently
+        // reintroduces the chroma error the codec was chosen to remove.
+        assert_eq!(output_video_pixel_format(&settings), "gbrp");
+        assert_eq!(
+            super::super::hardware::software_encoder_name(&settings.video_codec),
+            "utvideo"
+        );
+
+        // `crf: None` is load-bearing rather than cosmetic: the cache fill runs
+        // this validator on every segment, and a lossless codec has no CRF
+        // range, so a stray CRF would fail every segment render.
+        assert!(crf_range_for_codec(&settings.video_codec).is_none());
+        assert!(
+            validate_export_settings_options(&settings).is_empty(),
+            "preview_cache profile rejected: {:?}",
+            validate_export_settings_options(&settings)
+        );
+
+        // And the .mov extension is what makes that validation pass: the
+        // container is inferred from the output path, and MP4 cannot carry
+        // this codec.
+        let in_mp4 = ExportSettings {
+            output_path: PathBuf::from("segment_0000.mp4"),
+            ..settings.clone()
+        };
+        assert!(!validate_export_settings_options(&in_mp4).is_empty());
+    }
+
+    /// Feature: Preview render cache profile
+    /// Scenario: should retire caches written by the previous H.264 profile
+    #[test]
+    fn preview_cache_profile_hash_should_differ_from_the_h264_profile() {
+        let canvas = Canvas::new(1920, 1080);
+        let lossless = ExportSettings::preview_cache(PathBuf::new(), &canvas, None, None);
+
+        // The old profile: same frame, H.264 4:2:0 at CRF 28.
+        let legacy = ExportSettings {
+            video_codec: VideoCodec::H264,
+            crf: Some(28),
+            encoder_speed: Some("ultrafast".to_string()),
+            ..lossless.clone()
+        };
+
+        // The profile hash names the directory segments live in, so a differing
+        // hash is what makes every cache written by the old profile
+        // unreachable instead of being served at the wrong fidelity.
+        assert_ne!(
+            super::super::cache::compute_profile_hash(&lossless),
+            super::super::cache::compute_profile_hash(&legacy)
+        );
+    }
+
+    /// Feature: Preview render cache profile
     /// Scenario: should keep a vertical sequence vertical instead of pillarboxing it
     #[test]
     fn preview_cache_settings_should_follow_a_vertical_canvas() {
         let settings = ExportSettings::preview_cache(
-            PathBuf::from("segment_0000.mp4"),
+            PathBuf::from("segment_0000.mov"),
             &Canvas::new(1080, 1920),
             None,
             None,
@@ -11516,6 +11611,239 @@ mod tests {
 
         assert_eq!(settings.width, Some(1080));
         assert_eq!(settings.height, Some(1920));
+    }
+
+    // -----------------------------------------------------------------------
+    // Preview cache fidelity (FFmpeg-backed)
+    // -----------------------------------------------------------------------
+
+    const CACHE_FIDELITY_CANVAS: (u32, u32) = (96, 64);
+    const CACHE_FIDELITY_FPS: i32 = 10;
+    const CACHE_FIDELITY_SEC: f64 = 1.0;
+
+    /// Writes the picture the cache is most likely to damage.
+    ///
+    /// `testsrc2` is chosen for its hard, fully saturated colour edges and its
+    /// smooth ramps: those are exactly the two features 4:2:0 subsampling and
+    /// quantization destroy, and the two the agent reading these frames cares
+    /// about (text and UI are hard chroma edges). It is written back out as
+    /// Ut Video `gbrp` so the fixture itself is lossless and can serve as the
+    /// reference the render is compared against.
+    fn write_chroma_edge_source(ffmpeg: &std::path::Path, path: &std::path::Path) -> bool {
+        let mut build = std::process::Command::new(ffmpeg);
+        crate::core::process::configure_std_command(&mut build);
+        let built = build
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-nostdin",
+                "-f",
+                "lavfi",
+                "-i",
+                &format!(
+                    "testsrc2=size={}x{}:rate={}:duration={}",
+                    CACHE_FIDELITY_CANVAS.0,
+                    CACHE_FIDELITY_CANVAS.1,
+                    CACHE_FIDELITY_FPS,
+                    CACHE_FIDELITY_SEC
+                ),
+                "-c:v",
+                "utvideo",
+                "-pix_fmt",
+                "gbrp",
+            ])
+            .arg(path)
+            .output();
+
+        matches!(built, Ok(built) if built.status.success()) && path.exists()
+    }
+
+    /// Decodes a file to raw `gbrp` planes, one `Vec` per frame.
+    ///
+    /// `gbrp` is the compositor's own working format, so these bytes are the
+    /// planes themselves — nothing is converted on the way out and a comparison
+    /// of them is a comparison of the pictures.
+    fn decode_gbrp_frames(ffmpeg: &std::path::Path, path: &std::path::Path) -> Vec<Vec<u8>> {
+        let mut decode = std::process::Command::new(ffmpeg);
+        crate::core::process::configure_std_command(&mut decode);
+        let decoded = decode
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin", "-i"])
+            .arg(path)
+            .args(["-pix_fmt", "gbrp", "-f", "rawvideo", "-"])
+            .output()
+            .expect("decode to gbrp");
+        assert!(
+            decoded.status.success(),
+            "could not decode {}: {}",
+            path.display(),
+            String::from_utf8_lossy(&decoded.stderr)
+        );
+
+        let frame_bytes = 3 * CACHE_FIDELITY_CANVAS.0 as usize * CACHE_FIDELITY_CANVAS.1 as usize;
+        decoded
+            .stdout
+            .chunks_exact(frame_bytes)
+            .map(<[u8]>::to_vec)
+            .collect()
+    }
+
+    /// Renders `sequence` through the real builder with `settings` and returns
+    /// the result decoded back to `gbrp`.
+    fn render_and_decode_gbrp(
+        ffmpeg: &std::path::Path,
+        sequence: &Sequence,
+        assets: &HashMap<String, Asset>,
+        settings: &ExportSettings,
+    ) -> Vec<Vec<u8>> {
+        let args = build_complex_filter_args_with_audio_info(
+            sequence,
+            assets,
+            &HashMap::new(),
+            &HashMap::new(),
+            settings,
+        )
+        .expect("the builder must produce a filtergraph");
+
+        let mut render = std::process::Command::new(ffmpeg);
+        crate::core::process::configure_std_command(&mut render);
+        let result = render
+            .args(["-hide_banner", "-loglevel", "error", "-nostdin"])
+            .args(&args)
+            .output()
+            .expect("run ffmpeg");
+        assert!(
+            result.status.success(),
+            "ffmpeg refused the builder's graph: {}\n{args:?}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+
+        decode_gbrp_frames(ffmpeg, &settings.output_path)
+    }
+
+    /// The largest per-sample difference between two frame sequences, in 0-255.
+    fn max_plane_error(left: &[Vec<u8>], right: &[Vec<u8>]) -> u8 {
+        assert!(!left.is_empty(), "no frames to compare");
+        assert_eq!(left.len(), right.len(), "frame counts differ");
+        left.iter()
+            .zip(right.iter())
+            .flat_map(|(a, b)| a.iter().zip(b.iter()))
+            .map(|(a, b)| a.abs_diff(*b))
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Feature: Preview render cache fidelity
+    /// Scenario: a cached segment decodes back to the composite it was made from
+    ///
+    /// This is the claim the codec choice rests on, measured rather than
+    /// asserted: the cache is read by an agent that judges the frame, so any
+    /// error it introduces is error the agent attributes to the edit. The same
+    /// picture is put through the profile this replaced to show the measurement
+    /// is capable of failing — an all-zero result on a picture no codec could
+    /// damage would prove nothing.
+    ///
+    /// Ignored by default because it needs an `ffmpeg` binary (with `utvideo`).
+    /// Run with:
+    ///   cargo test -p openreelio --features gui --lib -- --ignored \
+    ///     the_preview_cache_is_byte_identical
+    #[test]
+    #[ignore = "requires an ffmpeg binary; run with --ignored"]
+    fn the_preview_cache_is_byte_identical_to_the_composite_it_caches() {
+        use crate::core::assets::VideoInfo;
+        use crate::core::test_ffmpeg::{require_or_skip_ffmpeg, skip_without_ffmpeg};
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        let dir = tempfile::tempdir().expect("temp dir");
+        let source = dir.path().join("chroma_edges.mov");
+        if !write_chroma_edge_source(&ffmpeg, &source) {
+            skip_without_ffmpeg("ffmpeg could not build the chroma-edge fixture");
+            return;
+        }
+
+        // A single full-frame clip at the canvas size and cadence: the composite
+        // is then the source frames themselves, so the source doubles as the
+        // reference the cache must reproduce.
+        let mut asset = Asset::new_video(
+            "edges",
+            &source.to_string_lossy(),
+            VideoInfo {
+                width: CACHE_FIDELITY_CANVAS.0,
+                height: CACHE_FIDELITY_CANVAS.1,
+                ..VideoInfo::default()
+            },
+        )
+        .with_duration(CACHE_FIDELITY_SEC)
+        .with_file_size(1_000_000);
+        asset.id = "edges".to_string();
+        let mut assets = HashMap::new();
+        assets.insert("edges".to_string(), asset);
+
+        let format = SequenceFormat::new(
+            CACHE_FIDELITY_CANVAS.0,
+            CACHE_FIDELITY_CANVAS.1,
+            CACHE_FIDELITY_FPS,
+            1,
+            48_000,
+        );
+        let canvas = format.canvas.clone();
+        let mut sequence = Sequence::new("Fidelity", format);
+        sequence.tracks.clear();
+        let mut track = Track::new_video("V1");
+        let mut clip = Clip::new("edges")
+            .with_source_range(0.0, CACHE_FIDELITY_SEC)
+            .place_at(0.0);
+        clip.id = "edges0".to_string();
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        let reference = decode_gbrp_frames(&ffmpeg, &source);
+
+        // When the segment is rendered through the real preview-cache profile
+        let cached = render_and_decode_gbrp(
+            &ffmpeg,
+            &sequence,
+            &assets,
+            &ExportSettings::preview_cache(
+                dir.path().join("segment_0000.mov"),
+                &canvas,
+                None,
+                None,
+            ),
+        );
+
+        // Then it decodes back to the composite exactly.
+        let lossless_error = max_plane_error(&reference, &cached);
+        eprintln!("[preview-cache] utvideo/gbrp max plane error: {lossless_error}/255");
+        assert_eq!(
+            lossless_error, 0,
+            "the preview cache must be a byte-exact record of the composite"
+        );
+
+        // And the profile this replaced damages the very same picture, so the
+        // zero above is a property of the codec and not of the fixture.
+        let legacy = render_and_decode_gbrp(
+            &ffmpeg,
+            &sequence,
+            &assets,
+            &ExportSettings {
+                output_path: dir.path().join("legacy_0000.mp4"),
+                video_codec: VideoCodec::H264,
+                crf: Some(28),
+                encoder_speed: Some("ultrafast".to_string()),
+                ..ExportSettings::preview_cache(PathBuf::new(), &canvas, None, None)
+            },
+        );
+        let lossy_error = max_plane_error(&reference, &legacy);
+        eprintln!("[preview-cache] legacy h264/yuv420p max plane error: {lossy_error}/255");
+        assert!(
+            lossy_error > 0,
+            "the fixture cannot detect codec error: H.264 4:2:0 reproduced it exactly"
+        );
     }
 
     /// Feature: Proxy frame fitting

--- a/src-tauri/src/core/render/hardware.rs
+++ b/src-tauri/src/core/render/hardware.rs
@@ -171,6 +171,7 @@ pub fn resolve_video_encoder(
     match codec {
         VideoCodec::Vp9 => return "libvpx-vp9".to_string(),
         VideoCodec::ProRes => return "prores_ks".to_string(),
+        VideoCodec::UtVideo => return "utvideo".to_string(),
         VideoCodec::Copy => return "copy".to_string(),
         VideoCodec::H264 | VideoCodec::H265 => {}
     }
@@ -229,6 +230,7 @@ pub fn software_encoder_name(codec: &VideoCodec) -> String {
         VideoCodec::H265 => "libx265".to_string(),
         VideoCodec::Vp9 => "libvpx-vp9".to_string(),
         VideoCodec::ProRes => "prores_ks".to_string(),
+        VideoCodec::UtVideo => "utvideo".to_string(),
         VideoCodec::Copy => "copy".to_string(),
     }
 }

--- a/src-tauri/src/core/settings/mod.rs
+++ b/src-tauri/src/core/settings/mod.rs
@@ -16,7 +16,12 @@ use std::path::PathBuf;
 use tracing::{info, warn};
 
 /// Settings schema version for migration support
-pub const SETTINGS_VERSION: u32 = 2;
+pub const SETTINGS_VERSION: u32 = 3;
+
+/// The render-cache size default before v3, sized for the old H.264 preview
+/// cache. The v3 lossless (UT Video) cache is ~45x larger, so a file still
+/// carrying this value would hold only seconds of cache; migration raises it.
+const PRE_V3_CACHE_SIZE_MB: u32 = 1024;
 
 /// Settings file name
 pub const SETTINGS_FILE: &str = "settings.json";
@@ -538,8 +543,18 @@ fn default_max_jobs() -> u32 {
     4
 }
 
+/// Default render-cache budget, in megabytes.
+///
+/// The preview render cache is lossless (Ut Video; see
+/// `ExportSettings::preview_cache`), which costs roughly 77.5 MB per second of
+/// 1080p timeline. The previous 1 GB budget held about 13 seconds of it — less
+/// than a single lookahead window — so the cache would thrash instead of
+/// serving anything. 8 GB is about 105 seconds of 1080p lookahead.
+///
+/// Users can still set anything inside the 128–16384 MB clamp applied by
+/// `PerformanceSettings` normalization.
 fn default_cache_size() -> u32 {
-    1024 // 1GB
+    8192 // 8GB
 }
 
 /// Integrated terminal settings
@@ -1289,6 +1304,15 @@ impl SettingsManager {
             settings.ai.assistant_runtime = AssistantRuntime::Codex;
         }
 
+        // The lossless preview cache (v3) writes ~45x larger segments than the
+        // old H.264 one, so a user still on the pre-v3 default (or below) would
+        // get a cache too small to hold even one playhead window and would
+        // thrash. Raise them to the new default; a user who deliberately chose a
+        // larger budget keeps it.
+        if settings.version < 3 && settings.performance.cache_size_mb <= PRE_V3_CACHE_SIZE_MB {
+            settings.performance.cache_size_mb = default_cache_size();
+        }
+
         settings.version = SETTINGS_VERSION;
         settings
     }
@@ -1961,6 +1985,36 @@ mod tests {
 
         assert_eq!(settings.version, SETTINGS_VERSION);
         assert_eq!(settings.ai.assistant_runtime, AssistantRuntime::Codex);
+    }
+
+    /// Feature: Settings migration
+    /// Scenario: a pre-v3 cache budget sized for the old H.264 cache is raised
+    ///
+    /// The lossless preview cache writes ~45x larger segments, so a user left on
+    /// the old 1 GB default would thrash. Migration raises them to the new
+    /// default while leaving a deliberately larger budget alone.
+    #[test]
+    fn should_raise_a_pre_v3_default_cache_budget_but_keep_a_larger_one() {
+        let temp_dir = TempDir::new().unwrap();
+        let raised = temp_dir.path().join(SETTINGS_FILE);
+        fs::write(
+            &raised,
+            r#"{ "version": 2, "performance": { "cacheSizeMb": 1024 } }"#,
+        )
+        .unwrap();
+        let settings = SettingsManager::new(temp_dir.path().to_path_buf()).load();
+        assert_eq!(settings.version, SETTINGS_VERSION);
+        assert_eq!(settings.performance.cache_size_mb, default_cache_size());
+
+        let kept_dir = TempDir::new().unwrap();
+        let kept = kept_dir.path().join(SETTINGS_FILE);
+        fs::write(
+            &kept,
+            r#"{ "version": 2, "performance": { "cacheSizeMb": 12288 } }"#,
+        )
+        .unwrap();
+        let settings = SettingsManager::new(kept_dir.path().to_path_buf()).load();
+        assert_eq!(settings.performance.cache_size_mb, 12288);
     }
 
     #[test]

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -2898,6 +2898,9 @@ pub async fn render_preview_cache(
         config,
         manifest,
         pending_indices,
+        // A whole-timeline fill keeps no window resident by force — the size cap
+        // governs what stays, so it cannot overrun the disk.
+        std::collections::HashSet::new(),
     )
 }
 
@@ -2924,6 +2927,7 @@ fn spawn_cache_fill(
     config: crate::core::render::RenderCacheConfig,
     manifest: crate::core::render::RenderCacheManifest,
     pending_indices: Vec<u32>,
+    protected_window: std::collections::HashSet<u32>,
 ) -> Result<RenderCacheJobResult, String> {
     use crate::core::render::cache::{enforce_cache_limit, load_manifest, save_manifest};
     use crate::core::render::ExportEngine;
@@ -2971,6 +2975,15 @@ fn spawn_cache_fill(
                 .map(|s| (s.index, s.start_sec, s.end_sec))
         })
         .collect();
+
+    // The segments the caller wants kept resident (the playhead window for
+    // `ensure_preview_window`; empty for a whole-timeline `render_preview_cache`
+    // fill, which must stay bounded by the size cap). It is deliberately NOT the
+    // whole `pending_indices`: protecting every pending segment of a cold
+    // whole-timeline fill would make the cap unenforceable and let the cache
+    // grow without bound. The segment currently being written is added per
+    // iteration so a single eviction pass can never delete the frame it just
+    // produced.
 
     let total_segments = manifest.segments.len() as u32;
 
@@ -3391,10 +3404,13 @@ fn spawn_cache_fill(
                             .to_string(),
                         export_result.file_size,
                     );
+                    let mut protected = protected_window.clone();
+                    protected.insert(*idx);
                     enforce_cache_limit(
                         &project_path,
                         &mut updated_manifest,
                         cache_config.max_cache_bytes,
+                        &protected,
                     );
                 }
                 Err(crate::core::render::ExportError::Cancelled) => {
@@ -3636,6 +3652,11 @@ pub async fn ensure_preview_window(
         config,
         manifest,
         window_pending,
+        // Keep the whole playhead window resident — including segments already
+        // cached — so filling the missing ones cannot evict the ones the
+        // playhead is sitting on. The window is a handful of segments, so this
+        // stays well under the size cap.
+        window_indices.iter().copied().collect(),
     )?;
 
     availability.job_id = Some(result.job_id);

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -9614,7 +9614,7 @@ warnings: string[] }
 /**
  * Video codec selection
  */
-export type VideoCodec = "h264" | "h265" | "vp9" | "prores" | "copy"
+export type VideoCodec = "h264" | "h265" | "vp9" | "prores" | "utvideo" | "copy"
 /**
  * Structured video export request used by UI and agent-driven export paths.
  */


### PR DESCRIPTION
### **User description**
## Why

The preview render cache is meant to be a pixel-accurate stand-in for the export, but it encoded segments as **H.264 4:2:0 CRF 28** — a lossy re-encode with chroma subsampling. Measured against the export composite, a cached frame differed by up to **9/255 on gradients and 155/255 on hard chroma edges** (text, UI, graphics). The cache is consumed by an agent that **judges** the frame, so it was judging the codec, not the edit.

A measured investigation (on the bundled ffmpeg) ruled out every 4:2:2 codec — ProRes 422 and DNxHR HQX both err **202/255** on 1-px chroma edges — and among the lossless 4:4:4 codecs, decode cost (the cache is read at random offsets in a scrub loop) picks the winner: FFV1 is 86 ms/frame, **UT Video is 10 ms/frame**.

## Change

- Encode the cache as **UT Video in `.mov`, pixel format `gbrp`** — the exact planes the compositor already emits (opaque alpha dropped), no colorspace conversion / subsampling / quantization. A decoded cache frame is now **byte-identical to the export composite**: measured **0/255, infinite PSNR**, proven end-to-end by a test that renders a real sequence through the cache profile and diffs the decoded `.mov` against the composite (the same test measures the old H.264 path at 65/255). Every frame is a keyframe, so seeking to frame N costs one decode, not N.
- Lossless is ~45x larger (77.5 MB/s of 1080p), so this ships with the budget that makes it usable:
  - default cache size **1 GB → 8 GB**, with a **settings migration** (SETTINGS_VERSION → 3) so existing users at the old default are raised too — a user who chose a larger budget keeps it;
  - the size cap can no longer be starved — a **whole-timeline fill** protects nothing by force (the cap always governs it), while a **playhead-window fill** keeps only its handful of window segments resident so filling the missing ones cannot evict the one the playhead sits on. (This replaces an earlier attempt that protected the whole pending set, which made a cold whole-timeline fill unable to evict anything — roughly 46 GB against an 8 GB cap.)
- Old H.264 segments self-retire (codec is in the profile hash, so a changed profile discards the manifest and prunes the directory). The cleanup predicate still recognizes legacy `segment_XXXX.mp4` names so pre-partition files are removable; the writer emits only `.mov`.

## Verification

- `cargo fmt` / `clippy -p openreelio --features gui --lib` / `--all-targets --features dev-full -- -D warnings` clean.
- `cargo test -p openreelio --features gui --lib` → **4245 passed**. New tests: fidelity byte-exactness (0/255 vs 65/255, ffmpeg-backed), lossless-settings/validator, profile-hash self-retirement, `.mov`-writes-but-recognizes-legacy-`.mp4`, eviction-protects-the-running-fill, and a settings migration that raises the old default but keeps a larger budget.
- #844 byte-exact windowed suite **15/15** (uses its own settings, unaffected). `cargo test -p openreelio-cli` → 231 + 164. `bindings.ts` gains only `"utvideo"` in the VideoCodec union (a widening; no exhaustive TS switch over it).
- Adversarial review: the codec swap is clean and fidelity-proven; two findings (the unbounded protected set and the un-migrated default) are fixed in this PR.

Follow-up (tracked): the highest-index-first eviction is still not playhead-aware — the flag-driven / playhead-distance eviction redesign is next.


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Implements lossless preview caching using Ut Video.

- Switches cache container from MP4 to MOV.

- Increases default cache size from 1GB to 8GB.

- Adds cache eviction protection for active fills.

- Ensures byte-identical frames between cache and export.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Compositor (GBRAP)"] -- "Verbatim Planes" --> B["Ut Video Encoder (GBRP)"]
  B -- "Lossless Storage" --> C["MOV Segment"]
  C -- "Byte-Identical" --> D["Export Reference"]
  E["Settings Migration"] -- "v2 -> v3" --> F["8GB Cache Budget"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>Update cache management for lossless MOV segments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/cache.rs

<ul><li>Changed default cache segment extension from <code>.mp4</code> to <code>.mov</code>.<br> <li> Increased default <code>max_cache_bytes</code> to 8GB to accommodate lossless data.<br> <li> Updated <code>enforce_cache_limit</code> to accept a <code>protected</code> set of indices to <br>prevent evicting segments currently being rendered.<br> <li> Maintained backward compatibility for deleting legacy <code>.mp4</code> cache <br>files.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/850/files#diff-630fc011e9e6377be668e04305949567349f26fefcf086384602a27b4aaec044">+109/-14</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Implement Ut Video lossless export profile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Added <code>UtVideo</code> to <code>VideoCodec</code> enum.<br> <li> Configured <code>preview_cache</code> settings to use <code>UtVideo</code> and <code>gbrp</code> pixel format <br>for mathematical losslessness.<br> <li> Removed CRF and encoder speed settings for the cache profile as they <br>don't apply to Ut Video.<br> <li> Added comprehensive FFmpeg-backed integration tests to verify <br>byte-identical fidelity.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/850/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+346/-18</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>render.rs</strong><dd><code>Protect active render windows from cache eviction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/render.rs

<ul><li>Updated <code>spawn_cache_fill</code> to handle protected segment windows during <br>eviction.<br> <li> Modified <code>ensure_preview_window</code> to protect the entire playhead window <br>from being evicted while filling.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/850/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hardware.rs</strong><dd><code>Register Ut Video encoder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/hardware.rs

- Added mapping for the `utvideo` software encoder.


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/850/files#diff-9d287d59f0552df6b5669019a6b4b1b0741c0c6b4e3d3ca44d7a34e62b3057a3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Migrate settings and increase default cache budget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/settings/mod.rs

<ul><li>Bumped <code>SETTINGS_VERSION</code> to 3.<br> <li> Implemented a migration path that raises the cache budget to 8GB for <br>users on the old 1GB default.<br> <li> Updated default performance settings to reflect the higher storage <br>requirements of lossless video.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/850/files#diff-b6fda75f34d5055a273697f0ba135552b64ea062449280e0a4817e7c1c78def8">+56/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bindings.ts</strong><dd><code>Update frontend codec types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bindings.ts

- Added `utvideo` to the TypeScript `VideoCodec` type definition.


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/850/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview-cache exports now use lossless Ut Video encoding in `.mov` files for improved visual fidelity.
  * Legacy `.mp4` cache files remain recognized for cleanup.
  * Increased the default preview-cache limit from 1 GB to 8 GB.

* **Bug Fixes**
  * Protected active and newly rendered preview segments from being evicted during cache cleanup.
  * Automatically updated older settings to the new cache-size default while preserving higher custom limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->