### PR TITLE
feat(preview): serve export-accurate cached frames while paused with a labeled draft fallback

### DIFF
--- a/src/components/preview/PreviewDraftBadge.tsx
+++ b/src/components/preview/PreviewDraftBadge.tsx
@@ -1,0 +1,41 @@
+/**
+ * PreviewDraftBadge Component
+ *
+ * Chip shown over a paused preview frame the live canvas cannot draw faithfully
+ * and the render cache has not filled yet.
+ *
+ * The picture on screen is a best-effort guess in that state — an unsupported
+ * blend mode folded down to normal, a transition drawn as a hard cut — so the
+ * badge says so rather than letting the frame pass for the export composite.
+ * It disappears the moment the segment's cached file lands, because a cached
+ * frame *is* the export composite.
+ */
+
+import { AlertTriangle } from 'lucide-react';
+
+/** Wording is deliberately explicit: "draft" alone reads as a proxy resolution hint. */
+const DRAFT_LABEL = 'DRAFT — preview may differ from export';
+
+/**
+ * Renders the draft-frame warning chip.
+ *
+ * @returns The badge element
+ */
+export function PreviewDraftBadge(): JSX.Element {
+  return (
+    <div
+      data-testid="preview-draft-badge"
+      // Announced politely rather than as an alert: it reports the fidelity of
+      // what is already on screen, and it appears and clears as the playhead
+      // moves between segments.
+      role="status"
+      aria-live="polite"
+      className="absolute left-2 top-2 flex items-center gap-1.5 rounded border border-amber-400/40 bg-amber-950/80 px-2 py-1 text-xs text-white shadow-lg backdrop-blur-sm"
+      style={{ zIndex: 45 }}
+      title="This frame was composited by the live preview, which cannot reproduce every export effect. Render the preview cache for an exact frame."
+    >
+      <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+      <span>{DRAFT_LABEL}</span>
+    </div>
+  );
+}

--- a/src/components/preview/TimelinePreviewPlayer.test.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.test.tsx
@@ -3,7 +3,11 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { TimelinePreviewPlayer } from './TimelinePreviewPlayer';
 import { usePlaybackStore } from '@/stores/playbackStore';
 import { useProjectStore } from '@/stores/projectStore';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
 import { useTimelineStore } from '@/stores/timelineStore';
+import { DESKTOP_RUNTIME_TEST_FLAG } from '@/services/runtimeEnvironment';
+import { invoke } from '@tauri-apps/api/core';
+import type { CacheSegmentStatusDto, RenderCacheStatus } from '@/bindings';
 import type { Asset, Clip, Sequence, Track } from '@/types';
 
 const frameBufferMock = vi.hoisted(() => ({
@@ -188,8 +192,51 @@ function createSequence(): Sequence {
   };
 }
 
+const CACHED_SEGMENT_PATH = '/cache/sequence-1/seg-0.mov';
+
+/** The frame-buffer asset id a cached segment's file is addressed under. */
+const CACHE_ASSET_ID = '__cache__sequence-1_0_42';
+
+function createCacheSegment(overrides: Partial<CacheSegmentStatusDto> = {}): CacheSegmentStatusDto {
+  return {
+    index: 0,
+    startSec: 0,
+    endSec: 10,
+    state: 'cached',
+    fingerprint: '42',
+    cachedPath: CACHED_SEGMENT_PATH,
+    flagged: false,
+    flagReasons: [],
+    ...overrides,
+  };
+}
+
+function createCacheStatus(
+  segment: CacheSegmentStatusDto,
+  sequenceId = 'sequence-1',
+): RenderCacheStatus {
+  return {
+    enabled: true,
+    sequenceId,
+    totalSegments: 1,
+    cachedSegments: segment.state === 'cached' ? 1 : 0,
+    staleSegments: 0,
+    renderingSegments: 0,
+    completionPercent: segment.state === 'cached' ? 100 : 0,
+    totalCachedBytes: 1024,
+    maxCacheBytes: 1073741824,
+    segmentStates: [segment],
+  };
+}
+
+/** A stand-in for the decoded frame; only its dimensions are read before drawing. */
+function createFrame(): ImageBitmap {
+  return { width: 640, height: 360 } as unknown as ImageBitmap;
+}
+
 describe('TimelinePreviewPlayer', () => {
   beforeEach(() => {
+    useRenderCacheStore.setState({ status: null, deadCachedPaths: new Set<string>() });
     installCanvasMock();
     frameBufferMock.getFrame.mockReturnValue(new Promise<ImageBitmap | null>(() => {}));
     usePlaybackStore.getState().reset();
@@ -213,6 +260,8 @@ describe('TimelinePreviewPlayer', () => {
   afterEach(() => {
     HTMLCanvasElement.prototype.getContext = originalGetContext;
     useTimelineStore.setState({ selectedClipIds: [] });
+    useRenderCacheStore.setState({ status: null, deadCachedPaths: new Set<string>() });
+    delete globalThis[DESKTOP_RUNTIME_TEST_FLAG];
   });
 
   it('keeps the visible canvas intact while the next frame is still extracting', async () => {
@@ -430,5 +479,292 @@ describe('TimelinePreviewPlayer', () => {
     render(<TimelinePreviewPlayer showControls={false} />);
 
     expect(screen.queryByTestId('transform-bounds')).not.toBeInTheDocument();
+  });
+
+  describe('cache-first paused frames', () => {
+    it('should draw the paused frame from the cached segment instead of compositing it live', async () => {
+      // The cached file is what the export pipeline wrote, so one decode of it
+      // is the exact composite — no per-clip extraction needed.
+      frameBufferMock.getFrame.mockResolvedValue(createFrame());
+      useRenderCacheStore.setState({ status: createCacheStatus(createCacheSegment()) });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+          CACHE_ASSET_ID,
+          CACHED_SEGMENT_PATH,
+          2,
+          FRAME_TARGET,
+        );
+      });
+
+      expect(frameBufferMock.getFrame).not.toHaveBeenCalledWith(
+        'asset-1',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+          'data-frame-source',
+          'cache',
+        );
+      });
+      expect(screen.queryByTestId('preview-draft-badge')).not.toBeInTheDocument();
+    });
+
+    it('should warn that a paused frame is a draft when a flagged segment has no cached file', async () => {
+      frameBufferMock.getFrame.mockResolvedValue(null);
+      useRenderCacheStore.setState({
+        status: createCacheStatus(
+          createCacheSegment({
+            state: 'empty',
+            cachedPath: null,
+            flagged: true,
+            flagReasons: ['blend_mode'],
+          }),
+        ),
+      });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+          'asset-1',
+          '/tmp/asset-1.mp4',
+          2,
+          FRAME_TARGET,
+        );
+      });
+
+      const badge = await screen.findByTestId('preview-draft-badge');
+      expect(badge).toHaveTextContent('DRAFT');
+      expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+        'data-frame-source',
+        'live',
+      );
+    });
+
+    it('should hide the draft warning during playback', async () => {
+      // Degrading the picture while the transport runs is the accepted trade;
+      // nagging about it every frame is not.
+      frameBufferMock.getFrame.mockResolvedValue(null);
+      usePlaybackStore.setState({ isPlaying: true });
+      useRenderCacheStore.setState({
+        status: createCacheStatus(
+          createCacheSegment({
+            state: 'empty',
+            cachedPath: null,
+            flagged: true,
+            flagReasons: ['blend_mode'],
+          }),
+        ),
+      });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalled();
+      });
+
+      expect(screen.queryByTestId('preview-draft-badge')).not.toBeInTheDocument();
+    });
+
+    it('should fall back to the live composite and retire a cached file that will not decode', async () => {
+      let cachedFrame: ImageBitmap | null = null;
+      frameBufferMock.getFrame.mockImplementation(async (assetId: string) =>
+        assetId.startsWith('__cache__') ? cachedFrame : null,
+      );
+      useRenderCacheStore.setState({
+        status: createCacheStatus(
+          createCacheSegment({ flagged: true, flagReasons: ['blend_mode'] }),
+        ),
+      });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+          'asset-1',
+          '/tmp/asset-1.mp4',
+          2,
+          FRAME_TARGET,
+        );
+      });
+
+      expect(useRenderCacheStore.getState().deadCachedPaths.has(CACHED_SEGMENT_PATH)).toBe(true);
+      expect(await screen.findByTestId('preview-draft-badge')).toBeInTheDocument();
+
+      // A fresh status snapshot supersedes the local death mark, and the fill it
+      // reports has to reach the parked frame without the playhead moving.
+      cachedFrame = createFrame();
+      globalThis[DESKTOP_RUNTIME_TEST_FLAG] = true;
+      vi.mocked(invoke).mockResolvedValue(createCacheStatus(createCacheSegment()));
+
+      await act(async () => {
+        await useRenderCacheStore.getState().refreshStatus();
+      });
+
+      expect(useRenderCacheStore.getState().deadCachedPaths.size).toBe(0);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+          'data-frame-source',
+          'cache',
+        );
+      });
+      expect(screen.queryByTestId('preview-draft-badge')).not.toBeInTheDocument();
+    });
+
+    it('should ignore a cache snapshot that describes a different sequence', async () => {
+      // The snapshot is refreshed asynchronously, so just after a sequence
+      // switch it still names segment files under the sequence that was open a
+      // moment ago. Drawing one would show another edit's picture as exact.
+      frameBufferMock.getFrame.mockResolvedValue(null);
+      useRenderCacheStore.setState({
+        status: createCacheStatus(
+          createCacheSegment({ flagged: true, flagReasons: ['blend_mode'] }),
+          'sequence-other',
+        ),
+      });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+          'asset-1',
+          '/tmp/asset-1.mp4',
+          2,
+          FRAME_TARGET,
+        );
+      });
+
+      expect(frameBufferMock.getFrame).not.toHaveBeenCalledWith(
+        expect.stringContaining('__cache__'),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+        'data-frame-source',
+        'live',
+      );
+      // The flag belongs to the other sequence's segments too, so it must not
+      // drive this sequence's badge either.
+      expect(screen.queryByTestId('preview-draft-badge')).not.toBeInTheDocument();
+    });
+
+    it('should upgrade the parked frame from live to cached when playback stops', async () => {
+      frameBufferMock.getFrame.mockImplementation(async (assetId: string) =>
+        assetId.startsWith('__cache__') ? createFrame() : null,
+      );
+      usePlaybackStore.setState({ isPlaying: true });
+      useRenderCacheStore.setState({ status: createCacheStatus(createCacheSegment()) });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+          'asset-1',
+          '/tmp/asset-1.mp4',
+          2,
+          FRAME_TARGET,
+        );
+      });
+      expect(frameBufferMock.getFrame).not.toHaveBeenCalledWith(
+        CACHE_ASSET_ID,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+
+      act(() => {
+        usePlaybackStore.setState({ isPlaying: false });
+      });
+
+      // The playhead has not moved, so only the pause edge can force this redraw.
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+          'data-frame-source',
+          'cache',
+        );
+      });
+      expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+        CACHE_ASSET_ID,
+        CACHED_SEGMENT_PATH,
+        2,
+        FRAME_TARGET,
+      );
+    });
+
+    it('should not blit a cached frame the playhead has already moved past', async () => {
+      const staleDecode = createDeferred<ImageBitmap | null>();
+      frameBufferMock.getFrame
+        .mockImplementationOnce(() => staleDecode.promise)
+        .mockReturnValue(new Promise<ImageBitmap | null>(() => {}));
+      useRenderCacheStore.setState({ status: createCacheStatus(createCacheSegment()) });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(frameBufferMock.getFrame).toHaveBeenCalledWith(
+          CACHE_ASSET_ID,
+          CACHED_SEGMENT_PATH,
+          2,
+          FRAME_TARGET,
+        );
+      });
+
+      act(() => {
+        usePlaybackStore.setState({ currentTime: 4 });
+      });
+
+      await act(async () => {
+        staleDecode.resolve(createFrame());
+        await Promise.resolve();
+      });
+
+      const visibleCanvas = screen.getByTestId('preview-canvas') as HTMLCanvasElement;
+      expect(contextByCanvas.get(visibleCanvas)!.drawImage).not.toHaveBeenCalled();
+      expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+        'data-frame-source',
+        'live',
+      );
+    });
+
+    it('should stop trusting a cached frame once an edit reports its segment stale', async () => {
+      // Without this the parked frame keeps showing the pre-edit composite,
+      // labelled exact, until a background fill eventually lands.
+      frameBufferMock.getFrame.mockImplementation(async (assetId: string) =>
+        assetId.startsWith('__cache__') ? createFrame() : null,
+      );
+      const segment = createCacheSegment({ flagged: true, flagReasons: ['blend_mode'] });
+      useRenderCacheStore.setState({ status: createCacheStatus(segment) });
+
+      render(<TimelinePreviewPlayer showControls={false} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+          'data-frame-source',
+          'cache',
+        );
+      });
+
+      act(() => {
+        useRenderCacheStore.setState({
+          status: createCacheStatus({ ...segment, state: 'stale', fingerprint: '43' }),
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('timeline-preview-player')).toHaveAttribute(
+          'data-frame-source',
+          'live',
+        );
+      });
+      expect(await screen.findByTestId('preview-draft-badge')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/preview/TimelinePreviewPlayer.tsx
+++ b/src/components/preview/TimelinePreviewPlayer.tsx
@@ -19,6 +19,7 @@ import { useRef, useEffect, useCallback, useState, useMemo, memo, type KeyboardE
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { usePlaybackStore } from '@/stores/playbackStore';
 import { useProjectStore } from '@/stores/projectStore';
+import { useRenderCacheStore } from '@/stores/renderCacheStore';
 import { usePlaybackLoop } from '@/hooks/usePlaybackLoop';
 import { useSequenceRenderGraph } from '@/hooks/useSequenceRenderGraph';
 import { useSequenceTextClipData } from '@/hooks/useSequenceTextClipData';
@@ -36,12 +37,20 @@ import { getActiveVisualLayers } from '@/utils/renderGraphLayers';
 import { isCaptionLikeClip } from '@/utils/captionClip';
 import { getEffectiveBlendMode } from '@/utils/blendModes';
 import {
+  cacheFrameAssetId,
+  cacheFrameOffsetSec,
+  cacheSegmentsForSequence,
+  findSegmentForTime,
+  resolveCachedSegmentForTime,
+} from '@/utils/cacheFrameSource';
+import {
   captionColorToRgba,
   getCaptionFontWeightNumber,
   normalizeCaptionPosition as normalizeCaptionPositionValue,
   normalizeCaptionStyle as normalizeCaptionStyleValue,
   resolveCaptionAnchor,
 } from '@/utils/captionStyle';
+import { PreviewDraftBadge } from './PreviewDraftBadge';
 import { SeekBar } from './SeekBar';
 import { TextPlacementOverlay, type TextPlacementCommitPayload } from './TextPlacementOverlay';
 import { TransformOverlay } from './TransformOverlay';
@@ -99,6 +108,15 @@ interface ActiveClipInfo {
 
 type DrawableVisual = HTMLImageElement | HTMLCanvasElement | ImageBitmap;
 
+/**
+ * Origin of the frame on screen.
+ *
+ * `cache` means the pixels were decoded from a render-cache segment, which the
+ * export pipeline produced — the frame is the export composite, not a guess.
+ * `live` means this component composited it from the source clips.
+ */
+type FrameSource = 'cache' | 'live';
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -144,6 +162,25 @@ function frameTargetForClip(
     maxWidth: Math.max(1, Math.round(canvasWidth * zoom)),
     maxHeight: Math.max(1, Math.round(canvasHeight * zoom)),
   };
+}
+
+/** Frame rate assumed when a sequence carries an unusable one. */
+const FALLBACK_SEQUENCE_FPS = 30;
+
+/**
+ * The sequence's frame rate as a number.
+ *
+ * The cached segment files sit on this grid, so the rate is what turns a
+ * timeline time into the frame the renderer actually wrote.
+ */
+function getSequenceFps(sequence: Sequence): number {
+  const fps = sequence.format?.fps;
+  if (!fps || fps.den === 0) {
+    return FALLBACK_SEQUENCE_FPS;
+  }
+
+  const value = fps.num / fps.den;
+  return Number.isFinite(value) && value > 0 ? value : FALLBACK_SEQUENCE_FPS;
 }
 
 /** Map BlendMode to Canvas globalCompositeOperation.
@@ -232,6 +269,15 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ width, height });
   const [isMultiFrameLoading, setIsMultiFrameLoading] = useState(false);
+  /**
+   * Where the picture currently on the visible canvas came from.
+   *
+   * Mirrored in a ref so the render pump can update it without the state write
+   * being part of a render-time dependency; the state copy exists only so the
+   * DRAFT badge can react to it.
+   */
+  const frameSourceRef = useRef<FrameSource>('live');
+  const [frameSource, setFrameSource] = useState<FrameSource>('live');
 
   // Ref to track latest render request time (for race condition prevention)
   const lastRenderTimeRef = useRef<number>(0);
@@ -431,6 +477,20 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         console.error('TimelinePreviewPlayer: Failed to get 2D canvas context');
         return;
       }
+
+      // Local rather than a hook callback so publishing the frame's origin costs
+      // renderFrame no dependency: its identity has to stay stable across cache
+      // status changes or every fill event would restart the render pump.
+      const applyFrameSource = (source: FrameSource): void => {
+        if (frameSourceRef.current === source) {
+          return;
+        }
+
+        frameSourceRef.current = source;
+        if (isMountedRef.current) {
+          setFrameSource(source);
+        }
+      };
 
       const renderSequenceToCanvas = async (
         targetCtx: CanvasRenderingContext2D,
@@ -653,6 +713,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
       };
 
       if (!activeSequence) {
+        applyFrameSource('live');
         ctx.fillStyle = '#000000';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         return;
@@ -662,6 +723,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
 
       if (activeClips.length === 0) {
         // No clips at this time - clear canvas and show black
+        applyFrameSource('live');
         ctx.fillStyle = '#000000';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         return;
@@ -690,6 +752,90 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
       // cache eviction, so a sequence with more clips than the cache's byte
       // budget holds cannot have a frame closed under it mid-composite.
       videoFrameBuffer.beginRenderPass();
+
+      // =====================================================================
+      // Cache-first frame (paused only)
+      // =====================================================================
+      //
+      // A cached segment file is what the export pipeline wrote, so one decode
+      // of it gives the exact composite for this instant instead of the live
+      // canvas' approximation of it. It is only attempted while paused: during
+      // playback the extra decode would compete with the per-clip decoders for
+      // the frame budget, and degrading the picture while the transport runs is
+      // the accepted trade every NLE makes.
+      //
+      // The store is read through `getState()` rather than a subscription so
+      // that a cache fill landing cannot change `renderFrame`'s identity and
+      // restart the render pump mid-frame.
+      if (!usePlaybackStore.getState().isPlaying) {
+        const { status: cacheStatus, deadCachedPaths } = useRenderCacheStore.getState();
+        // Gated on the snapshot's own sequence id: a snapshot taken before a
+        // sequence switch names files under the previous sequence's cache
+        // directory, and drawing one would show a different edit's picture
+        // labelled as this one's exact composite.
+        const segment = resolveCachedSegmentForTime(
+          cacheSegmentsForSequence(cacheStatus, activeSequence.id),
+          time,
+          deadCachedPaths,
+        );
+        const cachedPath = segment?.cachedPath ?? null;
+
+        if (segment && cachedPath) {
+          // The cached file is the whole composite already framed to the
+          // sequence canvas, so it is decoded at canvas size: the per-clip zoom
+          // inflation would only ask for pixels nothing will magnify.
+          const cachedFrame = await extractFrameForAsset(
+            cacheFrameAssetId(activeSequence.id, segment),
+            cachedPath,
+            cacheFrameOffsetSec(segment, time, getSequenceFps(activeSequence)),
+            { maxWidth: frameCanvas.width, maxHeight: frameCanvas.height },
+          );
+
+          // Unmount is checked as well as staleness: `clearAll()` runs in an
+          // earlier cleanup than the mount flag, so a decode still in flight
+          // when the player goes away resolves null for that reason alone. Left
+          // ungated it would retire a perfectly healthy file in the
+          // module-global dead set, for every later consumer.
+          if (!isMountedRef.current || time !== lastRenderTimeRef.current) {
+            return;
+          }
+
+          if (cachedFrame) {
+            // Final pixels: no clip transform, opacity or blend mode applies —
+            // the segment file already has all of that baked in.
+            frameCtx.fillStyle = '#000000';
+            frameCtx.fillRect(0, 0, frameCanvas.width, frameCanvas.height);
+
+            const fitScale = computeContainFit(
+              Math.max(1, cachedFrame.width),
+              Math.max(1, cachedFrame.height),
+              frameCanvas.width,
+              frameCanvas.height,
+            );
+            const drawWidth = cachedFrame.width * fitScale;
+            const drawHeight = cachedFrame.height * fitScale;
+            frameCtx.drawImage(
+              cachedFrame,
+              (frameCanvas.width - drawWidth) / 2,
+              (frameCanvas.height - drawHeight) / 2,
+              drawWidth,
+              drawHeight,
+            );
+
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(frameCanvas, 0, 0);
+
+            applyFrameSource('cache');
+            onFrameRender?.(time);
+            return;
+          }
+
+          // The manifest still names this file but it did not decode — evicted,
+          // or truncated by a crash. Retiring it here stops every consumer from
+          // reaching for it again until the next status refresh proves otherwise.
+          useRenderCacheStore.getState().markCachedPathDead(cachedPath);
+        }
+      }
 
       // Track loading state via ref to avoid re-renders during playback
       // Only update React state when transitioning between loading/not-loading
@@ -720,6 +866,7 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         ctx.drawImage(frameCanvas, 0, 0);
 
+        applyFrameSource('live');
         onFrameRender?.(time);
       } finally {
         // Clear multi-frame loading state even when a stale render exits early.
@@ -825,6 +972,82 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
       requestRenderFrame(currentTime);
     }
   }, [currentTime, requestRenderFrame]);
+
+  // Tracks the previous transport state so the pause edge can be detected.
+  const wasPlayingRef = useRef(isPlaying);
+
+  // Upgrade the parked frame when playback stops.
+  //
+  // The frame left on screen by the last played frame is a live composite,
+  // because the cache-first path deliberately stands aside during playback.
+  // Re-requesting the same time on the pause edge lets it be redrawn from the
+  // cache. The seek-skip guard is dropped to a value no time can equal, which
+  // is how this render is forced through: the playhead has not moved, so the
+  // scrub effect would otherwise dismiss the redraw as a duplicate.
+  useEffect(() => {
+    const wasPlaying = wasPlayingRef.current;
+    wasPlayingRef.current = isPlaying;
+
+    if (!wasPlaying || isPlaying) {
+      return;
+    }
+
+    lastSeekRenderTimeRef.current = -1;
+    requestRenderFrame(usePlaybackStore.getState().currentTime);
+  }, [isPlaying, requestRenderFrame]);
+
+  const cacheStatus = useRenderCacheStore((state) => state.status);
+
+  /**
+   * The cache segment the playhead is parked in, from a snapshot that actually
+   * describes this sequence.
+   */
+  const parkedSegment = useMemo(
+    () =>
+      findSegmentForTime(
+        cacheSegmentsForSequence(cacheStatus, activeSequence?.id ?? null),
+        currentTime,
+      ),
+    [activeSequence, cacheStatus, currentTime],
+  );
+
+  const deadCachedPaths = useRenderCacheStore((state) => state.deadCachedPaths);
+
+  /**
+   * Everything about the parked segment that can change what is drawn.
+   *
+   * A long fill emits a status snapshot per completed segment, and each is a
+   * fresh object; keying the upgrade effect on the snapshot itself would run a
+   * full recomposite a hundred times over for segments the playhead is nowhere
+   * near. Only a change to the segment under the playhead can change its
+   * picture — including whether its file is currently believed playable, which
+   * is how a refreshed snapshot clearing a death mark becomes visible here.
+   */
+  const parkedSegmentKey = parkedSegment
+    ? [
+        parkedSegment.index,
+        parkedSegment.state,
+        parkedSegment.fingerprint,
+        parkedSegment.cachedPath !== null && !deadCachedPaths.has(parkedSegment.cachedPath)
+          ? 'usable'
+          : 'unusable',
+      ].join(':')
+    : null;
+
+  // Upgrade the parked frame when its own segment changes state.
+  //
+  // A fill lands asynchronously and changes nothing the render pump watches, so
+  // without this the parked frame would keep showing the live guess until the
+  // playhead next moved. The reverse case matters too: an edit re-fingerprints
+  // the segment to stale, and this is what replaces the cached pixels of the
+  // pre-edit composite with an honest live draft.
+  useEffect(() => {
+    if (isPlaying || parkedSegmentKey === null) {
+      return;
+    }
+
+    requestRenderFrame(usePlaybackStore.getState().currentTime);
+  }, [parkedSegmentKey, isPlaying, requestRenderFrame]);
 
   // Release the decoded frames and the FFmpeg processes behind them when the
   // canvas preview goes away, so nothing keeps decoding for a player that is no
@@ -940,6 +1163,15 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
     [containerSize.width, containerSize.height, width, height],
   );
 
+  /**
+   * Whether the segment under the playhead is one the live preview cannot draw
+   * faithfully. Says nothing about where the frame on screen came from — that is
+   * `frameSource`, and only the two together mean "what you see is a draft".
+   */
+  const isFlaggedAtCurrentTime = parkedSegment?.flagged === true;
+
+  const showDraftBadge = !isPlaying && isFlaggedAtCurrentTime && frameSource === 'live';
+
   // ===========================================================================
   // Render Empty State
   // ===========================================================================
@@ -979,6 +1211,9 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
     <div
       ref={containerRef}
       data-testid="timeline-preview-player"
+      // Exposed so a test — and a human reading the DOM — can tell an exact
+      // cached frame from a live composite without inspecting pixels.
+      data-frame-source={frameSource}
       className={`relative isolate bg-black overflow-hidden ${className}`}
       style={{ aspectRatio, cursor: textPlacementModeActive ? 'text' : undefined }}
       tabIndex={0}
@@ -1014,6 +1249,9 @@ export const TimelinePreviewPlayer = memo(function TimelinePreviewPlayer({
         onCommit={onTextPlacementCommit}
         zIndex={40}
       />
+
+      {/* Draft Frame Warning */}
+      {showDraftBadge && <PreviewDraftBadge />}
 
       {/* Loading Indicator */}
       {isMultiFrameLoading && (

--- a/src/hooks/useIdleCacheFill.test.ts
+++ b/src/hooks/useIdleCacheFill.test.ts
@@ -268,6 +268,71 @@ describe('useIdleCacheFill', () => {
     expect(commands.renderPreviewCache).toHaveBeenCalledTimes(1);
   });
 
+  describe('cache status freshness', () => {
+    it('should re-key the status snapshot immediately when the sequence changes', async () => {
+      // The cache-first preview draws from this snapshot. Left until the idle
+      // window, it would keep naming the previous sequence's segment files.
+      renderHook(() => useIdleCacheFill());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      vi.mocked(commands.getCacheStatus).mockClear();
+
+      act(() => {
+        useProjectStore.setState({ activeSequenceId: 'seq2' });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(commands.getCacheStatus).toHaveBeenCalled();
+    });
+
+    it('should re-key the status snapshot immediately after an edit', async () => {
+      // Until the backend re-fingerprints, the snapshot reports the pre-edit
+      // composite as cached and the preview would present it as exact.
+      renderHook(() => useIdleCacheFill());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      vi.mocked(commands.getCacheStatus).mockClear();
+
+      commitEdit();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(commands.getCacheStatus).toHaveBeenCalled();
+      // Well before the debounced fill would have run.
+      expect(commands.renderPreviewCache).not.toHaveBeenCalled();
+    });
+
+    it('should re-key the status snapshot even with background caching off', async () => {
+      // Nothing else refreshes it in that mode, so the snapshot would otherwise
+      // stay stale without bound.
+      act(() => {
+        useSettingsStore.setState((state) => {
+          state.settings.performance.backgroundRenderCache = false;
+        });
+      });
+
+      renderHook(() => useIdleCacheFill());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      vi.mocked(commands.getCacheStatus).mockClear();
+
+      act(() => {
+        useProjectStore.setState({ activeSequenceId: 'seq2' });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(commands.getCacheStatus).toHaveBeenCalled();
+    });
+  });
+
   it('should stay inert when no sequence is active', async () => {
     act(() => {
       useProjectStore.setState({ activeSequenceId: null });

--- a/src/hooks/useIdleCacheFill.ts
+++ b/src/hooks/useIdleCacheFill.ts
@@ -30,6 +30,14 @@
  * "Per activation" rather than per sequence: leaving a sequence and coming
  * back arms another warm-up, since the cache may have been evicted meanwhile.
  *
+ * ## It also keeps the status snapshot honest
+ *
+ * Independently of the fill, it refreshes the cache status as soon as the
+ * active sequence or the project version changes. The cache-first preview draws
+ * from that snapshot, so a stale one is not merely out of date — it is what
+ * would put another sequence's frames, or a pre-edit composite, on screen
+ * labelled exact.
+ *
  * Mount this exactly once, at the editor root.
  */
 
@@ -105,6 +113,24 @@ export function useIdleCacheFill(): void {
         }
       });
   }, []);
+
+  // Re-key the cache snapshot immediately, before any debounce.
+  //
+  // The snapshot is what the cache-first preview trusts, and it is only as
+  // fresh as the last event that happened to refresh it. Two changes make it a
+  // liability the moment they land: a sequence switch leaves it describing
+  // another sequence's segment files, and an edit leaves it reporting pre-edit
+  // pixels as cached. Both are corrected by one round-trip, so it is taken
+  // straight away rather than after the idle window — and independently of the
+  // `enabled` toggle, since with background caching off nothing else would ever
+  // refresh it.
+  useEffect(() => {
+    if (!isDesktopRuntimeAvailable() || !activeSequenceId) {
+      return;
+    }
+
+    void useRenderCacheStore.getState().refreshStatus();
+  }, [activeSequenceId, stateVersion]);
 
   useEffect(() => {
     if (!isDesktopRuntimeAvailable() || !activeSequenceId || !enabled) {

--- a/src/utils/cacheFrameSource.test.ts
+++ b/src/utils/cacheFrameSource.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import type { CacheSegmentStatusDto, RenderCacheStatus } from '@/bindings';
+import {
+  cacheFrameAssetId,
+  cacheFrameOffsetSec,
+  cacheSegmentsForSequence,
+  findSegmentForTime,
+  resolveCachedSegmentForTime,
+} from './cacheFrameSource';
+
+function createSegment(overrides: Partial<CacheSegmentStatusDto> = {}): CacheSegmentStatusDto {
+  return {
+    index: 0,
+    startSec: 0,
+    endSec: 5,
+    state: 'cached',
+    fingerprint: '42',
+    cachedPath: '/cache/seq/seg-0.mov',
+    flagged: false,
+    flagReasons: [],
+    ...overrides,
+  };
+}
+
+const NO_DEAD_PATHS: ReadonlySet<string> = new Set<string>();
+
+describe('findSegmentForTime', () => {
+  const segments = [
+    createSegment({ index: 0, startSec: 0, endSec: 5 }),
+    createSegment({ index: 1, startSec: 5, endSec: 10, cachedPath: '/cache/seq/seg-1.mov' }),
+  ];
+
+  it('should return the segment owning the time when the time is inside it', () => {
+    expect(findSegmentForTime(segments, 2.5)?.index).toBe(0);
+    expect(findSegmentForTime(segments, 7)?.index).toBe(1);
+  });
+
+  it('should treat a segment boundary as belonging to the later segment', () => {
+    expect(findSegmentForTime(segments, 5)?.index).toBe(1);
+  });
+
+  it('should clamp the very end of the timeline into the last segment', () => {
+    // The playhead can park exactly on the final end time and no later segment
+    // owns that instant.
+    expect(findSegmentForTime(segments, 10)?.index).toBe(1);
+  });
+
+  it('should return null when the time falls outside every segment', () => {
+    expect(findSegmentForTime(segments, -1)).toBeNull();
+    expect(findSegmentForTime(segments, 10.5)).toBeNull();
+  });
+
+  it('should return null when there are no segments or the time is not finite', () => {
+    expect(findSegmentForTime([], 1)).toBeNull();
+    expect(findSegmentForTime(segments, Number.NaN)).toBeNull();
+  });
+});
+
+describe('resolveCachedSegmentForTime', () => {
+  it('should return the segment when it is cached with a usable path', () => {
+    const segments = [createSegment()];
+
+    expect(resolveCachedSegmentForTime(segments, 1, NO_DEAD_PATHS)?.index).toBe(0);
+  });
+
+  it('should serve a flagged segment, because a cached frame is the export composite', () => {
+    const segments = [createSegment({ flagged: true, flagReasons: ['blend_mode'] })];
+
+    expect(resolveCachedSegmentForTime(segments, 1, NO_DEAD_PATHS)).not.toBeNull();
+  });
+
+  it('should exclude a segment whose file another consumer found unplayable', () => {
+    const segments = [createSegment()];
+    const dead = new Set(['/cache/seq/seg-0.mov']);
+
+    expect(resolveCachedSegmentForTime(segments, 1, dead)).toBeNull();
+  });
+
+  it('should exclude segments that are not cached', () => {
+    for (const state of ['empty', 'rendering', 'stale', 'error'] as const) {
+      const segments = [createSegment({ state })];
+
+      expect(resolveCachedSegmentForTime(segments, 1, NO_DEAD_PATHS)).toBeNull();
+    }
+  });
+
+  it('should exclude a cached segment the backend refused to hand a path for', () => {
+    const segments = [createSegment({ cachedPath: null })];
+
+    expect(resolveCachedSegmentForTime(segments, 1, NO_DEAD_PATHS)).toBeNull();
+  });
+});
+
+describe('cacheSegmentsForSequence', () => {
+  const status: RenderCacheStatus = {
+    enabled: true,
+    sequenceId: 'sequence-1',
+    totalSegments: 1,
+    cachedSegments: 1,
+    staleSegments: 0,
+    renderingSegments: 0,
+    completionPercent: 100,
+    totalCachedBytes: 1024,
+    maxCacheBytes: 1073741824,
+    segmentStates: [createSegment()],
+  };
+
+  it('should hand back the segments when the snapshot describes the sequence', () => {
+    expect(cacheSegmentsForSequence(status, 'sequence-1')).toHaveLength(1);
+  });
+
+  it('should hand back nothing when the snapshot describes another sequence', () => {
+    // A snapshot taken before a sequence switch names files under the previous
+    // sequence's cache directory; drawing one would show a different edit.
+    expect(cacheSegmentsForSequence(status, 'sequence-2')).toHaveLength(0);
+    expect(
+      resolveCachedSegmentForTime(cacheSegmentsForSequence(status, 'sequence-2'), 1, NO_DEAD_PATHS),
+    ).toBeNull();
+  });
+
+  it('should hand back nothing without a snapshot or without a sequence', () => {
+    expect(cacheSegmentsForSequence(null, 'sequence-1')).toHaveLength(0);
+    expect(cacheSegmentsForSequence(status, null)).toHaveLength(0);
+  });
+});
+
+describe('cacheFrameAssetId', () => {
+  it('should embed the fingerprint so a re-rendered segment gets a fresh identity', () => {
+    const before = cacheFrameAssetId('seq-1', createSegment({ index: 3, fingerprint: '111' }));
+    const after = cacheFrameAssetId('seq-1', createSegment({ index: 3, fingerprint: '222' }));
+
+    expect(before).toBe('__cache__seq-1_3_111');
+    expect(after).not.toBe(before);
+  });
+});
+
+describe('cacheFrameOffsetSec', () => {
+  /** 30000/1001 — the rate whose grid does not line up with whole seconds. */
+  const NTSC_FPS = 30000 / 1001;
+  const INTEGER_FPS = 30;
+
+  /** The frame index the decoder resolves an offset to: nearest, not floor. */
+  function frameIndexAt(offsetSec: number, fps: number): number {
+    return Math.round(offsetSec * fps);
+  }
+
+  it('should convert a timeline time into an offset inside the segment file', () => {
+    const segment = createSegment({ startSec: 5, endSec: 10 });
+
+    expect(cacheFrameOffsetSec(segment, 7.5, INTEGER_FPS)).toBeCloseTo(2.5, 6);
+  });
+
+  it('should never return a negative offset', () => {
+    const segment = createSegment({ startSec: 5, endSec: 10 });
+
+    expect(cacheFrameOffsetSec(segment, 4, INTEGER_FPS)).toBe(0);
+  });
+
+  it('should resolve a time parked inside the final frame to the last frame the file holds', () => {
+    // The decoder addresses by nearest frame and errors out of range instead of
+    // saturating, so anything rounding past the end would fail the decode — and
+    // a failed decode retires the whole segment as unplayable.
+    const segment = createSegment({ startSec: 0, endSec: 5 });
+    const quarterFrameBeforeEnd = 5 - 0.25 / NTSC_FPS;
+
+    const offset = cacheFrameOffsetSec(segment, quarterFrameBeforeEnd, NTSC_FPS);
+
+    // The renderer's window is round(0 * fps)..round(5 * fps) = frames 0..149.
+    expect(frameIndexAt(offset, NTSC_FPS)).toBe(149);
+  });
+
+  it('should clamp the segment end itself onto the last frame', () => {
+    const segment = createSegment({ startSec: 0, endSec: 5 });
+
+    expect(frameIndexAt(cacheFrameOffsetSec(segment, 5, NTSC_FPS), NTSC_FPS)).toBe(149);
+  });
+
+  it('should address through the frame grid so an NTSC segment start keeps its phase', () => {
+    // Segment bounds are whole seconds but the renderer snaps its window to
+    // round(t * fps) and rebases the file to zero, so file frame 0 sits up to
+    // half a frame away from startSec. Segment 1 starts 0.15 frames late.
+    const segment = createSegment({ index: 1, startSec: 5, endSec: 10 });
+
+    const offset = cacheFrameOffsetSec(segment, 7.5, NTSC_FPS);
+
+    expect(offset).toBeCloseTo((Math.round(7.5 * NTSC_FPS) - 150) / NTSC_FPS, 9);
+    expect(offset).not.toBeCloseTo(2.5, 6);
+  });
+
+  it('should pick the frame the renderer wrote where a naive offset picks its neighbour', () => {
+    // Segment 3 starts 0.45 frames early, which is enough to shift the rounding.
+    const segment = createSegment({ index: 3, startSec: 15, endSec: 20 });
+
+    const offset = cacheFrameOffsetSec(segment, 17.5, NTSC_FPS);
+
+    expect(frameIndexAt(offset, NTSC_FPS)).toBe(74);
+    expect(frameIndexAt(17.5 - 15, NTSC_FPS)).toBe(75);
+  });
+
+  it('should keep the grid offset correct where the segment start rounds down', () => {
+    // Segment 4 starts 0.4 frames late — the opposite phase to segment 3.
+    const segment = createSegment({ index: 4, startSec: 20, endSec: 25 });
+
+    const offset = cacheFrameOffsetSec(segment, 20.05, NTSC_FPS);
+
+    expect(frameIndexAt(offset, NTSC_FPS)).toBe(2);
+    expect(frameIndexAt(20.05 - 20, NTSC_FPS)).toBe(1);
+  });
+
+  it('should address the only frame of a segment shorter than one frame', () => {
+    const segment = createSegment({ startSec: 5, endSec: 5.01 });
+
+    expect(cacheFrameOffsetSec(segment, 5.009, NTSC_FPS)).toBe(0);
+  });
+
+  it('should fall back to a continuous offset when the frame rate is unusable', () => {
+    const segment = createSegment({ startSec: 5, endSec: 10 });
+
+    expect(cacheFrameOffsetSec(segment, 7.5, 0)).toBeCloseTo(2.5, 6);
+    expect(cacheFrameOffsetSec(segment, 10, Number.NaN)).toBeCloseTo(4.999, 6);
+  });
+});

--- a/src/utils/cacheFrameSource.ts
+++ b/src/utils/cacheFrameSource.ts
@@ -1,0 +1,194 @@
+/**
+ * Cache Frame Source
+ *
+ * Pure lookup rules for serving a preview frame out of the render cache instead
+ * of re-compositing it live.
+ *
+ * ## Why cache-first applies to every fresh segment, flagged or not
+ *
+ * A cached segment file is produced by the export pipeline, so a frame decoded
+ * from it *is* the export composite for that instant — not an approximation of
+ * it. That makes it strictly better than the live canvas guess even where the
+ * live guess is believed faithful: identical picture, no per-clip decode fan-out,
+ * one read from an all-keyframe intra file. The `flagged` bit therefore has no
+ * say in whether the cache may be used; it only says how wrong the *live*
+ * fallback would be when the cache has nothing to offer, which is what drives
+ * the DRAFT badge.
+ *
+ * Freshness is carried by the segment fingerprint rather than by the file path:
+ * a re-rendered segment keeps its path but changes its fingerprint, so frame
+ * addressing that embeds the fingerprint retires stale entries automatically.
+ */
+
+import type { CacheSegmentStatusDto, RenderCacheStatus } from '@/bindings';
+
+/**
+ * Slack subtracted from a segment's end when the frame rate is unusable.
+ *
+ * Only a fallback: with a real frame rate the end clamp is half a frame (see
+ * {@link cacheFrameOffsetSec}), because the decoder addresses by nearest frame
+ * and errors out of range rather than saturating.
+ */
+export const CACHE_SEGMENT_END_EPSILON_SEC = 0.001;
+
+/**
+ * The segments of a cache snapshot, but only if it describes `sequenceId`.
+ *
+ * The status snapshot is refreshed asynchronously, so right after a sequence
+ * switch it still describes the sequence that was open a moment ago — and its
+ * segment paths point into that sequence's cache directory. Serving a frame
+ * from one would put another sequence's picture on screen labelled as the exact
+ * composite, which is worse than any live approximation. Every consumer of a
+ * snapshot must therefore go through this gate.
+ *
+ * @param status - Latest cache snapshot, or `null` when none has arrived
+ * @param sequenceId - Sequence the caller is drawing, or `null` when there is none
+ * @returns The snapshot's segments, or an empty list when it describes something else
+ */
+export function cacheSegmentsForSequence(
+  status: RenderCacheStatus | null,
+  sequenceId: string | null,
+): readonly CacheSegmentStatusDto[] {
+  if (!status || sequenceId === null || status.sequenceId !== sequenceId) {
+    return [];
+  }
+
+  return status.segmentStates;
+}
+
+/**
+ * Finds the segment covering `timeSec`, regardless of what it holds.
+ *
+ * Segments tile the sequence as half-open ranges `[startSec, endSec)`. The one
+ * exception is the very end of the timeline: the playhead can park exactly on
+ * the final segment's `endSec`, and there is no later segment to own that
+ * instant, so it is clamped back into the last segment.
+ *
+ * @param segments - Per-segment cache status, in any order
+ * @param timeSec - Timeline time in seconds
+ * @returns The covering segment, or `null` when the time falls outside every segment
+ */
+export function findSegmentForTime(
+  segments: readonly CacheSegmentStatusDto[],
+  timeSec: number,
+): CacheSegmentStatusDto | null {
+  if (!Number.isFinite(timeSec) || segments.length === 0) {
+    return null;
+  }
+
+  let lastSegment: CacheSegmentStatusDto | null = null;
+
+  for (const segment of segments) {
+    if (timeSec >= segment.startSec && timeSec < segment.endSec) {
+      return segment;
+    }
+
+    if (lastSegment === null || segment.endSec > lastSegment.endSec) {
+      lastSegment = segment;
+    }
+  }
+
+  if (lastSegment !== null && timeSec === lastSegment.endSec) {
+    return lastSegment;
+  }
+
+  return null;
+}
+
+/**
+ * Finds the segment covering `timeSec` whose cached file may be drawn from.
+ *
+ * Only a `cached` segment with an allowlisted path qualifies, and only while no
+ * consumer has reported that file unplayable since the last status refresh.
+ *
+ * @param segments - Per-segment cache status, in any order
+ * @param timeSec - Timeline time in seconds
+ * @param deadPaths - Cached files a consumer already found unplayable
+ * @returns The segment to decode from, or `null` to fall back to the live composite
+ */
+export function resolveCachedSegmentForTime(
+  segments: readonly CacheSegmentStatusDto[],
+  timeSec: number,
+  deadPaths: ReadonlySet<string>,
+): CacheSegmentStatusDto | null {
+  const segment = findSegmentForTime(segments, timeSec);
+  if (!segment || segment.state !== 'cached') {
+    return null;
+  }
+
+  const { cachedPath } = segment;
+  if (cachedPath === null || deadPaths.has(cachedPath)) {
+    return null;
+  }
+
+  return segment;
+}
+
+/**
+ * Builds the frame-buffer asset id a cached segment's file is addressed under.
+ *
+ * The fingerprint is part of the id on purpose: the frame buffer and its
+ * downstream frame cache key on the asset id, so a re-rendered segment (same
+ * path, new fingerprint) becomes a different asset and cannot be served a frame
+ * decoded from the picture it used to hold.
+ *
+ * @param sequenceId - Sequence the segment belongs to
+ * @param segment - Cached segment being drawn from
+ * @returns A frame-buffer asset id unique to this segment revision
+ */
+export function cacheFrameAssetId(sequenceId: string, segment: CacheSegmentStatusDto): string {
+  return `__cache__${sequenceId}_${segment.index}_${segment.fingerprint}`;
+}
+
+/**
+ * Converts a timeline time into an offset inside a cached segment's file.
+ *
+ * ## Why the offset goes through the frame grid
+ *
+ * A segment's declared bounds are wall-clock seconds, but the renderer snaps
+ * its window to the frame grid (`round(t * fps)`) and rebases the written file's
+ * timestamps to zero. At a non-integer rate — 29.97, 23.976, 59.94 — a bound
+ * like 15.000s does not sit on a frame, so file frame 0 is up to half a frame
+ * away from `startSec`. Subtracting seconds naively therefore lands on the
+ * neighbouring frame for a large share of parked positions in later segments.
+ * Differencing the two grid positions instead reproduces exactly the frame the
+ * renderer wrote.
+ *
+ * ## Why the end clamp is half a frame
+ *
+ * The decoder addresses by *nearest* frame and treats an out-of-range index as
+ * an error rather than saturating at the last one. Anything inside the final
+ * half-frame of a segment therefore rounds one frame past the end of the file,
+ * and the resulting failure would retire the whole segment as unplayable. The
+ * clamp keeps the request on the last frame the file actually holds.
+ *
+ * @param segment - Segment covering `timeSec`
+ * @param timeSec - Timeline time in seconds
+ * @param fps - Sequence frame rate; a non-positive or non-finite value falls
+ *   back to a continuous offset with a fixed millisecond of end slack
+ * @returns Seconds from the start of the segment file, inside its own duration
+ */
+export function cacheFrameOffsetSec(
+  segment: CacheSegmentStatusDto,
+  timeSec: number,
+  fps: number,
+): number {
+  const durationSec = Math.max(0, segment.endSec - segment.startSec);
+
+  if (!Number.isFinite(fps) || fps <= 0) {
+    const fallbackLastSec = Math.max(0, durationSec - CACHE_SEGMENT_END_EPSILON_SEC);
+    return Math.min(Math.max(0, timeSec - segment.startSec), fallbackLastSec);
+  }
+
+  const frameSec = 1 / fps;
+  // A segment shorter than one frame holds a single frame at offset zero, so
+  // there is nothing to address but the start of the file.
+  if (durationSec < frameSec) {
+    return 0;
+  }
+
+  const gridOffsetFrames = Math.round(timeSec * fps) - Math.round(segment.startSec * fps);
+  const lastAddressableSec = Math.max(0, durationSec - frameSec / 2);
+
+  return Math.min(Math.max(0, gridOffsetFrames * frameSec), lastAddressableSec);
+}


### PR DESCRIPTION
## Why

This PR completes the WYSIWYG loop the preview cache exists for. With #858, flagged segments get rendered through the real export pipeline during idle; but the viewer still always drew the WebView's live composite — which for flagged content is *semantically wrong* (blend modes degrade, transitions are absent, text metrics differ). Now, **while paused, the viewer shows the frame decoded from the lossless cache — byte-identical to the export composite — and when it can't, it says so** with an explicit DRAFT badge. Exact-on-pause, degrade-on-play: Premiere's Paused Resolution model, and the case that matters most for an agent judging a parked frame.

## Change

- **Cache-first seam in `TimelinePreviewPlayer.renderFrame`**: when paused on a time whose segment is cached and fresh (and belongs to the *current* sequence), the frame is decoded from the segment `.mov` through the existing resident-decoder facade (all-keyframe file — one decode per park; never an HTML `<video>`, whose `currentTime` is not frame-accurate) and drawn contain-fit. Decode failure falls back silently to the live composite and retires that path until the next status refresh.
- **Frame-grid-exact addressing** (`cacheFrameSource.ts`, pure + fully unit-tested): the offset into the segment file goes through the frame grid — `(round(t·fps) − round(start·fps)) / fps`, clamped to the last real frame at half-frame precision. The naive `t − start` version served the *neighbouring* frame for up to half of parked positions at NTSC rates (29.97/23.976/59.94) and hard-errored in the final half-frame of every segment; both defects were caught by adversarial review and are pinned by tests that fail against the naive math.
- **DRAFT badge** (`PreviewDraftBadge`): shown only when paused on a *flagged* segment served live — "DRAFT — preview may differ from export". Our live fallback can be a different image, not merely a softer one, which is outside every shipping NLE's draft model — so it is labeled, per the FCP viewer-readout / Premiere proxy-watermark precedent. The viewer container exposes `data-frame-source="cache" | "live"`.
- **Freshness ties**: an edit or sequence switch refreshes the cache snapshot immediately (un-debounced), so a stale frame is never served as exact across an edit; the parked frame upgrades automatically the moment its fill lands, and on the pause transition. The upgrade effect is keyed on the covering segment's identity, not the whole snapshot, so a long fill's per-segment events don't recomposite the parked frame ~120 times.

## Review rounds

Adversarial review found 3 MUST-FIX defects — cross-sequence frames served as cache truth, the end-clamp epsilon 17× too small for nearest-frame addressing (progressively disabling cache-first while scrubbing), and the NTSC phase error — plus unmount-poisoning of the dead-path set and the missing edit-invalidation tie. All fixed; each MUST-FIX has a regression test verified to fail against the unfixed code (7 reproduced failures).

## Verification

- `npx tsc --noEmit`, eslint, prettier clean on authored files.
- Targeted vitest **56/56** (frame-source math 21 incl. NTSC segments 1/3/4 vs naive-neighbour cases; player cache-first/badge/stale-blit/pause-edge/sequence-mismatch; idle-hook refresh ties). Sweep `src/components/preview src/utils src/hooks`: **144 files / 2825 tests passed**.
- Real zustand stores in tests; the only mock is the established `videoFrameBuffer` IPC-boundary seam.

With this, the user-facing loop is closed: edit → flags computed → idle fill through the export pipeline → red "needs render" bar turns green → paused viewer shows the export-accurate frame, or an honestly labeled draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paused timeline previews now use available rendered cache frames for improved visual fidelity.
  * Added a clear draft indicator when previews fall back to live compositing and may differ from exports.
  * Preview frame origins are now surfaced for improved transparency.

* **Bug Fixes**
  * Improved fallback handling when cached frames are unavailable, stale, mismatched, or fail to load.
  * Preview cache status now refreshes promptly after sequence changes and edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->