### PR TITLE
feat(render): converge the preview-cache fill and cancel only on fingerprint change

### DIFF
--- a/src-tauri/src/core/render/cache.rs
+++ b/src-tauri/src/core/render/cache.rs
@@ -2012,8 +2012,76 @@ pub fn clear_sequence_cache(project_dir: &Path, sequence_id: &str) -> std::io::R
     Ok(())
 }
 
-/// Enforces cache size limit by evicting the oldest cached segments (LRU by index).
-/// Returns the number of segments evicted.
+/// Removes the file a segment names and clears its entry, reporting success.
+///
+/// Accounting is left to the caller: a `Cached` segment's bytes are part of
+/// [`RenderCacheManifest::total_cached_bytes`] and a `Stale` one's may not be,
+/// and the two callers reconcile that differently.
+fn release_segment_file(seq_dir: &Path, segment: &mut RenderCacheSegment) -> bool {
+    let removed = match segment.cached_file.as_ref() {
+        Some(file) => match resolve_cached_segment_path(seq_dir, file) {
+            Some(full_path) => match std::fs::remove_file(&full_path) {
+                Ok(()) => true,
+                Err(error) => {
+                    tracing::warn!(
+                        "Failed to evict cache file {}: {error}",
+                        full_path.display()
+                    );
+                    false
+                }
+            },
+            // Unrecognized name: nothing of ours to remove, so drop the entry
+            // and let the caller's accounting reclaim its recorded size.
+            None => true,
+        },
+        // No file to remove.
+        None => true,
+    };
+
+    if removed {
+        segment.state = CacheSegmentState::Empty;
+        segment.cached_file = None;
+        segment.file_size_bytes = 0;
+    }
+    removed
+}
+
+/// Enforces the cache size limit, evicting dead bytes first and then the
+/// highest-index cached segments. Returns the number of segments evicted.
+///
+/// # Policy
+///
+/// Victims are chosen in two phases:
+///
+/// 1. **Stale segments**, ascending by index. Their files are superseded by an
+///    edit and nothing will ever read them again, so they are pure waste and go
+///    before anything a user could still play.
+/// 2. **Cached segments**, descending by index — playback starts at the head far
+///    more often than at the tail, so the tail is the cheapest thing to lose.
+///
+/// Phase 1 runs to completion rather than stopping once the manifest reports
+/// itself under the cap. Stale bytes are only intermittently reflected in
+/// [`RenderCacheManifest::total_cached_bytes`] (see the accounting note below),
+/// so a size check between stale victims would make the outcome depend on when
+/// the total was last recomputed. Freeing all of the dead bytes is both cheaper
+/// to reason about and never wrong.
+///
+/// The whole function still early-returns when the manifest is already under the
+/// cap, so the stale sweep only runs when the cache is over budget. That is
+/// deliberate: this is the *size guard*, and routine stale cleanup belongs to
+/// [`cleanup_stale_files`], which the fill's prepare path already runs.
+///
+/// # Accounting note
+///
+/// `recalculate_total_size` sums `Cached` segments only, but the
+/// `Cached` → `Stale` transition in [`refresh_manifest_plan_fingerprints`] does
+/// not recompute the total, so a stale segment's bytes may still be counted
+/// until the next recalculation. Phase 1 therefore recomputes the total once at
+/// its end instead of subtracting per segment, which is correct either way and
+/// mirrors what [`cleanup_stale_files`] does. Phase 2 keeps its incremental
+/// subtraction, which is exact for `Cached` segments and avoids an O(n*m) sweep.
+///
+/// # Protection
 ///
 /// `protected` names segments an in-flight fill is currently producing; they are
 /// never evicted. Without that, a fill and the size cap deadlock each other: the
@@ -2023,8 +2091,15 @@ pub fn clear_sequence_cache(project_dir: &Path, sequence_id: &str) -> std::io::R
 /// moment it landed and re-requested on the next pass, forever. Callers with no
 /// fill in flight pass an empty set.
 ///
-/// This is a guard, not the eviction policy: choosing victims by distance from
-/// the playhead instead of by index is a separate change.
+/// # Why not evict by playhead distance
+///
+/// A survey of how established NLEs expose render-cache management found no
+/// evidence of playhead-proximity eviction: the controls they offer are framed
+/// around age and validity — deleting render files that are unused or
+/// superseded. That matches the failure mode we would expect from proximity
+/// eviction, which re-scores every cached segment on each scrub and thrashes the
+/// cache under exactly the interaction it is meant to serve. Dead bytes first,
+/// then highest index, is therefore the policy here.
 pub fn enforce_cache_limit(
     project_dir: &Path,
     manifest: &mut RenderCacheManifest,
@@ -2046,8 +2121,33 @@ pub fn enforce_cache_limit(
         };
     let mut evicted = 0;
 
-    // Evict from the end (highest index) first — user is more likely to play from the start
-    let indices: Vec<u32> = manifest
+    // Phase 1: dead bytes, oldest first, to completion.
+    let stale_indices: Vec<u32> = manifest
+        .segments
+        .iter()
+        .filter(|s| s.state == CacheSegmentState::Stale)
+        .filter(|s| !protected.contains(&s.index))
+        .map(|s| s.index)
+        .collect();
+
+    let stale_considered = !stale_indices.is_empty();
+    for idx in stale_indices {
+        if let Some(segment) = manifest.segments.iter_mut().find(|s| s.index == idx) {
+            if release_segment_file(&seq_dir, segment) {
+                evicted += 1;
+            }
+        }
+    }
+    // Recomputed whenever a stale segment was *considered*, not only when one was
+    // removed: the total may have been carrying those stale bytes all along (see
+    // the accounting note), and phase 2's budget must be measured against live
+    // bytes either way.
+    if stale_considered {
+        manifest.recalculate_total_size();
+    }
+
+    // Phase 2: live bytes, tail first, only as far as the cap requires.
+    let cached_indices: Vec<u32> = manifest
         .segments
         .iter()
         .filter(|s| s.state == CacheSegmentState::Cached)
@@ -2056,41 +2156,17 @@ pub fn enforce_cache_limit(
         .rev()
         .collect();
 
-    for idx in indices {
+    for idx in cached_indices {
         if manifest.total_cached_bytes <= max_bytes {
             break;
         }
 
         if let Some(segment) = manifest.segments.iter_mut().find(|s| s.index == idx) {
-            let mut file_removed = false;
-            if let Some(ref file) = segment.cached_file {
-                match resolve_cached_segment_path(&seq_dir, file) {
-                    Some(full_path) => match std::fs::remove_file(&full_path) {
-                        Ok(()) => file_removed = true,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to evict cache file {}: {e}",
-                                full_path.display()
-                            );
-                        }
-                    },
-                    // Unrecognized name: nothing of ours to remove, so drop the entry
-                    // and let the accounting below reclaim its recorded size.
-                    None => file_removed = true,
-                }
-            } else {
-                file_removed = true; // No file to remove
-            }
-
-            if file_removed {
+            let freed = segment.file_size_bytes;
+            if release_segment_file(&seq_dir, segment) {
                 // Subtract this segment's size from the running total instead of
                 // recalculating across all segments (avoids O(n*m) cost).
-                manifest.total_cached_bytes = manifest
-                    .total_cached_bytes
-                    .saturating_sub(segment.file_size_bytes);
-                segment.state = CacheSegmentState::Empty;
-                segment.cached_file = None;
-                segment.file_size_bytes = 0;
+                manifest.total_cached_bytes = manifest.total_cached_bytes.saturating_sub(freed);
                 evicted += 1;
             }
         }
@@ -3829,6 +3905,105 @@ mod tests {
         assert_eq!(evicted, 2);
         assert_eq!(manifest.segments[0].state, CacheSegmentState::Empty);
         assert_eq!(manifest.segments[1].state, CacheSegmentState::Empty);
+    }
+
+    /// Builds an over-cap manifest of `count` 500-byte cached segments and marks
+    /// the named indices stale, leaving their files on disk.
+    ///
+    /// Staling this way mirrors `refresh_manifest_plan_fingerprints`, which flips
+    /// the state without recomputing `total_cached_bytes`.
+    fn manifest_with_stale_segments(
+        seg_dir: &Path,
+        profile: &str,
+        count: u32,
+        stale: &[u32],
+    ) -> RenderCacheManifest {
+        std::fs::create_dir_all(seg_dir).unwrap();
+        let mut manifest = RenderCacheManifest::new("seq1", profile, count as f64 * 5.0, 5.0);
+        for index in 0..count {
+            let name = segment_cache_file_name(index);
+            std::fs::write(seg_dir.join(&name), vec![0u8; 500]).unwrap();
+            manifest.mark_segment_cached(index, name, 500);
+        }
+        for index in stale {
+            manifest.segments[*index as usize].state = CacheSegmentState::Stale;
+        }
+        manifest
+    }
+
+    /// Feature: Preview cache size guard
+    /// Scenario: dead bytes are reclaimed before anything still playable
+    #[test]
+    fn should_evict_stale_segments_before_cached_ones() {
+        // Given an over-cap cache whose stale segments sit at low indices, where
+        // the cached-only, index-descending order would evict the tail instead.
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = preview_profile_hash(&test_canvas());
+        let seg_dir = profile_cache_dir(tmp.path(), "seq1", &profile).unwrap();
+        let mut manifest = manifest_with_stale_segments(&seg_dir, &profile, 4, &[1, 2]);
+
+        // When the cap is enforced
+        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 1000, &HashSet::new());
+
+        // Then only the stale segments were reclaimed, and the playable tail
+        // survived because freeing the dead bytes was already enough.
+        assert_eq!(evicted, 2);
+        assert_eq!(manifest.segments[1].state, CacheSegmentState::Empty);
+        assert_eq!(manifest.segments[2].state, CacheSegmentState::Empty);
+        assert!(!seg_dir.join(segment_cache_file_name(1)).exists());
+        assert!(!seg_dir.join(segment_cache_file_name(2)).exists());
+        assert_eq!(manifest.segments[0].state, CacheSegmentState::Cached);
+        assert_eq!(manifest.segments[3].state, CacheSegmentState::Cached);
+        assert!(seg_dir.join(segment_cache_file_name(3)).exists());
+        assert_eq!(manifest.total_cached_bytes, 1000);
+    }
+
+    /// Feature: Preview cache size guard
+    /// Scenario: the stale sweep does not stop halfway
+    ///
+    /// Stale bytes are only intermittently counted in `total_cached_bytes`, so a
+    /// size check between stale victims would leave dead files behind depending
+    /// on when the total was last recomputed.
+    #[test]
+    fn should_sweep_every_stale_segment_when_the_cache_is_over_its_cap() {
+        // Given an over-cap cache with more stale segments than the cap needs
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = preview_profile_hash(&test_canvas());
+        let seg_dir = profile_cache_dir(tmp.path(), "seq1", &profile).unwrap();
+        let mut manifest = manifest_with_stale_segments(&seg_dir, &profile, 4, &[1, 2, 3]);
+
+        // When the cap is enforced
+        let evicted = enforce_cache_limit(tmp.path(), &mut manifest, 1400, &HashSet::new());
+
+        // Then every stale segment is gone, not just enough of them
+        assert_eq!(evicted, 3);
+        for index in 1..4u32 {
+            assert_eq!(
+                manifest.segments[index as usize].state,
+                CacheSegmentState::Empty
+            );
+            assert!(!seg_dir.join(segment_cache_file_name(index)).exists());
+        }
+        assert_eq!(manifest.total_cached_bytes, 500);
+    }
+
+    /// Feature: Preview cache size guard
+    /// Scenario: a stale segment the running fill owns is left alone
+    #[test]
+    fn should_not_sweep_stale_segments_the_running_fill_is_producing() {
+        // Given an over-cap cache whose stale segment is protected
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = preview_profile_hash(&test_canvas());
+        let seg_dir = profile_cache_dir(tmp.path(), "seq1", &profile).unwrap();
+        let mut manifest = manifest_with_stale_segments(&seg_dir, &profile, 4, &[1]);
+
+        // When the cap is enforced while the fill holds that segment
+        let protected: HashSet<u32> = [1].into_iter().collect();
+        enforce_cache_limit(tmp.path(), &mut manifest, 1000, &protected);
+
+        // Then its file survives
+        assert_eq!(manifest.segments[1].state, CacheSegmentState::Stale);
+        assert!(seg_dir.join(segment_cache_file_name(1)).exists());
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -41,6 +41,7 @@ pub mod hdr;
 mod pip_stitch;
 pub mod plan;
 pub(crate) mod preview_cancel;
+pub(crate) mod preview_fill;
 mod render_window;
 pub mod smart;
 mod transform_layout;
@@ -80,6 +81,9 @@ pub use cache::{
     RenderCacheConfig, RenderCacheManifest, RenderCacheSegment, RenderCacheStatus,
     SegmentFingerprint, SegmentFlagReason, SEGMENT_FINGERPRINT_UNSET,
 };
+
+// Preview cache fill re-exports
+pub use preview_fill::PreviewCacheScope;
 
 // Smart render re-exports
 pub use smart::{

--- a/src-tauri/src/core/render/preview_cancel.rs
+++ b/src-tauri/src/core/render/preview_cancel.rs
@@ -8,26 +8,46 @@
 //! [`PreviewCacheCancel::is_superseded`] between segments, and the segment
 //! currently rendering is cancelled through its own oneshot so the exporter
 //! kills FFmpeg, deletes the partial output and returns `ExportError::Cancelled`.
+//!
+//! # Two kinds of cancel
+//!
+//! Superseding is the blunt one and stops the whole fill. The armed segment also
+//! carries its *identity* — index plus plan fingerprint — so a fill that is
+//! merely retargeted can cancel only the segment whose work actually changed and
+//! leave the fill running; see
+//! [`PreviewCacheCancel::cancel_segment_if_stale`] and
+//! [`crate::core::render::preview_fill`]. That cancel deliberately never sets the
+//! supersede flag, which is how the fill loop tells the two apart.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use tokio::sync::oneshot;
 
+use super::cache::SegmentFingerprint;
+use super::preview_fill::CacheFillWorkSet;
+
+/// The segment whose FFmpeg is currently running, and the handle that kills it.
+struct ArmedSegment {
+    index: u32,
+    fingerprint: SegmentFingerprint,
+    sender: oneshot::Sender<()>,
+}
+
 /// Cancellation shared between a preview-cache fill task and the call that
 /// supersedes it.
 #[derive(Default)]
 pub struct PreviewCacheCancel {
     superseded: AtomicBool,
-    segment: Mutex<Option<oneshot::Sender<()>>>,
+    segment: Mutex<Option<ArmedSegment>>,
 }
 
 impl PreviewCacheCancel {
     /// Marks the fill superseded and cancels the segment in flight, if any.
     pub fn trigger(&self) {
         self.superseded.store(true, Ordering::Release);
-        if let Some(sender) = self.segment.lock().ok().and_then(|mut slot| slot.take()) {
-            let _ = sender.send(());
+        if let Some(armed) = self.segment.lock().ok().and_then(|mut slot| slot.take()) {
+            let _ = armed.sender.send(());
         }
     }
 
@@ -44,7 +64,14 @@ impl PreviewCacheCancel {
     /// flag *before* taking the lock, so the two cannot interleave into a state
     /// where the flag is set yet a live sender sits in the slot that nothing will
     /// ever fire — which would leave the segment rendering uncancellably.
-    pub fn arm_segment(&self) -> oneshot::Receiver<()> {
+    ///
+    /// `index` and `fingerprint` identify the work this encode is producing, so
+    /// a later request can tell whether it is still the right encode.
+    pub fn arm_segment(
+        &self,
+        index: u32,
+        fingerprint: SegmentFingerprint,
+    ) -> oneshot::Receiver<()> {
         let (sender, receiver) = oneshot::channel();
         match self.segment.lock() {
             Ok(mut slot) => {
@@ -52,7 +79,11 @@ impl PreviewCacheCancel {
                     *slot = None;
                     let _ = sender.send(());
                 } else {
-                    *slot = Some(sender);
+                    *slot = Some(ArmedSegment {
+                        index,
+                        fingerprint,
+                        sender,
+                    });
                 }
             }
             // Fail safe: an unusable lock must cancel the segment, never leave it
@@ -70,11 +101,65 @@ impl PreviewCacheCancel {
             *slot = None;
         }
     }
+
+    /// The segment currently encoding, if any.
+    pub fn in_flight(&self) -> Option<(u32, SegmentFingerprint)> {
+        self.segment
+            .lock()
+            .ok()
+            .and_then(|slot| slot.as_ref().map(|armed| (armed.index, armed.fingerprint)))
+    }
+
+    /// Cancels the segment in flight when `desired` no longer wants the work it
+    /// is producing, and reports whether it fired.
+    ///
+    /// This is the targeted counterpart to [`trigger`](Self::trigger): it kills
+    /// one encode without marking the fill superseded, so the fill loop treats
+    /// the resulting `Cancelled` as "pick this segment up again with fresh
+    /// inputs" rather than "stop". A segment whose fingerprint is unchanged is
+    /// left alone, because re-rendering it would produce the same bytes.
+    ///
+    /// Reading the identity and taking the sender happen under one lock
+    /// acquisition so the segment cannot be swapped out between the two.
+    pub fn cancel_segment_if_stale(&self, desired: &CacheFillWorkSet) -> bool {
+        let Ok(mut slot) = self.segment.lock() else {
+            // The slot is unreadable, so no identity can be compared and no
+            // sender can be taken. Nothing armed after this point can render
+            // anyway: `arm_segment` fails safe by pre-cancelling whenever the
+            // lock is unusable.
+            tracing::warn!("Preview cache cancel slot unavailable; skipping targeted cancel");
+            return false;
+        };
+
+        let Some(armed) = slot.as_ref() else {
+            return false;
+        };
+        if desired.fingerprint_of(armed.index) == Some(armed.fingerprint) {
+            return false;
+        }
+
+        // `take` rather than a borrow: the sender is consumed by sending, and the
+        // slot must not keep naming an encode that is already being torn down.
+        if let Some(armed) = slot.take() {
+            let _ = armed.sender.send(());
+            return true;
+        }
+        false
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn work(segments: &[(u32, SegmentFingerprint)]) -> CacheFillWorkSet {
+        CacheFillWorkSet::new(
+            "seq1",
+            "profile-a",
+            super::super::preview_fill::PreviewCacheScope::WholeTimeline,
+            segments.to_vec(),
+        )
+    }
 
     /// Feature: Preview cache cancellation
     /// Scenario: triggering marks the fill superseded
@@ -91,7 +176,7 @@ mod tests {
     #[test]
     fn should_cancel_the_armed_segment_when_triggered() {
         let cancel = PreviewCacheCancel::default();
-        let mut receiver = cancel.arm_segment();
+        let mut receiver = cancel.arm_segment(0, 10);
         assert_eq!(
             receiver.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
@@ -113,7 +198,7 @@ mod tests {
         let cancel = PreviewCacheCancel::default();
         cancel.trigger();
 
-        let mut receiver = cancel.arm_segment();
+        let mut receiver = cancel.arm_segment(0, 10);
 
         assert_eq!(receiver.try_recv(), Ok(()));
     }
@@ -123,7 +208,7 @@ mod tests {
     #[test]
     fn should_drop_the_sender_on_disarm() {
         let cancel = PreviewCacheCancel::default();
-        let mut receiver = cancel.arm_segment();
+        let mut receiver = cancel.arm_segment(0, 10);
         cancel.disarm_segment();
 
         cancel.trigger();
@@ -134,5 +219,76 @@ mod tests {
             receiver.try_recv(),
             Err(oneshot::error::TryRecvError::Closed)
         );
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: the armed segment reports which work it is producing
+    #[test]
+    fn should_report_the_armed_segment_identity_when_a_segment_is_rendering() {
+        let cancel = PreviewCacheCancel::default();
+        assert_eq!(cancel.in_flight(), None);
+
+        let _receiver = cancel.arm_segment(3, 42);
+        assert_eq!(cancel.in_flight(), Some((3, 42)));
+
+        cancel.disarm_segment();
+        assert_eq!(cancel.in_flight(), None);
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: the segment in flight is still producing the wanted bytes
+    #[test]
+    fn should_not_cancel_the_armed_segment_when_its_fingerprint_is_unchanged() {
+        let cancel = PreviewCacheCancel::default();
+        let mut receiver = cancel.arm_segment(1, 20);
+
+        let fired = cancel.cancel_segment_if_stale(&work(&[(0, 99), (1, 20)]));
+
+        assert!(!fired);
+        assert_eq!(
+            receiver.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        );
+        assert_eq!(cancel.in_flight(), Some((1, 20)));
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: the segment in flight was edited, or is no longer wanted
+    #[test]
+    fn should_cancel_the_armed_segment_when_its_work_is_stale_or_dropped() {
+        let cancel = PreviewCacheCancel::default();
+        let mut moved = cancel.arm_segment(1, 20);
+        assert!(cancel.cancel_segment_if_stale(&work(&[(1, 21)])));
+        assert_eq!(moved.try_recv(), Ok(()));
+
+        let cancel = PreviewCacheCancel::default();
+        let mut dropped = cancel.arm_segment(1, 20);
+        assert!(cancel.cancel_segment_if_stale(&work(&[(0, 10)])));
+        assert_eq!(dropped.try_recv(), Ok(()));
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: a targeted cancel leaves the fill itself running
+    ///
+    /// The supersede flag is what the fill loop reads to decide whether to stop,
+    /// so a segment-level cancel must never set it.
+    #[test]
+    fn should_not_mark_the_fill_superseded_when_only_a_segment_is_cancelled() {
+        let cancel = PreviewCacheCancel::default();
+        let _receiver = cancel.arm_segment(1, 20);
+
+        cancel.cancel_segment_if_stale(&work(&[(1, 21)]));
+
+        assert!(!cancel.is_superseded());
+    }
+
+    /// Feature: Preview cache cancellation
+    /// Scenario: no segment is rendering when a retarget arrives
+    #[test]
+    fn should_do_nothing_when_no_segment_is_armed() {
+        let cancel = PreviewCacheCancel::default();
+
+        assert!(!cancel.cancel_segment_if_stale(&work(&[(1, 21)])));
+        assert!(!cancel.is_superseded());
     }
 }

--- a/src-tauri/src/core/render/preview_fill.rs
+++ b/src-tauri/src/core/render/preview_fill.rs
@@ -1,0 +1,990 @@
+//! Convergent preview-cache fill.
+//!
+//! A fill is described by the set of segments it is trying to produce — its
+//! [`CacheFillWorkSet`] — rather than by the frozen list it was spawned with.
+//! That distinction is what makes repeated requests convergent instead of
+//! destructive.
+//!
+//! # Why a request is not automatically a supersede
+//!
+//! The cache is filled by whatever notices work to do: a manual request, an
+//! edit landing, a status refresh. Treating every one of those as "cancel the
+//! in-flight FFmpeg and start again" means a burst of requests renders nothing
+//! at all — each one kills the encode the previous one started, so the fill
+//! never converges while the user is working.
+//!
+//! The rule adopted here — informed by how background render caching behaves in
+//! established finishing tools — is: *cancel a segment only when that segment's
+//! own work changed*. A request that asks for the same work as the fill running
+//! is a no-op ([`EnsureAction::AlreadyConverging`]); a request that changes the
+//! queue swaps the queue in place and leaves an unaffected in-flight encode
+//! alone ([`EnsureAction::Retarget`]); only a request for a different sequence
+//! or a different encode profile — where nothing already on disk is
+//! byte-compatible — throws the fill away ([`EnsureAction::Supersede`]).
+//!
+//! Segment identity is the plan fingerprint
+//! ([`SegmentFingerprint`]), which already covers the render plan, the encode
+//! profile, the renderer's compositor semantics and the timeline content inside
+//! the segment's window. If it is unchanged, re-rendering the segment would
+//! produce the same bytes, so the encode in flight is still the right one.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::cache::{RenderCacheManifest, SegmentFingerprint};
+
+/// Which segments a preview-cache fill request is asking for.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviewCacheScope {
+    /// Every segment that needs rendering, in timeline order.
+    #[default]
+    WholeTimeline,
+    /// Only segments the live preview cannot draw faithfully, and only those the
+    /// export path can actually render.
+    ///
+    /// This is the scope that buys accuracy rather than smoothness: a flagged
+    /// segment is one where what the user sees and what the export produces
+    /// disagree, so filling it replaces a guess with the real composite.
+    Flagged,
+}
+
+impl PreviewCacheScope {
+    /// Stable key for this scope in event payloads.
+    ///
+    /// Matches the serde representation, so a frontend can compare it against
+    /// the value it would send.
+    pub fn event_key(self) -> &'static str {
+        match self {
+            Self::WholeTimeline => "whole_timeline",
+            Self::Flagged => "flagged",
+        }
+    }
+
+    /// The wider of two scopes.
+    ///
+    /// [`WholeTimeline`](Self::WholeTimeline) subsumes
+    /// [`Flagged`](Self::Flagged): every flagged segment needing a render is also
+    /// a segment needing a render. When two requests meet, the fill keeps the
+    /// wider label so it never advertises itself as doing less than it is.
+    pub fn broader(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::WholeTimeline, _) | (_, Self::WholeTimeline) => Self::WholeTimeline,
+            (Self::Flagged, Self::Flagged) => Self::Flagged,
+        }
+    }
+}
+
+/// The segments one convergent preview-cache fill is trying to produce.
+///
+/// The queue is shared with the running fill task, which pops from it, and with
+/// later requests, which replace it wholesale. Both ends therefore agree on
+/// exactly one thing: a segment index paired with the fingerprint of the work
+/// that segment currently represents.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheFillWorkSet {
+    /// Sequence whose cache is being filled.
+    pub sequence_id: String,
+    /// Encode profile the segments are produced with.
+    pub profile_hash: String,
+    /// What this fill advertises itself as doing.
+    ///
+    /// Carried on the work set rather than captured at spawn time so that a
+    /// retarget which widens the fill also widens the label every event reports —
+    /// see [`merge_work_sets`].
+    pub scope: PreviewCacheScope,
+    /// `(index, fingerprint)` pairs, ascending by index (canonicalized on
+    /// construction).
+    pub segments: Vec<(u32, SegmentFingerprint)>,
+}
+
+impl CacheFillWorkSet {
+    /// Builds a work set, canonicalizing the segment list.
+    ///
+    /// Segments are sorted ascending by index and de-duplicated by index, so two
+    /// requests that name the same work in a different order compare equal. That
+    /// equality is what [`decide_ensure_action`] uses to recognize a repeated
+    /// request, so the ordering cannot be left to the caller.
+    ///
+    /// A duplicated index keeps its first fingerprint after sorting; the caller
+    /// derives the list from a manifest, where an index appears once, so a
+    /// duplicate can only be a caller bug and there is no better answer to pick.
+    pub fn new(
+        sequence_id: impl Into<String>,
+        profile_hash: impl Into<String>,
+        scope: PreviewCacheScope,
+        segments: Vec<(u32, SegmentFingerprint)>,
+    ) -> Self {
+        let mut segments = segments;
+        segments.sort_by_key(|(index, _)| *index);
+        segments.dedup_by_key(|(index, _)| *index);
+        Self {
+            sequence_id: sequence_id.into(),
+            profile_hash: profile_hash.into(),
+            scope,
+            segments,
+        }
+    }
+
+    /// The fingerprint this work set expects for `index`, if it wants it at all.
+    pub fn fingerprint_of(&self, index: u32) -> Option<SegmentFingerprint> {
+        self.segments
+            .iter()
+            .find(|(candidate, _)| *candidate == index)
+            .map(|(_, fingerprint)| *fingerprint)
+    }
+
+    /// Number of segments still queued.
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Whether nothing is left to render.
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Number of segments queued other than `index`.
+    ///
+    /// The fill measures its own progress with this: a retarget can put the
+    /// segment that just finished back on the queue (its manifest entry was
+    /// momentarily `Rendering`, which a fresh prepare resets to `Error`), and
+    /// counting it as both done and outstanding would understate progress
+    /// forever.
+    pub fn len_excluding(&self, index: u32) -> usize {
+        self.segments
+            .iter()
+            .filter(|(candidate, _)| *candidate != index)
+            .count()
+    }
+
+    /// Pops the lowest-index segment `still_needed` accepts, discarding the
+    /// entries it rejects along the way.
+    ///
+    /// The fill re-reads the manifest before every segment, so a queued entry
+    /// can have been rendered, evicted or invalidated since it was queued. It is
+    /// removed either way: an entry that no longer needs rendering has nothing
+    /// left to do, and leaving it queued would make the fill re-examine it
+    /// forever.
+    pub fn pop_next_where(
+        &mut self,
+        still_needed: impl Fn(u32) -> bool,
+    ) -> Option<(u32, SegmentFingerprint)> {
+        while !self.segments.is_empty() {
+            let entry = self.segments.remove(0);
+            if still_needed(entry.0) {
+                return Some(entry);
+            }
+        }
+        None
+    }
+}
+
+/// A read-only view of the fill currently registered as active.
+pub struct ActiveFillView<'a> {
+    /// The queue that fill is working through.
+    pub work: &'a CacheFillWorkSet,
+    /// `(index, fingerprint)` of the segment whose FFmpeg is running, if any.
+    pub in_flight: Option<(u32, SegmentFingerprint)>,
+}
+
+/// What a fresh fill request should do about the fill already in flight.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EnsureAction {
+    /// Nothing is running: register and spawn.
+    Start,
+    /// The running fill is already producing exactly this work set.
+    AlreadyConverging,
+    /// Same fill, different work set: swap the queue in place. `cancel_in_flight`
+    /// is true only when the in-flight segment's fingerprint moved or it left the
+    /// work set, so a segment still being rendered correctly finishes.
+    Retarget {
+        /// Whether the segment currently encoding is now producing the wrong bytes.
+        cancel_in_flight: bool,
+    },
+    /// Different sequence or encode profile: everything on disk is byte-incompatible.
+    Supersede,
+}
+
+/// Decides how a fresh fill request relates to the fill already in flight.
+///
+/// See the module docs for why a repeated request converges instead of
+/// restarting.
+///
+/// `desired` must already have been folded through [`merge_work_sets`], so what
+/// arrives here is the complete set the fill should be converging on.
+///
+/// # The `AlreadyConverging` invariant
+///
+/// A no-op requires *two* things, not one: the queue must be unchanged **and**
+/// whatever is encoding right now must still be wanted at the same fingerprint.
+/// The second half is not redundant, because the in-flight segment has been
+/// popped and so is normally missing from the queue — comparing queues alone
+/// would declare "nothing to do" while an encode produced bytes this request has
+/// already invalidated.
+///
+/// Today the reconcile step in the ensure path resets an interrupted
+/// `Rendering` segment to `Error`, which puts the in-flight segment back into
+/// every freshly derived work set and therefore makes the queues differ anyway.
+/// That is an accident of one policy choice, not a guarantee; the invariant is
+/// checked directly so a future `Preserve` policy cannot turn it into a silent
+/// data bug.
+pub fn decide_ensure_action(
+    active: Option<&ActiveFillView<'_>>,
+    desired: &CacheFillWorkSet,
+) -> EnsureAction {
+    let Some(active) = active else {
+        return EnsureAction::Start;
+    };
+
+    // A different sequence or profile writes to a different directory with
+    // different encode settings, so none of the running fill's remaining work
+    // can be reused and converging onto it is meaningless.
+    if active.work.sequence_id != desired.sequence_id
+        || active.work.profile_hash != desired.profile_hash
+    {
+        return EnsureAction::Supersede;
+    }
+
+    // The in-flight encode is only wrong if *its own* work changed: either the
+    // new work set no longer wants that segment, or it wants it at a different
+    // fingerprint. A neighbouring segment moving says nothing about it.
+    //
+    // The in-flight segment is normally *absent* from the active queue, because
+    // the fill pops before it encodes. So an unchanged queue does not by itself
+    // mean there is nothing to do: the encode running right now could still be
+    // producing bytes this request no longer wants.
+    let in_flight_is_wanted = match active.in_flight {
+        Some((index, fingerprint)) => desired.fingerprint_of(index) == Some(fingerprint),
+        None => true,
+    };
+
+    if active.work.segments == desired.segments && in_flight_is_wanted {
+        return EnsureAction::AlreadyConverging;
+    }
+
+    EnsureAction::Retarget {
+        cancel_in_flight: !in_flight_is_wanted,
+    }
+}
+
+/// Folds a fresh request into the work a running fill already owns.
+///
+/// Callers must have established that the two describe the same sequence and
+/// encode profile; a mismatch there is [`EnsureAction::Supersede`], not a merge.
+///
+/// A request in the **same scope** replaces the active set outright: it was
+/// derived from a freshly reconciled manifest, so it is a complete and more
+/// current answer to the same question.
+///
+/// A request in a **different scope** is unioned instead, and keeps the
+/// [`broader`](PreviewCacheScope::broader) label. Replacing here would silently
+/// throw away work: a `Flagged` request arriving while a `WholeTimeline` fill is
+/// running would shrink that fill to the flagged segments alone, and nothing
+/// would ever put the rest back. On an index in both sets the fresher
+/// fingerprint — the incoming one — wins.
+///
+/// # Folding in the segment that is encoding
+///
+/// `in_flight` is the identity of the segment whose FFmpeg is running. It
+/// appears in **neither** list: the fill pops a segment before it encodes it,
+/// and a fresh request may have no opinion about it either. Leaving it out would
+/// make it look dropped, which cancels a perfectly good encode *and* strands the
+/// segment in no queue at all — a request for more work would lose work.
+///
+/// So it is re-added at the fingerprint it is being encoded for whenever nothing
+/// else in the merged set already names it. The rule holds in every direction:
+///
+/// - **Cross-scope.** A `Flagged` request omits an unflagged in-flight segment
+///   because its filter tests "is this flagged", not "is this being worked on".
+///   Silence there is not a decision, so the broader fill keeps the segment.
+/// - **Same scope, today.** The ensure path reconciles the interrupted
+///   `Rendering` state to `Error`, so a same-scope request already lists the
+///   in-flight segment at the manifest's current fingerprint. That entry wins,
+///   and the fold changes nothing.
+/// - **Same scope, under a future `Preserve` policy.** The segment would stay
+///   `Rendering`, drop out of `needs_render`, and vanish from the request — as
+///   "already being handled", not "unwanted". The fold keeps it, so the policy
+///   change cannot turn into a spurious cancel.
+///
+/// The effect is that the cancel decision keys purely on a *fingerprint change*
+/// rather than on absence. A segment that genuinely disappeared — the timeline
+/// shrank past it — is no longer cancelled, but it cannot corrupt anything:
+/// [`verdict_for_rendered_segment`] discards bytes whose segment is gone from
+/// the manifest. The cost is one wasted encode in a rare case, against a
+/// guaranteed lost encode in a common one.
+pub fn merge_work_sets(
+    active: &CacheFillWorkSet,
+    desired: &CacheFillWorkSet,
+    in_flight: Option<(u32, SegmentFingerprint)>,
+) -> CacheFillWorkSet {
+    let cross_scope = active.scope != desired.scope;
+    let mut segments = desired.segments.clone();
+
+    if cross_scope {
+        segments.extend(
+            active
+                .segments
+                .iter()
+                .filter(|(index, _)| desired.fingerprint_of(*index).is_none())
+                .copied(),
+        );
+    }
+
+    if let Some((index, fingerprint)) = in_flight {
+        if !segments.iter().any(|(candidate, _)| *candidate == index) {
+            segments.push((index, fingerprint));
+        }
+    }
+
+    CacheFillWorkSet::new(
+        desired.sequence_id.clone(),
+        desired.profile_hash.clone(),
+        if cross_scope {
+            active.scope.broader(desired.scope)
+        } else {
+            desired.scope
+        },
+        segments,
+    )
+}
+
+/// What to do with a segment whose encode just succeeded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RenderedSegmentVerdict {
+    /// The bytes still match what the manifest says the segment should be.
+    Accept,
+    /// The segment's identity moved while it was encoding: throw the file away.
+    Discard,
+}
+
+/// Decides whether a finished encode may be recorded as this segment's cache.
+///
+/// `rendered` is the fingerprint the encode was started for; `stored` is what
+/// the manifest says the segment's fingerprint is *now*, freshly reloaded.
+///
+/// They can differ: an edit landing mid-encode re-fingerprints the manifest, and
+/// the encode that is already running was built from the pre-edit timeline. If
+/// such a file were marked `Cached` it would inherit the new fingerprint by
+/// association and look current forever — the freshness check compares stored
+/// fingerprints against the plan, sees a match, and never re-renders it. That is
+/// a permanently wrong cache served as truth, so a mismatch discards.
+///
+/// A segment that has vanished from the manifest (`stored` is `None`) also
+/// discards: there is nothing left to attach the bytes to.
+pub fn verdict_for_rendered_segment(
+    rendered: SegmentFingerprint,
+    stored: Option<SegmentFingerprint>,
+) -> RenderedSegmentVerdict {
+    if stored == Some(rendered) {
+        RenderedSegmentVerdict::Accept
+    } else {
+        RenderedSegmentVerdict::Discard
+    }
+}
+
+/// What a fill does after its current segment reports `Cancelled`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancelledOutcome {
+    /// A newer fill owns the cache now: stop.
+    StopFill,
+    /// Only this segment was cancelled: keep going with the retargeted queue.
+    ContinueFill,
+}
+
+/// Maps a cancelled segment onto the fill's next move.
+///
+/// The exporter reports the same `Cancelled` error whichever cancel fired, so
+/// the fill distinguishes them by the supersede flag: a targeted cancel never
+/// sets it (see
+/// [`PreviewCacheCancel::cancel_segment_if_stale`](super::preview_cancel::PreviewCacheCancel::cancel_segment_if_stale)),
+/// which is exactly what makes the segment-level cancel non-fatal to the fill.
+pub fn cancelled_outcome(superseded: bool) -> CancelledOutcome {
+    if superseded {
+        CancelledOutcome::StopFill
+    } else {
+        CancelledOutcome::ContinueFill
+    }
+}
+
+/// Picks the segments a fill of `scope` should produce, in timeline order.
+///
+/// Only segments that need rendering are ever selected;
+/// [`PreviewCacheScope::Flagged`] narrows that to segments the live preview
+/// cannot draw faithfully.
+///
+/// A flagged segment is skipped when *any* of its reasons is not
+/// [`fill_renderable`](super::cache::SegmentFlagReason::fill_renderable): those
+/// mark content the export path itself refuses or errors on (compound clips,
+/// missing assets, overlay-track media), so queueing them would make the fill
+/// retry a render that can only fail, forever. The flag still stands — the
+/// preview there is still untrustworthy — it just cannot be resolved by
+/// rendering.
+pub fn select_fill_segments(
+    manifest: &RenderCacheManifest,
+    scope: PreviewCacheScope,
+) -> Vec<(u32, SegmentFingerprint)> {
+    manifest
+        .segments
+        .iter()
+        .filter(|segment| segment.needs_render())
+        .filter(|segment| match scope {
+            PreviewCacheScope::WholeTimeline => true,
+            PreviewCacheScope::Flagged => {
+                segment.flagged()
+                    && segment
+                        .flag_reasons
+                        .iter()
+                        .all(|reason| reason.fill_renderable())
+            }
+        })
+        .map(|segment| (segment.index, segment.fingerprint))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::render::cache::{CacheSegmentState, SegmentFlagReason};
+
+    const PROFILE: &str = "profile-a";
+
+    fn work(segments: &[(u32, SegmentFingerprint)]) -> CacheFillWorkSet {
+        scoped_work(PreviewCacheScope::WholeTimeline, segments)
+    }
+
+    fn scoped_work(
+        scope: PreviewCacheScope,
+        segments: &[(u32, SegmentFingerprint)],
+    ) -> CacheFillWorkSet {
+        CacheFillWorkSet::new("seq1", PROFILE, scope, segments.to_vec())
+    }
+
+    fn active<'a>(
+        work: &'a CacheFillWorkSet,
+        in_flight: Option<(u32, SegmentFingerprint)>,
+    ) -> ActiveFillView<'a> {
+        ActiveFillView { work, in_flight }
+    }
+
+    fn manifest_with(
+        segments: Vec<(CacheSegmentState, Vec<SegmentFlagReason>)>,
+    ) -> RenderCacheManifest {
+        let mut manifest =
+            RenderCacheManifest::new("seq1", PROFILE, segments.len() as f64 * 5.0, 5.0);
+        for (index, (state, reasons)) in segments.into_iter().enumerate() {
+            let segment = &mut manifest.segments[index];
+            segment.state = state;
+            segment.flag_reasons = reasons;
+            segment.fingerprint = 100 + index as u64;
+        }
+        manifest
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_ensure_action
+    // -----------------------------------------------------------------------
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: nothing is running
+    #[test]
+    fn should_start_when_no_fill_is_active() {
+        let desired = work(&[(0, 10), (1, 11)]);
+
+        assert_eq!(decide_ensure_action(None, &desired), EnsureAction::Start);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a repeated request asks for work already under way
+    #[test]
+    fn should_report_already_converging_when_the_work_set_is_unchanged() {
+        let running = work(&[(0, 10), (1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = work(&[(0, 10), (1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::AlreadyConverging
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the queue grows while the in-flight segment is unaffected
+    #[test]
+    fn should_retarget_without_cancelling_when_the_in_flight_segment_is_unchanged() {
+        let running = work(&[(0, 10), (1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = work(&[(0, 10), (1, 11), (2, 12)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Retarget {
+                cancel_in_flight: false
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the segment being encoded was edited
+    #[test]
+    fn should_cancel_the_in_flight_segment_when_its_fingerprint_moved() {
+        let running = work(&[(0, 10), (1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = work(&[(0, 99), (1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Retarget {
+                cancel_in_flight: true
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the segment being encoded is no longer wanted
+    #[test]
+    fn should_cancel_the_in_flight_segment_when_it_left_the_work_set() {
+        let running = work(&[(0, 10), (1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = work(&[(1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Retarget {
+                cancel_in_flight: true
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: an edit lands on a segment that is not the one encoding
+    #[test]
+    fn should_not_cancel_the_in_flight_segment_when_a_different_segment_moved() {
+        let running = work(&[(0, 10), (1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = work(&[(0, 10), (1, 99)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Retarget {
+                cancel_in_flight: false
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the encode profile changed
+    #[test]
+    fn should_supersede_when_the_profile_hash_differs() {
+        let running = work(&[(0, 10)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = CacheFillWorkSet::new(
+            "seq1",
+            "profile-b",
+            PreviewCacheScope::WholeTimeline,
+            vec![(0, 10)],
+        );
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Supersede
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a different sequence became active
+    #[test]
+    fn should_supersede_when_the_sequence_differs() {
+        let running = work(&[(0, 10)]);
+        let view = active(&running, Some((0, 10)));
+        let desired = CacheFillWorkSet::new(
+            "seq2",
+            PROFILE,
+            PreviewCacheScope::WholeTimeline,
+            vec![(0, 10)],
+        );
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Supersede
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the same work named in a different order
+    ///
+    /// Construction order must not decide whether a fill is restarted.
+    #[test]
+    fn should_report_already_converging_when_only_the_construction_order_differs() {
+        let running = work(&[(0, 10), (1, 11), (2, 12)]);
+        let view = active(&running, None);
+        let desired = work(&[(2, 12), (0, 10), (1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::AlreadyConverging
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the in-flight segment was popped and is wanted unchanged
+    ///
+    /// This is the shape production actually produces: the encoding segment is
+    /// absent from the active queue because the fill popped it.
+    #[test]
+    fn should_retarget_without_cancelling_when_the_popped_segment_is_wanted_unchanged() {
+        // The fill popped segment 0 and is encoding it, so its queue holds only 1.
+        let running = work(&[(1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        // A fresh request re-lists segment 0 at the same fingerprint.
+        let desired = work(&[(0, 10), (1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Retarget {
+                cancel_in_flight: false
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the queue is unchanged but the encode is producing stale bytes
+    ///
+    /// The in-flight segment is popped, so queue equality alone would call this
+    /// a no-op and let a superseded encode be recorded as truth.
+    #[test]
+    fn should_retarget_when_the_queue_matches_but_the_in_flight_segment_is_unwanted() {
+        let running = work(&[(1, 11)]);
+        let view = active(&running, Some((0, 10)));
+        // Same queue, but segment 0 is no longer wanted at fingerprint 10.
+        let desired = work(&[(1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::Retarget {
+                cancel_in_flight: true
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: no encode is running during the pop-to-arm window
+    ///
+    /// Nothing is in flight, so an unchanged queue really is a no-op.
+    #[test]
+    fn should_report_already_converging_when_nothing_is_in_flight_and_the_queue_matches() {
+        let running = work(&[(0, 10), (1, 11)]);
+        let view = active(&running, None);
+        let desired = work(&[(0, 10), (1, 11)]);
+
+        assert_eq!(
+            decide_ensure_action(Some(&view), &desired),
+            EnsureAction::AlreadyConverging
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // merge_work_sets
+    // -----------------------------------------------------------------------
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a flagged request arrives while the whole timeline is filling
+    #[test]
+    fn should_keep_the_wider_work_when_a_flagged_request_meets_a_whole_timeline_fill() {
+        let running = scoped_work(
+            PreviewCacheScope::WholeTimeline,
+            &[(0, 10), (1, 11), (2, 12)],
+        );
+        let incoming = scoped_work(PreviewCacheScope::Flagged, &[(1, 99)]);
+
+        let merged = merge_work_sets(&running, &incoming, None);
+
+        // Union, not replacement: the whole-timeline work is not thrown away.
+        assert_eq!(merged.segments, vec![(0, 10), (1, 99), (2, 12)]);
+        // And the fresher fingerprint for the shared index wins.
+        assert_eq!(merged.fingerprint_of(1), Some(99));
+        assert_eq!(merged.scope, PreviewCacheScope::WholeTimeline);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a whole-timeline request arrives while only flagged is filling
+    #[test]
+    fn should_widen_the_scope_when_a_whole_timeline_request_meets_a_flagged_fill() {
+        let running = scoped_work(PreviewCacheScope::Flagged, &[(3, 13)]);
+        let incoming = scoped_work(PreviewCacheScope::WholeTimeline, &[(0, 10), (1, 11)]);
+
+        let merged = merge_work_sets(&running, &incoming, None);
+
+        assert_eq!(merged.segments, vec![(0, 10), (1, 11), (3, 13)]);
+        assert_eq!(merged.scope, PreviewCacheScope::WholeTimeline);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a request in the same scope is a complete, fresher answer
+    #[test]
+    fn should_replace_the_work_set_when_the_incoming_scope_is_the_same() {
+        let running = work(&[(0, 10), (1, 11), (2, 12)]);
+        let incoming = work(&[(1, 11)]);
+
+        let merged = merge_work_sets(&running, &incoming, None);
+
+        assert_eq!(merged.segments, vec![(1, 11)]);
+        assert_eq!(merged.scope, PreviewCacheScope::WholeTimeline);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a narrower request must not strand the segment being encoded
+    ///
+    /// A `WholeTimeline` fill is encoding segment 0 with 1 and 2 still queued.
+    /// A `Flagged` request arrives naming only segment 5 — its filter tests
+    /// "is this flagged", so segment 0 is simply outside the question it asked.
+    /// Segment 0 is in neither list, and without the fold it would look dropped:
+    /// a valid encode killed, and the segment left in no queue at all. A request
+    /// for *more* work would have lost work.
+    #[test]
+    fn should_keep_the_encoding_segment_when_a_narrower_request_says_nothing_about_it() {
+        let running = scoped_work(PreviewCacheScope::WholeTimeline, &[(1, 11), (2, 12)]);
+        let incoming = scoped_work(PreviewCacheScope::Flagged, &[(5, 15)]);
+        let in_flight = Some((0, 10));
+
+        let merged = merge_work_sets(&running, &incoming, in_flight);
+
+        assert_eq!(merged.segments, vec![(0, 10), (1, 11), (2, 12), (5, 15)]);
+        assert_eq!(merged.scope, PreviewCacheScope::WholeTimeline);
+
+        // And the encode in flight survives.
+        let view = active(&running, in_flight);
+        assert_eq!(
+            decide_ensure_action(Some(&view), &merged),
+            EnsureAction::Retarget {
+                cancel_in_flight: false
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the narrower request *does* have an opinion, and it differs
+    ///
+    /// The fold must not shield an encode whose work genuinely moved: when the
+    /// incoming request names the in-flight segment at a new fingerprint, that
+    /// entry wins and the encode is cancelled.
+    #[test]
+    fn should_still_cancel_the_encoding_segment_when_a_narrower_request_re_fingerprints_it() {
+        let running = scoped_work(PreviewCacheScope::WholeTimeline, &[(1, 11), (2, 12)]);
+        let incoming = scoped_work(PreviewCacheScope::Flagged, &[(0, 99), (5, 15)]);
+        let in_flight = Some((0, 10));
+
+        let merged = merge_work_sets(&running, &incoming, in_flight);
+
+        assert_eq!(merged.fingerprint_of(0), Some(99));
+
+        let view = active(&running, in_flight);
+        assert_eq!(
+            decide_ensure_action(Some(&view), &merged),
+            EnsureAction::Retarget {
+                cancel_in_flight: true
+            }
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a same-scope request that omits the segment being encoded
+    ///
+    /// Today's reconcile resets an interrupted `Rendering` segment to `Error`, so
+    /// a same-scope request lists it and the fold is a no-op. Under a `Preserve`
+    /// policy it would drop out as "already being handled"; the fold keeps the
+    /// encode alive either way, so the policy choice cannot become a data bug.
+    #[test]
+    fn should_keep_the_encoding_segment_when_a_same_scope_request_omits_it() {
+        let running = work(&[(1, 11)]);
+        let incoming = work(&[(1, 11), (2, 12)]);
+        let in_flight = Some((0, 10));
+
+        let merged = merge_work_sets(&running, &incoming, in_flight);
+
+        assert_eq!(merged.segments, vec![(0, 10), (1, 11), (2, 12)]);
+
+        let view = active(&running, in_flight);
+        assert_eq!(
+            decide_ensure_action(Some(&view), &merged),
+            EnsureAction::Retarget {
+                cancel_in_flight: false
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // verdict_for_rendered_segment
+    // -----------------------------------------------------------------------
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the segment's identity did not move while it encoded
+    #[test]
+    fn should_accept_a_rendered_segment_when_its_fingerprint_still_matches() {
+        assert_eq!(
+            verdict_for_rendered_segment(42, Some(42)),
+            RenderedSegmentVerdict::Accept
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: an edit landed while the segment was encoding
+    ///
+    /// Recording these bytes would attach pre-edit pixels to the post-edit
+    /// fingerprint, which no later freshness check could ever detect.
+    #[test]
+    fn should_discard_a_rendered_segment_when_its_fingerprint_moved_mid_encode() {
+        assert_eq!(
+            verdict_for_rendered_segment(42, Some(43)),
+            RenderedSegmentVerdict::Discard
+        );
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the segment no longer exists in the manifest
+    #[test]
+    fn should_discard_a_rendered_segment_when_the_manifest_no_longer_has_it() {
+        assert_eq!(
+            verdict_for_rendered_segment(42, None),
+            RenderedSegmentVerdict::Discard
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Work-set queue
+    // -----------------------------------------------------------------------
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the queue skips segments that stopped needing a render
+    #[test]
+    fn should_skip_queued_segments_when_they_no_longer_need_rendering() {
+        let mut queue = work(&[(0, 10), (1, 11), (2, 12)]);
+        assert_eq!(queue.len(), 3);
+
+        let popped = queue.pop_next_where(|index| index == 2);
+
+        assert_eq!(popped, Some((2, 12)));
+        assert_eq!(queue.len(), 0);
+        assert!(queue.is_empty());
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: progress must not count a re-queued finished segment twice
+    #[test]
+    fn should_exclude_the_named_segment_when_counting_what_is_outstanding() {
+        let queue = work(&[(0, 10), (1, 11), (2, 12)]);
+
+        assert_eq!(queue.len_excluding(1), 2);
+        // An index that is not queued changes nothing.
+        assert_eq!(queue.len_excluding(7), 3);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the queue pops in timeline order
+    #[test]
+    fn should_pop_the_lowest_index_first_when_every_segment_still_needs_rendering() {
+        let mut queue = work(&[(2, 12), (0, 10), (1, 11)]);
+
+        assert_eq!(queue.pop_next_where(|_| true), Some((0, 10)));
+        assert_eq!(queue.pop_next_where(|_| true), Some((1, 11)));
+        assert_eq!(queue.len(), 1);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: nothing in the queue is renderable any more
+    #[test]
+    fn should_return_nothing_when_no_queued_segment_still_needs_rendering() {
+        let mut queue = work(&[(0, 10), (1, 11)]);
+
+        assert_eq!(queue.pop_next_where(|_| false), None);
+        assert!(queue.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // cancelled_outcome
+    // -----------------------------------------------------------------------
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a supersede cancelled the segment
+    #[test]
+    fn should_stop_the_fill_when_a_cancelled_segment_was_superseded() {
+        assert_eq!(cancelled_outcome(true), CancelledOutcome::StopFill);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: only the segment itself was cancelled
+    #[test]
+    fn should_continue_the_fill_when_a_cancelled_segment_was_only_retargeted() {
+        assert_eq!(cancelled_outcome(false), CancelledOutcome::ContinueFill);
+    }
+
+    // -----------------------------------------------------------------------
+    // select_fill_segments
+    // -----------------------------------------------------------------------
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the whole-timeline scope takes every segment needing a render
+    #[test]
+    fn should_select_every_renderable_segment_when_the_scope_is_the_whole_timeline() {
+        let manifest = manifest_with(vec![
+            (CacheSegmentState::Empty, Vec::new()),
+            (CacheSegmentState::Cached, Vec::new()),
+            (CacheSegmentState::Stale, vec![SegmentFlagReason::Transform]),
+        ]);
+
+        let selected = select_fill_segments(&manifest, PreviewCacheScope::WholeTimeline);
+
+        assert_eq!(selected, vec![(0, 100), (2, 102)]);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: the flagged scope ignores segments the preview draws correctly
+    #[test]
+    fn should_select_only_flagged_segments_when_the_scope_is_flagged() {
+        let manifest = manifest_with(vec![
+            (CacheSegmentState::Empty, Vec::new()),
+            (CacheSegmentState::Empty, vec![SegmentFlagReason::BlendMode]),
+        ]);
+
+        let selected = select_fill_segments(&manifest, PreviewCacheScope::Flagged);
+
+        assert_eq!(selected, vec![(1, 101)]);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a flagged segment the export path cannot render is skipped
+    ///
+    /// One unrenderable ingredient fails the whole segment, so queueing it would
+    /// make the fill retry a render that can only error.
+    #[test]
+    fn should_skip_flagged_segments_when_any_reason_is_not_fill_renderable() {
+        let manifest = manifest_with(vec![
+            (
+                CacheSegmentState::Empty,
+                vec![
+                    SegmentFlagReason::Transform,
+                    SegmentFlagReason::MissingAsset,
+                ],
+            ),
+            (CacheSegmentState::Empty, vec![SegmentFlagReason::Transform]),
+        ]);
+
+        let selected = select_fill_segments(&manifest, PreviewCacheScope::Flagged);
+
+        assert_eq!(selected, vec![(1, 101)]);
+    }
+
+    /// Feature: Convergent preview-cache fill
+    /// Scenario: a flagged segment that is already cached needs no fill
+    #[test]
+    fn should_not_select_flagged_segments_when_they_are_already_cached() {
+        let manifest = manifest_with(vec![(
+            CacheSegmentState::Cached,
+            vec![SegmentFlagReason::Transform],
+        )]);
+
+        let selected = select_fill_segments(&manifest, PreviewCacheScope::Flagged);
+
+        assert!(selected.is_empty());
+    }
+}

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -2697,19 +2697,239 @@ fn reconcile_cache_manifest(
 }
 
 use crate::core::render::preview_cancel::PreviewCacheCancel;
+use crate::core::render::preview_fill::{
+    self, ActiveFillView, CacheFillWorkSet, CancelledOutcome, EnsureAction, PreviewCacheScope,
+};
 
-/// Cancellation handle and identity for the active cache render task.
+/// Cancellation handle, identity and live queue of the active cache render task.
 ///
-/// Starting a new cache render supersedes any in-flight background task so that
-/// only one cache render is active at a time.
+/// At most one cache render is active at a time, but a later request does not
+/// automatically replace it: the decision is
+/// [`preview_fill::decide_ensure_action`], and a request that only changes
+/// *which* segments are wanted retargets `work` in place instead of restarting.
 struct ActiveCacheRender {
     job_id: String,
     sequence_id: String,
     cancel: std::sync::Arc<PreviewCacheCancel>,
+    /// Segments the running fill is still trying to produce.
+    ///
+    /// Shared with the fill task, which pops from it, so a retarget is visible
+    /// to the loop on its next iteration without restarting anything.
+    work: std::sync::Arc<std::sync::Mutex<CacheFillWorkSet>>,
 }
 
 static ACTIVE_CACHE_RENDER: std::sync::LazyLock<std::sync::Mutex<Option<ActiveCacheRender>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+/// What [`ensure_cache_fill`] settled on inside the registry critical section.
+///
+/// Carried out of the lock so the emits and the task spawn happen without
+/// holding it.
+enum EnsureOutcome {
+    /// Register and spawn a new fill; `superseded` names the fill it replaced.
+    Spawn {
+        /// `(job_id, sequence_id)` of the replaced fill, for its cancel event.
+        superseded: Option<(String, String)>,
+    },
+    /// The running fill is already producing this work set; nothing to do.
+    Converging { job_id: String },
+    /// The running fill's queue was swapped in place.
+    Retargeted {
+        job_id: String,
+        /// Size of the merged queue the fill is now converging on.
+        queued: u32,
+    },
+}
+
+/// Folds a request into a registered fill's work and asks
+/// [`preview_fill::decide_ensure_action`] what to do about it.
+///
+/// Returns the action together with the work set the fill should end up
+/// converging on, which is the *merged* set — a request in a narrower scope must
+/// not shrink a broader fill.
+///
+/// Split out only so the borrow of the registry entry and of its queue guard
+/// both end before the caller mutates the registry.
+fn decide_ensure_action_for(
+    active: &ActiveCacheRender,
+    active_work: &CacheFillWorkSet,
+    desired: &CacheFillWorkSet,
+) -> (EnsureAction, CacheFillWorkSet) {
+    // Read once and use for both the merge and the decision: two reads could
+    // straddle the fill arming or disarming a segment, and then the target would
+    // be folded for one identity while the verdict was computed against another.
+    let in_flight = active.cancel.in_flight();
+    let target = preview_fill::merge_work_sets(active_work, desired, in_flight);
+    let view = ActiveFillView {
+        work: active_work,
+        in_flight,
+    };
+    (
+        preview_fill::decide_ensure_action(Some(&view), &target),
+        target,
+    )
+}
+
+/// Clears the cancel slot's in-flight identity when a fill iteration ends,
+/// however it ends.
+///
+/// The identity is published at *pop* time rather than at encode time, so every
+/// early exit between the two — a project closed, a graph that will not build, a
+/// plan that fails validation — has to retract it. A `Drop` guard covers those
+/// exits without threading a `disarm_segment` call through each one, where a
+/// missed branch would leave the registry claiming an encode that is not
+/// running.
+struct ArmedSegmentGuard(std::sync::Arc<PreviewCacheCancel>);
+
+impl Drop for ArmedSegmentGuard {
+    fn drop(&mut self) {
+        self.0.disarm_segment();
+    }
+}
+
+/// How a fill's end-of-queue check resolved, decided under the registry lock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FillExit {
+    /// Work is still queued; keep going.
+    Continue,
+    /// The queue is empty and this fill has deregistered itself.
+    Finished,
+    /// The registry belongs to someone else; stop without deregistering.
+    Superseded,
+}
+
+/// Settles whether a fill with an empty-looking queue may stop.
+///
+/// This closes the dying-fill race. Seeing an empty queue and *then* taking the
+/// registry lock to deregister leaves a window in which an ensure call takes the
+/// registry, finds this fill still registered, and retargets it — pushing work
+/// onto a queue whose owner is already on its way out. That work would never be
+/// rendered and no later request would notice, because the registry entry
+/// disappears a moment later.
+///
+/// Re-reading the queue *under the registry lock* removes the window: an ensure
+/// call has to hold that same lock to retarget, so either it lands before this
+/// check (and the re-read sees the new work, returning
+/// [`Continue`](FillExit::Continue)) or it lands after (and finds no registered
+/// fill, so it starts a new one). Lock order is registry → queue, matching
+/// `ensure_cache_fill`, so the two cannot deadlock.
+fn settle_fill_exit(job_id: &str, work: &std::sync::Mutex<CacheFillWorkSet>) -> FillExit {
+    let Ok(mut handle) = ACTIVE_CACHE_RENDER.lock() else {
+        // The registry cannot be read, so nothing can be retargeted onto this
+        // fill either. Stopping is the only safe move.
+        tracing::warn!("Preview cache registry unavailable; ending fill");
+        return FillExit::Finished;
+    };
+
+    if handle.as_ref().is_none_or(|active| active.job_id != job_id) {
+        return FillExit::Superseded;
+    }
+
+    match work.lock() {
+        Ok(queue) if !queue.is_empty() => FillExit::Continue,
+        Ok(_) => {
+            *handle = None;
+            FillExit::Finished
+        }
+        Err(_) => {
+            tracing::warn!("Preview cache fill queue unavailable; ending fill");
+            *handle = None;
+            FillExit::Finished
+        }
+    }
+}
+
+/// Retracts a preview-cache segment whose encode was cancelled, and reports
+/// whether the fill itself should stop.
+///
+/// Used for both cancellation windows — before the encode starts and during it —
+/// so a segment cancelled either way is left renderable rather than failed, and
+/// the fill's next move is decided by the same rule in both cases.
+fn retract_cancelled_segment(
+    app_handle: &tauri::AppHandle,
+    project_path: &std::path::Path,
+    seq_id: &str,
+    job_id: &str,
+    index: u32,
+    plan_hash: Option<String>,
+    superseded: bool,
+) -> CancelledOutcome {
+    reload_mutate_save_manifest(project_path, seq_id, |manifest| {
+        if let Some(segment) = manifest
+            .segments
+            .iter_mut()
+            .find(|segment| segment.index == index)
+        {
+            segment.state = crate::core::render::CacheSegmentState::Empty;
+            segment.cached_file = None;
+            segment.file_size_bytes = 0;
+        }
+    });
+
+    let outcome = preview_fill::cancelled_outcome(superseded);
+    let message = match outcome {
+        CancelledOutcome::StopFill => {
+            format!("Preview cache segment {index} superseded by a newer render")
+        }
+        CancelledOutcome::ContinueFill => {
+            format!("Preview cache segment {index} restarted with newer inputs")
+        }
+    };
+    emit_render_lifecycle(
+        app_handle,
+        RenderLifecycleEvent {
+            job_id: job_id.to_string(),
+            sequence_id: Some(seq_id.to_string()),
+            kind: RenderLifecycleKind::PreviewCache,
+            state: RenderLifecycleState::Cancelled,
+            progress: None,
+            message: Some(message),
+            output_path: None,
+            plan_hash,
+        },
+    );
+
+    outcome
+}
+
+/// Reloads a sequence's cache manifest, applies `mutate`, and saves the result.
+///
+/// Every manifest write in the fill loop goes through this. A manifest snapshot
+/// read before an `.await` — or simply read a moment earlier, since the ensure
+/// path runs on a different thread — is stale by the time it is written back,
+/// and saving it whole reverts everything that landed in between: `Cached` →
+/// `Stale` demotions, refreshed fingerprints, work another request queued. The
+/// reverted state then reads as "nothing to do" and the retargeted work is lost.
+///
+/// Reloading immediately before the mutation, applying only the one segment's
+/// change, and saving with no `.await` in between narrows that window to the
+/// span of this function.
+fn reload_mutate_save_manifest(
+    project_path: &std::path::Path,
+    seq_id: &str,
+    mutate: impl FnOnce(&mut crate::core::render::RenderCacheManifest),
+) -> Option<crate::core::render::RenderCacheManifest> {
+    let mut manifest = match crate::core::render::load_manifest(project_path, seq_id) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => {
+            tracing::warn!("Cache manifest for sequence {seq_id} disappeared before a write");
+            return None;
+        }
+        Err(error) => {
+            tracing::warn!("Failed to reload cache manifest for sequence {seq_id}: {error}");
+            return None;
+        }
+    };
+
+    mutate(&mut manifest);
+
+    if let Err(error) = crate::core::render::save_manifest(project_path, &manifest) {
+        tracing::warn!("Failed to save cache manifest for sequence {seq_id}: {error}");
+        return None;
+    }
+
+    Some(manifest)
+}
 
 /// Everything a preview cache command needs from the open project, copied out
 /// from under the project lock so nothing downstream holds it.
@@ -2850,16 +3070,24 @@ fn prepare_cache_manifest(
 ///
 /// Triggers background rendering of uncached segments. Returns the cache
 /// status immediately; rendering progress is reported via Tauri events.
-/// If a previous cache render is still running it is cancelled first.
+///
+/// `scope` selects which segments are wanted;
+/// [`PreviewCacheScope::WholeTimeline`] when omitted.
+///
+/// A fill already in flight is *converged onto*, not cancelled: calling this
+/// repeatedly with unchanged work is a no-op, and a changed work set retargets
+/// the running fill. See [`crate::core::render::preview_fill`].
 #[tauri::command]
 #[specta::specta]
 pub async fn render_preview_cache(
     state: State<'_, AppState>,
     ffmpeg_state: State<'_, crate::core::ffmpeg::SharedFFmpegState>,
     app_handle: tauri::AppHandle,
+    scope: Option<PreviewCacheScope>,
 ) -> Result<RenderCacheJobResult, String> {
     use crate::core::render::cache::preview_profile_hash;
 
+    let scope = scope.unwrap_or_default();
     let config = resolve_cache_config(&app_handle);
 
     // Gather project data
@@ -2871,6 +3099,20 @@ pub async fn render_preview_cache(
         project_path,
         seq_id,
     } = gather_cache_render_inputs(&state).await?;
+
+    // `State<'_>` cannot be moved into the spawned task, so the runner is cloned
+    // out here. It stays optional so that an already-current cache still reports
+    // `AlreadyCached` when FFmpeg is missing, exactly as it did while the fill
+    // was inlined: the "FFmpeg not initialized" error is only raised on the path
+    // that actually spawns.
+    //
+    // Cloned *before* the manifest is prepared, and deliberately so: this is the
+    // last `.await` on the path, and `ensure_cache_fill` saves the manifest
+    // prepared below. An await between the two would let a running fill mark a
+    // segment `Cached` in the meantime, and saving the older snapshot would
+    // revert it to `Error` — orphaning the file it just wrote and undercounting
+    // the cache size. Nothing between here and that save may await.
+    let ffmpeg_runner = ffmpeg_state.read().await.runner().cloned();
 
     let profile_hash = preview_profile_hash(&sequence.format.canvas);
     let manifest = prepare_cache_manifest(
@@ -2884,22 +3126,10 @@ pub async fn render_preview_cache(
         &config,
     )?;
 
-    // Find segments that need rendering
-    let pending_indices: Vec<u32> = manifest
-        .segments
-        .iter()
-        .filter(|s| s.needs_render())
-        .map(|s| s.index)
-        .collect();
+    // Find segments this scope wants rendered
+    let pending = preview_fill::select_fill_segments(&manifest, scope);
 
-    // `State<'_>` cannot be moved into the spawned task, so the runner is cloned
-    // out here. It stays optional so that an already-current cache still reports
-    // `AlreadyCached` when FFmpeg is missing, exactly as it did while the fill
-    // was inlined: the "FFmpeg not initialized" error is only raised on the path
-    // that actually spawns.
-    let ffmpeg_runner = ffmpeg_state.read().await.runner().cloned();
-
-    spawn_cache_fill(
+    ensure_cache_fill(
         app_handle,
         ffmpeg_runner,
         project_path,
@@ -2907,23 +3137,27 @@ pub async fn render_preview_cache(
         profile_hash,
         config,
         manifest,
-        pending_indices,
+        pending,
+        scope,
     )
 }
 
-/// Fills the named segments of a sequence's preview cache in the background.
+/// Converges the preview cache of a sequence onto the named segments.
 ///
-/// Shared by every command that wants cache segments produced: the caller
-/// decides *which* segments and this owns the rest — the already-current
-/// early return, persisting the manifest, and the background fill task.
+/// Its caller — [`render_preview_cache`] — decides *which* segments are wanted;
+/// this owns the rest: the already-current early return, persisting the
+/// manifest, reconciling with any fill already running, and the background fill
+/// task.
 ///
 /// `manifest` must already be reconciled and re-fingerprinted; this function
-/// trusts `pending_indices` and does not recompute freshness.
+/// trusts `pending` and does not recompute freshness.
 ///
-/// Starting a fill supersedes any fill already in flight, so at most one cache
-/// render is running at a time.
+/// At most one cache render runs at a time, but this does not simply supersede:
+/// [`preview_fill::decide_ensure_action`] decides whether to start, converge
+/// silently, retarget the running fill's queue, or replace it outright. This is
+/// the only place that registers into [`ACTIVE_CACHE_RENDER`].
 #[allow(clippy::too_many_arguments)]
-fn spawn_cache_fill(
+fn ensure_cache_fill(
     app_handle: tauri::AppHandle,
     ffmpeg_runner: Option<crate::core::ffmpeg::FFmpegRunner>,
     project_path: std::path::PathBuf,
@@ -2931,14 +3165,16 @@ fn spawn_cache_fill(
     profile_hash: String,
     config: crate::core::render::RenderCacheConfig,
     manifest: crate::core::render::RenderCacheManifest,
-    pending_indices: Vec<u32>,
+    pending: Vec<(u32, crate::core::render::SegmentFingerprint)>,
+    scope: PreviewCacheScope,
 ) -> Result<RenderCacheJobResult, String> {
     use crate::core::render::cache::{enforce_cache_limit, load_manifest, save_manifest};
     use crate::core::render::ExportEngine;
     use tauri::Emitter;
 
     let cache_job_id = ulid::Ulid::new().to_string();
-    let total_pending = pending_indices.len() as u32;
+    let desired = CacheFillWorkSet::new(seq_id.clone(), profile_hash.clone(), scope, pending);
+    let total_pending = desired.len() as u32;
 
     if total_pending == 0 {
         emit_render_lifecycle(
@@ -2968,19 +3204,133 @@ fn spawn_cache_fill(
     save_manifest(&project_path, &manifest)
         .map_err(|error| format!("Failed to save cache manifest: {error}"))?;
 
-    // Collect segment time ranges before spawning (avoids borrow issues)
-    let segment_ranges: Vec<(u32, f64, f64)> = pending_indices
-        .iter()
-        .filter_map(|idx| {
-            manifest
-                .segments
-                .iter()
-                .find(|s| s.index == *idx)
-                .map(|s| (s.index, s.start_sec, s.end_sec))
-        })
-        .collect();
-
     let total_segments = manifest.segments.len() as u32;
+
+    // Checked before the critical section so a failure here cannot leave a
+    // registration behind with no task to honour it. A fill can only be in
+    // flight if FFmpeg resolved, so the converge and retarget arms below are
+    // unaffected in practice.
+    let ffmpeg_runner = ffmpeg_runner.ok_or("FFmpeg not initialized")?;
+
+    let job_seq_id = seq_id.clone();
+    let job_profile_hash = profile_hash.clone();
+    let cache_config = config;
+
+    let cache_job_id_for_task = cache_job_id.clone();
+    let cancel = std::sync::Arc::new(PreviewCacheCancel::default());
+    let task_cancel = cancel.clone();
+    let work = std::sync::Arc::new(std::sync::Mutex::new(desired.clone()));
+    let task_work = work.clone();
+
+    // Reconcile with the fill already in flight and register this one in a
+    // single critical section, so two concurrent calls cannot both end up
+    // running: if the decision and the register were separate locks, a second
+    // call could decide (finding nothing yet registered) and register over this
+    // one, leaving this fill with no one able to cancel it. A supersede that
+    // lands before the task spawns is still caught by the loop-top
+    // `is_superseded()`.
+    let outcome = if let Ok(mut handle) = ACTIVE_CACHE_RENDER.lock() {
+        let (action, target) = match handle.as_ref() {
+            None => (EnsureAction::Start, desired.clone()),
+            Some(active) => match active.work.lock() {
+                Ok(active_work) => decide_ensure_action_for(active, &active_work, &desired),
+                // The running fill's queue cannot be read, so there is no way to
+                // converge onto it: take over wholesale rather than guess.
+                Err(_) => (EnsureAction::Supersede, desired.clone()),
+            },
+        };
+
+        match action {
+            EnsureAction::Start | EnsureAction::Supersede => {
+                let previous = handle.take();
+                if let Some(previous) = &previous {
+                    previous.cancel.trigger();
+                }
+                *handle = Some(ActiveCacheRender {
+                    job_id: cache_job_id.clone(),
+                    sequence_id: seq_id.clone(),
+                    cancel,
+                    work,
+                });
+                EnsureOutcome::Spawn {
+                    superseded: previous.map(|previous| (previous.job_id, previous.sequence_id)),
+                }
+            }
+            // Both arms below are only produced from a registered fill, so a
+            // missing entry means the decision and the registry disagree. Fail
+            // loudly instead of fabricating a job id or spawning a fill that
+            // nothing owns.
+            EnsureAction::AlreadyConverging => match handle.as_ref() {
+                Some(active) => EnsureOutcome::Converging {
+                    job_id: active.job_id.clone(),
+                },
+                None => {
+                    tracing::error!(
+                        "Preview cache registry lost its active fill while converging onto it"
+                    );
+                    return Err(
+                        "Preview cache fill state is inconsistent; please try again".to_string()
+                    );
+                }
+            },
+            EnsureAction::Retarget { cancel_in_flight } => match handle.as_ref() {
+                Some(active) => {
+                    if let Ok(mut active_work) = active.work.lock() {
+                        *active_work = target.clone();
+                    }
+                    // Ordered after the swap: the running fill must already see
+                    // the new queue when it picks the cancelled segment back up.
+                    if cancel_in_flight {
+                        active.cancel.cancel_segment_if_stale(&target);
+                    }
+                    EnsureOutcome::Retargeted {
+                        job_id: active.job_id.clone(),
+                        queued: target.len() as u32,
+                    }
+                }
+                None => {
+                    tracing::error!(
+                        "Preview cache registry lost its active fill while retargeting it"
+                    );
+                    return Err(
+                        "Preview cache fill state is inconsistent; please try again".to_string()
+                    );
+                }
+            },
+        }
+    } else {
+        // The registry is unusable. Spawn anyway rather than refusing to fill —
+        // this fill just cannot be cancelled, which is the pre-existing
+        // behaviour of an unlockable registry.
+        EnsureOutcome::Spawn { superseded: None }
+    };
+
+    let superseded = match outcome {
+        EnsureOutcome::Converging { job_id } => {
+            tracing::debug!("Preview cache fill {job_id} is already producing this work set");
+            return Ok(RenderCacheJobResult {
+                job_id,
+                sequence_id: seq_id,
+                total_segments,
+                segments_to_render: total_pending,
+                status: RenderCacheJobStatus::AlreadyConverging,
+            });
+        }
+        EnsureOutcome::Retargeted { job_id, queued } => {
+            tracing::info!("Retargeted preview cache fill {job_id}");
+            return Ok(RenderCacheJobResult {
+                job_id,
+                sequence_id: seq_id,
+                total_segments,
+                // The merged queue, not this request's own list: a narrower
+                // request folded into a broader fill still reports the real
+                // amount of outstanding work.
+                segments_to_render: queued,
+                status: RenderCacheJobStatus::Retargeted,
+            });
+        }
+        EnsureOutcome::Spawn { superseded } => superseded,
+    };
 
     emit_render_lifecycle(
         &app_handle,
@@ -2996,43 +3346,13 @@ fn spawn_cache_fill(
         },
     );
 
-    let ffmpeg_runner = ffmpeg_runner.ok_or("FFmpeg not initialized")?;
-
-    let job_seq_id = seq_id.clone();
-    let job_profile_hash = profile_hash.clone();
-    let cache_config = config;
-
-    let cache_job_id_for_task = cache_job_id.clone();
-    let cancel = std::sync::Arc::new(PreviewCacheCancel::default());
-    let task_cancel = cancel.clone();
-
-    // Supersede any in-flight fill and register this one in a single critical
-    // section, so two concurrent calls cannot both end up running: if the take
-    // and the register were separate locks, a second call could take (finding
-    // nothing yet registered) and register over this one, leaving this fill with
-    // no one able to cancel it. A supersede that lands before the task spawns is
-    // still caught by the loop-top `is_superseded()`.
-    let superseded = if let Ok(mut handle) = ACTIVE_CACHE_RENDER.lock() {
-        let previous = handle.take();
-        if let Some(previous) = &previous {
-            previous.cancel.trigger();
-        }
-        *handle = Some(ActiveCacheRender {
-            job_id: cache_job_id.clone(),
-            sequence_id: seq_id.clone(),
-            cancel,
-        });
-        previous
-    } else {
-        None
-    };
-    if let Some(previous) = superseded {
+    if let Some((previous_job_id, previous_sequence_id)) = superseded {
         tracing::info!("Superseded previous cache render task");
         emit_render_lifecycle(
             &app_handle,
             RenderLifecycleEvent {
-                job_id: previous.job_id,
-                sequence_id: Some(previous.sequence_id),
+                job_id: previous_job_id,
+                sequence_id: Some(previous_sequence_id),
                 kind: RenderLifecycleKind::PreviewCache,
                 state: RenderLifecycleState::Cancelled,
                 progress: None,
@@ -3063,7 +3383,11 @@ fn spawn_cache_fill(
             },
         );
 
-        for (completed, (idx, start_sec, end_sec)) in segment_ranges.iter().enumerate() {
+        // The queue is not frozen at spawn time: a later request can retarget it
+        // while this loop runs, so every iteration re-reads what is left rather
+        // than walking a list captured up front.
+        let mut completed: usize = 0;
+        loop {
             // A newer fill has taken over: stop before starting another segment
             // rather than render work no one will read.
             if task_cancel.is_superseded() {
@@ -3071,8 +3395,19 @@ fn spawn_cache_fill(
                 break;
             }
 
+            // Nothing queued: stop, but settle that under the registry lock so a
+            // concurrent retarget cannot push work onto a fill that is leaving.
+            match settle_fill_exit(&cache_job_id_for_task, &task_work) {
+                FillExit::Continue => {}
+                FillExit::Finished => break,
+                FillExit::Superseded => {
+                    completed_normally = false;
+                    break;
+                }
+            }
+
             // Re-load manifest to get latest state
-            let mut current_manifest = match load_manifest(&project_path, &job_seq_id) {
+            let current_manifest = match load_manifest(&project_path, &job_seq_id) {
                 Ok(Some(m)) => m,
                 Ok(None) => {
                     let message = format!(
@@ -3116,6 +3451,65 @@ fn spawn_cache_fill(
                     break;
                 }
             };
+
+            // Take the lowest-index segment still worth rendering. Entries the
+            // manifest has moved on from — rendered by this fill's own earlier
+            // pass, evicted, or re-queued by a retarget after they were already
+            // produced — are dropped rather than re-encoded.
+            let next = match task_work.lock() {
+                Ok(mut queue) => queue.pop_next_where(|index| {
+                    current_manifest
+                        .segments
+                        .iter()
+                        .any(|segment| segment.index == index && segment.needs_render())
+                }),
+                Err(_) => {
+                    tracing::warn!("Preview cache fill queue unavailable; stopping fill");
+                    completed_normally = false;
+                    break;
+                }
+            };
+            let Some((idx, fingerprint)) = next else {
+                // The pop drained the queue without finding work. Same race as
+                // the loop-top check, same atomic exit.
+                match settle_fill_exit(&cache_job_id_for_task, &task_work) {
+                    FillExit::Continue => continue,
+                    FillExit::Finished => break,
+                    FillExit::Superseded => {
+                        completed_normally = false;
+                        break;
+                    }
+                }
+            };
+
+            // The window comes from the manifest, the identity from the queue:
+            // the queue's fingerprint is what a later request compares against,
+            // so arming with anything else would make retarget decisions
+            // disagree with what is actually encoding.
+            let Some((start_sec, end_sec)) = current_manifest
+                .segments
+                .iter()
+                .find(|segment| segment.index == idx)
+                .map(|segment| (segment.start_sec, segment.end_sec))
+            else {
+                continue;
+            };
+
+            // Publish this segment's identity *now*, at pop time, not when the
+            // encode starts. Between the two the fill re-acquires the project
+            // lock, rebuilds the graph and validates — several awaits, during
+            // which the segment is in no queue at all. If the cancel slot were
+            // still empty there, a request landing in that window would see
+            // nothing in flight, decline to cancel, and let the encode run on
+            // pre-edit state; the finished file would then be recorded against
+            // the post-edit fingerprint and look current forever.
+            //
+            // Arming early means a cancel can fire before the exporter is
+            // holding the receiver, so the receiver is polled once immediately
+            // before the encode and a fired cancel is honoured there instead.
+            let mut segment_cancel_rx = task_cancel.arm_segment(idx, fingerprint);
+            // Retracts the identity on every path out of this iteration.
+            let _armed = ArmedSegmentGuard(task_cancel.clone());
 
             // Re-acquire fresh project state for each segment to avoid rendering
             // with stale data if the user edits the timeline during cache rendering.
@@ -3214,22 +3608,26 @@ fn spawn_cache_fill(
                 }
             };
 
-            // Mark rendering
-            if let Some(segment) = current_manifest
-                .segments
-                .iter_mut()
-                .find(|s| s.index == *idx)
-            {
-                segment.state = crate::core::render::CacheSegmentState::Rendering;
-            }
-            let _ = save_manifest(&project_path, &current_manifest);
+            // Mark rendering. Reloaded rather than written from the snapshot
+            // taken before the project lock above: an ensure call on another
+            // thread may have demoted segments or refreshed fingerprints in
+            // between, and saving the older snapshot would revert that.
+            reload_mutate_save_manifest(&project_path, &job_seq_id, |manifest| {
+                if let Some(segment) = manifest
+                    .segments
+                    .iter_mut()
+                    .find(|segment| segment.index == idx)
+                {
+                    segment.state = crate::core::render::CacheSegmentState::Rendering;
+                }
+            });
 
             // Build segment export settings
             let seg_output = match crate::core::render::segment_cache_file(
                 &project_path,
                 &job_seq_id,
                 &job_profile_hash,
-                *idx,
+                idx,
             ) {
                 Ok(path) => path,
                 Err(error) => {
@@ -3250,8 +3648,8 @@ fn spawn_cache_fill(
             let seg_settings = crate::core::render::ExportSettings::preview_cache(
                 seg_output.clone(),
                 &fresh_sequence.format.canvas,
-                Some(*start_sec),
-                Some(*end_sec),
+                Some(start_sec),
+                Some(end_sec),
             );
 
             let validation = match validate_export_settings_off_runtime(
@@ -3266,6 +3664,9 @@ fn spawn_cache_fill(
                 Err(error) => {
                     tracing::warn!("Preview cache segment {} validation failed: {error}", idx);
                     let _ = app_handle.emit("render-cache-error", error);
+                    // The fill is stopping on an error, so it must not go on to
+                    // announce itself complete.
+                    completed_normally = false;
                     break;
                 }
             };
@@ -3326,9 +3727,37 @@ fn spawn_cache_fill(
             }
             let segment_plan_hash = render_plan.plan_hash.clone();
 
+            // The identity has been armed since the pop, so a cancel may already
+            // have fired while this segment was being prepared. Honour it here
+            // rather than starting an encode nobody wants. `Closed` counts as
+            // cancelled too: the sender is only ever dropped by disarming, so a
+            // closed channel means this encode could no longer be stopped.
+            let cancelled_before_encode = !matches!(
+                segment_cancel_rx.try_recv(),
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+            );
+            if cancelled_before_encode {
+                match retract_cancelled_segment(
+                    &app_handle,
+                    &project_path,
+                    &job_seq_id,
+                    &cache_job_id_for_task,
+                    idx,
+                    Some(segment_plan_hash.clone()),
+                    task_cancel.is_superseded(),
+                ) {
+                    CancelledOutcome::StopFill => {
+                        completed_normally = false;
+                        break;
+                    }
+                    CancelledOutcome::ContinueFill => continue,
+                }
+            }
+
             // Render with fresh data. The segment cancel lets a superseding fill
-            // kill this FFmpeg mid-encode instead of orphaning it.
-            let segment_cancel_rx = task_cancel.arm_segment();
+            // kill this FFmpeg mid-encode instead of orphaning it, and carries the
+            // segment's identity so a fill that was merely retargeted can cancel
+            // this encode only if this segment's own work changed.
             let result = engine
                 .export_sequence_with_effects_for_plan(
                     &fresh_sequence,
@@ -3342,118 +3771,128 @@ fn spawn_cache_fill(
                 .await;
             task_cancel.disarm_segment();
 
-            // Update manifest
-            let mut updated_manifest = match load_manifest(&project_path, &job_seq_id) {
-                Ok(Some(m)) => m,
-                Ok(None) => {
-                    let message = format!(
-                        "Cache manifest disappeared while finalizing sequence {}",
-                        job_seq_id
-                    );
-                    let _ = app_handle.emit("render-cache-error", message.clone());
-                    emit_render_lifecycle(
-                        &app_handle,
-                        RenderLifecycleEvent {
-                            job_id: cache_job_id_for_task.clone(),
-                            sequence_id: Some(job_seq_id.clone()),
-                            kind: RenderLifecycleKind::PreviewCache,
-                            state: RenderLifecycleState::Failed,
-                            progress: None,
-                            message: Some(message),
-                            output_path: None,
-                            plan_hash: None,
-                        },
-                    );
-                    completed_normally = false;
-                    break;
-                }
-                Err(error) => {
-                    let message = format!("Failed to reload cache manifest: {error}");
-                    let _ = app_handle.emit("render-cache-error", message.clone());
-                    emit_render_lifecycle(
-                        &app_handle,
-                        RenderLifecycleEvent {
-                            job_id: cache_job_id_for_task.clone(),
-                            sequence_id: Some(job_seq_id.clone()),
-                            kind: RenderLifecycleKind::PreviewCache,
-                            state: RenderLifecycleState::Failed,
-                            progress: None,
-                            message: Some(message),
-                            output_path: None,
-                            plan_hash: None,
-                        },
-                    );
-                    completed_normally = false;
-                    break;
-                }
-            };
-
             match result {
                 Ok(export_result) => {
-                    updated_manifest.mark_segment_cached(
-                        *idx,
-                        seg_output
-                            .file_name()
-                            .unwrap_or_default()
-                            .to_string_lossy()
-                            .to_string(),
-                        export_result.file_size,
-                    );
+                    // The identity this encode was started for may have moved
+                    // while it ran. Reload, compare, and only then record —
+                    // `mark_segment_cached` writes `Cached` next to whatever
+                    // fingerprint the manifest now holds, so accepting a
+                    // mismatched file would bind pre-edit pixels to a post-edit
+                    // identity that every later freshness check reports as
+                    // current. That never self-heals.
+                    let mut verdict = preview_fill::RenderedSegmentVerdict::Discard;
+                    let cached_name = seg_output
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string();
+                    let saved =
+                        reload_mutate_save_manifest(&project_path, &job_seq_id, |manifest| {
+                            let stored = manifest
+                                .segments
+                                .iter()
+                                .find(|segment| segment.index == idx)
+                                .map(|segment| segment.fingerprint);
+                            verdict =
+                                preview_fill::verdict_for_rendered_segment(fingerprint, stored);
+                            match verdict {
+                                preview_fill::RenderedSegmentVerdict::Accept => {
+                                    manifest.mark_segment_cached(
+                                        idx,
+                                        cached_name,
+                                        export_result.file_size,
+                                    );
+                                }
+                                preview_fill::RenderedSegmentVerdict::Discard => {
+                                    if let Some(segment) = manifest
+                                        .segments
+                                        .iter_mut()
+                                        .find(|segment| segment.index == idx)
+                                    {
+                                        segment.state =
+                                            crate::core::render::CacheSegmentState::Empty;
+                                        segment.cached_file = None;
+                                        segment.file_size_bytes = 0;
+                                    }
+                                }
+                            }
+                        });
+
+                    if verdict == preview_fill::RenderedSegmentVerdict::Discard {
+                        // The bytes belong to a timeline that no longer exists.
+                        // The retarget that moved the fingerprint also re-queued
+                        // the segment, so it will be rendered again from current
+                        // inputs; this attempt counts as no progress.
+                        if let Err(error) = std::fs::remove_file(&seg_output) {
+                            tracing::warn!(
+                                "Failed to remove superseded cache segment {}: {error}",
+                                seg_output.display()
+                            );
+                        }
+                        tracing::info!(
+                            "Discarded preview cache segment {idx}: its render plan changed while it was encoding"
+                        );
+                        continue;
+                    }
+
                     // Only the segment just written is pinned: a fill must stay
                     // bounded by the size cap, and a single eviction pass must
                     // never delete the frame it just produced.
-                    let protected = std::collections::HashSet::from([*idx]);
-                    enforce_cache_limit(
-                        &project_path,
-                        &mut updated_manifest,
-                        cache_config.max_cache_bytes,
-                        &protected,
-                    );
+                    if let Some(mut manifest) = saved {
+                        let protected = std::collections::HashSet::from([idx]);
+                        if enforce_cache_limit(
+                            &project_path,
+                            &mut manifest,
+                            cache_config.max_cache_bytes,
+                            &protected,
+                        ) > 0
+                        {
+                            let _ = save_manifest(&project_path, &manifest);
+                        }
+                    }
+
+                    completed += 1;
                 }
                 Err(crate::core::render::ExportError::Cancelled) => {
-                    // A newer fill superseded this one mid-segment. The exporter
-                    // already killed FFmpeg and removed the partial file; leave
-                    // the segment renderable (not failed) so the timeline shows
-                    // work still to do, not a permanent error, and stop the loop.
-                    if let Some(seg) = updated_manifest
-                        .segments
-                        .iter_mut()
-                        .find(|s| s.index == *idx)
-                    {
-                        seg.state = crate::core::render::CacheSegmentState::Empty;
-                        seg.cached_file = None;
-                        seg.file_size_bytes = 0;
-                    }
-                    let _ = save_manifest(&project_path, &updated_manifest);
-                    emit_render_lifecycle(
+                    // Something cancelled this segment mid-encode. The exporter
+                    // already killed FFmpeg and removed the partial file; the
+                    // segment is left renderable (not failed) either way, so the
+                    // timeline shows work still to do rather than a permanent
+                    // error. Whether the fill itself is over depends on which
+                    // cancel fired: a supersede stops it, a retarget only
+                    // discarded this one encode.
+                    match retract_cancelled_segment(
                         &app_handle,
-                        RenderLifecycleEvent {
-                            job_id: cache_job_id_for_task.clone(),
-                            sequence_id: Some(job_seq_id.clone()),
-                            kind: RenderLifecycleKind::PreviewCache,
-                            state: RenderLifecycleState::Cancelled,
-                            progress: None,
-                            message: Some(format!(
-                                "Preview cache segment {} superseded by a newer render",
-                                idx
-                            )),
-                            output_path: None,
-                            plan_hash: Some(segment_plan_hash.clone()),
-                        },
-                    );
-                    completed_normally = false;
-                    break;
+                        &project_path,
+                        &job_seq_id,
+                        &cache_job_id_for_task,
+                        idx,
+                        Some(segment_plan_hash.clone()),
+                        task_cancel.is_superseded(),
+                    ) {
+                        CancelledOutcome::StopFill => {
+                            completed_normally = false;
+                            break;
+                        }
+                        // The retarget put this segment back in the queue with
+                        // its new fingerprint, so the next iteration picks it up
+                        // again against fresh inputs. It counts as no progress.
+                        CancelledOutcome::ContinueFill => continue,
+                    }
                 }
                 Err(error) => {
-                    if let Some(seg) = updated_manifest
-                        .segments
-                        .iter_mut()
-                        .find(|s| s.index == *idx)
-                    {
-                        seg.state = crate::core::render::CacheSegmentState::Error;
-                        seg.cached_file = None;
-                        seg.file_size_bytes = 0;
-                    }
+                    reload_mutate_save_manifest(&project_path, &job_seq_id, |manifest| {
+                        if let Some(segment) = manifest
+                            .segments
+                            .iter_mut()
+                            .find(|segment| segment.index == idx)
+                        {
+                            segment.state = crate::core::render::CacheSegmentState::Error;
+                            segment.cached_file = None;
+                            segment.file_size_bytes = 0;
+                        }
+                    });
+
                     let error_message =
                         format!("Failed to render cache segment {}: {}", idx, error);
                     let _ = app_handle.emit("render-cache-error", error_message.clone());
@@ -3470,11 +3909,40 @@ fn spawn_cache_fill(
                             plan_hash: Some(segment_plan_hash.clone()),
                         },
                     );
+                    // Deliberately not counted as completed: a failed segment
+                    // produced nothing, and reporting it as progress would let a
+                    // fill of nothing but failures read as finished work.
                     completed_normally = false;
                 }
             }
 
-            let _ = save_manifest(&project_path, &updated_manifest);
+            // The denominator moves: a retarget can grow or shrink the queue
+            // mid-fill, so progress is measured against what this fill has done
+            // plus what it still has left, not against the count it started
+            // with.
+            //
+            // The segment just handled is excluded from "what is left" even
+            // though it may sit in the queue again: a request that landed while
+            // it was encoding re-derives its work set from a manifest where this
+            // segment reads as `Rendering`, which reconciliation resets to
+            // `Error` — so it is re-queued at the same fingerprint and would
+            // otherwise be counted as both done and outstanding, pinning
+            // progress below where it belongs. The pop-time `needs_render` check
+            // drops it on the next pass.
+            //
+            // The scope label is read from the shared queue, not from this
+            // task's spawn-time copy, so a fill that was widened by a retarget
+            // reports the wider scope from then on.
+            let (remaining, active_scope) = match task_work.lock() {
+                Ok(queue) => (queue.len_excluding(idx), queue.scope),
+                Err(_) => (0, scope),
+            };
+            let total_known = completed + remaining;
+            let percent = if total_known == 0 {
+                100.0
+            } else {
+                (completed as f64 / total_known as f64) * 100.0
+            };
 
             // Emit progress
             let _ = app_handle.emit(
@@ -3482,9 +3950,10 @@ fn spawn_cache_fill(
                 serde_json::json!({
                     "jobId": cache_job_id_for_task.clone(),
                     "sequenceId": job_seq_id.clone(),
-                    "completedSegments": completed + 1,
-                    "totalSegments": total_pending,
-                    "percent": ((completed + 1) as f64 / total_pending as f64) * 100.0,
+                    "completedSegments": completed,
+                    "totalSegments": total_known,
+                    "percent": percent,
+                    "scope": active_scope.event_key(),
                 }),
             );
             emit_render_lifecycle(
@@ -3494,7 +3963,7 @@ fn spawn_cache_fill(
                     sequence_id: Some(job_seq_id.clone()),
                     kind: RenderLifecycleKind::PreviewCache,
                     state: RenderLifecycleState::Running,
-                    progress: Some(((completed + 1) as f64 / total_pending as f64) * 100.0),
+                    progress: Some(percent),
                     message: Some(format!("Rendered preview cache segment {}", idx)),
                     output_path: None,
                     plan_hash: Some(segment_plan_hash),
@@ -3511,6 +3980,13 @@ fn spawn_cache_fill(
                 serde_json::json!({
                     "jobId": cache_job_id_for_task.clone(),
                     "sequenceId": job_seq_id.clone(),
+                    // From the shared queue, so a fill widened by a retarget
+                    // reports what it actually finished, not what it started as.
+                    "scope": task_work
+                        .lock()
+                        .map(|queue| queue.scope)
+                        .unwrap_or(scope)
+                        .event_key(),
                 }),
             );
             emit_render_lifecycle(
@@ -3555,6 +4031,14 @@ pub enum RenderCacheJobStatus {
     Started,
     /// All segments are already cached; no rendering needed
     AlreadyCached,
+    /// A fill already in flight is producing exactly this work; nothing changed.
+    ///
+    /// The returned job id is that running fill's, not a new one.
+    AlreadyConverging,
+    /// A fill already in flight had its queue swapped to this work set.
+    ///
+    /// The returned job id is that running fill's, not a new one.
+    Retargeted,
 }
 
 /// Result of starting a render cache job

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -709,11 +709,17 @@ async clearRenderCache() : Promise<Result<ClearCacheResult, string>> {
  * 
  * Triggers background rendering of uncached segments. Returns the cache
  * status immediately; rendering progress is reported via Tauri events.
- * If a previous cache render is still running it is cancelled first.
+ * 
+ * `scope` selects which segments are wanted;
+ * [`PreviewCacheScope::WholeTimeline`] when omitted.
+ * 
+ * A fill already in flight is *converged onto*, not cancelled: calling this
+ * repeatedly with unchanged work is a no-op, and a changed work set retargets
+ * the running fill. See [`crate::core::render::preview_fill`].
  */
-async renderPreviewCache() : Promise<Result<RenderCacheJobResult, string>> {
+async renderPreviewCache(scope: PreviewCacheScope | null) : Promise<Result<RenderCacheJobResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("render_preview_cache") };
+    return { status: "ok", data: await TAURI_INVOKE("render_preview_cache", { scope }) };
 } catch (e) {
     return { status: "error", error: e  as any };
 }
@@ -6783,6 +6789,23 @@ poolMisses: number;
  */
 hitRate: number }
 /**
+ * Which segments a preview-cache fill request is asking for.
+ */
+export type PreviewCacheScope = 
+/**
+ * Every segment that needs rendering, in timeline order.
+ */
+"whole_timeline" | 
+/**
+ * Only segments the live preview cannot draw faithfully, and only those the
+ * export path can actually render.
+ * 
+ * This is the scope that buys accuracy rather than smoothness: a flagged
+ * segment is one where what the user sees and what the export produces
+ * disagree, so filling it replaces a guess with the real composite.
+ */
+"flagged"
+/**
  * Preview plan for an EditScript.
  */
 export type PreviewPlanDto = { 
@@ -7218,7 +7241,19 @@ export type RenderCacheJobStatus =
 /**
  * All segments are already cached; no rendering needed
  */
-"already_cached"
+"already_cached" | 
+/**
+ * A fill already in flight is producing exactly this work; nothing changed.
+ * 
+ * The returned job id is that running fill's, not a new one.
+ */
+"already_converging" | 
+/**
+ * A fill already in flight had its queue swapped to this work set.
+ * 
+ * The returned job id is that running fill's, not a new one.
+ */
+"retargeted"
 /**
  * Cache status information returned to the frontend
  */

--- a/src/hooks/useRenderCache.test.ts
+++ b/src/hooks/useRenderCache.test.ts
@@ -127,6 +127,41 @@ describe('useRenderCache', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it.each(['already_converging', 'retargeted'] as const)(
+    'should not latch isRendering when the request was absorbed by a running fill (%s)',
+    async (status) => {
+      // A fill already in flight took this request over, so this call started
+      // nothing of its own and no completion event of its own will ever arrive.
+      vi.mocked(commands.getCacheStatus).mockResolvedValue({
+        status: 'ok',
+        data: mockStatus,
+      } as never);
+      vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+        status: 'ok',
+        data: {
+          jobId: 'running-job',
+          sequenceId: 'seq1',
+          totalSegments: 4,
+          segmentsToRender: 2,
+          status,
+        },
+      } as never);
+
+      const { result } = renderHook(() => useRenderCache());
+
+      await waitFor(() => {
+        expect(result.current.status).toEqual(mockStatus);
+      });
+
+      await act(async () => {
+        await result.current.renderCache();
+      });
+
+      expect(result.current.isRendering).toBe(false);
+      expect(result.current.error).toBeNull();
+    },
+  );
+
   it('should reset state after clearing cache', async () => {
     vi.mocked(commands.getCacheStatus).mockResolvedValue({
       status: 'ok',

--- a/src/hooks/useRenderCache.ts
+++ b/src/hooks/useRenderCache.ts
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { commands } from '@/bindings';
-import type { RenderCacheStatus, CacheSegmentStatusDto } from '@/bindings';
+import type { RenderCacheStatus, CacheSegmentStatusDto, PreviewCacheScope } from '@/bindings';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { isDesktopRuntimeAvailable } from '@/services/runtimeEnvironment';
 
@@ -17,6 +17,11 @@ interface CacheProgressPayload {
   completedSegments: number;
   totalSegments: number;
   percent: number;
+  /**
+   * Which segments the running fill is producing. Optional: a fill started by an
+   * older backend emits no scope.
+   */
+  scope?: PreviewCacheScope;
 }
 
 /** Return type for the useRenderCache hook */
@@ -81,11 +86,22 @@ export function useRenderCache(): UseRenderCacheReturn {
     setError(null);
 
     try {
-      const result = await commands.renderPreviewCache();
+      // `null` selects the whole timeline; the flagged scope is not driven from
+      // this hook yet.
+      const result = await commands.renderPreviewCache(null);
       if (result.status === 'ok') {
         if (result.data.status === 'already_cached') {
           setIsRendering(false);
           setProgress(100);
+        } else if (
+          result.data.status === 'already_converging' ||
+          result.data.status === 'retargeted'
+        ) {
+          // This call started nothing: a fill already in flight absorbed the
+          // request. Its own progress and completion events drive the UI through
+          // the listeners below, so this hook must not latch a rendering state
+          // that no event of its own will ever clear.
+          setIsRendering(false);
         }
       } else {
         setError(result.error);
@@ -95,7 +111,9 @@ export function useRenderCache(): UseRenderCacheReturn {
       setError(e instanceof Error ? e.message : String(e));
       setIsRendering(false);
     }
-  }, [backendAvailable]);
+
+    await refreshStatus();
+  }, [backendAvailable, refreshStatus]);
 
   const clearCache = useCallback(async () => {
     if (!backendAvailable) {


### PR DESCRIPTION
### **User description**
## Why

The preview-cache fill was non-convergent by construction: any new fill request unconditionally superseded the running one, killing the in-flight FFmpeg — so a call pattern that re-requests as the user works could kill and restart forever (the reason the old `ensure_preview_window` shipped with a "do not wire" warning, retired in #851). Primary-source research settled the correct model: FCP pauses background renders and keeps partials; Flame cancels a render job **only when its segment was modified**; Resolve's Smart Cache work is playhead-independent. This PR makes the fill work that way, and adds the `flagged` scope that fills only the segments classified in #852.

## Change

**`core/render/preview_fill.rs` (new)** — the decision logic, pure and `--lib`-tested:
- `CacheFillWorkSet`: the canonicalized `(index, fingerprint)` queue one fill drains, now shared and retargetable in place.
- `decide_ensure_action`: `Start` / `AlreadyConverging` (identical work, nothing to do — **no kill**) / `Retarget { cancel_in_flight }` (swap the queue; cancel the in-flight segment **only if its own fingerprint changed**) / `Supersede` (different sequence or encode profile: everything on disk is byte-incompatible).
- `merge_work_sets`: a request with a different scope unions with the running work (broader label wins) and folds the in-flight segment in, so asking for *more* work can never lose work. Cancellation keys purely on fingerprint change.
- `select_fill_segments`: `whole_timeline` (unchanged selection) or `flagged` — only fill-renderable flagged segments, so the fill cannot error-loop on content the export refuses (compound clips, missing assets, overlay media).

**`preview_cancel.rs`** — the armed slot now carries the in-flight `(index, fingerprint)` identity; `cancel_segment_if_stale` fires a **targeted** cancel under one lock without marking the fill superseded, so the loop continues instead of dying. Identity is armed **at pop time**, before any await, closing the window where an edit could land while the segment was in neither the queue nor the slot.

**`ipc/commands/render.rs`** — `ensure_cache_fill` decides inside the single active-render critical section; the fill loop drains the shared queue against the freshly reloaded manifest. Three races found by adversarial review are closed structurally:
- a rendered segment is marked `Cached` only after a fingerprint-equality check against the just-reloaded manifest — a stale render can never be stamped with a fresh identity (the poisoned-cache case; it did not self-heal);
- fill exit re-checks the queue and deregisters in one critical section, so a retarget can never land on a fill that is already leaving (lost work);
- every manifest write in the loop is a reload → single-segment mutation → save with no await in between, so concurrent fingerprint refreshes are never clobbered by a pre-await snapshot.
- `render_preview_cache` gains `scope` (`null` == whole timeline; existing frontend call updated); `RenderCacheJobStatus` gains `already_converging` / `retargeted`; progress/complete events carry a `scope` key (additive).

**`cache.rs`** — eviction is now two-phase: stale segments first (dead bytes), then cached highest-index-first with the size-cap check. Research verdict recorded in the doc: no NLE evicts timeline render caches by playhead distance; a guard, not a heuristic.

**Frontend** — `useRenderCache` passes the scope, clears `isRendering` on the two no-spawn statuses, and always refreshes status after a request.

## Verification

- `cargo fmt --check` / `clippy -p openreelio --features gui --lib` / `--all-targets --features dev-full -- -D warnings` clean.
- `cargo test -p openreelio --features gui --lib` → **4318 passed** (+39 over the classifier base: decision table in the true production shape — in-flight popped off the queue —, targeted-cancel identity semantics, merge/union incl. the in-flight fold, scope selection, fingerprint-guard verdicts, stale-first eviction, exit settlement).
- `npx tsc --noEmit` clean; `useRenderCache` / `CacheStatusBar` vitest 13/13. `bindings.ts` regenerated, idempotent (md5-stable across runs).
- Three review rounds before this PR: the initial adversarial pass found 3 concurrency MUST-FIXes (identity gap, dying-fill race, manifest lost-update); the verification pass traced all three fixes sound and found 1 more (the merge dropping the in-flight segment); all fixed, final pass clean.

With this, the backend of the flag-driven cache is complete: #851 retired the non-convergent trigger, #852 decides *what* needs the export path, and this PR makes filling it convergent and interruption-safe. Next: frontend wiring (idle-debounced trigger, cache-first playback seam, labeled draft fallback).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements a convergent preview cache fill, canceling only on fingerprint change.

- Introduces `PreviewCacheScope` for `whole_timeline` or `flagged` segments.

- Refactors `render_preview_cache` to manage active fill state and merge work.

- Prioritizes eviction of stale cache segments before cached ones.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Frontend[Frontend UI] -- "renderPreviewCache(scope)" --> IPC[IPC Command: render_preview_cache]
  IPC -- "calls" --> EnsureFill[ensure_cache_fill]
  EnsureFill -- "decides action via" --> PreviewFillLogic[preview_fill module]
  PreviewFillLogic -- "manages" --> ActiveCacheRender[ActiveCacheRender (job, cancel, work)]
  ActiveCacheRender -- "updates" --> CacheFillWorkSet[CacheFillWorkSet (segments, scope)]
  CacheFillWorkSet -- "drives" --> FillLoop[Background Fill Loop]
  FillLoop -- "renders segments" --> RenderCacheManifest[RenderCacheManifest]
  RenderCacheManifest -- "updates status" --> Frontend
  FillLoop -- "evicts via" --> EnforceCacheLimit[enforce_cache_limit]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Updates TypeScript bindings for convergent cache fill and scopes</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+39/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRenderCache.ts</strong><dd><code>Updates frontend hook to support new cache fill behavior and progress </code><br><code>scope</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-59d9ea0ad79ed1caab12ac76fe295a918a4973b117f682672da00d071a789351">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong><dd><code>Refactors cache fill command to be convergent and scope-aware</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-2ea1655afe6d8b89723a383add940946c7ae5b827d4de213179a539c0ed1bfd9">+682/-198</a></td>

</tr>

<tr>
  <td><strong>preview_fill.rs</strong><dd><code>Introduces convergent logic for preview cache filling and work set </code><br><code>management</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-a72e4416b604e21e9d232ddf479dbd7fafcaba3d3b56f861d71c71aef94bf956">+990/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cache.rs</strong><dd><code>Refactors cache limit enforcement to prioritize stale segment eviction</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-630fc011e9e6377be668e04305949567349f26fefcf086384602a27b4aaec044">+209/-34</a></td>

</tr>

<tr>
  <td><strong>preview_cancel.rs</strong><dd><code>Enhances cancellation to support targeted segment cancellation without </code><br><code>superseding</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-c6ba5a23a51d915b18055176444a6064028daa7ae5c5f0cb472869a60c41aa3c">+164/-8</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useRenderCache.test.ts</strong><dd><code>Adds tests for new cache job statuses in frontend hook</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-fd2b7f9004674c4d3ad84423a73389ce7823e1da1761f16fc5f6b9a3de68a218">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Exports new preview fill types and modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/853/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview-cache generation now supports whole-timeline or targeted segment updates.
  * New requests can join or retarget an active cache-generation task instead of unnecessarily restarting it.
  * Progress updates reflect the current generation scope and dynamic workload.

* **Bug Fixes**
  * Cache cleanup now removes stale segments before other cached content.
  * In-progress segments are protected, and outdated rendered data is discarded safely.
  * Rendering state now resets correctly when requests converge on an existing task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->