### PR TITLE
docs(render): scope the cache byte-identity claim and pin the temporal-filter set

### DIFF
--- a/src-tauri/src/core/effects/capabilities.rs
+++ b/src-tauri/src/core/effects/capabilities.rs
@@ -443,6 +443,52 @@ mod tests {
     use super::*;
 
     #[test]
+    fn should_pin_the_temporal_filter_set_the_preview_cache_fidelity_note_relies_on() {
+        // Temporal filters consume multiple source frames per output frame. A
+        // windowed preview-cache segment gives them full context today only
+        // because windowed renders decode whole inputs (no input-side seek
+        // pruning), which is half of the cache's byte-identical-to-export
+        // property. A new effect mapping to one of these filters — or seek
+        // pruning of windowed inputs — requires lead-in handles for segments
+        // containing it. If this assertion fails, read the Fidelity note on
+        // `ExportSettings::preview_cache` before extending the known list.
+        const TEMPORAL_FFMPEG_FILTERS: &[&str] = &[
+            "vidstabtransform",
+            "tmix",
+            "tblend",
+            "minterpolate",
+            "framerate",
+            "mpdecimate",
+            "decimate",
+            "deflicker",
+            "atadenoise",
+            "hqdn3d",
+            "yadif",
+            "bwdif",
+            "estdif",
+            "w3fdif",
+            "fieldmatch",
+            "nnedi",
+        ];
+
+        let mut temporal_in_use: Vec<String> = all_effect_capabilities()
+            .into_iter()
+            .filter_map(|capability| capability.ffmpeg_filter)
+            .filter(|filter| TEMPORAL_FFMPEG_FILTERS.contains(&filter.as_str()))
+            .collect();
+        temporal_in_use.sort();
+        temporal_in_use.dedup();
+
+        assert_eq!(
+            temporal_in_use,
+            vec!["vidstabtransform".to_string()],
+            "the set of temporal ffmpeg filters reachable from effects changed; \
+             segments containing them need lead-in handles before the preview \
+             cache can claim byte-identity — see ExportSettings::preview_cache"
+        );
+    }
+
+    #[test]
     fn capability_marks_ai_setup_effects_as_not_exportable() {
         for effect_type in [
             EffectType::BackgroundRemoval,

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -880,6 +880,22 @@ impl ExportSettings {
     /// the difference between reviewing the edit and reviewing the codec. Every
     /// frame is a keyframe, so any frame is a seek target.
     ///
+    /// ## Where the byte-identical property comes from — and what would break it
+    ///
+    /// Lossless encoding removes the codec from the equation; the other half of
+    /// the property is that a *windowed* segment render runs the same filter
+    /// graph over the same frames as the full export. That holds today because
+    /// windowed renders fold in absolute time and decode whole inputs — nothing
+    /// is seek-pruned — so even a temporal filter (one that consumes multiple
+    /// source frames per output frame; currently only `vidstabtransform` via
+    /// `EffectType::Stabilize`) sees identical context in both paths. Two future
+    /// changes would silently break this and must add lead-in handles (render
+    /// extra frames before the window and discard them) for segments containing
+    /// temporal filters: input-side seek pruning of windowed renders, or a new
+    /// effect mapping to a temporal ffmpeg filter. A tripwire test in
+    /// `core::effects::capabilities` pins the temporal-filter set so the second
+    /// change cannot land unnoticed.
+    ///
     /// The cost is size: roughly 45x an H.264 draft encode, about 77.5 MB per
     /// second of 1080p timeline. The default cache budget is sized for that
     /// (see `PerformanceSettings::cache_size_mb`).


### PR DESCRIPTION
### **User description**
## Why

The preview cache's byte-identical-to-export property has two ingredients: the lossless codec (#850) and the fact that a windowed segment render runs the same filter graph over the same frames as the full export. The second half is currently true only because windowed renders decode whole inputs — nothing is seek-pruned — so even a temporal filter sees identical context. We DO already ship one temporal filter: `EffectType::Stabilize` maps to `vidstabtransform`. Two future changes would silently break byte-identity for segments containing temporal filters: input-side seek pruning of windowed renders (tracked as an open optimization idea), or a new effect mapping to a temporal ffmpeg filter.

## Change

- The `ExportSettings::preview_cache` Fidelity doc now states where the property comes from and exactly what would break it (lead-in handles required in either case).
- A tripwire test in `core::effects::capabilities` pins the set of temporal ffmpeg filters reachable from effects to exactly `{vidstabtransform}` against a deny-list (tmix, tblend, minterpolate, framerate, decimate, deinterlacers, temporal denoisers, …), with a failure message pointing at the Fidelity note — so the second breaking change cannot land unnoticed.

Docs + one test; no behavior change.

## Verification

- `cargo test -p openreelio --features gui --lib core::effects::capabilities` → 4 passed (incl. the new tripwire).
- `cargo fmt` / `clippy -p openreelio --features gui --lib -- -D warnings` clean.


___

### **PR Type**
Documentation, Tests


___

### **Description**
- Documents the byte-identical property of the preview cache.

- Explains dependencies on lossless codecs and filter graphs.

- Adds a tripwire test for temporal ffmpeg filters.

- Ensures future temporal filters require lead-in handles.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ExportSettings Documentation"] -- "Defines" --> B["Byte-Identity Property"]
  C["Capabilities Test"] -- "Pins" --> D["Temporal Filter Set"]
  D -- "Protects" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capabilities.rs</strong><dd><code>Add tripwire test for temporal FFmpeg filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/effects/capabilities.rs

<ul><li>Added a new test <br><code>should_pin_the_temporal_filter_set_the_preview_cache_fidelity_note_relies_on</code>.<br> <li> Defines a list of known temporal FFmpeg filters.<br> <li> Asserts that only <code>vidstabtransform</code> is currently in use to prevent <br>silent regressions in cache fidelity.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/857/files#diff-100e73d47480888d9eadeddb9da8456ecace6d4a3e5ebed8fb204fd85fd09c85">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Document preview cache fidelity and breaking conditions</code>&nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Expanded the <code>preview_cache</code> documentation to explain the <br>"byte-identical" property.<br> <li> Detailed the conditions (lossless encoding and windowed render <br>context) required to maintain fidelity.<br> <li> Identified future changes (seek pruning or new temporal filters) that <br>would necessitate lead-in handles.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/857/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when windowed segment renders remain byte-identical to full exports.
  * Documented how temporal video effects may require additional lead-in frames if rendering behavior changes.
* **Tests**
  * Added coverage to detect unexpected temporal FFmpeg filters that could affect preview-cache fidelity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->