### PR TITLE
fix(render): follow the resolved FFmpeg's spelling for frame-rate passthrough

### DIFF
--- a/src-tauri/src/core/analysis/visual.rs
+++ b/src-tauri/src/core/analysis/visual.rs
@@ -781,8 +781,12 @@ impl VisualAnalyzer {
             .arg(video_path)
             .arg("-vf")
             .arg("mpdecimate,showinfo")
-            .arg("-vsync")
-            .arg("vfr")
+            // Spelling follows the resolved binary: FFmpeg 7.0 removed
+            // `-vsync`, and builds older than 5.1 do not know `-fps_mode`.
+            .args(crate::core::ffmpeg::frame_rate_policy_args(
+                &self.ffmpeg_path,
+                crate::core::ffmpeg::FrameRatePolicy::Vfr,
+            ))
             .arg("-f")
             .arg("null")
             .arg("-")

--- a/src-tauri/src/core/ffmpeg/detection.rs
+++ b/src-tauri/src/core/ffmpeg/detection.rs
@@ -528,6 +528,96 @@ pub(super) fn probe_binary_runs(binary_path: &Path) -> FFmpegResult<()> {
     run_version_probe(binary_path).map(|_| ())
 }
 
+/// How FFmpeg should map decoded frames to output frames.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameRatePolicy {
+    /// One output frame per decoded frame, no rate conversion.
+    Passthrough,
+    /// Keep source timestamps, dropping duplicated frames.
+    Vfr,
+}
+
+impl FrameRatePolicy {
+    fn value(self) -> &'static str {
+        match self {
+            Self::Passthrough => "passthrough",
+            Self::Vfr => "vfr",
+        }
+    }
+}
+
+/// Returns the CLI arguments selecting `policy` in the spelling this FFmpeg
+/// binary understands.
+///
+/// FFmpeg 7.0 removed `-vsync` (deprecated since 5.1), while builds older than
+/// 5.1 do not know its replacement `-fps_mode` — so neither spelling works
+/// everywhere and the choice must follow the resolved binary. The support
+/// check runs `-version` once per binary path and caches the answer for the
+/// life of the process. A version that cannot be parsed (a git build such as
+/// `N-113…`) is treated as modern: the bundled and managed binaries this app
+/// prefers are always current, and only an ancient system fallback still
+/// needs `-vsync`.
+pub fn frame_rate_policy_args(ffmpeg_path: &Path, policy: FrameRatePolicy) -> [&'static str; 2] {
+    let flag = if binary_supports_fps_mode(ffmpeg_path) {
+        "-fps_mode"
+    } else {
+        "-vsync"
+    };
+    [flag, policy.value()]
+}
+
+/// Cached per-binary answer to "does this FFmpeg know `-fps_mode`?".
+fn binary_supports_fps_mode(ffmpeg_path: &Path) -> bool {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, bool>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Ok(map) = cache.lock() {
+        if let Some(&known) = map.get(ffmpeg_path) {
+            return known;
+        }
+    }
+
+    // A binary that cannot even report its version will fail its real spawn
+    // with a clearer error; answer with the modern spelling in the meantime.
+    let supports = run_version_probe(ffmpeg_path)
+        .map(|line| version_line_supports_fps_mode(&line))
+        .unwrap_or(true);
+
+    if let Ok(mut map) = cache.lock() {
+        map.insert(ffmpeg_path.to_path_buf(), supports);
+    }
+    supports
+}
+
+/// Decides `-fps_mode` support from the first line of `ffmpeg -version`.
+///
+/// `-fps_mode` arrived in 5.1, so any parseable `major.minor` at or above that
+/// answers yes. Unparseable versions (git builds, vendor strings) answer yes —
+/// see [`frame_rate_policy_args`] for why modern is the right default.
+fn version_line_supports_fps_mode(first_line: &str) -> bool {
+    let Some(rest) = first_line.strip_prefix("ffmpeg version ") else {
+        return true;
+    };
+    let Some(token) = rest.split_whitespace().next() else {
+        return true;
+    };
+    // Accept distro spellings like "n6.1.1" alongside plain "6.1.1".
+    let token = token.strip_prefix(['n', 'N']).unwrap_or(token);
+
+    let mut numbers = token
+        .split(['.', '-', '_'])
+        .map(|part| part.parse::<u32>().ok());
+    let Some(Some(major)) = numbers.next() else {
+        return true;
+    };
+    let minor = numbers.next().flatten().unwrap_or(0);
+
+    major > 5 || (major == 5 && minor >= 1)
+}
+
 /// Validate that FFmpeg binaries are functional
 pub fn validate_ffmpeg(info: &FFmpegInfo) -> FFmpegResult<()> {
     // Test ffmpeg
@@ -803,5 +893,57 @@ mod tests {
                 panic!("Unexpected error: {}", e);
             }
         }
+    }
+
+    #[test]
+    fn should_choose_fps_mode_for_releases_at_or_above_5_1() {
+        for line in [
+            "ffmpeg version 5.1 Copyright (c) 2000-2022",
+            "ffmpeg version 5.1.2-static https://johnvansickle.com/ffmpeg/",
+            "ffmpeg version 6.1.1-3ubuntu5 Copyright (c) 2000-2023",
+            "ffmpeg version n7.0.2 Copyright (c) 2000-2024",
+            "ffmpeg version 9.0.1-essentials_build-www.gyan.dev Copyright (c)",
+        ] {
+            assert!(
+                version_line_supports_fps_mode(line),
+                "expected modern: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_fall_back_to_vsync_for_releases_below_5_1() {
+        for line in [
+            "ffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright (c) 2000-2021",
+            "ffmpeg version n5.0.3 Copyright (c) 2000-2022",
+            "ffmpeg version 3.4.11 Copyright (c) 2000-2022",
+        ] {
+            assert!(
+                !version_line_supports_fps_mode(line),
+                "expected legacy: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_treat_an_unparseable_version_as_modern() {
+        // Git builds and vendor strings carry no release number; the binaries
+        // this app bundles or manages are always current, so modern wins.
+        for line in [
+            "ffmpeg version N-113007-g8d24a28d06 Copyright (c) 2000-2023",
+            "ffmpeg version git-2024-01-01-abcdef Copyright (c)",
+            "not an ffmpeg banner at all",
+        ] {
+            assert!(
+                version_line_supports_fps_mode(line),
+                "expected modern: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_spell_the_policy_with_the_flag_the_binary_understands() {
+        assert_eq!(FrameRatePolicy::Passthrough.value(), "passthrough");
+        assert_eq!(FrameRatePolicy::Vfr.value(), "vfr");
     }
 }

--- a/src-tauri/src/core/preview/decoder.rs
+++ b/src-tauri/src/core/preview/decoder.rs
@@ -740,12 +740,13 @@ impl ResidentDecoder {
             .args(["-an", "-sn", "-dn"])
             // Passthrough keeps one output frame per decoded frame; the default
             // rate conversion would duplicate or drop frames on a
-            // variable-rate source and desynchronise the pipe cursor.
-            //
-            // `-vsync 0` rather than the newer `-fps_mode passthrough` it is an
-            // alias for: the resolver can land on a system FFmpeg older than
-            // 5.1, which does not know `-fps_mode` and would refuse to start.
-            .args(["-vsync", "0"])
+            // variable-rate source and desynchronise the pipe cursor. The flag
+            // spelling follows the resolved binary: FFmpeg 7.0 removed
+            // `-vsync`, while builds older than 5.1 do not know `-fps_mode`.
+            .args(crate::core::ffmpeg::frame_rate_policy_args(
+                &self.ffmpeg,
+                crate::core::ffmpeg::FrameRatePolicy::Passthrough,
+            ))
             .args(["-vf", &scale])
             .args(["-f", "rawvideo", "-pix_fmt", "rgba"])
             .arg("-")
@@ -1493,7 +1494,10 @@ mod ffmpeg_backed_tests {
                 "testsrc2=size={TEST_WIDTH}x{TEST_HEIGHT}:rate=30:duration=3"
             ))
             .args(["-vf", "setpts='(if(lt(N,15),N/30,0.5+(N-15)/5))/TB'"])
-            .args(["-vsync", "passthrough"])
+            .args(crate::core::ffmpeg::frame_rate_policy_args(
+                ffmpeg,
+                crate::core::ffmpeg::FrameRatePolicy::Passthrough,
+            ))
             .args(["-c:v", "libx264", "-g", "250", "-pix_fmt", "yuv420p"])
             .arg(&source)
             .output()
@@ -1574,7 +1578,11 @@ mod ffmpeg_backed_tests {
             .args(["-hide_banner", "-loglevel", "error", "-nostdin"])
             .arg("-i")
             .arg(source)
-            .args(["-an", "-sn", "-dn", "-vsync", "0"])
+            .args(["-an", "-sn", "-dn"])
+            .args(crate::core::ffmpeg::frame_rate_policy_args(
+                ffmpeg,
+                crate::core::ffmpeg::FrameRatePolicy::Passthrough,
+            ))
             .args(["-vf", &format!("scale={TEST_WIDTH}:{TEST_HEIGHT}")])
             .args(["-f", "rawvideo", "-pix_fmt", "rgba", "-"])
             .output()


### PR DESCRIPTION
### **User description**
## Why

Found live during end-to-end verification of the cache-first preview: on the current bundled FFmpeg (9.0.1) **every resident-decoder frame extraction fails** with `Unrecognized option 'vsync'` — FFmpeg 7.0 removed `-vsync` (deprecated since 5.1). The decoder deliberately used `-vsync 0` so a pre-5.1 *system* FFmpeg could still start, but that bet inverted: the binaries the app actually prefers (bundled, managed) are modern, and the modern ones now refuse the flag. Impact: the canvas live preview and the new cache-first paused frames both produce nothing but fallbacks. (This was chip task_8bdf1813; now demonstrated against the real dev app.)

## Change

- New `frame_rate_policy_args(ffmpeg_path, policy)` in `core::ffmpeg::detection`: picks `-fps_mode` vs `-vsync` by probing `ffmpeg -version` **once per binary path** (cached for the process lifetime). Parseable version ≥ 5.1 → `-fps_mode`; older → `-vsync`; unparseable (git/vendor builds) → modern, since only an ancient system fallback still needs the legacy spelling.
- Call sites converted: the resident preview decoder's spawn (passthrough) and the shot-detection `mpdecimate` pass in `analysis/visual.rs` (vfr), plus the decoder test helpers.

## Verification

- `cargo test -p openreelio --features gui --lib` → 4324 passed (19 in `core::ffmpeg::detection`, incl. 4 new version-parse tests: ≥5.1, <5.1, unparseable-treated-as-modern, policy spellings).
- `clippy --features gui --lib` and `--all-targets --features dev-full` `-D warnings` clean; `cargo fmt --check` clean.
- **Live proof**: with this patch applied to the running dev app (bundled ffmpeg 9.0.1), `get_preview_frame` on a lossless cache segment went from `Unrecognized option 'vsync'` to returning a frame, and the paused viewer now serves `data-frame-source="cache"` with the DRAFT badge cleared.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Detects FFmpeg version to choose between `-fps_mode` and `-vsync` flags.

- Fixes frame extraction failures on FFmpeg 7.0+ by avoiding deprecated flags.

- Implements a thread-safe cache for FFmpeg version detection results.

- Updates visual analysis and preview decoders to use the dynamic flag selection.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Detection
    D1["frame_rate_policy_args"] -- "checks" --> D2["binary_supports_fps_mode"]
    D2 -- "probes & caches" --> D3["FFmpeg Binary"]
  end
  subgraph Consumers
    C1["VisualAnalyzer"] -- "uses" --> D1
    C2["ResidentDecoder"] -- "uses" --> D1
    C3["Test Helpers"] -- "uses" --> D1
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>visual.rs</strong><dd><code>Update visual analysis to use dynamic FFmpeg flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/analysis/visual.rs

<ul><li>Replaced hardcoded <code>-vsync vfr</code> with dynamic arguments from <br><code>frame_rate_policy_args</code>.<br> <li> Ensures compatibility with modern FFmpeg versions during shot <br>detection.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/860/files#diff-346e15d22b8214a4a6de70119d028f2c78c316b4ff1e958ace769cf773c05b39">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>detection.rs</strong><dd><code>Implement FFmpeg version detection and flag mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/ffmpeg/detection.rs

<ul><li>Added <code>FrameRatePolicy</code> enum to represent <code>Passthrough</code> and <code>Vfr</code> modes.<br> <li> Implemented <code>frame_rate_policy_args</code> to select <code>-fps_mode</code> (≥5.1) or <br><code>-vsync</code> (<5.1).<br> <li> Added a thread-safe <code>CACHE</code> using <code>OnceLock</code> and <code>Mutex</code> to store version <br>probe results.<br> <li> Added comprehensive unit tests for version string parsing and flag <br>selection.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/860/files#diff-0cb454d500c76c6c39a98864a5e353cabf625c2adddfb404f211622b2e338397">+142/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>decoder.rs</strong><dd><code>Adopt dynamic FFmpeg flags in preview decoder and tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/preview/decoder.rs

<ul><li>Updated <code>ResidentDecoder</code> to use dynamic frame rate policy arguments <br>instead of hardcoded <code>-vsync 0</code>.<br> <li> Refactored FFmpeg-backed test helpers to use the new version-aware <br>flag selection.<br> <li> Fixed potential crashes when running against FFmpeg 7.0+ in preview <br>mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/860/files#diff-88c593d7177b81997286310ca70669ae3e15f7db2400bcc78ecb433d9e69d65e">+16/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

