### PR TITLE
feat(ui): fill the preview cache automatically while the editor is idle

### DIFF
--- a/src-tauri/src/core/settings/mod.rs
+++ b/src-tauri/src/core/settings/mod.rs
@@ -519,6 +519,10 @@ pub struct PerformanceSettings {
     /// Cache size in MB
     #[serde(default = "default_cache_size")]
     pub cache_size_mb: u32,
+
+    /// Render flagged timeline segments into the preview cache while the editor is idle
+    #[serde(default = "default_true")]
+    pub background_render_cache: bool,
 }
 
 impl Default for PerformanceSettings {
@@ -531,6 +535,7 @@ impl Default for PerformanceSettings {
             max_concurrent_jobs: default_max_jobs(),
             memory_limit_mb: 0,
             cache_size_mb: default_cache_size(),
+            background_render_cache: true,
         }
     }
 }
@@ -1697,6 +1702,25 @@ mod tests {
         // Defaults for missing fields
         assert!(settings.general.show_welcome_on_startup);
         assert_eq!(settings.appearance.theme, "dark");
+    }
+
+    #[test]
+    fn should_default_background_render_cache_on() {
+        // Settings files written before the field existed must still opt into
+        // idle preview-cache filling rather than silently disabling it.
+        let temp_dir = TempDir::new().unwrap();
+        let settings_path = temp_dir.path().join(SETTINGS_FILE);
+        fs::write(
+            &settings_path,
+            r#"{"version": 1, "performance": {"proxyGeneration": false}}"#,
+        )
+        .unwrap();
+
+        let manager = SettingsManager::new(temp_dir.path().to_path_buf());
+        let settings = manager.load();
+
+        assert!(!settings.performance.proxy_generation);
+        assert!(settings.performance.background_render_cache);
     }
 
     #[test]

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -161,6 +161,10 @@ pub struct AutoSaveSettingsDto {
     pub backup_count: u32,
 }
 
+fn default_true_dto() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct PerformanceSettingsDto {
@@ -171,6 +175,9 @@ pub struct PerformanceSettingsDto {
     pub max_concurrent_jobs: u32,
     pub memory_limit_mb: u32,
     pub cache_size_mb: u32,
+    /// Older settings files predate this field, so it defaults rather than failing to load.
+    #[serde(default = "default_true_dto")]
+    pub background_render_cache: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Type, Default)]
@@ -372,6 +379,7 @@ impl From<AppSettings> for AppSettingsDto {
                 max_concurrent_jobs: s.performance.max_concurrent_jobs,
                 memory_limit_mb: s.performance.memory_limit_mb,
                 cache_size_mb: s.performance.cache_size_mb,
+                background_render_cache: s.performance.background_render_cache,
             },
             ai: AISettingsDto {
                 assistant_runtime: match s.ai.assistant_runtime {
@@ -518,6 +526,7 @@ impl From<AppSettingsDto> for AppSettings {
                 max_concurrent_jobs: dto.performance.max_concurrent_jobs,
                 memory_limit_mb: dto.performance.memory_limit_mb,
                 cache_size_mb: dto.performance.cache_size_mb,
+                background_render_cache: dto.performance.background_render_cache,
             },
             ai: AISettings {
                 assistant_runtime: match dto.ai.assistant_runtime {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -6650,7 +6650,11 @@ model: string;
  * ISO 8601 timestamp when this perception result was produced
  */
 analyzedAt: string }
-export type PerformanceSettingsDto = { hardwareAcceleration: boolean; gpuDeviceId: string | null; proxyGeneration: boolean; proxyResolution: string; maxConcurrentJobs: number; memoryLimitMb: number; cacheSizeMb: number }
+export type PerformanceSettingsDto = { hardwareAcceleration: boolean; gpuDeviceId: string | null; proxyGeneration: boolean; proxyResolution: string; maxConcurrentJobs: number; memoryLimitMb: number; cacheSizeMb: number; 
+/**
+ * Older settings files predate this field, so it defaults rather than failing to load.
+ */
+backgroundRenderCache?: boolean }
 /**
  * Persisted permission decision DTO aligned with the frontend session kernel vocabulary.
  */

--- a/src/components/features/editor/EditorView.tsx
+++ b/src/components/features/editor/EditorView.tsx
@@ -26,6 +26,7 @@ import {
 // Direct imports instead of barrel to avoid bundling all 100+ hooks
 import { useTimelineActions } from '@/hooks/useTimelineActions';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useIdleCacheFill } from '@/hooks/useIdleCacheFill';
 import { useAudioPlayback } from '@/hooks/useAudioPlayback';
 import { useTextClip } from '@/hooks/useTextClip';
 import { useSequenceTextClipData } from '@/hooks/useSequenceTextClipData';
@@ -795,6 +796,11 @@ export function EditorView({ sequence, appVersion = '0.1.0' }: EditorViewProps):
     handlePasteAttributes,
     handleRemoveAttributes,
   } = useTimelineActions({ sequence });
+
+  // Mounted here — and only here — because the editor root is the one surface
+  // that stays mounted for the whole session. The timeline is dockable and the
+  // preview players swap, so either would restart the debounce on remount.
+  useIdleCacheFill();
 
   // Text clip operations
   const { addTextClip, updateTextClip } = useTextClip();

--- a/src/components/features/settings/sections/PerformanceSettings.test.tsx
+++ b/src/components/features/settings/sections/PerformanceSettings.test.tsx
@@ -21,6 +21,7 @@ const baseSettings: PerformanceSettingsType = {
   maxConcurrentJobs: 4,
   memoryLimitMb: 0,
   cacheSizeMb: 1024,
+  backgroundRenderCache: true,
 };
 
 describe('PerformanceSettings', () => {

--- a/src/components/features/settings/sections/PerformanceSettings.tsx
+++ b/src/components/features/settings/sections/PerformanceSettings.tsx
@@ -79,6 +79,24 @@ export function PerformanceSettings({
       </div>
 
       <div>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={settings.backgroundRenderCache}
+            onChange={(e) => onUpdate({ backgroundRenderCache: e.target.checked })}
+            disabled={disabled}
+            className="w-4 h-4 rounded border-editor-border bg-editor-bg text-primary-500 focus:ring-primary-500/50 focus:ring-offset-0"
+          />
+          <div>
+            <span className="text-sm text-editor-text">Background render caching</span>
+            <p className="text-xs text-editor-text-muted">
+              Automatically renders flagged timeline segments while idle
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div>
         <label
           htmlFor="proxyResolution"
           className="block text-sm font-medium text-editor-text mb-2"

--- a/src/components/preview/UnifiedPreviewPlayer.tsx
+++ b/src/components/preview/UnifiedPreviewPlayer.tsx
@@ -64,7 +64,7 @@ const PLAYBACK_QUALITY_OPTIONS: Array<{ value: PreviewPlaybackQuality; label: st
 const MEDIA_PREFERENCE_OPTIONS: Array<{ value: PreviewMediaPreference; label: string }> = [
   { value: 'auto', label: 'Auto' },
   { value: 'proxy', label: 'Proxy' },
-  { value: 'renderCache', label: 'Render cache' },
+  { value: 'renderCache', label: 'Composited (accurate)' },
 ];
 const AUDIO_DRIFT_WARNING_MS = 50;
 const AUDIO_DRIFT_CRITICAL_MS = 500;

--- a/src/components/timeline/CacheStatusBar.test.tsx
+++ b/src/components/timeline/CacheStatusBar.test.tsx
@@ -1,9 +1,17 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { CacheStatusBar } from './CacheStatusBar';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
 import type { CacheSegmentStatusDto } from '../../bindings';
 
 describe('CacheStatusBar', () => {
+  // Reset before rendering rather than after: the store is shared, and writing
+  // to it while a component from the previous case is still mounted would be
+  // an unwrapped React update.
+  beforeEach(() => {
+    useRenderCacheStore.getState()._resetForTests();
+  });
+
   const makeSegments = (states: string[]): CacheSegmentStatusDto[] =>
     states.map((state, i) => ({
       index: i,
@@ -18,16 +26,14 @@ describe('CacheStatusBar', () => {
 
   it('should render nothing when duration is zero', () => {
     const { container } = render(
-      <CacheStatusBar segments={[]} duration={0} zoom={10} scrollX={0} />
+      <CacheStatusBar segments={[]} duration={0} zoom={10} scrollX={0} />,
     );
     expect(container.querySelector('[data-testid="cache-status-bar"]')).toBeNull();
   });
 
   it('should render segment bars for non-empty states', () => {
     const segments = makeSegments(['cached', 'stale', 'empty']);
-    render(
-      <CacheStatusBar segments={segments} duration={15} zoom={10} scrollX={0} />
-    );
+    render(<CacheStatusBar segments={segments} duration={15} zoom={10} scrollX={0} />);
 
     const bar = screen.getByTestId('cache-status-bar');
     expect(bar).toBeTruthy();
@@ -39,9 +45,7 @@ describe('CacheStatusBar', () => {
 
   it('should render a visible segment for cached state', () => {
     const segments = makeSegments(['cached']);
-    render(
-      <CacheStatusBar segments={segments} duration={5} zoom={10} scrollX={0} />
-    );
+    render(<CacheStatusBar segments={segments} duration={5} zoom={10} scrollX={0} />);
 
     // Cached segment should be visible with its title describing the state
     const segment = screen.getByTitle('cached: 0.0s - 5.0s');
@@ -50,9 +54,7 @@ describe('CacheStatusBar', () => {
 
   it('should display correct title with time range', () => {
     const segments = makeSegments(['stale']);
-    render(
-      <CacheStatusBar segments={segments} duration={5} zoom={10} scrollX={0} />
-    );
+    render(<CacheStatusBar segments={segments} duration={5} zoom={10} scrollX={0} />);
 
     const segment = screen.getByTitle('stale: 0.0s - 5.0s');
     expect(segment).toBeTruthy();
@@ -60,9 +62,7 @@ describe('CacheStatusBar', () => {
 
   it('should position segments correctly based on zoom', () => {
     const segments = makeSegments(['cached', 'cached']);
-    render(
-      <CacheStatusBar segments={segments} duration={10} zoom={20} scrollX={0} />
-    );
+    render(<CacheStatusBar segments={segments} duration={10} zoom={20} scrollX={0} />);
 
     const bar = screen.getByTestId('cache-status-bar');
     const children = bar.querySelectorAll('[title]');
@@ -77,5 +77,86 @@ describe('CacheStatusBar', () => {
     const second = children[1] as HTMLElement;
     expect(second.style.left).toBe('100px');
     expect(second.style.width).toBe('100px');
+  });
+
+  describe('flagged segments', () => {
+    const flaggedEmpty = (): CacheSegmentStatusDto[] => [
+      {
+        index: 0,
+        startSec: 0,
+        endSec: 5,
+        state: 'empty',
+        fingerprint: '0',
+        cachedPath: null,
+        flagged: true,
+        flagReasons: ['blend_mode', 'speed'],
+      },
+    ];
+
+    it('should render a needs-render bar when an empty segment is flagged', () => {
+      render(<CacheStatusBar segments={flaggedEmpty()} duration={5} zoom={10} scrollX={0} />);
+
+      const bar = screen.getByTestId('cache-status-bar');
+      const children = bar.querySelectorAll('[title]');
+      expect(children.length).toBe(1);
+      expect((children[0] as HTMLElement).style.backgroundColor).toBe('rgba(239, 68, 68, 0.35)');
+    });
+
+    it('should render nothing when an empty segment is not flagged', () => {
+      const segments = makeSegments(['empty']);
+
+      render(<CacheStatusBar segments={segments} duration={5} zoom={10} scrollX={0} />);
+
+      const bar = screen.getByTestId('cache-status-bar');
+      expect(bar.querySelectorAll('[title]').length).toBe(0);
+    });
+
+    it('should list the flag reasons in the tooltip', () => {
+      render(<CacheStatusBar segments={flaggedEmpty()} duration={5} zoom={10} scrollX={0} />);
+
+      const bar = screen.getByTestId('cache-status-bar');
+      const title = (bar.querySelector('[title]') as HTMLElement).title;
+      expect(title).toContain('needs render (blend_mode, speed)');
+    });
+
+    it('should give errors a hue distinct from needs-render, not a dimmer red', () => {
+      // The bar is 6px tall: two reds separated only by alpha are
+      // indistinguishable at that size.
+      const { container } = render(
+        <CacheStatusBar segments={makeSegments(['error'])} duration={5} zoom={10} scrollX={0} />,
+      );
+      const errorColor = (container.querySelector('[title]') as HTMLElement).style.backgroundColor;
+
+      cleanup();
+      render(<CacheStatusBar segments={flaggedEmpty()} duration={5} zoom={10} scrollX={0} />);
+      const needsRenderColor = (
+        screen.getByTestId('cache-status-bar').querySelector('[title]') as HTMLElement
+      ).style.backgroundColor;
+
+      expect(errorColor).toBe('rgba(217, 70, 239, 0.7)');
+      expect(errorColor).not.toBe(needsRenderColor);
+    });
+  });
+
+  describe('fill errors', () => {
+    it('should surface a failed fill in the bar tooltip', () => {
+      useRenderCacheStore.setState({ error: 'ffmpeg exited with 1' });
+
+      render(
+        <CacheStatusBar segments={makeSegments(['cached'])} duration={5} zoom={10} scrollX={0} />,
+      );
+
+      expect(screen.getByTestId('cache-status-bar').title).toBe(
+        'Render cache error: ffmpeg exited with 1',
+      );
+    });
+
+    it('should carry no bar tooltip while the cache is healthy', () => {
+      render(
+        <CacheStatusBar segments={makeSegments(['cached'])} duration={5} zoom={10} scrollX={0} />,
+      );
+
+      expect(screen.getByTestId('cache-status-bar').hasAttribute('title')).toBe(false);
+    });
   });
 });

--- a/src/components/timeline/CacheStatusBar.tsx
+++ b/src/components/timeline/CacheStatusBar.tsx
@@ -5,12 +5,18 @@
  * - Green = cached (ready for instant playback)
  * - Yellow = stale (needs re-render)
  * - Blue = currently rendering
- * - Transparent = empty (not yet cached)
- * - Red = error
+ * - Dim red = empty but flagged (the live preview cannot draw it faithfully)
+ * - Transparent = empty and unflagged (nothing to gain from caching it)
+ * - Fuchsia = error
+ *
+ * Red is reserved for "needs render" (the NLE red-bar convention) and errors
+ * get their own hue: the bar is 6px tall, so two reds separated only by alpha
+ * would be indistinguishable at that size.
  */
 
 import React, { useMemo } from 'react';
-import type { CacheSegmentStatusDto, CacheSegmentState } from '@/bindings';
+import type { CacheSegmentStatusDto } from '@/bindings';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
 
 /** Props for the CacheStatusBar component */
 interface CacheStatusBarProps {
@@ -24,9 +30,12 @@ interface CacheStatusBarProps {
   scrollX: number;
 }
 
-/** Map segment state to a color */
-function stateColor(state: CacheSegmentState): string {
-  switch (state) {
+/** Fill for an uncached segment the live preview cannot draw faithfully */
+const NEEDS_RENDER_COLOR = 'rgba(239, 68, 68, 0.35)';
+
+/** Map a segment to a color */
+function segmentColor(seg: CacheSegmentStatusDto): string {
+  switch (seg.state) {
     case 'cached':
       return 'rgba(34, 197, 94, 0.6)'; // green
     case 'stale':
@@ -34,15 +43,32 @@ function stateColor(state: CacheSegmentState): string {
     case 'rendering':
       return 'rgba(59, 130, 246, 0.6)'; // blue
     case 'error':
-      return 'rgba(239, 68, 68, 0.6)'; // red
+      return 'rgba(217, 70, 239, 0.7)'; // fuchsia — distinct hue, not a dimmer red
     default:
-      return 'transparent'; // empty
+      // Empty. A flagged stretch is one the preview is drawing wrong right now,
+      // so it earns a "needs render" bar, following the red-bar convention of
+      // other NLEs; an unflagged one draws nothing because caching it would buy
+      // no accuracy.
+      return seg.flagged ? NEEDS_RENDER_COLOR : 'transparent';
   }
+}
+
+/** Build the hover text for a segment */
+function segmentTitle(seg: CacheSegmentStatusDto): string {
+  const range = `${seg.startSec.toFixed(1)}s - ${seg.endSec.toFixed(1)}s`;
+  if (!seg.flagged) {
+    return `${seg.state}: ${range}`;
+  }
+
+  const reasons = seg.flagReasons.length > 0 ? ` (${seg.flagReasons.join(', ')})` : '';
+  return `${seg.state}: ${range} — needs render${reasons}`;
 }
 
 export const CacheStatusBar: React.FC<CacheStatusBarProps> = React.memo(
   ({ segments, duration, zoom, scrollX }) => {
     const totalWidth = duration * zoom;
+    // The only place a failed fill is visible: the error reaches no other UI.
+    const cacheError = useRenderCacheStore((state) => state.error);
 
     const bars = useMemo(() => {
       if (duration <= 0 || segments.length === 0) return null;
@@ -50,7 +76,7 @@ export const CacheStatusBar: React.FC<CacheStatusBarProps> = React.memo(
       return segments.map((seg) => {
         const left = seg.startSec * zoom;
         const width = (seg.endSec - seg.startSec) * zoom;
-        const color = stateColor(seg.state);
+        const color = segmentColor(seg);
 
         if (color === 'transparent') return null;
 
@@ -63,7 +89,7 @@ export const CacheStatusBar: React.FC<CacheStatusBarProps> = React.memo(
               width: `${width}px`,
               backgroundColor: color,
             }}
-            title={`${seg.state}: ${seg.startSec.toFixed(1)}s - ${seg.endSec.toFixed(1)}s`}
+            title={segmentTitle(seg)}
           />
         );
       });
@@ -75,6 +101,7 @@ export const CacheStatusBar: React.FC<CacheStatusBarProps> = React.memo(
       <div
         className="relative h-1.5 bg-neutral-800/50 border-b border-neutral-700/30 overflow-hidden"
         data-testid="cache-status-bar"
+        title={cacheError !== null ? `Render cache error: ${cacheError}` : undefined}
       >
         <div
           className="absolute top-0 h-full"

--- a/src/hooks/useIdleCacheFill.test.ts
+++ b/src/hooks/useIdleCacheFill.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StrictMode } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useIdleCacheFill, IDLE_FILL_DELAY_MS } from './useIdleCacheFill';
+import { useProjectStore, usePlaybackStore, useSettingsStore } from '@/stores';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
+import { DESKTOP_RUNTIME_TEST_FLAG } from '@/services/runtimeEnvironment';
+
+// Mock only the Tauri IPC boundary; every store below is the real one.
+vi.mock('@/bindings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/bindings')>();
+  return {
+    ...actual,
+    commands: {
+      ...actual.commands,
+      renderPreviewCache: vi.fn(),
+      getCacheStatus: vi.fn(),
+      clearRenderCache: vi.fn(),
+    },
+  };
+});
+
+import { commands } from '@/bindings';
+
+const INITIAL_STATE_VERSION = 7;
+
+/** Simulate a project mutation: the op log advances the state version. */
+function commitEdit(): void {
+  act(() => {
+    useProjectStore.setState({ stateVersion: useProjectStore.getState().stateVersion + 1 });
+  });
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe('useIdleCacheFill', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    globalThis[DESKTOP_RUNTIME_TEST_FLAG] = true;
+
+    vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+      status: 'ok',
+      data: {
+        jobId: 'job-1',
+        sequenceId: 'seq1',
+        totalSegments: 1,
+        segmentsToRender: 1,
+        status: 'started',
+      },
+    } as never);
+    vi.mocked(commands.getCacheStatus).mockResolvedValue({
+      status: 'error',
+      error: 'No project open',
+    } as never);
+
+    useRenderCacheStore.getState()._resetForTests();
+    useProjectStore.setState({
+      activeSequenceId: 'seq1',
+      stateVersion: INITIAL_STATE_VERSION,
+    });
+    usePlaybackStore.getState().setIsPlaying(false, 'test-setup');
+    useSettingsStore.setState((state) => {
+      state.settings.performance.backgroundRenderCache = true;
+    });
+  });
+
+  afterEach(() => {
+    useRenderCacheStore.getState()._resetForTests();
+    delete globalThis[DESKTOP_RUNTIME_TEST_FLAG];
+  });
+
+  it('should warm up the cache for an already active sequence without any edit', async () => {
+    renderHook(() => useIdleCacheFill());
+
+    await advance(IDLE_FILL_DELAY_MS - 100);
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+
+    await advance(100);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+    expect(commands.renderPreviewCache).toHaveBeenCalledWith('flagged');
+  });
+
+  it('should warm up a sequence that becomes active after mount', async () => {
+    act(() => {
+      useProjectStore.setState({ activeSequenceId: null });
+    });
+
+    renderHook(() => useIdleCacheFill());
+
+    await advance(IDLE_FILL_DELAY_MS * 2);
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+
+    act(() => {
+      useProjectStore.setState({ activeSequenceId: 'seq1' });
+    });
+
+    await advance(IDLE_FILL_DELAY_MS);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('should arm exactly one warm-up per active sequence', async () => {
+    const { rerender } = renderHook(() => useIdleCacheFill());
+
+    await advance(IDLE_FILL_DELAY_MS);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+
+    // Rerenders that change nothing must not arm another warm-up.
+    rerender();
+    act(() => {
+      useProjectStore.setState({ activeSequenceId: 'seq1' });
+    });
+    await advance(IDLE_FILL_DELAY_MS * 2);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useProjectStore.setState({ activeSequenceId: 'seq2' });
+    });
+    await advance(IDLE_FILL_DELAY_MS);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(2);
+  });
+
+  it('should still warm up under StrictMode', async () => {
+    // StrictMode runs mount → cleanup → mount on the same instance, so the
+    // refs survive. If the cleanup only cleared the timer, the second mount
+    // would see the warm-up as already armed and never schedule one.
+    renderHook(() => useIdleCacheFill(), { wrapper: StrictMode });
+
+    await advance(IDLE_FILL_DELAY_MS);
+
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+    expect(commands.renderPreviewCache).toHaveBeenCalledWith('flagged');
+  });
+
+  it('should not retry a failing fill until the next edit', async () => {
+    vi.mocked(commands.renderPreviewCache).mockRejectedValue(new Error('ffmpeg exited with 1'));
+
+    const { rerender } = renderHook(() => useIdleCacheFill());
+    await advance(IDLE_FILL_DELAY_MS);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+
+    // Neither a bare rerender nor a toggle cycle — the path that normally
+    // re-arms a warm-up — may retry a fill that just failed: its error reaches
+    // no blocking UI, so the retry would be invisible and unbounded.
+    rerender();
+    act(() => {
+      useSettingsStore.setState((state) => {
+        state.settings.performance.backgroundRenderCache = false;
+      });
+      useSettingsStore.setState((state) => {
+        state.settings.performance.backgroundRenderCache = true;
+      });
+    });
+    await advance(IDLE_FILL_DELAY_MS * 2);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+
+    // A real edit is the user action that re-arms it.
+    commitEdit();
+    await advance(IDLE_FILL_DELAY_MS);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not warm up when background render caching is disabled', async () => {
+    act(() => {
+      useSettingsStore.setState((state) => {
+        state.settings.performance.backgroundRenderCache = false;
+      });
+    });
+
+    renderHook(() => useIdleCacheFill());
+
+    await advance(IDLE_FILL_DELAY_MS * 3);
+
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+  });
+
+  it('should request a flagged fill once the idle delay elapses after an edit', async () => {
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    await advance(IDLE_FILL_DELAY_MS - 100);
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+
+    await advance(100);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+    expect(commands.renderPreviewCache).toHaveBeenCalledWith('flagged');
+  });
+
+  it('should restart the delay when another edit lands before it elapses', async () => {
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    await advance(1000);
+
+    commitEdit();
+    await advance(IDLE_FILL_DELAY_MS - 100);
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+
+    await advance(100);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('should defer the fill while playing and run it when playback stops', async () => {
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    act(() => {
+      usePlaybackStore.getState().setIsPlaying(true, 'test');
+    });
+
+    await advance(IDLE_FILL_DELAY_MS * 2);
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+
+    await act(async () => {
+      usePlaybackStore.getState().setIsPlaying(false, 'test');
+    });
+
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+    expect(commands.renderPreviewCache).toHaveBeenCalledWith('flagged');
+  });
+
+  it('should never request a fill when background render caching is disabled', async () => {
+    act(() => {
+      useSettingsStore.setState((state) => {
+        state.settings.performance.backgroundRenderCache = false;
+      });
+    });
+
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    await advance(IDLE_FILL_DELAY_MS * 3);
+
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+  });
+
+  it('should cancel a pending fill when the toggle is switched off mid-delay', async () => {
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    await advance(1000);
+
+    act(() => {
+      useSettingsStore.setState((state) => {
+        state.settings.performance.backgroundRenderCache = false;
+      });
+    });
+
+    await advance(IDLE_FILL_DELAY_MS * 2);
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+  });
+
+  it('should not restart the delay when only the playhead moves', async () => {
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    await advance(1000);
+
+    act(() => {
+      usePlaybackStore.setState({ currentTime: 1.5 });
+      usePlaybackStore.setState({ currentTime: 1.9 });
+    });
+
+    await advance(IDLE_FILL_DELAY_MS - 1000);
+    expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stay inert when no sequence is active', async () => {
+    act(() => {
+      useProjectStore.setState({ activeSequenceId: null });
+    });
+
+    renderHook(() => useIdleCacheFill());
+
+    commitEdit();
+    await advance(IDLE_FILL_DELAY_MS * 2);
+
+    expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useIdleCacheFill.ts
+++ b/src/hooks/useIdleCacheFill.ts
@@ -1,0 +1,162 @@
+/**
+ * useIdleCacheFill — Fills the preview render cache while the editor is idle.
+ *
+ * ## What it does
+ *
+ * After an edit settles (no further project mutation for {@link IDLE_FILL_DELAY_MS}),
+ * it asks the backend to render the *flagged* segments: the stretches the live
+ * preview cannot draw faithfully, where what the user sees and what the export
+ * produces disagree. Filling those replaces a guess with the real composite.
+ *
+ * ## Why it is not playhead-driven
+ *
+ * Scrubbing and `currentTime` are deliberately not inputs. Flag-driven caching
+ * buys *accuracy*, not smoothness, and a segment is wrong wherever it sits on
+ * the timeline — so the fill is playhead-independent. Subscribing to the
+ * playhead would also restart the debounce on every animation frame.
+ *
+ * ## Playback gates, it does not cancel
+ *
+ * A fill that comes due during playback stays pending rather than being
+ * dropped: rendering while frames are being served would compete for the same
+ * decoder. It runs as soon as playback stops.
+ *
+ * ## Warm-up
+ *
+ * A sequence becoming active arms one fill per activation, through the same
+ * timer and the same playback gate. Without it a user who opens a project and
+ * only reviews it would never get a background fill — there is no manual fill
+ * control in the UI — and its flagged stretches would stay red forever.
+ * "Per activation" rather than per sequence: leaving a sequence and coming
+ * back arms another warm-up, since the cache may have been evicted meanwhile.
+ *
+ * Mount this exactly once, at the editor root.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useProjectStore, usePlaybackStore, useSettingsStore } from '@/stores';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
+import { isDesktopRuntimeAvailable } from '@/services/runtimeEnvironment';
+
+/** How long the project must stay unchanged before a fill is triggered. */
+export const IDLE_FILL_DELAY_MS = 2000;
+
+/**
+ * Schedules a debounced, idle-time fill of the flagged preview cache segments.
+ */
+export function useIdleCacheFill(): void {
+  const stateVersion = useProjectStore((state) => state.stateVersion);
+  const activeSequenceId = useProjectStore((state) => state.activeSequenceId);
+  const isPlaying = usePlaybackStore((state) => state.isPlaying);
+  const enabled = useSettingsStore((state) => state.settings.performance.backgroundRenderCache);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** A fill is owed but has not run yet. */
+  const pendingRef = useRef(false);
+  /** The debounce already elapsed; only playback is holding the fill back. */
+  const elapsedRef = useRef(false);
+  /**
+   * The last project version this hook acted on.
+   *
+   * Seeded from the first render, so version churn alone never triggers a
+   * fill — only a version the hook has not acted on yet does. The warm-up
+   * below is what covers the "opened a project, made no edit" case.
+   */
+  const lastVersionRef = useRef<number>(stateVersion);
+  /**
+   * The sequence whose warm-up has already been armed.
+   *
+   * Compared against the active sequence rather than counted, so a rerender
+   * that changes nothing re-arms nothing and each activation of a sequence
+   * arms exactly one warm-up.
+   */
+  const warmedSequenceRef = useRef<string | null>(null);
+  /**
+   * The sequence whose last fill failed.
+   *
+   * A fill that keeps failing must not be retried on every idle window: the
+   * error reaches no blocking UI, so an automatic retry loop would be
+   * invisible and unbounded. Only a real edit (a new `stateVersion`) arms
+   * another attempt.
+   */
+  const failedSequenceRef = useRef<string | null>(null);
+
+  const cancelPending = useCallback((): void => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingRef.current = false;
+    elapsedRef.current = false;
+    // The armed warm-up is being dropped, so let it arm again if the hook
+    // becomes eligible once more (the toggle is switched back on, say).
+    warmedSequenceRef.current = null;
+  }, []);
+
+  const runFill = useCallback((sequenceId: string): void => {
+    pendingRef.current = false;
+    elapsedRef.current = false;
+    void useRenderCacheStore
+      .getState()
+      .renderCache('flagged')
+      .then(() => {
+        if (useRenderCacheStore.getState().error !== null) {
+          failedSequenceRef.current = sequenceId;
+        }
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopRuntimeAvailable() || !activeSequenceId || !enabled) {
+      cancelPending();
+      return;
+    }
+
+    const alreadyFailed = failedSequenceRef.current === activeSequenceId;
+    const needsWarmUp = !alreadyFailed && warmedSequenceRef.current !== activeSequenceId;
+    const wasEdited = lastVersionRef.current !== stateVersion;
+    if (!needsWarmUp && !wasEdited) {
+      return;
+    }
+    if (wasEdited) {
+      failedSequenceRef.current = null;
+    }
+    warmedSequenceRef.current = activeSequenceId;
+    lastVersionRef.current = stateVersion;
+
+    // A warm-up goes through the same timer and the same playback gate as an
+    // edit: there is no immediate-fire path to keep in sync.
+    pendingRef.current = true;
+    elapsedRef.current = false;
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      elapsedRef.current = true;
+      // Read playback live: the timer outlives the render that scheduled it.
+      if (usePlaybackStore.getState().isPlaying) {
+        return;
+      }
+      runFill(activeSequenceId);
+    }, IDLE_FILL_DELAY_MS);
+  }, [stateVersion, activeSequenceId, enabled, cancelPending, runFill]);
+
+  useEffect(() => {
+    if (isPlaying || !enabled || !activeSequenceId) {
+      return;
+    }
+    if (!pendingRef.current || !elapsedRef.current) {
+      return;
+    }
+    runFill(activeSequenceId);
+  }, [isPlaying, enabled, activeSequenceId, runFill]);
+
+  useEffect(() => {
+    // Full cancel, not just a clearTimeout: leaving the armed-warm-up mark set
+    // while dropping the timer would make a remount (React StrictMode does one
+    // on every dev mount) see the warm-up as already handled and never re-arm
+    // a timer for it.
+    return cancelPending;
+  }, [cancelPending]);
+}

--- a/src/hooks/usePreviewMode.test.ts
+++ b/src/hooks/usePreviewMode.test.ts
@@ -355,7 +355,7 @@ describe('usePreviewMode', () => {
       });
 
       expect(result.current.mode).toBe('canvas');
-      expect(result.current.reason).toBe('Render cache preferred');
+      expect(result.current.reason).toBe('Composited preview preferred');
     });
 
     it('should return video mode with multiple clips all having ready proxies', () => {

--- a/src/hooks/usePreviewMode.ts
+++ b/src/hooks/usePreviewMode.ts
@@ -354,7 +354,7 @@ export function usePreviewMode({
     if (mediaPreference === 'renderCache') {
       const result: PreviewModeResult = {
         mode: 'canvas',
-        reason: 'Render cache preferred',
+        reason: 'Composited preview preferred',
         hasGeneratingProxy: false,
         clipsNeedingProxy: 0,
       };

--- a/src/hooks/useRenderCache.test.ts
+++ b/src/hooks/useRenderCache.test.ts
@@ -18,6 +18,22 @@ vi.mock('@tauri-apps/api/event', () => ({
 }));
 
 import { commands } from '@/bindings';
+import type { CacheSegmentStatusDto } from '@/bindings';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
+
+const makeSegment = (
+  index: number,
+  state: CacheSegmentStatusDto['state'],
+): CacheSegmentStatusDto => ({
+  index,
+  startSec: index * 5,
+  endSec: (index + 1) * 5,
+  state,
+  fingerprint: String(index),
+  cachedPath: state === 'cached' ? `/cache/seg-${index}.mp4` : null,
+  flagged: false,
+  flagReasons: [],
+});
 
 const mockStatus = {
   enabled: true,
@@ -30,16 +46,18 @@ const mockStatus = {
   totalCachedBytes: 1024,
   maxCacheBytes: 1073741824,
   segmentStates: [
-    { startSec: 0, endSec: 5, state: 'cached' as const },
-    { startSec: 5, endSec: 10, state: 'cached' as const },
-    { startSec: 10, endSec: 15, state: 'stale' as const },
-    { startSec: 15, endSec: 20, state: 'empty' as const },
+    makeSegment(0, 'cached'),
+    makeSegment(1, 'cached'),
+    makeSegment(2, 'stale'),
+    makeSegment(3, 'empty'),
   ],
 };
 
 describe('useRenderCache', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The hook is a view onto a module-level store; start every case clean.
+    useRenderCacheStore.getState()._resetForTests();
     globalThis[DESKTOP_RUNTIME_TEST_FLAG] = true;
     delete (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });

--- a/src/hooks/useRenderCache.ts
+++ b/src/hooks/useRenderCache.ts
@@ -1,28 +1,16 @@
 /**
- * useRenderCache — Hook for managing render cache state.
+ * useRenderCache — Thin React adapter over the render cache store.
  *
- * Fetches cache status from the backend, listens for progress events,
- * and provides actions to trigger/clear cache rendering.
+ * The state, the backend calls and the Tauri event wiring all live in
+ * `renderCacheStore`; this hook only subscribes a component to them and owns
+ * the attach/detach lifecycle of the shared listeners. Keeping the surface
+ * unchanged means existing consumers (the timeline indicator) need no edits.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { commands } from '@/bindings';
-import type { RenderCacheStatus, CacheSegmentStatusDto, PreviewCacheScope } from '@/bindings';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useCallback, useEffect } from 'react';
+import type { RenderCacheStatus, CacheSegmentStatusDto } from '@/bindings';
 import { isDesktopRuntimeAvailable } from '@/services/runtimeEnvironment';
-
-/** Cache progress event payload */
-interface CacheProgressPayload {
-  sequenceId: string;
-  completedSegments: number;
-  totalSegments: number;
-  percent: number;
-  /**
-   * Which segments the running fill is producing. Optional: a fill started by an
-   * older backend emits no scope.
-   */
-  scope?: PreviewCacheScope;
-}
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
 
 /** Return type for the useRenderCache hook */
 interface UseRenderCacheReturn {
@@ -36,7 +24,7 @@ interface UseRenderCacheReturn {
   error: string | null;
   /** Segment states for the cache indicator bar */
   segments: CacheSegmentStatusDto[];
-  /** Trigger cache rendering for pending segments */
+  /** Trigger cache rendering for the whole timeline */
   renderCache: () => Promise<void>;
   /** Clear all cached segments */
   clearCache: () => Promise<void>;
@@ -44,165 +32,40 @@ interface UseRenderCacheReturn {
   refreshStatus: () => Promise<void>;
 }
 
+/**
+ * Subscribes to render cache state and keeps the shared backend listeners alive
+ * for as long as at least one consumer is mounted.
+ */
 export function useRenderCache(): UseRenderCacheReturn {
-  const [status, setStatus] = useState<RenderCacheStatus | null>(null);
-  const [isRendering, setIsRendering] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [error, setError] = useState<string | null>(null);
-  const unlistenRefs = useRef<UnlistenFn[]>([]);
-  const backendAvailable = isDesktopRuntimeAvailable();
+  const status = useRenderCacheStore((state) => state.status);
+  const isRendering = useRenderCacheStore((state) => state.isRendering);
+  const progress = useRenderCacheStore((state) => state.progress);
+  const error = useRenderCacheStore((state) => state.error);
+  const renderCacheScoped = useRenderCacheStore((state) => state.renderCache);
+  const clearCache = useRenderCacheStore((state) => state.clearCache);
+  const refreshStatus = useRenderCacheStore((state) => state.refreshStatus);
 
-  const refreshStatus = useCallback(async () => {
-    if (!backendAvailable) {
-      setStatus(null);
-      setError(null);
-      return;
-    }
-
-    const result = await commands.getCacheStatus();
-    if (result.status === 'ok') {
-      setStatus(result.data);
-      setError(null);
-    } else {
-      setStatus(null);
-      const message = String(result.error);
-      if (message.includes('No project open') || message.includes('No active sequence')) {
-        setError(null);
-        return;
-      }
-
-      setError(message);
-    }
-  }, [backendAvailable]);
-
-  const renderCache = useCallback(async () => {
-    if (!backendAvailable) {
-      setError('Render cache is only available in the desktop app runtime.');
-      return;
-    }
-
-    setIsRendering(true);
-    setProgress(0);
-    setError(null);
-
-    try {
-      // `null` selects the whole timeline; the flagged scope is not driven from
-      // this hook yet.
-      const result = await commands.renderPreviewCache(null);
-      if (result.status === 'ok') {
-        if (result.data.status === 'already_cached') {
-          setIsRendering(false);
-          setProgress(100);
-        } else if (
-          result.data.status === 'already_converging' ||
-          result.data.status === 'retargeted'
-        ) {
-          // This call started nothing: a fill already in flight absorbed the
-          // request. Its own progress and completion events drive the UI through
-          // the listeners below, so this hook must not latch a rendering state
-          // that no event of its own will ever clear.
-          setIsRendering(false);
-        }
-      } else {
-        setError(result.error);
-        setIsRendering(false);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setIsRendering(false);
-    }
-
-    await refreshStatus();
-  }, [backendAvailable, refreshStatus]);
-
-  const clearCache = useCallback(async () => {
-    if (!backendAvailable) {
-      setError('Render cache is only available in the desktop app runtime.');
-      return;
-    }
-
-    try {
-      const result = await commands.clearRenderCache();
-      if (result.status === 'ok') {
-        setStatus(null);
-        setProgress(0);
-        setIsRendering(false);
-        await refreshStatus();
-      } else {
-        setError(result.error);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [backendAvailable, refreshStatus]);
-
-  // Listen for cache progress and completion events
   useEffect(() => {
-    if (!backendAvailable) {
+    if (!isDesktopRuntimeAvailable()) {
       return;
     }
 
-    let disposed = false;
-
-    const setupListeners = async (): Promise<void> => {
-      try {
-        const progressUnlisten = await listen<CacheProgressPayload>(
-          'render-cache-progress',
-          (event) => {
-            setProgress(event.payload.percent);
-            // Refresh full status so CacheStatusBar updates per-segment
-            void refreshStatus();
-          },
-        );
-
-        const completeUnlisten = await listen<{ sequenceId: string }>(
-          'render-cache-complete',
-          async () => {
-            setIsRendering(false);
-            setProgress(100);
-            await refreshStatus();
-          },
-        );
-
-        const errorUnlisten = await listen<string>('render-cache-error', (event) => {
-          // Per-segment errors do not stop the overall cache render.
-          // isRendering is only cleared on render-cache-complete.
-          setError(event.payload);
-        });
-
-        if (disposed) {
-          progressUnlisten();
-          completeUnlisten();
-          errorUnlisten();
-          return;
-        }
-
-        unlistenRefs.current = [progressUnlisten, completeUnlisten, errorUnlisten];
-      } catch (listenerError) {
-        if (!disposed) {
-          setIsRendering(false);
-          setError(listenerError instanceof Error ? listenerError.message : String(listenerError));
-        }
-      }
-    };
-
-    void setupListeners();
-
+    const { attachListeners, detachListeners } = useRenderCacheStore.getState();
+    attachListeners();
     return () => {
-      disposed = true;
-      for (const unlisten of unlistenRefs.current) {
-        if (typeof unlisten === 'function') {
-          unlisten();
-        }
-      }
-      unlistenRefs.current = [];
+      detachListeners();
     };
-  }, [backendAvailable, refreshStatus]);
+  }, []);
 
-  // Load initial status
   useEffect(() => {
     void refreshStatus();
   }, [refreshStatus]);
+
+  // This hook keeps whole-timeline semantics; scoped fills go through the
+  // store directly (see useIdleCacheFill).
+  const renderCache = useCallback(async (): Promise<void> => {
+    await renderCacheScoped(null);
+  }, [renderCacheScoped]);
 
   return {
     status,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -143,6 +143,9 @@ export type {
 export { useAgentArtifactReviewStore } from './agentArtifactReviewStore';
 export { useAgentDelegationStore } from './agentDelegationStore';
 
+export { useRenderCacheStore } from './renderCacheStore';
+export type { RenderCacheState, RenderCacheActions, RenderCacheStore } from './renderCacheStore';
+
 export { usePreviewStore, MIN_ZOOM, MAX_ZOOM, ZOOM_STEP, ZOOM_PRESETS } from './previewStore';
 export type { ZoomMode, PreviewState, PreviewActions, PreviewStore } from './previewStore';
 

--- a/src/stores/renderCacheStore.test.ts
+++ b/src/stores/renderCacheStore.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { useRenderCacheStore } from './renderCacheStore';
+import { DESKTOP_RUNTIME_TEST_FLAG } from '@/services/runtimeEnvironment';
+
+// Mock the Tauri IPC boundary only.
+vi.mock('@/bindings', () => ({
+  commands: {
+    getCacheStatus: vi.fn(),
+    renderPreviewCache: vi.fn(),
+    clearRenderCache: vi.fn(),
+  },
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+  emit: vi.fn(),
+}));
+
+import { commands } from '@/bindings';
+import type { CacheSegmentStatusDto } from '@/bindings';
+import { listen } from '@tauri-apps/api/event';
+
+const cachedSegment: CacheSegmentStatusDto = {
+  index: 0,
+  startSec: 0,
+  endSec: 5,
+  state: 'cached',
+  fingerprint: '42',
+  cachedPath: '/cache/seg-0.mp4',
+  flagged: false,
+  flagReasons: [],
+};
+
+const mockStatus = {
+  enabled: true,
+  sequenceId: 'seq1',
+  totalSegments: 1,
+  cachedSegments: 1,
+  staleSegments: 0,
+  renderingSegments: 0,
+  completionPercent: 100,
+  totalCachedBytes: 1024,
+  maxCacheBytes: 1073741824,
+  segmentStates: [cachedSegment],
+};
+
+/** Unlisten functions handed out by the mocked `listen`, in registration order. */
+function unlistenResults(): Array<() => void> {
+  return vi.mocked(listen).mock.results.map((result) => result.value as unknown as () => void);
+}
+
+describe('renderCacheStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-seeded per test: the global afterEach restores mocks, which would
+    // otherwise strip this implementation after the first case.
+    vi.mocked(listen).mockImplementation(() => Promise.resolve(vi.fn()));
+    useRenderCacheStore.getState()._resetForTests();
+    globalThis[DESKTOP_RUNTIME_TEST_FLAG] = true;
+  });
+
+  afterEach(() => {
+    useRenderCacheStore.getState()._resetForTests();
+    delete globalThis[DESKTOP_RUNTIME_TEST_FLAG];
+  });
+
+  describe('listener ref-counting', () => {
+    it('should register each backend event once when several consumers attach', async () => {
+      const { attachListeners } = useRenderCacheStore.getState();
+
+      attachListeners();
+      attachListeners();
+
+      await waitFor(() => {
+        expect(listen).toHaveBeenCalledTimes(3);
+      });
+
+      const events = vi.mocked(listen).mock.calls.map(([event]) => event);
+      expect(events).toEqual([
+        'render-cache-progress',
+        'render-cache-complete',
+        'render-cache-error',
+      ]);
+    });
+
+    it('should keep listeners alive until the last consumer detaches', async () => {
+      const { attachListeners, detachListeners } = useRenderCacheStore.getState();
+
+      attachListeners();
+      attachListeners();
+
+      await waitFor(() => {
+        expect(listen).toHaveBeenCalledTimes(3);
+      });
+
+      const unlisteners = await Promise.all(unlistenResults());
+
+      detachListeners();
+      for (const unlisten of unlisteners) {
+        expect(unlisten).not.toHaveBeenCalled();
+      }
+
+      detachListeners();
+      for (const unlisten of unlisteners) {
+        expect(unlisten).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('should register again after a full detach/attach cycle', async () => {
+      const { attachListeners, detachListeners } = useRenderCacheStore.getState();
+
+      attachListeners();
+      await waitFor(() => expect(listen).toHaveBeenCalledTimes(3));
+      detachListeners();
+
+      attachListeners();
+      await waitFor(() => expect(listen).toHaveBeenCalledTimes(6));
+    });
+
+    it('should not orphan listeners when attach/detach/attach happens inside one registration await', async () => {
+      // React StrictMode does exactly this on every dev mount: the second
+      // attach starts while the first registration is still awaiting listen().
+      // Both would see a live ref-count on resolution, and without a
+      // generation stamp the later one silently overwrites the earlier
+      // handles, leaving the first set registered forever.
+      let releasePending!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePending = resolve;
+      });
+
+      const created: Array<() => void> = [];
+      vi.mocked(listen).mockImplementation(async () => {
+        await gate;
+        const unlisten = vi.fn();
+        created.push(unlisten);
+        return unlisten;
+      });
+
+      const { attachListeners, detachListeners } = useRenderCacheStore.getState();
+
+      attachListeners();
+      detachListeners();
+      attachListeners();
+
+      releasePending();
+      await waitFor(() => {
+        expect(created.length).toBe(6);
+      });
+
+      // Exactly one set survives; the orphaned set must have torn itself down.
+      const tornDown = created.filter((unlisten) => vi.mocked(unlisten).mock.calls.length > 0);
+      expect(tornDown).toHaveLength(3);
+
+      detachListeners();
+      for (const unlisten of created) {
+        expect(unlisten).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('renderCache', () => {
+    beforeEach(() => {
+      vi.mocked(commands.getCacheStatus).mockResolvedValue({
+        status: 'ok',
+        data: mockStatus,
+      } as never);
+    });
+
+    it('should pass the requested scope through to the backend', async () => {
+      vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+        status: 'ok',
+        data: {
+          jobId: 'job-1',
+          sequenceId: 'seq1',
+          totalSegments: 1,
+          segmentsToRender: 1,
+          status: 'started',
+        },
+      } as never);
+
+      await useRenderCacheStore.getState().renderCache('flagged');
+
+      expect(commands.renderPreviewCache).toHaveBeenCalledWith('flagged');
+      expect(useRenderCacheStore.getState().isRendering).toBe(true);
+    });
+
+    it('should request the whole timeline when the scope is null', async () => {
+      vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+        status: 'ok',
+        data: {
+          jobId: 'job-2',
+          sequenceId: 'seq1',
+          totalSegments: 1,
+          segmentsToRender: 1,
+          status: 'started',
+        },
+      } as never);
+
+      await useRenderCacheStore.getState().renderCache(null);
+
+      expect(commands.renderPreviewCache).toHaveBeenCalledWith(null);
+    });
+
+    it.each(['already_converging', 'retargeted'] as const)(
+      'should leave a running fill untouched when it absorbed the request (%s)',
+      async (status) => {
+        vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+          status: 'ok',
+          data: {
+            jobId: 'running-job',
+            sequenceId: 'seq1',
+            totalSegments: 1,
+            segmentsToRender: 1,
+            status,
+          },
+        } as never);
+
+        // A fill is already running and has reported progress.
+        useRenderCacheStore.setState({ isRendering: true, progress: 42 });
+
+        await useRenderCacheStore.getState().renderCache('flagged');
+
+        // The running fill's own events keep both fields current; this call
+        // must neither clear the rendering state nor rewind its progress.
+        expect(useRenderCacheStore.getState().isRendering).toBe(true);
+        expect(useRenderCacheStore.getState().progress).toBe(42);
+        expect(useRenderCacheStore.getState().error).toBeNull();
+      },
+    );
+
+    it('should not rewind a running fill before the backend has answered', async () => {
+      let resolveCall!: (value: unknown) => void;
+      vi.mocked(commands.renderPreviewCache).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve;
+          }) as never,
+      );
+
+      useRenderCacheStore.setState({ isRendering: true, progress: 42 });
+
+      const pending = useRenderCacheStore.getState().renderCache('flagged');
+
+      // In flight: nothing may be set optimistically.
+      expect(useRenderCacheStore.getState().isRendering).toBe(true);
+      expect(useRenderCacheStore.getState().progress).toBe(42);
+
+      resolveCall({
+        status: 'ok',
+        data: {
+          jobId: 'running-job',
+          sequenceId: 'seq1',
+          totalSegments: 1,
+          segmentsToRender: 1,
+          status: 'already_converging',
+        },
+      });
+      await pending;
+
+      expect(useRenderCacheStore.getState().progress).toBe(42);
+    });
+
+    it('should report a completed cache as fully rendered', async () => {
+      vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+        status: 'ok',
+        data: {
+          jobId: 'job-3',
+          sequenceId: 'seq1',
+          totalSegments: 1,
+          segmentsToRender: 0,
+          status: 'already_cached',
+        },
+      } as never);
+
+      await useRenderCacheStore.getState().renderCache('flagged');
+
+      expect(useRenderCacheStore.getState().isRendering).toBe(false);
+      expect(useRenderCacheStore.getState().progress).toBe(100);
+    });
+
+    it('should surface backend failures without latching a rendering state', async () => {
+      vi.mocked(commands.renderPreviewCache).mockResolvedValue({
+        status: 'error',
+        error: 'ffmpeg exited with 1',
+      } as never);
+
+      await useRenderCacheStore.getState().renderCache('flagged');
+
+      expect(useRenderCacheStore.getState().isRendering).toBe(false);
+      // A successful status refresh follows and clears `error`; the failure
+      // this call reported must survive it, or no UI could ever show it.
+      expect(useRenderCacheStore.getState().error).toBe('ffmpeg exited with 1');
+    });
+
+    it('should surface a rejected fill request', async () => {
+      vi.mocked(commands.renderPreviewCache).mockRejectedValue(new Error('IPC channel closed'));
+
+      await useRenderCacheStore.getState().renderCache('flagged');
+
+      expect(useRenderCacheStore.getState().error).toBe('IPC channel closed');
+    });
+  });
+
+  describe('dead cached paths', () => {
+    it('should remember a path marked dead', () => {
+      useRenderCacheStore.getState().markCachedPathDead('/cache/seg-0.mp4');
+
+      expect(useRenderCacheStore.getState().deadCachedPaths.has('/cache/seg-0.mp4')).toBe(true);
+    });
+
+    it('should drop death marks once a fresh status snapshot arrives', async () => {
+      vi.mocked(commands.getCacheStatus).mockResolvedValue({
+        status: 'ok',
+        data: mockStatus,
+      } as never);
+
+      useRenderCacheStore.getState().markCachedPathDead('/cache/seg-0.mp4');
+      await useRenderCacheStore.getState().refreshStatus();
+
+      expect(useRenderCacheStore.getState().deadCachedPaths.size).toBe(0);
+    });
+
+    it('should keep death marks when the status refresh failed', async () => {
+      vi.mocked(commands.getCacheStatus).mockResolvedValue({
+        status: 'error',
+        error: 'Failed to load cache manifest',
+      } as never);
+
+      useRenderCacheStore.getState().markCachedPathDead('/cache/seg-0.mp4');
+      await useRenderCacheStore.getState().refreshStatus();
+
+      expect(useRenderCacheStore.getState().deadCachedPaths.has('/cache/seg-0.mp4')).toBe(true);
+    });
+  });
+
+  describe('refreshStatus', () => {
+    it('should treat "no project open" as an empty status rather than an error', async () => {
+      vi.mocked(commands.getCacheStatus).mockResolvedValue({
+        status: 'error',
+        error: 'No project open',
+      } as never);
+
+      await useRenderCacheStore.getState().refreshStatus();
+
+      expect(useRenderCacheStore.getState().status).toBeNull();
+      expect(useRenderCacheStore.getState().error).toBeNull();
+    });
+
+    it('should stay idle outside the desktop runtime', async () => {
+      delete globalThis[DESKTOP_RUNTIME_TEST_FLAG];
+
+      await useRenderCacheStore.getState().refreshStatus();
+
+      expect(commands.getCacheStatus).not.toHaveBeenCalled();
+      expect(useRenderCacheStore.getState().status).toBeNull();
+      expect(useRenderCacheStore.getState().error).toBeNull();
+    });
+  });
+});

--- a/src/stores/renderCacheStore.ts
+++ b/src/stores/renderCacheStore.ts
@@ -1,0 +1,306 @@
+/**
+ * Render Cache Store
+ *
+ * Single source of truth for preview render-cache status, fill progress and
+ * backend event wiring.
+ *
+ * ## Why a store rather than hook-local state
+ *
+ * More than one surface needs the same cache picture at the same time: the
+ * timeline indicator bar, the idle fill scheduler, and (from the cache-first
+ * preview onward) the player deciding whether a cached segment can be drawn.
+ * Held in hook state, each consumer would register its own Tauri event
+ * listeners and hold a divergent copy of the same backend truth. The store
+ * keeps one copy and, through `attachListeners`/`detachListeners`, at most one
+ * registration of each backend event no matter how many components subscribe.
+ *
+ * Plain Zustand (no Immer) is deliberate: the state carries a `Set`, and
+ * replacing it with a fresh copy is clearer here than enabling Immer's Map/Set
+ * plugin for a single field.
+ */
+
+import { create } from 'zustand';
+import { commands } from '@/bindings';
+import type { RenderCacheStatus, PreviewCacheScope } from '@/bindings';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { isDesktopRuntimeAvailable } from '@/services/runtimeEnvironment';
+
+/** Message shown when a cache action is attempted outside the desktop runtime. */
+const DESKTOP_ONLY_MESSAGE = 'Render cache is only available in the desktop app runtime.';
+
+/**
+ * Backend errors that simply mean "there is nothing to report yet".
+ *
+ * They are a normal state on app start, not a failure worth surfacing.
+ */
+const BENIGN_STATUS_ERRORS = ['No project open', 'No active sequence'] as const;
+
+/** Cache progress event payload */
+interface CacheProgressPayload {
+  sequenceId: string;
+  completedSegments: number;
+  totalSegments: number;
+  percent: number;
+  /**
+   * Which segments the running fill is producing. Optional: a fill started by an
+   * older backend emits no scope.
+   */
+  scope?: PreviewCacheScope;
+}
+
+/** Render cache state */
+export interface RenderCacheState {
+  /** Current cache status (null if not loaded) */
+  status: RenderCacheStatus | null;
+  /** Whether a cache fill is currently running */
+  isRendering: boolean;
+  /** Fill progress percentage (0-100) */
+  progress: number;
+  /** Error message if any */
+  error: string | null;
+  /**
+   * Cached segment files a consumer found unplayable since the last refresh.
+   *
+   * The manifest can name a file that no longer decodes (evicted, truncated by
+   * a crash). A consumer that hits one marks it here so every other consumer
+   * stops reaching for it, without waiting for the backend to notice.
+   */
+  deadCachedPaths: Set<string>;
+}
+
+/** Render cache actions */
+export interface RenderCacheActions {
+  /** Refresh cache status from the backend */
+  refreshStatus: () => Promise<void>;
+  /**
+   * Ask the backend to fill the cache.
+   *
+   * @param scope - Which segments to fill; `null` means the whole timeline.
+   */
+  renderCache: (scope: PreviewCacheScope | null) => Promise<void>;
+  /** Clear all cached segments */
+  clearCache: () => Promise<void>;
+  /** Mark a cached segment file as unplayable until the next successful refresh */
+  markCachedPathDead: (path: string) => void;
+  /** Register backend cache listeners (ref-counted; safe to call from every consumer) */
+  attachListeners: () => void;
+  /** Release one listener registration; the last release tears the listeners down */
+  detachListeners: () => void;
+  /** Restore initial state and drop every listener registration (for testing purposes) */
+  _resetForTests: () => void;
+}
+
+/** Combined render cache store */
+export type RenderCacheStore = RenderCacheState & RenderCacheActions;
+
+const INITIAL_STATE: RenderCacheState = {
+  status: null,
+  isRendering: false,
+  progress: 0,
+  error: null,
+  deadCachedPaths: new Set<string>(),
+};
+
+// =============================================================================
+// Listener ref-counting (module scope: one registration per process, not per store read)
+// =============================================================================
+
+let listenerRefCount = 0;
+let listenerHandles: UnlistenFn[] = [];
+/**
+ * Bumped whenever the listener set is torn down.
+ *
+ * `listen()` is async, so an attach → detach → attach cycle that completes
+ * inside one await window puts two registrations in flight at once. Without a
+ * generation stamp both would see a live ref-count on resolution and the second
+ * would overwrite the first's handles, orphaning listeners that keep firing
+ * with no consumer left. React StrictMode performs exactly that cycle on every
+ * dev mount.
+ */
+let listenerGeneration = 0;
+
+function releaseListenerHandles(): void {
+  for (const unlisten of listenerHandles) {
+    if (typeof unlisten === 'function') {
+      unlisten();
+    }
+  }
+  listenerHandles = [];
+}
+
+async function registerListeners(): Promise<void> {
+  const generation = listenerGeneration;
+
+  try {
+    const handles = await Promise.all([
+      listen<CacheProgressPayload>('render-cache-progress', (event) => {
+        useRenderCacheStore.setState({ progress: event.payload.percent });
+        // Refresh full status so the timeline indicator updates per segment.
+        void useRenderCacheStore.getState().refreshStatus();
+      }),
+      listen<{ sequenceId: string }>('render-cache-complete', async () => {
+        useRenderCacheStore.setState({ isRendering: false, progress: 100 });
+        await useRenderCacheStore.getState().refreshStatus();
+      }),
+      listen<string>('render-cache-error', (event) => {
+        // Per-segment errors do not stop the overall fill; `isRendering` is
+        // only cleared on render-cache-complete.
+        useRenderCacheStore.setState({ error: event.payload });
+      }),
+    ]);
+
+    const isStale = generation !== listenerGeneration || listenerRefCount === 0;
+    if (isStale || listenerHandles.length > 0) {
+      // Either every consumer detached while this registration was in flight,
+      // or a later registration already won the slot. Drop the handles this
+      // call created rather than orphaning someone else's.
+      for (const unlisten of handles) {
+        if (typeof unlisten === 'function') {
+          unlisten();
+        }
+      }
+      return;
+    }
+
+    listenerHandles = handles;
+  } catch (listenerError) {
+    useRenderCacheStore.setState({
+      isRendering: false,
+      error: listenerError instanceof Error ? listenerError.message : String(listenerError),
+    });
+  }
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+/** Global render cache store */
+export const useRenderCacheStore = create<RenderCacheStore>((set, get) => ({
+  ...INITIAL_STATE,
+
+  refreshStatus: async () => {
+    if (!isDesktopRuntimeAvailable()) {
+      set({ status: null, error: null });
+      return;
+    }
+
+    const result = await commands.getCacheStatus();
+    if (result.status === 'ok') {
+      set((state) => ({
+        status: result.data,
+        error: null,
+        // A fresh snapshot supersedes local death marks: whatever the backend
+        // now reports as cached is the current truth about those files.
+        deadCachedPaths: state.deadCachedPaths.size > 0 ? new Set<string>() : state.deadCachedPaths,
+      }));
+      return;
+    }
+
+    const message = String(result.error);
+    if (BENIGN_STATUS_ERRORS.some((benign) => message.includes(benign))) {
+      set({ status: null, error: null });
+      return;
+    }
+
+    set({ status: null, error: message });
+  },
+
+  renderCache: async (scope) => {
+    if (!isDesktopRuntimeAvailable()) {
+      set({ error: DESKTOP_ONLY_MESSAGE });
+      return;
+    }
+
+    // `isRendering`/`progress` are set from the outcome, never optimistically:
+    // this request may land on a fill that is already running, and rewinding
+    // its progress to 0 before the backend has said anything would report a
+    // restart that never happened.
+    set({ error: null });
+
+    let failure: string | null = null;
+
+    try {
+      const result = await commands.renderPreviewCache(scope);
+      if (result.status === 'ok') {
+        if (result.data.status === 'started') {
+          set({ isRendering: true, progress: 0 });
+        } else if (result.data.status === 'already_cached') {
+          set({ isRendering: false, progress: 100 });
+        }
+        // `already_converging` / `retargeted`: this call started nothing — a
+        // fill already in flight absorbed the request, and its own progress and
+        // completion events keep both fields current. Writing either here would
+        // clobber a genuinely running fill.
+      } else {
+        failure = result.error;
+        set({ error: failure });
+      }
+    } catch (e) {
+      failure = e instanceof Error ? e.message : String(e);
+      set({ error: failure });
+    }
+
+    await get().refreshStatus();
+
+    // A successful status refresh clears `error`, which would otherwise erase
+    // the failure this call just reported before anything could render it.
+    if (failure !== null) {
+      set({ error: failure });
+    }
+  },
+
+  clearCache: async () => {
+    if (!isDesktopRuntimeAvailable()) {
+      set({ error: DESKTOP_ONLY_MESSAGE });
+      return;
+    }
+
+    try {
+      const result = await commands.clearRenderCache();
+      if (result.status === 'ok') {
+        set({ status: null, progress: 0, isRendering: false });
+        await get().refreshStatus();
+      } else {
+        set({ error: result.error });
+      }
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : String(e) });
+    }
+  },
+
+  markCachedPathDead: (path) => {
+    set((state) => {
+      if (state.deadCachedPaths.has(path)) {
+        return state;
+      }
+      const next = new Set(state.deadCachedPaths);
+      next.add(path);
+      return { deadCachedPaths: next };
+    });
+  },
+
+  attachListeners: () => {
+    listenerRefCount += 1;
+    if (listenerRefCount === 1) {
+      void registerListeners();
+    }
+  },
+
+  detachListeners: () => {
+    listenerRefCount = Math.max(0, listenerRefCount - 1);
+    if (listenerRefCount === 0) {
+      // Invalidate any registration still in flight before dropping the ones
+      // that already landed.
+      listenerGeneration += 1;
+      releaseListenerHandles();
+    }
+  },
+
+  _resetForTests: () => {
+    listenerRefCount = 0;
+    listenerGeneration += 1;
+    releaseListenerHandles();
+    set({ ...INITIAL_STATE, deadCachedPaths: new Set<string>() });
+  },
+}));

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -112,6 +112,8 @@ export interface PerformanceSettings {
   maxConcurrentJobs: number;
   memoryLimitMb: number;
   cacheSizeMb: number;
+  /** Render flagged timeline segments into the preview cache while the editor is idle */
+  backgroundRenderCache: boolean;
 }
 
 /** AI provider type */
@@ -319,6 +321,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     maxConcurrentJobs: 4,
     memoryLimitMb: 0,
     cacheSizeMb: 1024,
+    backgroundRenderCache: true,
   },
   ai: {
     assistantRuntime: 'codex',


### PR DESCRIPTION
### **User description**
## Why

The preview cache backend (#850–#853) is complete but unreachable from the app: nothing ever triggered a fill, so every segment stayed `empty` and the status bar rendered a permanently blank strip. This PR wires the first half of the user-facing loop — segments the live preview cannot draw faithfully now get rendered through the export pipeline **automatically while the editor is idle**, the Resolve Smart Cache model the founder chose (validated against FCP's 0.3s / Resolve's 5s idle timers).

## Change

- **`renderCacheStore`** (new): the cache status moves from per-hook local state into a shared zustand store — one ref-counted set of Tauri event listeners regardless of how many consumers mount, `renderCache(scope)` parameterized, and a `deadCachedPaths` set ready for the cache-first playback seam (next PR). `useRenderCache` becomes a thin adapter with an unchanged public API.
- **`useIdleCacheFill`** (new, mounted once in `EditorView`): 2s debounce on `projectStore.stateVersion` (the real edit signal — scrubbing cannot reset it), playback **gates** rather than cancels (a deferred fill fires when playback stops), plus a one-per-activation **warm-up** so a project that is opened and only reviewed still gets its flagged segments cached. A failing fill is not retried until the next real edit. Safe to over-call: the backend fill is idempotent/convergent.
- **Settings**: `Performance → Background render caching` toggle (default on), carried through the Rust settings model with a serde default so old settings files load unchanged.
- **`CacheStatusBar`**: flagged-but-uncached segments now show a dim red "needs render" bar (the universal NLE render-bar convention); tooltips name the flag reasons; error segments moved to a distinct hue so the two states are distinguishable on a 6px strip; the store's fill error surfaces on the bar's tooltip.
- The preview dropdown option mislabeled "Render cache" (it never played cached media — it just forced the slower canvas path) is renamed to **"Composited (accurate)"**, which is what it actually does.

## Review rounds

Adversarial review before this PR found and fix-verified two real defects, both reproduced by probe and now covered by regression tests that fail against the unfixed code:
- a listener-registration race that permanently leaked Tauri event listeners on attach→detach→attach inside one `listen()` await (StrictMode hits it on every dev mount);
- the warm-up fill being silently killed by StrictMode's double-mount (the exact "opened a project, made no edit" case it exists for).

Plus: no optimistic `isRendering`/`progress` clobbering of an already-running fill, and bounded retry semantics.

## Verification

- `npx tsc --noEmit`, eslint, prettier clean.
- Targeted vitest 46/46 (store 17, idle hook 13, status bar 11, adapter 8 — one IPC-boundary mock, real stores everywhere, per the Testing Trophy policy).
- Sweep `src/hooks src/stores src/components/timeline`: **125 files / 2472 tests passed**; settings/preview/editor/architecture sweep 460 passed.
- Rust side (settings field): `cargo test core::settings` 49 passed incl. the new default test; `cargo check`/`clippy --features gui -D warnings` clean; `bindings.ts` machine-regenerated and idempotent.

Next PR completes the loop: cache-first frames while paused (decoded from the lossless cache via the resident decoder) + the labeled DRAFT fallback.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements automatic background rendering for flagged segments while idle.

- Refactors render cache state and logic into a Zustand store.

- Updates cache status bar to show flagged segments and fill errors.

- Adds a new setting to enable/disable background render caching.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  EditorView[EditorView] -- "mounts" --> UseIdleCacheFill[useIdleCacheFill Hook]
  UseIdleCacheFill -- "observes changes in" --> ProjectStore[ProjectStore]
  UseIdleCacheFill -- "observes playback state" --> PlaybackStore[PlaybackStore]
  UseIdleCacheFill -- "checks setting" --> SettingsStore[SettingsStore]
  UseIdleCacheFill -- "triggers fill when idle" --> RenderCacheStore[renderCacheStore (Zustand)]
  RenderCacheStore -- "calls Tauri command" --> RenderPreviewCache[commands.renderPreviewCache]
  RenderCacheStore -- "listens for events" --> TauriEvents[render-cache-progress, -complete, -error]
  TauriEvents -- "update state in" --> RenderCacheStore
  RenderCacheStore -- "updates UI via" --> CacheStatusBar[CacheStatusBar]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>bindings.ts</strong><dd><code>Updates TypeScript bindings for background render cache setting</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Exports `useRenderCacheStore` and its types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-a962836e7056c855240fcab71b4e4f6a56e8462e298844f0b928226d230cda83">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settingsStore.ts</strong><dd><code>Adds <code>backgroundRenderCache</code> to performance settings interface and <br>default</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-ce49e0cdebbd35f82e7bd42214719d77cac39a9afef79f7e67b2c35489380d9a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Adds <code>background_render_cache</code> to performance settings with default true</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-b6fda75f34d5055a273697f0ba135552b64ea062449280e0a4817e7c1c78def8">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>system.rs</strong><dd><code>Adds <code>background_render_cache</code> to DTO with default true for <br>deserialization</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-d336ae3f810f000d1bade79194e4327dfd7ef63b25b0601948f933da1f03b7fa">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>EditorView.tsx</strong><dd><code>Mounts `useIdleCacheFill` hook at the editor root</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-382f457b2b2ae7d56d3a83f74c92b764a355a1f23c23ae7bb103d3ad306a63da">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PerformanceSettings.tsx</strong><dd><code>Adds UI toggle for background render caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-b695b308d185fcdd136c620a1c33ccfa0b5236766f36bf95d5d4f152af8b6c1c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UnifiedPreviewPlayer.tsx</strong><dd><code>Renames "Render cache" media preference to "Composited (accurate)"</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-adaddc60a186fc62f38d0b905bfd7d21f7dd7f9033b84132ec8c50648b8ac82c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CacheStatusBar.tsx</strong><dd><code>Enhances status bar to show flagged segments and fill errors</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-d72814f3cf0be821ad4ef0af4b00000dc084ab4373a9f7f1eeffcda928e8880b">+37/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useIdleCacheFill.ts</strong><dd><code>Implements a debounced hook for idle-time flagged cache filling</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-6f23c835375e296adb178ff3fea09518188412ab4bce89d2c3183d3225cf28d8">+162/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>usePreviewMode.ts</strong><dd><code>Updates reason string for render cache media preference</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-69d58c4cdc6e3faccda1a977b18588371f4f4b76108de1bde4180d6df2c9c596">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderCacheStore.ts</strong><dd><code>Implements Zustand store for render cache state and event handling</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-e5f816be0faccce19cf6694313b9b65c00ec85762d1be18437bbb4545e3de536">+306/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>PerformanceSettings.test.tsx</strong><dd><code>Adds `backgroundRenderCache` to performance settings tests</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-87581dc2236e3eac156ca87b1f0b7bcb36a331bd6e2a09c23257b3863962b3d7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CacheStatusBar.test.tsx</strong><dd><code>Adds tests for flagged segments, error display, and store reset</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-49d3527c9b64487e49fc59a8c36c6b32366550fdda1e6887f3db23990d047f89">+96/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useIdleCacheFill.test.ts</strong><dd><code>Adds comprehensive tests for idle cache fill logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-3da56ceaf54368e86b92cd7779cc33d2b66184cf71495583165c0260cf800601">+283/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>usePreviewMode.test.ts</strong><dd><code>Updates test expectation for render cache preference reason</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-a5e3d868d4d1a1fc6c512f31c640f3bc3003bdf14f7d855fa2e75f02df378b87">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRenderCache.test.ts</strong><dd><code>Updates tests to use `renderCacheStore` and its reset method</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-fd2b7f9004674c4d3ad84423a73389ce7823e1da1761f16fc5f6b9a3de68a218">+22/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderCacheStore.test.ts</strong><dd><code>Adds tests for `renderCacheStore` listener ref-counting and actions</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-00b849bcb8ee750d9e618fa5d098ca00688f28b8317e40c63e2be0fe074ec6e4">+360/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useRenderCache.ts</strong><dd><code>Refactors hook to be a thin adapter over `renderCacheStore`</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/858/files#diff-59d9ea0ad79ed1caab12ac76fe295a918a4973b117f682672da00d071a789351">+31/-168</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

