### PR TITLE
feat(agents): give the in-app Codex and Claude Code bridge eyes on the composited edit

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@
 # `cargo test -p openreelio --lib regenerate_text_preset_manifest -- --ignored`.
 # Reformatting it here would only churn against the generator.
 src/data/textPresets.manifest.json
+
+# Agent worktrees checked out inside the repository.
+.claude/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,9 @@ export default tseslint.config(
       'playwright-report/**',
       'test-results/**',
       'coverage/**',
+      // Agent worktrees are checked out inside the repository; linting them
+      // would lint a second copy of the tree (and its build output).
+      '.claude/**',
     ],
   },
   {

--- a/src/agents/external/adapters/openreelioCodexTools.test.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.test.ts
@@ -164,6 +164,51 @@ describe('openreelio.frame_extract', () => {
     expect(responseText(response)).toContain('between');
     expect(invoke).not.toHaveBeenCalled();
   });
+
+  it('should forward the affectedRanges an apply handed back', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      payload: { status: 'ok', mode: 'grid', sheet: { path: 'sheet.jpg' } },
+      images: [{ path: 'sheet.jpg', mimeType: 'image/jpeg', data: IMAGE_BASE64 }],
+    });
+
+    const ranges = [
+      { startSec: 2, endSec: 6 },
+      { startSec: 11.5, endSec: 12 },
+    ];
+    const response = await callTool('frame_extract', { ranges, grid: 'auto', labelCells: true });
+
+    expect(response.success).toBe(true);
+    expect(invoke).toHaveBeenCalledWith(
+      'extract_timeline_frames',
+      expect.objectContaining({
+        request: expect.objectContaining({ ranges, grid: 'auto', labelCells: true }),
+      }),
+    );
+  });
+
+  it('should pin an affected hand-off to the op the apply ended at', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      payload: { status: 'ok', mode: 'grid', sheet: { path: 'sheet.jpg' } },
+      images: [],
+    });
+
+    await callTool('frame_extract', { affected: true, afterOp: ' op-42 ', grid: 'auto' });
+
+    expect(invoke).toHaveBeenCalledWith(
+      'extract_timeline_frames',
+      expect.objectContaining({
+        request: expect.objectContaining({ affected: true, afterOp: 'op-42' }),
+      }),
+    );
+  });
+
+  it('should reject ranges that are not { startSec, endSec } pairs', async () => {
+    const response = await callTool('frame_extract', { ranges: [{ startSec: 1 }] });
+
+    expect(response.success).toBe(false);
+    expect(responseText(response)).toContain('ranges');
+    expect(invoke).not.toHaveBeenCalled();
+  });
 });
 
 describe('openreelio.render_proxy', () => {
@@ -663,6 +708,118 @@ describe('executeOpenReelioAgentToolCall', () => {
   });
 });
 
+describe('openreelio.command_execute inspection hand-off', () => {
+  const APPROVING_CONTEXT: OpenReelioCodexToolContext = {
+    ...CONTEXT,
+    approvalDecisionProvider: () => 'accept',
+  };
+
+  /** Answer every backend call one approved command makes; `planResult` is the apply's report. */
+  function stubApprovedCommand(planResult: Record<string, unknown>): void {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      switch (command) {
+        case 'get_project_state':
+          return Promise.resolve({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+        case 'validate_command_payload':
+          return Promise.resolve(null);
+        case 'create_external_agent_approval_token':
+          return Promise.resolve({
+            token: 'approval-token',
+            tokenId: 'token-1',
+            projectId: 'project-1',
+            runtimeId: 'codex',
+          });
+        case 'execute_agent_plan':
+          return Promise.resolve(planResult);
+        default:
+          return Promise.reject(new Error(`unexpected command '${command}'`));
+      }
+    });
+  }
+
+  async function applySplitClip(): Promise<{ nextStep?: string; affectedRanges?: unknown }> {
+    const state = await handleOpenReelioCodexDynamicToolCall(
+      callRequest('project_state'),
+      APPROVING_CONTEXT,
+    );
+    if (!state) {
+      throw new Error('Expected a project_state response');
+    }
+    const { contextToken } = JSON.parse(responseText(state)) as { contextToken: string };
+
+    const response = await handleOpenReelioCodexDynamicToolCall(
+      callRequest('command_execute', {
+        commandType: 'SplitClip',
+        payload: { sequenceId: 'seq-1', trackId: 'track-1', clipId: 'clip-1', splitTime: 4 },
+        contextToken,
+      }),
+      APPROVING_CONTEXT,
+    );
+    if (!response) {
+      throw new Error('Expected a command_execute response');
+    }
+    return JSON.parse(responseText(response)) as { nextStep?: string; affectedRanges?: unknown };
+  }
+
+  it('should hand the ranges it changed back as a frame_extract request', async () => {
+    stubApprovedCommand({
+      planId: 'plan-1',
+      success: true,
+      totalSteps: 1,
+      stepsCompleted: 1,
+      stepResults: [{ stepId: 'step-1', success: true, durationMs: 1, operationId: 'op-7' }],
+      operationIds: ['op-7'],
+      executionTimeMs: 1,
+      affectedRanges: [{ startSec: 2, endSec: 6 }],
+    });
+
+    const result = await applySplitClip();
+
+    expect(result.affectedRanges).toEqual([{ startSec: 2, endSec: 6 }]);
+    expect(result.nextStep).toContain('openreelio.frame_extract');
+    expect(result.nextStep).toContain('ranges: [{"startSec":2,"endSec":6}]');
+    expect(result.nextStep).toContain("grid: 'auto', labelCells: true");
+    expect(result.nextStep).toContain("affected: true, afterOp: 'op-7'");
+  });
+
+  it('should omit the afterOp option when the apply reported no op id', async () => {
+    stubApprovedCommand({
+      planId: 'plan-1',
+      success: true,
+      totalSteps: 1,
+      stepsCompleted: 1,
+      stepResults: [{ stepId: 'step-1', success: true, durationMs: 1 }],
+      operationIds: [],
+      executionTimeMs: 1,
+      affectedRanges: [{ startSec: 0, endSec: 1.5 }],
+    });
+
+    const result = await applySplitClip();
+
+    expect(result.nextStep).toContain('ranges: [{"startSec":0,"endSec":1.5}]');
+    expect(result.nextStep).not.toContain('afterOp');
+  });
+
+  it('should fall back to the recorded hand-off when no ranges came back', async () => {
+    stubApprovedCommand({
+      planId: 'plan-1',
+      success: true,
+      totalSteps: 1,
+      stepsCompleted: 1,
+      stepResults: [{ stepId: 'step-1', success: true, durationMs: 1, operationId: 'op-7' }],
+      operationIds: ['op-7'],
+      executionTimeMs: 1,
+    });
+
+    const result = await applySplitClip();
+
+    expect(result.affectedRanges).toBeUndefined();
+    expect(result.nextStep).toContain("affected: true, grid: 'auto', labelCells: true");
+    expect(result.nextStep).toContain("atCuts: true, grid: 'auto'");
+    expect(result.nextStep).not.toContain('ranges:');
+  });
+});
+
 describe('developer instructions', () => {
   const instructions = buildOpenReelioCodexDeveloperInstructions({
     projectId: 'project-1',
@@ -671,7 +828,9 @@ describe('developer instructions', () => {
 
   it('should tell the agent to look at the edit after applying it', () => {
     expect(instructions).toContain('openreelio.frame_extract');
+    expect(instructions).toContain("ranges: <affectedRanges>, grid: 'auto'");
     expect(instructions).toContain("affected: true, grid: 'auto'");
+    expect(instructions).toContain("afterOp: <the result's last operationId>");
     expect(instructions).toContain('atCaptions: true');
     expect(instructions).toContain('perShot: true');
     expect(instructions).toContain('openreelio.render_proxy');
@@ -731,10 +890,22 @@ interface FrameProbeRecipe {
   span?: number;
   limit?: number;
   affected?: boolean;
+  afterOp?: string;
+  ranges?: Array<{ startSec: number; endSec: number }>;
 }
 
 const SAMPLER_EXCLUSIVE_KEYS = ['time', 'times', 'between', 'count', 'asset', 'file'] as const;
 const GRID_ONLY_KEYS = ['between', 'count', 'cellWidth', 'cellHeight', 'labelCells'] as const;
+/** Samplers `ranges` replaces rather than joins: it names the windows outright. */
+const RANGES_EXCLUSIVE_KEYS = [
+  'atCuts',
+  'atTransitions',
+  'atCaptions',
+  'atMarkers',
+  'perShot',
+  'affected',
+  'around',
+] as const;
 
 /**
  * Mirror of the three request checks the Rust frame probe applies, so a recipe
@@ -752,12 +923,22 @@ function frameProbeRejection(recipe: FrameProbeRecipe): string | null {
     recipe.atMarkers ||
     recipe.perShot ||
     recipe.affected ||
+    recipe.ranges !== undefined ||
     recipe.around !== undefined,
   );
 
   const named = SAMPLER_EXCLUSIVE_KEYS.filter((key) => recipe[key] !== undefined);
   if (samplerActive && named.length > 0) {
     return `a sampler cannot be combined with ${named.join(', ')}`;
+  }
+
+  if (recipe.ranges !== undefined) {
+    const clashing = RANGES_EXCLUSIVE_KEYS.filter(
+      (key) => recipe[key] !== undefined && recipe[key] !== false,
+    );
+    if (clashing.length > 0) {
+      return `ranges cannot be combined with ${clashing.join(', ')}`;
+    }
   }
 
   const gridOnly = GRID_ONLY_KEYS.filter(
@@ -780,8 +961,16 @@ function frameProbeRejection(recipe: FrameProbeRecipe): string | null {
 /** Every frame_extract request the developer instructions spell out. */
 const INSTRUCTION_RECIPES: Array<{ text: string; request: FrameProbeRecipe }> = [
   {
+    text: "ranges: <affectedRanges>, grid: 'auto', labelCells: true",
+    request: { ranges: [{ startSec: 2, endSec: 6 }], grid: 'auto', labelCells: true },
+  },
+  {
     text: "affected: true, grid: 'auto', labelCells: true",
     request: { affected: true, grid: 'auto', labelCells: true },
+  },
+  {
+    text: "afterOp: <the result's last operationId>",
+    request: { affected: true, grid: 'auto', afterOp: 'op-42' },
   },
   { text: "atCuts: true, grid: 'auto'", request: { atCuts: true, grid: 'auto' } },
   {
@@ -812,10 +1001,27 @@ describe('frameProbeRejection', () => {
     );
   });
 
+  it('should treat ranges as a sampler that stands on its own', () => {
+    const ranges = [{ startSec: 2, endSec: 6 }];
+    expect(frameProbeRejection({ ranges, times: [1] })).toContain('sampler cannot be combined');
+    expect(frameProbeRejection({ ranges, file: 'draft.mp4' })).toContain(
+      'sampler cannot be combined',
+    );
+    expect(frameProbeRejection({ ranges, between: [0, 5] })).toContain(
+      'sampler cannot be combined',
+    );
+    expect(frameProbeRejection({ ranges, affected: true })).toContain('ranges cannot be combined');
+    expect(frameProbeRejection({ ranges, atCuts: true })).toContain('ranges cannot be combined');
+  });
+
   it('should accept a sampler sheet and a file sweep', () => {
     expect(frameProbeRejection({ atCuts: true, grid: 'auto' })).toBeNull();
     expect(frameProbeRejection({ file: 'draft.mp4', between: [0, 5], grid: '4x3' })).toBeNull();
     expect(frameProbeRejection({ times: [1, 2], grid: 'auto' })).toBeNull();
+    expect(
+      frameProbeRejection({ ranges: [{ startSec: 2, endSec: 6 }], grid: 'auto', labelCells: true }),
+    ).toBeNull();
+    expect(frameProbeRejection({ affected: true, afterOp: 'op-42', grid: 'auto' })).toBeNull();
   });
 });
 

--- a/src/agents/external/adapters/openreelioCodexTools.test.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.test.ts
@@ -1,0 +1,440 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type Event, type UnlistenFn } from '@tauri-apps/api/event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildOpenReelioCodexDeveloperInstructions,
+  executeOpenReelioAgentToolCall,
+  handleOpenReelioCodexDynamicToolCall,
+  OPENREELIO_CODEX_DYNAMIC_TOOLS,
+  type OpenReelioCodexToolContext,
+} from './openreelioCodexTools';
+import {
+  isCodexDynamicToolCallOutputTextItem,
+  type CodexAppServerRequest,
+  type CodexDynamicToolCallResponse,
+  type CodexJsonObject,
+} from './CodexAppServerClient';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+const CONTEXT: OpenReelioCodexToolContext = {
+  projectId: 'project-1',
+  cwd: 'D:/projects/demo',
+  runtimeId: 'codex',
+  sessionId: 'session-1',
+  sessionKnown: true,
+};
+
+/** One-pixel JPEG stand-in; only its base64-ness matters to these tests. */
+const IMAGE_BASE64 = 'Zm9vYmFyYmF6cXV1eA==';
+
+type EventHandler = (event: Event<unknown>) => void;
+
+function makeEvent<T>(payload: T): Event<T> {
+  return { event: 'e', id: 1, payload } as unknown as Event<T>;
+}
+
+function callRequest(tool: string, args: CodexJsonObject = {}): CodexAppServerRequest {
+  return {
+    id: 1,
+    method: 'item/tool/call',
+    params: { tool, arguments: args },
+  };
+}
+
+async function callTool(
+  tool: string,
+  args: CodexJsonObject = {},
+): Promise<CodexDynamicToolCallResponse> {
+  const response = await handleOpenReelioCodexDynamicToolCall(callRequest(tool, args), CONTEXT);
+  if (!response) {
+    throw new Error(`Expected a response for '${tool}'`);
+  }
+  return response;
+}
+
+function responseText(response: CodexDynamicToolCallResponse): string {
+  return response.contentItems
+    .filter(isCodexDynamicToolCallOutputTextItem)
+    .map((item) => item.text)
+    .join('\n');
+}
+
+/**
+ * Register a `listen` mock that captures the handler per event name and lets a
+ * test emit into it. Renders resolve through events, so this is the external
+ * boundary the render tests drive.
+ */
+function stubListen(): { handlers: Map<string, EventHandler>; unlistened: () => number } {
+  const handlers = new Map<string, EventHandler>();
+  let unlistenCount = 0;
+  vi.mocked(listen).mockImplementation((eventName: string, handler: unknown) => {
+    handlers.set(eventName, handler as EventHandler);
+    return Promise.resolve<UnlistenFn>(() => {
+      unlistenCount += 1;
+    });
+  });
+  return { handlers, unlistened: () => unlistenCount };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('openreelio.frame_extract', () => {
+  it('should ask the frame probe for inline bytes and return the pictures before the report', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      payload: {
+        status: 'ok',
+        mode: 'grid',
+        sheet: { path: 'C:/demo/.openreelio/cache/frames/a/sheet.jpg', cols: 2, rows: 2 },
+      },
+      images: [
+        {
+          path: 'C:/demo/.openreelio/cache/frames/a/sheet.jpg',
+          mimeType: 'image/jpeg',
+          data: IMAGE_BASE64,
+        },
+      ],
+    });
+
+    const response = await callTool('frame_extract', { affected: true, grid: 'auto' });
+
+    expect(invoke).toHaveBeenCalledWith(
+      'extract_timeline_frames',
+      expect.objectContaining({
+        request: expect.objectContaining({ affected: true, grid: 'auto', inline: true }),
+      }),
+    );
+
+    expect(response.success).toBe(true);
+    expect(response.contentItems[0]).toEqual({
+      type: 'inputImage',
+      imageUrl: `data:image/jpeg;base64,${IMAGE_BASE64}`,
+    });
+    expect(response.contentItems[1]?.type).toBe('inputText');
+
+    const text = responseText(response);
+    expect(text).not.toContain(IMAGE_BASE64);
+    expect(text).toContain('C:/demo/.openreelio/cache/frames/a/sheet.jpg');
+  });
+
+  it('should keep every returned still as its own image block', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      payload: { status: 'ok', mode: 'timeline', frames: [{ timelineSec: 1 }, { timelineSec: 2 }] },
+      images: [
+        { path: 'a.png', mimeType: 'image/png', data: IMAGE_BASE64 },
+        { path: 'b.png', mimeType: 'image/png', data: IMAGE_BASE64 },
+      ],
+    });
+
+    const response = await callTool('frame_extract', { times: [1, 2] });
+
+    expect(response.contentItems.filter((item) => item.type === 'inputImage')).toHaveLength(2);
+    expect(JSON.parse(responseText(response)).imageCount).toBe(2);
+  });
+
+  it('should report a probe rejection as a failed tool call', async () => {
+    vi.mocked(invoke).mockRejectedValue('--affected reads the ranges the last edit changed');
+
+    const response = await callTool('frame_extract', { affected: true });
+
+    expect(response.success).toBe(false);
+    expect(response.contentItems).toHaveLength(1);
+    expect(responseText(response)).toContain('--affected reads the ranges the last edit changed');
+  });
+
+  it('should reject a between range that is not a pair', async () => {
+    const response = await callTool('frame_extract', { between: [1] });
+
+    expect(response.success).toBe(false);
+    expect(responseText(response)).toContain('between');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe('openreelio.render_proxy', () => {
+  function stubProject(): void {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_project_info') {
+        return Promise.resolve({ id: 'project-1', name: 'Demo', path: 'D:/projects/demo' });
+      }
+      if (command === 'get_project_state') {
+        return Promise.resolve({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+      }
+      if (command === 'render_range') {
+        return Promise.resolve({ jobId: 'job-1', outputPath: 'ignored', status: 'started' });
+      }
+      return Promise.reject(new Error(`unexpected command '${command}'`));
+    });
+  }
+
+  it('should wait for the render to complete and hand back the file it wrote', async () => {
+    const { handlers, unlistened } = stubListen();
+    stubProject();
+
+    const pending = callTool('render_proxy', { start: 2, end: 6 });
+    await vi.waitFor(() => {
+      expect(handlers.has('render-complete')).toBe(true);
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    handlers.get('render-complete')?.(
+      makeEvent({
+        jobId: 'job-1',
+        outputPath: 'D:/projects/demo/.openreelio/cache/renders/agent/proxy-1.mp4',
+        durationSec: 4,
+        fileSize: 1024,
+        encodingTimeSec: 3,
+      }),
+    );
+
+    const response = await pending;
+    const result = JSON.parse(responseText(response));
+
+    expect(response.success).toBe(true);
+    expect(result.status).toBe('ok');
+    expect(result.jobId).toBe('job-1');
+    expect(result.outputPath).toBe('D:/projects/demo/.openreelio/cache/renders/agent/proxy-1.mp4');
+    expect(result.durationSec).toBe(4);
+    expect(result.nextStep).toContain('frame_extract');
+    expect(unlistened()).toBe(2);
+  });
+
+  it('should write the draft inside the project cache and translate the proxy preset', async () => {
+    const { handlers } = stubListen();
+    stubProject();
+
+    const pending = callTool('render_proxy', { start: 0, end: 1 });
+    await vi.waitFor(() => {
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    const call = vi.mocked(invoke).mock.calls.find(([name]) => name === 'render_range');
+    const args = call?.[1] as { outputPath: string; preset: string; sequenceId: string };
+    expect(args.outputPath.startsWith('D:/projects/demo/.openreelio/cache/renders/agent/')).toBe(
+      true,
+    );
+    expect(args.outputPath.endsWith('.mp4')).toBe(true);
+    expect(args.sequenceId).toBe('seq-1');
+    // `proxy_480p` is a CLI-only preset id; the desktop path is given the draft
+    // preset it does accept, and the substitution is reported.
+    expect(args.preset).toBe('mp4_draft');
+
+    handlers.get('render-complete')?.(
+      makeEvent({
+        jobId: 'job-1',
+        outputPath: args.outputPath,
+        durationSec: 1,
+        fileSize: 1,
+        encodingTimeSec: 1,
+      }),
+    );
+
+    const result = JSON.parse(responseText(await pending));
+    expect(result.requestedPreset).toBe('proxy_480p');
+    expect(String(result.warnings?.[0])).toContain('mp4_draft');
+  });
+
+  it('should separate a cancelled render from a failed one', async () => {
+    const { handlers } = stubListen();
+    stubProject();
+
+    const pending = callTool('render_proxy', { start: 0, end: 1 });
+    await vi.waitFor(() => {
+      expect(handlers.has('render-lifecycle')).toBe(true);
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    handlers.get('render-lifecycle')?.(
+      makeEvent({
+        jobId: 'job-1',
+        sequenceId: 'seq-1',
+        kind: 'range_export',
+        state: 'cancelled',
+        progress: null,
+        message: 'Export cancelled',
+        outputPath: null,
+        planHash: null,
+      }),
+    );
+
+    const response = await pending;
+    expect(response.success).toBe(false);
+    expect(JSON.parse(responseText(response)).status).toBe('cancelled');
+  });
+
+  function stubStuckRender(): void {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_project_info') {
+        return Promise.resolve({ id: 'project-1', name: 'Demo', path: 'D:/projects/demo' });
+      }
+      if (command === 'get_project_state') {
+        return Promise.resolve({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+      }
+      if (command === 'render_range') {
+        return Promise.resolve({ jobId: 'job-1', outputPath: 'ignored', status: 'started' });
+      }
+      if (command === 'cancel_render') {
+        return Promise.resolve({ jobId: 'job-1', cancelled: true });
+      }
+      return Promise.reject(new Error(`unexpected command '${command}'`));
+    });
+  }
+
+  async function waitForRenderStart(): Promise<void> {
+    await vi.waitFor(async () => {
+      await Promise.resolve();
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+  }
+
+  it('should cancel the job and report a timeout when the render never finishes', async () => {
+    vi.useFakeTimers();
+    try {
+      stubListen();
+      stubStuckRender();
+
+      const pending = callTool('render_proxy', { start: 0, end: 1 });
+      await waitForRenderStart();
+
+      // Still waiting just short of the Codex budget.
+      await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'cancel_render')).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+
+      const result = JSON.parse(responseText(await pending));
+      expect(result.status).toBe('timeout');
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'cancel_render')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should give up before the loopback MCP call timeout on a Claude session', async () => {
+    vi.useFakeTimers();
+    try {
+      stubListen();
+      stubStuckRender();
+
+      const pending = handleOpenReelioCodexDynamicToolCall(
+        callRequest('render_proxy', { start: 0, end: 1 }),
+        { ...CONTEXT, runtimeId: 'claude_code' },
+      );
+      await waitForRenderStart();
+
+      // The backend abandons a `tools/call` at 300s; the wait must end first.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+      const response = await pending;
+      if (!response) {
+        throw new Error('Expected a render_proxy response');
+      }
+      expect(JSON.parse(responseText(response)).status).toBe('timeout');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should refuse a range whose end is not after its start', async () => {
+    stubListen();
+    stubProject();
+
+    const response = await callTool('render_proxy', { start: 5, end: 5 });
+
+    expect(response.success).toBe(false);
+    expect(responseText(response)).toContain('greater than start');
+    expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(false);
+  });
+});
+
+describe('executeOpenReelioAgentToolCall', () => {
+  it('should route pictures into images and keep base64 out of the text', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      payload: { status: 'ok', mode: 'grid', sheet: { path: 'sheet.jpg' } },
+      images: [{ path: 'sheet.jpg', mimeType: 'image/jpeg', data: IMAGE_BASE64 }],
+    });
+
+    const result = await executeOpenReelioAgentToolCall({
+      toolName: 'frame_extract',
+      args: { perShot: true, grid: 'auto' },
+      context: { ...CONTEXT, runtimeId: 'claude_code' },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.images).toEqual([{ data: IMAGE_BASE64, mimeType: 'image/jpeg' }]);
+    expect(result.text).not.toContain(IMAGE_BASE64);
+    expect(result.text).not.toContain('data:image');
+    expect(result.text).toContain('sheet.jpg');
+  });
+
+  it('should omit images entirely for a text-only tool', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      activeSequenceId: 'seq-1',
+      assets: [],
+      sequences: [],
+    });
+
+    const result = await executeOpenReelioAgentToolCall({
+      toolName: 'timeline_snapshot',
+      args: {},
+      context: { ...CONTEXT, runtimeId: 'claude_code' },
+    });
+
+    expect(result.images).toBeUndefined();
+  });
+});
+
+describe('developer instructions', () => {
+  const instructions = buildOpenReelioCodexDeveloperInstructions({
+    projectId: 'project-1',
+    cwd: 'D:/projects/demo',
+  });
+
+  it('should tell the agent to look at the edit after applying it', () => {
+    expect(instructions).toContain('openreelio.frame_extract');
+    expect(instructions).toContain("affected: true, grid: 'auto'");
+    expect(instructions).toContain('atCaptions: true');
+    expect(instructions).toContain('perShot: true');
+    expect(instructions).toContain('openreelio.render_proxy');
+  });
+
+  it('should name every tool in the dotted form the Claude adapter rewrites', () => {
+    for (const tool of ['frame_extract', 'render_proxy']) {
+      expect(instructions).toContain(`openreelio.${tool}`);
+      expect(instructions).not.toContain(`mcp__openreelio__${tool}`);
+    }
+  });
+
+  it('should advertise both new tools in the catalog', () => {
+    const names = OPENREELIO_CODEX_DYNAMIC_TOOLS.map((tool) => tool.name);
+    expect(names).toContain('frame_extract');
+    expect(names).toContain('render_proxy');
+  });
+});
+
+describe('openreelio.preview_describe', () => {
+  it('should point at the frame probe instead of claiming raw frame access', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_project_state') {
+        return Promise.resolve({ activeSequenceId: null, assets: [], sequences: [] });
+      }
+      return Promise.resolve(false);
+    });
+
+    const text = responseText(await callTool('preview_describe'));
+    const parsed = JSON.parse(text) as { mediaInspection: Record<string, unknown> };
+
+    expect(parsed.mediaInspection.rawFrameAccess).toBeUndefined();
+    expect(parsed.mediaInspection.frameExtraction).toBe('openreelio.frame_extract');
+    expect(String(parsed.mediaInspection.message)).toContain('openreelio.frame_extract');
+  });
+});

--- a/src/agents/external/adapters/openreelioCodexTools.test.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.test.ts
@@ -35,6 +35,12 @@ const CONTEXT: OpenReelioCodexToolContext = {
 /** One-pixel JPEG stand-in; only its base64-ness matters to these tests. */
 const IMAGE_BASE64 = 'Zm9vYmFyYmF6cXV1eA==';
 
+/**
+ * The Claude-side render wait, kept 90s under the loopback MCP server's 900s
+ * `render_proxy` timeout so the answer still reaches a listening backend.
+ */
+const CLAUDE_RENDER_BUDGET_MS = 13.5 * 60 * 1000;
+
 type EventHandler = (event: Event<unknown>) => void;
 
 function makeEvent<T>(payload: T): Event<T> {
@@ -204,11 +210,49 @@ describe('openreelio.render_proxy', () => {
     expect(result.jobId).toBe('job-1');
     expect(result.outputPath).toBe('D:/projects/demo/.openreelio/cache/renders/agent/proxy-1.mp4');
     expect(result.durationSec).toBe(4);
-    expect(result.nextStep).toContain('frame_extract');
+    // The follow-up must be a request the probe accepts: samplers are not
+    // available with `file`, and `between` needs an explicit grid.
+    expect(result.nextStep).toContain('openreelio.frame_extract');
+    expect(result.nextStep).toContain('file: outputPath');
+    expect(result.nextStep).toContain('between: [0, 4]');
+    expect(result.nextStep).toContain("grid: '4x3'");
+    expect(result.nextStep).not.toContain("grid: 'auto'");
     expect(unlistened()).toBe(2);
   });
 
-  it('should write the draft inside the project cache and translate the proxy preset', async () => {
+  it('should name the follow-up tool the way the calling host names it', async () => {
+    const { handlers } = stubListen();
+    stubProject();
+
+    const pending = handleOpenReelioCodexDynamicToolCall(
+      callRequest('render_proxy', { start: 0, end: 1 }),
+      { ...CONTEXT, runtimeId: 'claude_code' },
+    );
+    await vi.waitFor(() => {
+      expect(handlers.has('render-complete')).toBe(true);
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    handlers.get('render-complete')?.(
+      makeEvent({
+        jobId: 'job-1',
+        outputPath: 'D:/projects/demo/.openreelio/cache/renders/agent/proxy-1.mp4',
+        durationSec: 1,
+        fileSize: 1,
+        encodingTimeSec: 1,
+      }),
+    );
+
+    const response = await pending;
+    if (!response) {
+      throw new Error('Expected a render_proxy response');
+    }
+    const result = JSON.parse(responseText(response));
+    expect(result.nextStep).toContain('mcp__openreelio__frame_extract');
+    expect(result.nextStep).not.toContain('openreelio.frame_extract');
+  });
+
+  it('should write the draft inside the project cache and send the proxy preset unchanged', async () => {
     const { handlers } = stubListen();
     stubProject();
 
@@ -224,9 +268,9 @@ describe('openreelio.render_proxy', () => {
     );
     expect(args.outputPath.endsWith('.mp4')).toBe(true);
     expect(args.sequenceId).toBe('seq-1');
-    // `proxy_480p` is a CLI-only preset id; the desktop path is given the draft
-    // preset it does accept, and the substitution is reported.
-    expect(args.preset).toBe('mp4_draft');
+    // The desktop host serves `proxy_480p` itself now, so nothing is
+    // substituted and the draft keeps the sequence's own frame shape.
+    expect(args.preset).toBe('proxy_480p');
 
     handlers.get('render-complete')?.(
       makeEvent({
@@ -239,8 +283,147 @@ describe('openreelio.render_proxy', () => {
     );
 
     const result = JSON.parse(responseText(await pending));
-    expect(result.requestedPreset).toBe('proxy_480p');
-    expect(String(result.warnings?.[0])).toContain('mp4_draft');
+    expect(result.preset).toBe('proxy_480p');
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('should refuse a delivery preset so the .mp4 draft path stays honest', async () => {
+    stubListen();
+    stubProject();
+
+    const response = await callTool('render_proxy', { start: 0, end: 1, preset: 'prores' });
+
+    expect(response.success).toBe(false);
+    expect(responseText(response)).toContain('proxy_480p');
+    expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(false);
+  });
+
+  it('should settle from a terminal event that arrives before the job id is known', async () => {
+    const { handlers } = stubListen();
+    // A holder rather than a local: TypeScript narrows a `let` assigned only
+    // inside a callback down to `null` at every later use.
+    const start: { release: (() => void) | null } = { release: null };
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_project_info') {
+        return Promise.resolve({ id: 'project-1', name: 'Demo', path: 'D:/projects/demo' });
+      }
+      if (command === 'get_project_state') {
+        return Promise.resolve({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+      }
+      if (command === 'render_range') {
+        return new Promise((resolve) => {
+          start.release = () =>
+            resolve({ jobId: 'job-1', outputPath: 'ignored', status: 'started' });
+        });
+      }
+      return Promise.reject(new Error(`unexpected command '${command}'`));
+    });
+
+    const pending = callTool('render_proxy', { start: 0, end: 1 });
+    await vi.waitFor(() => {
+      expect(start.release).not.toBeNull();
+    });
+
+    // The encoder finished before `render_range` even answered with its id.
+    handlers.get('render-complete')?.(
+      makeEvent({
+        jobId: 'job-1',
+        outputPath: 'D:/projects/demo/.openreelio/cache/renders/agent/proxy-early.mp4',
+        durationSec: 1,
+        fileSize: 2,
+        encodingTimeSec: 1,
+      }),
+    );
+    start.release?.();
+
+    const result = JSON.parse(responseText(await pending));
+    expect(result.status).toBe('ok');
+    expect(result.outputPath).toContain('proxy-early.mp4');
+  });
+
+  it('should ignore a terminal event for another job', async () => {
+    const { handlers } = stubListen();
+    stubProject();
+
+    let settled = false;
+    const pending = callTool('render_proxy', { start: 0, end: 1 }).then((response) => {
+      settled = true;
+      return response;
+    });
+    await vi.waitFor(() => {
+      expect(handlers.has('render-complete')).toBe(true);
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    handlers.get('render-complete')?.(
+      makeEvent({
+        jobId: 'someone-elses-job',
+        outputPath: 'D:/projects/demo/other.mp4',
+        durationSec: 9,
+        fileSize: 9,
+        encodingTimeSec: 9,
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    handlers.get('render-complete')?.(
+      makeEvent({
+        jobId: 'job-1',
+        outputPath: 'D:/projects/demo/mine.mp4',
+        durationSec: 1,
+        fileSize: 1,
+        encodingTimeSec: 1,
+      }),
+    );
+
+    const result = JSON.parse(responseText(await pending));
+    expect(result.outputPath).toBe('D:/projects/demo/mine.mp4');
+  });
+
+  it('should report a failed render as failed and name no output file', async () => {
+    const { handlers } = stubListen();
+    stubProject();
+
+    const pending = callTool('render_proxy', { start: 0, end: 1 });
+    await vi.waitFor(() => {
+      expect(handlers.has('render-lifecycle')).toBe(true);
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    handlers.get('render-lifecycle')?.(
+      makeEvent({
+        jobId: 'job-1',
+        sequenceId: 'seq-1',
+        kind: 'range_export',
+        state: 'failed',
+        progress: null,
+        message: 'Encoder exited with status 1',
+        outputPath: null,
+        planHash: null,
+      }),
+    );
+
+    const response = await pending;
+    const result = JSON.parse(responseText(response));
+    expect(response.success).toBe(false);
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('Encoder exited');
+    // Nothing was written, so there is no file to point frame_extract at.
+    expect(result.outputPath).toBeUndefined();
+    expect(result.nextStep).toBeUndefined();
+  });
+
+  it('should refuse a range longer than the draft cap', async () => {
+    stubListen();
+    stubProject();
+
+    const response = await callTool('render_proxy', { start: 0, end: 400 });
+
+    expect(response.success).toBe(false);
+    expect(responseText(response)).toContain('300s');
+    expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(false);
   });
 
   it('should separate a cancelled render from a failed one', async () => {
@@ -331,14 +514,101 @@ describe('openreelio.render_proxy', () => {
       );
       await waitForRenderStart();
 
-      // The backend abandons a `tools/call` at 300s; the wait must end first.
-      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      // The backend abandons a `render_proxy` call at 900s; the wait must end
+      // first, with margin for the answer to travel back.
+      await vi.advanceTimersByTimeAsync(CLAUDE_RENDER_BUDGET_MS);
 
       const response = await pending;
       if (!response) {
         throw new Error('Expected a render_proxy response');
       }
       expect(JSON.parse(responseText(response)).status).toBe('timeout');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should count the budget from when the call arrived, not from when the render starts', async () => {
+    vi.useFakeTimers();
+    try {
+      stubListen();
+      // A slow preamble: reading project state costs four minutes before the
+      // render can even be started.
+      const preambleMs = 4 * 60 * 1000;
+      const slowRead = <T>(value: T): Promise<T> =>
+        new Promise<T>((resolve) => {
+          setTimeout(() => resolve(value), preambleMs);
+        });
+      vi.mocked(invoke).mockImplementation((command: string) => {
+        if (command === 'get_project_info') {
+          return slowRead({ id: 'project-1', name: 'Demo', path: 'D:/projects/demo' });
+        }
+        if (command === 'get_project_state') {
+          return slowRead({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+        }
+        if (command === 'render_range') {
+          return Promise.resolve({ jobId: 'job-1', outputPath: 'ignored', status: 'started' });
+        }
+        if (command === 'cancel_render') {
+          return Promise.resolve({ jobId: 'job-1', cancelled: true });
+        }
+        return Promise.reject(new Error(`unexpected command '${command}'`));
+      });
+
+      const startedAt = Date.now();
+      let settledAt = 0;
+      const pending = handleOpenReelioCodexDynamicToolCall(
+        callRequest('render_proxy', { start: 0, end: 1 }),
+        { ...CONTEXT, runtimeId: 'claude_code' },
+      ).then((response) => {
+        settledAt = Date.now();
+        return response;
+      });
+
+      await vi.advanceTimersByTimeAsync(preambleMs);
+      await waitForRenderStart();
+      await vi.advanceTimersByTimeAsync(CLAUDE_RENDER_BUDGET_MS);
+
+      const response = await pending;
+      if (!response) {
+        throw new Error('Expected a render_proxy response');
+      }
+      expect(JSON.parse(responseText(response)).status).toBe('timeout');
+      // A budget armed after the preamble would have answered at 4 + 13.5
+      // minutes, long after the backend stopped listening.
+      expect(settledAt - startedAt).toBeLessThanOrEqual(CLAUDE_RENDER_BUDGET_MS);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not await the cancellation before answering a timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      stubListen();
+      vi.mocked(invoke).mockImplementation((command: string) => {
+        if (command === 'get_project_info') {
+          return Promise.resolve({ id: 'project-1', name: 'Demo', path: 'D:/projects/demo' });
+        }
+        if (command === 'get_project_state') {
+          return Promise.resolve({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+        }
+        if (command === 'render_range') {
+          return Promise.resolve({ jobId: 'job-1', outputPath: 'ignored', status: 'started' });
+        }
+        if (command === 'cancel_render') {
+          // A backend that never answers must not hold the tool call open.
+          return new Promise(() => undefined);
+        }
+        return Promise.reject(new Error(`unexpected command '${command}'`));
+      });
+
+      const pending = callTool('render_proxy', { start: 0, end: 1 });
+      await waitForRenderStart();
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+
+      const result = JSON.parse(responseText(await pending));
+      expect(result.status).toBe('timeout');
     } finally {
       vi.useRealTimers();
     }
@@ -419,6 +689,134 @@ describe('developer instructions', () => {
     expect(names).toContain('frame_extract');
     expect(names).toContain('render_proxy');
   });
+
+  it('should only recommend frame_extract requests the probe accepts', () => {
+    for (const recipe of INSTRUCTION_RECIPES) {
+      expect(instructions).toContain(recipe.text);
+      expect({ recipe: recipe.text, rejection: frameProbeRejection(recipe.request) }).toEqual({
+        recipe: recipe.text,
+        rejection: null,
+      });
+    }
+  });
+
+  it('should never offer a bare between fallback', () => {
+    // `between` without an explicit COLSxROWS is rejected outright, so it must
+    // not appear as the thing to reach for when a sampler comes back empty.
+    expect(instructions).not.toContain('between: [start, end]');
+    for (const line of instructions.split('\n').filter((entry) => entry.includes('between:'))) {
+      expect(line).toMatch(/grid: '\d+x\d+'/);
+    }
+  });
+});
+
+/** A frame_extract request as the instructions spell it. */
+interface FrameProbeRecipe {
+  time?: number;
+  times?: number[];
+  between?: [number, number];
+  count?: number;
+  asset?: string;
+  file?: string;
+  grid?: string;
+  cellWidth?: number;
+  cellHeight?: number;
+  labelCells?: boolean;
+  atCuts?: boolean;
+  atTransitions?: boolean;
+  atCaptions?: boolean;
+  atMarkers?: boolean;
+  perShot?: boolean;
+  around?: number;
+  span?: number;
+  limit?: number;
+  affected?: boolean;
+}
+
+const SAMPLER_EXCLUSIVE_KEYS = ['time', 'times', 'between', 'count', 'asset', 'file'] as const;
+const GRID_ONLY_KEYS = ['between', 'count', 'cellWidth', 'cellHeight', 'labelCells'] as const;
+
+/**
+ * Mirror of the three request checks the Rust frame probe applies, so a recipe
+ * the instructions hand an agent cannot silently become one the probe rejects.
+ *
+ * Sources: `ensure_sampler_selectors_unused`, `ensure_grid_only_flags_unused`
+ * and `resolve_auto_grid_selection` in
+ * `src-tauri/src/core/render/frame_probe/mod.rs`.
+ */
+function frameProbeRejection(recipe: FrameProbeRecipe): string | null {
+  const samplerActive = Boolean(
+    recipe.atCuts ||
+    recipe.atTransitions ||
+    recipe.atCaptions ||
+    recipe.atMarkers ||
+    recipe.perShot ||
+    recipe.affected ||
+    recipe.around !== undefined,
+  );
+
+  const named = SAMPLER_EXCLUSIVE_KEYS.filter((key) => recipe[key] !== undefined);
+  if (samplerActive && named.length > 0) {
+    return `a sampler cannot be combined with ${named.join(', ')}`;
+  }
+
+  const gridOnly = GRID_ONLY_KEYS.filter(
+    (key) => recipe[key] !== undefined && recipe[key] !== false,
+  );
+  if (!recipe.grid && gridOnly.length > 0) {
+    return `${gridOnly.join(', ')} requires grid`;
+  }
+
+  if (recipe.grid === 'auto' && !samplerActive && recipe.times === undefined) {
+    return "grid 'auto' needs a sampler or times";
+  }
+  if (recipe.grid && recipe.grid !== 'auto' && !recipe.between && !recipe.times) {
+    return 'a grid needs between or times';
+  }
+
+  return null;
+}
+
+/** Every frame_extract request the developer instructions spell out. */
+const INSTRUCTION_RECIPES: Array<{ text: string; request: FrameProbeRecipe }> = [
+  {
+    text: "affected: true, grid: 'auto', labelCells: true",
+    request: { affected: true, grid: 'auto', labelCells: true },
+  },
+  { text: "atCuts: true, grid: 'auto'", request: { atCuts: true, grid: 'auto' } },
+  {
+    text: "around: <edited time>, span: 1, grid: 'auto'",
+    request: { around: 12, span: 1, grid: 'auto' },
+  },
+  {
+    text: "atCaptions: true, grid: 'auto', cellWidth: 640",
+    request: { atCaptions: true, grid: 'auto', cellWidth: 640 },
+  },
+  {
+    text: "perShot: true, grid: 'auto', limit: 24",
+    request: { perShot: true, grid: 'auto', limit: 24 },
+  },
+  {
+    text: "{ file: outputPath, between: [0, durationSec], grid: '4x3', labelCells: true }",
+    request: { file: 'draft.mp4', between: [0, 12], grid: '4x3', labelCells: true },
+  },
+];
+
+describe('frameProbeRejection', () => {
+  it('should reject the requests the Rust probe rejects', () => {
+    expect(frameProbeRejection({ between: [0, 10] })).toContain('requires grid');
+    expect(frameProbeRejection({ atCaptions: true, cellWidth: 640 })).toContain('requires grid');
+    expect(frameProbeRejection({ between: [0, 10], grid: 'auto' })).toContain('sampler or times');
+    expect(frameProbeRejection({ file: 'draft.mp4', atCuts: true, grid: 'auto' })).toContain(
+      'sampler cannot be combined',
+    );
+  });
+
+  it('should accept a sampler sheet and a file sweep', () => {
+    expect(frameProbeRejection({ atCuts: true, grid: 'auto' })).toBeNull();
+    expect(frameProbeRejection({ file: 'draft.mp4', between: [0, 5], grid: '4x3' })).toBeNull();
+    expect(frameProbeRejection({ times: [1, 2], grid: 'auto' })).toBeNull();
+  });
 });
 
 describe('openreelio.preview_describe', () => {
@@ -436,5 +834,29 @@ describe('openreelio.preview_describe', () => {
     expect(parsed.mediaInspection.rawFrameAccess).toBeUndefined();
     expect(parsed.mediaInspection.frameExtraction).toBe('openreelio.frame_extract');
     expect(String(parsed.mediaInspection.message)).toContain('openreelio.frame_extract');
+  });
+
+  it('should spell the pointers the way a Claude session sees them', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_project_state') {
+        return Promise.resolve({ activeSequenceId: null, assets: [], sequences: [] });
+      }
+      return Promise.resolve(false);
+    });
+
+    const response = await handleOpenReelioCodexDynamicToolCall(callRequest('preview_describe'), {
+      ...CONTEXT,
+      runtimeId: 'claude_code',
+    });
+    if (!response) {
+      throw new Error('Expected a preview_describe response');
+    }
+    const parsed = JSON.parse(responseText(response)) as {
+      mediaInspection: Record<string, unknown>;
+    };
+
+    expect(parsed.mediaInspection.frameExtraction).toBe('mcp__openreelio__frame_extract');
+    expect(parsed.mediaInspection.rangeRender).toBe('mcp__openreelio__render_proxy');
+    expect(String(parsed.mediaInspection.message)).not.toContain('openreelio.frame_extract');
   });
 });

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 
 import {
   commands,
@@ -49,6 +49,12 @@ export interface OpenReelioCodexToolContext extends OpenReelioCodexSessionContex
   sessionId: string;
   sessionKnown?: boolean;
   approvalDecisionProvider?: ExternalAgentApprovalDecisionProvider;
+  /**
+   * Host-assigned id of the single tool call being served, when the host has
+   * one. It is what lets a cancelled call reach the work it started — a draft
+   * render keeps encoding otherwise.
+   */
+  callId?: string;
 }
 
 const EXTERNAL_AGENT_MUTATION_TIMEOUT_MS = 5 * 60 * 1000;
@@ -790,25 +796,30 @@ const FRAME_EXTRACT_SCHEMA: CodexJsonObject = {
     grid: {
       type: 'string',
       description:
-        "Contact sheet layout as COLSxROWS, or 'auto' to size it from the samples. A sheet is ONE image, so it is the cheap way to look at many moments.",
+        "Contact sheet layout as COLSxROWS, or 'auto' to size it from the samples. A sheet is ONE image, so it is the cheap way to look at many moments. 'auto' needs a sampler or times to size itself; with between, pass an explicit COLSxROWS.",
     },
     between: {
       type: 'array',
       items: { type: 'number' },
       description:
-        '[start, end] timeline seconds a grid samples uniformly. Uniform sampling lands on no edit event, so prefer an event sampler when one fits.',
+        '[start, end] seconds a grid samples uniformly. Requires grid, and with between the grid must be an explicit COLSxROWS. Uniform sampling lands on no edit event, so prefer an event sampler when one fits.',
     },
     cellWidth: {
-      type: 'number',
-      description: 'Contact sheet cell width in pixels; raise it when reading burned-in text.',
+      type: 'integer',
+      minimum: 64,
+      maximum: 1024,
+      description:
+        'Contact sheet cell width in pixels; raise it when reading burned-in text. Requires grid.',
     },
     cellHeight: {
-      type: 'number',
-      description: 'Contact sheet cell height in pixels.',
+      type: 'integer',
+      minimum: 64,
+      maximum: 1024,
+      description: 'Contact sheet cell height in pixels. Requires grid.',
     },
     labelCells: {
       type: 'boolean',
-      description: "Burn each cell's index and timecode into the contact sheet.",
+      description: "Burn each cell's index and timecode into the contact sheet. Requires grid.",
     },
     mode: {
       type: 'string',
@@ -817,13 +828,15 @@ const FRAME_EXTRACT_SCHEMA: CodexJsonObject = {
         "'composite' (default) renders the whole stack — captions, text, transforms, blends — exactly as export does; 'fast' is the cheap topmost-clip-only look that shows none of the edit.",
     },
     maxWidth: {
-      type: 'number',
+      type: 'integer',
+      minimum: 1,
+      maximum: 3840,
       description: 'Maximum output width in pixels. Aspect ratio is preserved and never upscaled.',
     },
     file: {
       type: 'string',
       description:
-        'Rendered video inside the project directory to read instead of the timeline, such as the outputPath returned by openreelio.render_proxy. Cells then map back as fileSec.',
+        'Rendered video inside the project directory to read instead of the timeline, such as the outputPath returned by render_proxy. Times are relative to the file and cells map back as fileSec. Samplers are not available with file; use times, or between with an explicit grid.',
     },
     atCuts: {
       type: 'boolean',
@@ -847,23 +860,27 @@ const FRAME_EXTRACT_SCHEMA: CodexJsonObject = {
     },
     around: {
       type: 'number',
+      minimum: 0,
       description: 'Sample a window centred on this timeline time, in seconds.',
     },
     span: {
       type: 'number',
+      exclusiveMinimum: 0,
       description: 'Half-width of the around window in seconds.',
     },
     aroundCount: {
-      type: 'number',
+      type: 'integer',
+      minimum: 1,
       description: 'Number of samples the around window produces.',
     },
     affected: {
       type: 'boolean',
       description:
-        'Sample exactly the timeline ranges the last applied edit changed. Errors when no edit recorded a hand-off; fall back to atCuts or between around the edited time.',
+        "Sample exactly the timeline ranges the last applied edit changed. Errors when no edit recorded a hand-off; fall back to atCuts: true, grid: 'auto', or around: <edited time>, span: 1, grid: 'auto'.",
     },
     limit: {
-      type: 'number',
+      type: 'integer',
+      minimum: 1,
       description:
         'Largest number of sampler times to keep. At most 12 separate stills come back inline, so pass grid for anything wider.',
     },
@@ -871,22 +888,35 @@ const FRAME_EXTRACT_SCHEMA: CodexJsonObject = {
   additionalProperties: false,
 };
 
+/**
+ * Longest range the bridge will draft-render in one call, in seconds.
+ *
+ * A range render is uncancellable from the agent's side once it is running and
+ * blocks the tool call until it finishes, so an unbounded request is an
+ * unbounded stall. Five minutes of timeline is far more than any "does this
+ * motion read?" question needs.
+ */
+const RENDER_PROXY_MAX_RANGE_SEC = 300;
+
 const RENDER_PROXY_SCHEMA: CodexJsonObject = {
   type: 'object',
   required: ['start', 'end'],
   properties: {
     start: {
       type: 'number',
+      minimum: 0,
       description: 'Range start in timeline seconds. Must be non-negative and below end.',
     },
     end: {
       type: 'number',
-      description: 'Range end in timeline seconds.',
+      minimum: 0,
+      description: `Range end in timeline seconds. The range must be at most ${RENDER_PROXY_MAX_RANGE_SEC}s long; render a narrower window and look at that.`,
     },
     preset: {
       type: 'string',
+      enum: ['proxy_480p', 'mp4_draft'],
       description:
-        'Render preset id. Defaults to proxy_480p, which the desktop host serves with its fast 720p draft preset. Pass a desktop preset id such as mp4_draft, youtube_1080p, or prores for a specific format.',
+        'Render preset id, MP4 either way. Defaults to proxy_480p: a CRF 30 ultrafast draft fitted to the sequence canvas (short edge at most 480) at the sequence frame rate, so vertical stays vertical. mp4_draft is a fixed 1280x720 at 30 fps draft; pass it only when the exact 720p30 frame matters.',
     },
   },
   additionalProperties: false,
@@ -1117,12 +1147,13 @@ export function buildOpenReelioCodexDeveloperInstructions(
     '- Shell and filesystem tools are secondary; prefer OpenReelio tools for video-editing state and mutations.',
     '',
     'Look at the edit before you report on it:',
-    "- After every openreelio.plan_apply or openreelio.command_execute, call openreelio.frame_extract with affected: true, grid: 'auto', labelCells: true, and look at the picture before you say what changed. If affected reports no recorded hand-off, sample the seconds you edited instead: atCuts: true, or between: [start, end] around the edited time.",
-    '- For caption or text edits, inspect with atCaptions: true and cellWidth: 640 so the burned-in words are legible.',
+    "- After every openreelio.plan_apply or openreelio.command_execute, call openreelio.frame_extract with affected: true, grid: 'auto', labelCells: true, and look at the picture before you say what changed. If affected reports no recorded hand-off, sample the seconds you edited instead: atCuts: true, grid: 'auto', or around: <edited time>, span: 1, grid: 'auto'.",
+    "- For caption or text edits, inspect with atCaptions: true, grid: 'auto', cellWidth: 640 so the burned-in words are legible.",
     "- Before finishing a task, sweep the whole cut once with perShot: true, grid: 'auto', limit: 24.",
     "- Do not compute inspection times yourself. frame_extract samples the edit's own events (affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, around); uniform between sampling lands on no event and is for whole-timeline overviews only.",
+    "- cellWidth, cellHeight, labelCells and between only apply to a contact sheet and are rejected without grid. grid: 'auto' sizes itself from a sampler or times, so between always needs an explicit grid such as '4x3'.",
     '- frame_extract shows the composited edit by default. Only pass mode: "fast" when you deliberately want the raw footage without captions, text or effects.',
-    "- Use openreelio.render_proxy only for motion or pacing questions a still cannot answer, then inspect its outputPath with openreelio.frame_extract { file: outputPath, atCuts: true, grid: 'auto' }. Never full-render to check your work.",
+    `- Use openreelio.render_proxy only for motion or pacing questions a still cannot answer, and keep the range under ${RENDER_PROXY_MAX_RANGE_SEC}s. Then inspect its outputPath with openreelio.frame_extract { file: outputPath, between: [0, durationSec], grid: '4x3', labelCells: true } — file times are relative to the file, and samplers are not available with file.`,
     '- Never claim a cut, caption, overlay, or transition looks right without having extracted a frame that shows it.',
     '',
     'Available OpenReelio dynamic tools:',
@@ -1202,7 +1233,7 @@ export async function handleOpenReelioCodexDynamicToolCall(
       case 'diagnostics_read':
         return toolResponse(await buildDiagnosticsResponse());
       case 'preview_describe':
-        return toolResponse(await buildPreviewDescription());
+        return toolResponse(await buildPreviewDescription(context));
       case 'frame_extract': {
         const result = await extractFramesToolCall(toolCall.arguments);
         return toolResponseWithImages(result.value, result.images, result.value.status === 'ok');
@@ -1629,7 +1660,21 @@ async function buildDiagnosticsResponse(): Promise<CodexJsonObject> {
   };
 }
 
-async function buildPreviewDescription(): Promise<CodexJsonObject> {
+/**
+ * Name a bridge tool the way the host making the call names it.
+ *
+ * Codex calls the dotted dynamic-tool id; Claude only ever sees the loopback
+ * MCP server's prefixed name. A pointer written in the other host's spelling
+ * names a tool the agent cannot call, so every id the bridge hands back is
+ * spelled for its own caller.
+ */
+function toolIdFor(runtimeId: OpenReelioCodexToolContext['runtimeId'], name: string): string {
+  return runtimeId === 'claude_code' ? `mcp__openreelio__${name}` : `openreelio.${name}`;
+}
+
+async function buildPreviewDescription(
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
   const [state, playbackModule, previewModule, transcriptionAvailable] = await Promise.all([
     readOptionalProjectState(),
     import('@/stores/playbackStore'),
@@ -1657,12 +1702,11 @@ async function buildPreviewDescription(): Promise<CodexJsonObject> {
       panY: previewState.panY,
     },
     mediaInspection: {
-      frameExtraction: 'openreelio.frame_extract',
-      rangeRender: 'openreelio.render_proxy',
+      frameExtraction: toolIdFor(context.runtimeId, 'frame_extract'),
+      rangeRender: toolIdFor(context.runtimeId, 'render_proxy'),
       transcriptAccess: transcriptionAvailable,
       waveformAccess: false,
-      message:
-        'Use openreelio.frame_extract to actually see the composited edit as stills or a contact sheet, openreelio.render_proxy for a draft of a range when motion matters, openreelio.clip_analyze for indexed frame samples, openreelio.clip_describe for semantic clip-local frame evidence, and openreelio.transcription_generate for speech-to-text subtitle timing. Waveform inspection is not exposed through this bridge yet.',
+      message: `Use ${toolIdFor(context.runtimeId, 'frame_extract')} to actually see the composited edit as stills or a contact sheet, ${toolIdFor(context.runtimeId, 'render_proxy')} for a draft of a range when motion matters, ${toolIdFor(context.runtimeId, 'clip_analyze')} for indexed frame samples, ${toolIdFor(context.runtimeId, 'clip_describe')} for semantic clip-local frame evidence, and ${toolIdFor(context.runtimeId, 'transcription_generate')} for speech-to-text subtitle timing. Waveform inspection is not exposed through this bridge yet.`,
     },
   };
 }
@@ -1792,15 +1836,16 @@ function stripInlineImageBytes(value: unknown): unknown {
 const RENDER_PROXY_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
- * The same budget for a Claude session, kept under the loopback MCP server's
- * own 300s `tools/call` timeout (`MCP_CALL_TIMEOUT`).
+ * The budget for a Claude session, kept under the loopback MCP server's own
+ * `tools/call` timeout for `render_proxy` (900s; 300s for every other tool).
  *
  * Past that point the backend answers Claude with a timeout error and discards
  * whatever the frontend eventually says, so a longer wait here would not buy
  * the agent an answer — it would only hide the outcome behind a response nobody
- * reads.
+ * reads. The 90s margin covers the round trip between the frontend giving up
+ * and the backend receiving the answer.
  */
-const RENDER_PROXY_MCP_TIMEOUT_MS = 4.5 * 60 * 1000;
+const RENDER_PROXY_MCP_TIMEOUT_MS = 13.5 * 60 * 1000;
 
 /** The wait budget for the runtime this call came from. */
 function resolveRenderProxyTimeoutMs(context: OpenReelioCodexToolContext): number {
@@ -1809,21 +1854,25 @@ function resolveRenderProxyTimeoutMs(context: OpenReelioCodexToolContext): numbe
     : RENDER_PROXY_TIMEOUT_MS;
 }
 
-/** Preset id the tool documents, matching the CLI's `--proxy` shorthand. */
+/**
+ * Preset id the tool documents and sends, matching the CLI's `--proxy`
+ * shorthand: a CRF 30 ultrafast draft fitted to the sequence canvas.
+ *
+ * The desktop render path serves this id itself, so nothing is substituted and
+ * a vertical sequence is drafted vertical rather than letterboxed into 720p.
+ */
 const RENDER_PROXY_DEFAULT_PRESET = 'proxy_480p';
 
 /**
- * Preset the desktop render command is actually given for a proxy request.
- *
- * `ExportPreset::from_legacy_id` — the only preset table `render_range` knows —
- * has no `proxy_480p` arm; that id lives in the CLI's own table. Until the
- * desktop path learns it, a proxy request is served by the host's fast draft
- * preset and the substitution is reported rather than hidden.
+ * Presets the bridge will draft with. Both write MP4, which is what makes the
+ * hard-coded `.mp4` output extension correct for either one.
  */
-const RENDER_PROXY_HOST_PRESET = 'mp4_draft';
+const RENDER_PROXY_ALLOWED_PRESETS = new Set([RENDER_PROXY_DEFAULT_PRESET, 'mp4_draft']);
 
-/** Preset ids that mean "a fast draft to look at", not a specific format. */
-const RENDER_PROXY_PRESET_ALIASES = new Set(['proxy', 'proxy_480p']);
+/** The draft presets, quoted, for a rejection the agent can act on. */
+function describeAllowedRenderPresets(): string {
+  return [...RENDER_PROXY_ALLOWED_PRESETS].map((id) => `'${id}'`).join(' or ');
+}
 
 /** Terminal state of a range render, as the bridge reports it. */
 interface RenderProxyOutcome {
@@ -1839,6 +1888,31 @@ interface RenderProxyOutcome {
 let renderProxyOutputSequence = 0;
 
 /**
+ * Draft renders currently blocking a tool call, keyed by the host's call id.
+ *
+ * A render outlives the agent's interest in it: when the host abandons the
+ * `tools/call` (its timeout, or the user stopping the session), the encoder is
+ * still running and the only way to stop it is `cancel_render`. The bridge
+ * cancel path reaches it through this registry.
+ */
+const inflightRenderCancellations = new Map<string, () => void>();
+
+/**
+ * Cancel the draft render blocking `callId`, if one is in flight.
+ *
+ * Returns whether a render was found, so the caller can tell a cancelled
+ * render from a call that was only waiting on approval.
+ */
+export function cancelInflightAgentRender(callId: string): boolean {
+  const cancel = inflightRenderCancellations.get(callId);
+  if (!cancel) {
+    return false;
+  }
+  cancel();
+  return true;
+}
+
+/**
  * Render one timeline range to a draft file inside the project and wait for it.
  *
  * The output lands in the project's own cache directory, which is both an
@@ -1849,6 +1923,13 @@ async function renderProxyToolCall(
   args: CodexJsonObject | null,
   context: OpenReelioCodexToolContext,
 ): Promise<CodexJsonObject> {
+  // Armed before the first await: the host's own `tools/call` clock started
+  // when the call arrived, so every second spent reading project state is a
+  // second off this budget. Deriving the render timeout from a deadline fixed
+  // here keeps the total wait inside it however slow the preamble is.
+  const budgetMs = resolveRenderProxyTimeoutMs(context);
+  const deadlineAt = Date.now() + budgetMs;
+
   if (!args) {
     throw new Error('OpenReelio render_proxy requires object arguments.');
   }
@@ -1861,15 +1942,21 @@ async function renderProxyToolCall(
       message: `OpenReelio render_proxy requires end (${end}) to be greater than start (${start}).`,
     };
   }
+  if (end - start > RENDER_PROXY_MAX_RANGE_SEC) {
+    return {
+      status: 'error',
+      message: `OpenReelio render_proxy renders at most ${RENDER_PROXY_MAX_RANGE_SEC}s in one call, and this range is ${Math.round(
+        end - start,
+      )}s. Render a narrower window around the moment in question, or look at stills with frame_extract instead.`,
+    };
+  }
 
-  const requestedPreset = getString(args, 'preset')?.trim() || RENDER_PROXY_DEFAULT_PRESET;
-  const warnings: string[] = [];
-  let preset = requestedPreset;
-  if (RENDER_PROXY_PRESET_ALIASES.has(requestedPreset.toLowerCase())) {
-    preset = RENDER_PROXY_HOST_PRESET;
-    warnings.push(
-      `The desktop render path does not accept the '${requestedPreset}' preset, so this draft was rendered with '${RENDER_PROXY_HOST_PRESET}' instead.`,
-    );
+  const preset = getString(args, 'preset')?.trim() || RENDER_PROXY_DEFAULT_PRESET;
+  if (!RENDER_PROXY_ALLOWED_PRESETS.has(preset)) {
+    return {
+      status: 'error',
+      message: `OpenReelio render_proxy renders drafts only: pass ${describeAllowedRenderPresets()}, not '${preset}'. Full-quality presets are for delivery, not for checking work.`,
+    };
   }
 
   const [projectInfo, projectState] = await Promise.all([
@@ -1895,34 +1982,52 @@ async function renderProxyToolCall(
   }
 
   const outputPath = buildAgentRenderOutputPath(projectPath);
+  const callId = context.callId ?? null;
   const render = await startRangeRenderAndWait({
     sequenceId,
     outputPath,
     preset,
     start,
     end,
-    timeoutMs: resolveRenderProxyTimeoutMs(context),
+    deadlineAt,
+    budgetMs,
+    registerCancellation: callId
+      ? (cancel) => {
+          inflightRenderCancellations.set(callId, cancel);
+          return () => inflightRenderCancellations.delete(callId);
+        }
+      : undefined,
   });
+
+  // The file only exists when the encoder finished; naming a path the render
+  // never wrote invites the agent to point frame_extract at nothing.
+  const producedFile = render.outcome.status === 'ok';
+  const durationSec = render.outcome.durationSec ?? end - start;
 
   return {
     status: render.outcome.status,
     jobId: render.jobId,
     sequenceId,
     preset,
-    requestedPreset,
     start,
     end,
-    outputPath: render.outcome.outputPath ?? outputPath,
+    ...(producedFile ? { outputPath: render.outcome.outputPath ?? outputPath } : {}),
     durationSec: render.outcome.durationSec,
     fileSize: render.outcome.fileSize,
     encodingTimeSec: render.outcome.encodingTimeSec,
     message: render.outcome.message,
-    warnings: warnings.length > 0 ? warnings : undefined,
-    nextStep:
-      render.outcome.status === 'ok'
-        ? "Look at the render: openreelio.frame_extract { file: outputPath, atCuts: true, grid: 'auto' }."
-        : undefined,
+    nextStep: producedFile
+      ? `Look at the render: ${toolIdFor(
+          context.runtimeId,
+          'frame_extract',
+        )} { file: outputPath, between: [0, ${roundSeconds(durationSec)}], grid: '4x3', labelCells: true }. File times are relative to the file, and samplers are not available with file.`
+      : undefined,
   };
+}
+
+/** Round a duration to the two decimals a timecode hint is worth. */
+function roundSeconds(seconds: number): number {
+  return Math.round(seconds * 100) / 100;
 }
 
 /** Build the cache path a bridge-initiated render writes to. */
@@ -1947,7 +2052,15 @@ interface RangeRenderRequest {
   preset: string;
   start: number;
   end: number;
-  timeoutMs: number;
+  /** Wall-clock instant the wait must end by, fixed before the call's first await. */
+  deadlineAt: number;
+  /** The full budget the deadline was derived from, for the timeout message. */
+  budgetMs: number;
+  /**
+   * Publish a cancel hook for as long as the render is in flight, and return
+   * the function that withdraws it.
+   */
+  registerCancellation?: (cancel: () => void) => () => void;
 }
 
 /**
@@ -1984,30 +2097,47 @@ async function startRangeRenderAndWait(
     }
   };
 
-  const unlisteners = await Promise.all([
-    listen<RenderCompleteEvent>('render-complete', (event) => {
-      deliver(event.payload.jobId, {
-        status: 'ok',
-        outputPath: event.payload.outputPath,
-        durationSec: event.payload.durationSec,
-        fileSize: event.payload.fileSize,
-        encodingTimeSec: event.payload.encodingTimeSec,
-      });
-    }),
-    listen<RenderLifecycleEvent>('render-lifecycle', (event) => {
-      const { state } = event.payload;
-      if (state !== 'failed' && state !== 'cancelled') {
-        return;
-      }
-      deliver(event.payload.jobId, {
-        status: state,
-        message: event.payload.message ?? undefined,
-      });
-    }),
-  ]);
+  // The host can abandon the call while the encoder runs; `cancelled` is the
+  // hook it pulls, and it settles the wait the same way a cancel event would.
+  let cancelled = false;
+  let requestCancel: (() => void) | null = null;
+  const abandoned = new Promise<'cancelled'>((resolve) => {
+    requestCancel = () => {
+      cancelled = true;
+      resolve('cancelled');
+    };
+  });
 
+  // Registered one at a time inside the try: a second `listen` that rejects
+  // must still detach the first, and `finally` is what guarantees that.
+  const unlisteners: UnlistenFn[] = [];
+  const withdrawCancellation = request.registerCancellation?.(() => requestCancel?.());
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
+    unlisteners.push(
+      await listen<RenderCompleteEvent>('render-complete', (event) => {
+        deliver(event.payload.jobId, {
+          status: 'ok',
+          outputPath: event.payload.outputPath,
+          durationSec: event.payload.durationSec,
+          fileSize: event.payload.fileSize,
+          encodingTimeSec: event.payload.encodingTimeSec,
+        });
+      }),
+    );
+    unlisteners.push(
+      await listen<RenderLifecycleEvent>('render-lifecycle', (event) => {
+        const { state } = event.payload;
+        if (state !== 'failed' && state !== 'cancelled') {
+          return;
+        }
+        deliver(event.payload.jobId, {
+          status: state,
+          message: event.payload.message ?? undefined,
+        });
+      }),
+    );
+
     const started = await commands.renderRange(
       request.sequenceId,
       request.outputPath,
@@ -2025,19 +2155,31 @@ async function startRangeRenderAndWait(
     if (early) {
       return { jobId, outcome: early };
     }
+    if (cancelled) {
+      // The host gave up while the job was still being started, so the job id
+      // only became cancellable now.
+      return { jobId, outcome: cancelRunningRender(jobId) };
+    }
 
     const timeout = new Promise<'timeout'>((resolve) => {
-      timer = setTimeout(() => resolve('timeout'), request.timeoutMs);
+      // Derived from the deadline rather than the budget: the preamble already
+      // spent part of it, and the host's clock does not restart here.
+      timer = setTimeout(() => resolve('timeout'), Math.max(0, request.deadlineAt - Date.now()));
     });
-    const settled = await Promise.race([terminal, timeout]);
+    const settled = await Promise.race([terminal, timeout, abandoned]);
+    if (settled === 'cancelled') {
+      return { jobId, outcome: cancelRunningRender(jobId) };
+    }
     if (settled === 'timeout') {
-      await commands.cancelRender(jobId);
+      // Fire-and-forget: the agent is already out of time, so it gets its
+      // answer now rather than after another backend round trip.
+      void commands.cancelRender(jobId);
       return {
         jobId,
         outcome: {
           status: 'timeout',
           message: `The range render did not finish within ${Math.round(
-            request.timeoutMs / 1000,
+            request.budgetMs / 1000,
           )}s and was cancelled. Render a shorter range.`,
         },
       };
@@ -2045,10 +2187,26 @@ async function startRangeRenderAndWait(
     return { jobId, outcome: settled };
   } finally {
     clearTimeout(timer);
+    withdrawCancellation?.();
     for (const unlisten of unlisteners) {
       unlisten();
     }
   }
+}
+
+/**
+ * Ask the backend to stop a running render without waiting for it to confirm.
+ *
+ * The caller has already decided what to answer; awaiting the cancellation
+ * would only delay that answer behind a round trip whose result changes
+ * nothing.
+ */
+function cancelRunningRender(jobId: string): RenderProxyOutcome {
+  void commands.cancelRender(jobId);
+  return {
+    status: 'cancelled',
+    message: 'The draft render was cancelled before it finished.',
+  };
 }
 
 async function insertMediaToolCall(
@@ -2289,7 +2447,7 @@ async function executeApprovedCommand(
     approval: buildApprovalExecutionSummary(execution),
     result: execution.result,
     affectedRanges: readAffectedRanges(execution.result),
-    nextStep: buildInspectionNextStep(execution.result),
+    nextStep: buildInspectionNextStep(execution.result, context.runtimeId),
     targeting: payloadNormalization.notes.length > 0 ? payloadNormalization.notes : undefined,
     refresh,
   };
@@ -2307,14 +2465,25 @@ function readAffectedRanges(result: AgentPlanResult): unknown {
   return Array.isArray(ranges) && ranges.length > 0 ? ranges : undefined;
 }
 
-/** Tell the agent where to look now that the edit is applied. */
-function buildInspectionNextStep(result: AgentPlanResult): string | undefined {
+/**
+ * Tell the agent where to look now that the edit is applied.
+ *
+ * The fallback is spelled out as a request the frame probe accepts: `between`
+ * is rejected without an explicit `COLSxROWS` grid, so the recovery path an
+ * agent reads under pressure must not name it.
+ */
+function buildInspectionNextStep(
+  result: AgentPlanResult,
+  runtimeId: OpenReelioCodexToolContext['runtimeId'],
+): string | undefined {
   if (!result.success) {
     return undefined;
   }
+  const tool = toolIdFor(runtimeId, 'frame_extract');
+  const look = `Look at what changed: ${tool} { affected: true, grid: 'auto', labelCells: true }.`;
   return readAffectedRanges(result)
-    ? "Look at what changed: openreelio.frame_extract { affected: true, grid: 'auto', labelCells: true }."
-    : "Look at what changed: openreelio.frame_extract { affected: true, grid: 'auto', labelCells: true }. If no hand-off is recorded, sample the edited seconds instead with atCuts or between.";
+    ? look
+    : `${look} If no hand-off is recorded, sample the edited seconds instead: { atCuts: true, grid: 'auto' }, or { around: <edited time>, span: 1, grid: 'auto' }.`;
 }
 
 async function validateCommandToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
@@ -2475,7 +2644,7 @@ async function applyApprovedPlan(
     approval: buildApprovalExecutionSummary(execution),
     result: execution.result,
     affectedRanges: readAffectedRanges(execution.result),
-    nextStep: buildInspectionNextStep(execution.result),
+    nextStep: buildInspectionNextStep(execution.result, context.runtimeId),
     targeting: validation.normalizationNotes.length > 0 ? validation.normalizationNotes : undefined,
     refresh,
   };
@@ -3295,9 +3464,13 @@ function buildTranscriptionResponse(
         'timeline-relative segments instead.';
       response.importHint = response.timelineMappingSkippedReason;
     } else {
-      const timelineCaptionSegments = mapCaptionSegmentsToClipTimeline(captionSegments, clipMapping);
+      const timelineCaptionSegments = mapCaptionSegmentsToClipTimeline(
+        captionSegments,
+        clipMapping,
+      );
       response.timelineSegmentCount = timelineCaptionSegments.length;
-      response.skippedTimelineSegmentCount = captionSegments.length - timelineCaptionSegments.length;
+      response.skippedTimelineSegmentCount =
+        captionSegments.length - timelineCaptionSegments.length;
       response.timelineCaptionSegments = timelineCaptionSegments as unknown as CodexJsonObject[];
       response.importHint =
         'Use timelineCaptionSegments as ImportGeneratedCaptions.segments when creating subtitles for this timeline clip.';
@@ -4927,10 +5100,12 @@ function toolResponse(value: unknown, success = true): CodexDynamicToolCallRespo
 /**
  * Build a dynamic-tool response that carries pictures alongside its JSON.
  *
- * Images come first so the host renders them before the text that explains
- * them, and each is a `data:` URL because that is the only image form the Codex
- * app-server dynamic-tool protocol accepts. `value` must already be free of
- * base64 bytes: the picture travels once, as a picture.
+ * Images come first here, which is the order Codex renders them in, and each is
+ * a `data:` URL because that is the only image form the Codex app-server
+ * dynamic-tool protocol accepts. The Claude path does not inherit that order:
+ * the loopback MCP wrapper rebuilds the result as one text block followed by
+ * the image blocks, so on that host the text leads. `value` must already be
+ * free of base64 bytes either way: the picture travels once, as a picture.
  */
 function toolResponseWithImages(
   value: unknown,

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -873,10 +873,38 @@ const FRAME_EXTRACT_SCHEMA: CodexJsonObject = {
       minimum: 1,
       description: 'Number of samples the around window produces.',
     },
+    ranges: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        required: ['startSec', 'endSec'],
+        properties: {
+          startSec: {
+            type: 'number',
+            minimum: 0,
+            description: 'Range start in timeline seconds.',
+          },
+          endSec: {
+            type: 'number',
+            minimum: 0,
+            description: 'Range end in timeline seconds.',
+          },
+        },
+        additionalProperties: false,
+      },
+      description:
+        "The preferred way to look at what you changed: the affectedRanges a plan_apply or command_execute result returned, handed straight back. The sampler looks at each range's start, its cuts, its middle and its end. Cannot be combined with affected, time, times, between, file, or another sampler.",
+    },
     affected: {
       type: 'boolean',
       description:
-        "Sample exactly the timeline ranges the last applied edit changed. Errors when no edit recorded a hand-off; fall back to atCuts: true, grid: 'auto', or around: <edited time>, span: 1, grid: 'auto'.",
+        "Sample exactly the timeline ranges the last applied edit changed, read from the hand-off that edit recorded. Prefer ranges when the apply result handed you affectedRanges. Errors when no edit recorded a hand-off; fall back to atCuts: true, grid: 'auto', or around: <edited time>, span: 1, grid: 'auto'.",
+    },
+    afterOp: {
+      type: 'string',
+      description:
+        'With affected: true, refuse a hand-off that does not end at this op id, so an edit the user made after yours cannot be read as your own. Pass the last operationId the apply result returned.',
     },
     limit: {
       type: 'integer',
@@ -1038,7 +1066,7 @@ export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
     namespace: 'openreelio',
     name: 'frame_extract',
     description:
-      'Look at the edit. Returns pictures of the composited timeline — captions, text, transforms and blends, exactly what export produces — as stills or one labelled contact sheet, plus the JSON that maps every cell back to its timecode and the reason it was sampled. Do not compute the times yourself: use affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, or around. At most 12 separate stills come back inline; a contact sheet is one image.',
+      'Look at the edit. Returns pictures of the composited timeline — captions, text, transforms and blends, exactly what export produces — as stills or one labelled contact sheet, plus the JSON that maps every cell back to its timecode and the reason it was sampled. Do not compute the times yourself: pass the affectedRanges an apply returned as ranges, or use affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, or around. At most 12 separate stills come back inline; a contact sheet is one image.',
     inputSchema: FRAME_EXTRACT_SCHEMA,
   },
   {
@@ -1147,10 +1175,11 @@ export function buildOpenReelioCodexDeveloperInstructions(
     '- Shell and filesystem tools are secondary; prefer OpenReelio tools for video-editing state and mutations.',
     '',
     'Look at the edit before you report on it:',
-    "- After every openreelio.plan_apply or openreelio.command_execute, call openreelio.frame_extract with affected: true, grid: 'auto', labelCells: true, and look at the picture before you say what changed. If affected reports no recorded hand-off, sample the seconds you edited instead: atCuts: true, grid: 'auto', or around: <edited time>, span: 1, grid: 'auto'.",
+    "- After every openreelio.plan_apply or openreelio.command_execute, look at the picture before you say what changed: hand the affectedRanges the result returned straight to openreelio.frame_extract as ranges: <affectedRanges>, grid: 'auto', labelCells: true.",
+    "- When a result carried no affectedRanges, ask the probe to read the hand-off itself with affected: true, grid: 'auto', labelCells: true, pinned to your own edit with afterOp: <the result's last operationId>. If affected reports no recorded hand-off, sample the seconds you edited instead: atCuts: true, grid: 'auto', or around: <edited time>, span: 1, grid: 'auto'.",
     "- For caption or text edits, inspect with atCaptions: true, grid: 'auto', cellWidth: 640 so the burned-in words are legible.",
     "- Before finishing a task, sweep the whole cut once with perShot: true, grid: 'auto', limit: 24.",
-    "- Do not compute inspection times yourself. frame_extract samples the edit's own events (affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, around); uniform between sampling lands on no event and is for whole-timeline overviews only.",
+    "- Do not compute inspection times yourself. frame_extract samples the edit's own events (ranges, affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, around); uniform between sampling lands on no event and is for whole-timeline overviews only.",
     "- cellWidth, cellHeight, labelCells and between only apply to a contact sheet and are rejected without grid. grid: 'auto' sizes itself from a sampler or times, so between always needs an explicit grid such as '4x3'.",
     '- frame_extract shows the composited edit by default. Only pass mode: "fast" when you deliberately want the raw footage without captions, text or effects.',
     `- Use openreelio.render_proxy only for motion or pacing questions a still cannot answer, and keep the range under ${RENDER_PROXY_MAX_RANGE_SEC}s. Then inspect its outputPath with openreelio.frame_extract { file: outputPath, between: [0, durationSec], grid: '4x3', labelCells: true } — file times are relative to the file, and samplers are not available with file.`,
@@ -1757,8 +1786,26 @@ async function extractFramesToolCall(
   };
 }
 
+/** One timeline range the `ranges` sampler looks at. */
+interface FrameProbeRange {
+  startSec: number;
+  endSec: number;
+}
+
+/**
+ * The `extract_timeline_frames` request as this bridge sends it.
+ *
+ * `ranges` and `afterOp` belong to the probe's request contract but are not in
+ * the generated bindings yet, so they are declared here rather than by
+ * hand-editing `src/bindings.ts`.
+ */
+type FrameProbeRequest = TimelineFrameProbeRequestDto & {
+  ranges?: FrameProbeRange[] | null;
+  afterOp?: string | null;
+};
+
 /** Translate tool arguments into the frame-probe request DTO. */
-function buildFrameProbeRequest(args: CodexJsonObject): TimelineFrameProbeRequestDto {
+function buildFrameProbeRequest(args: CodexJsonObject): FrameProbeRequest {
   const between = readNumberArrayArg(args, 'between', 'frame_extract');
   if (between && between.length !== 2) {
     throw new Error('OpenReelio frame_extract requires between to be [start, end].');
@@ -1783,12 +1830,45 @@ function buildFrameProbeRequest(args: CodexJsonObject): TimelineFrameProbeReques
     around: getFiniteNumberArg(args, 'around', 'frame_extract') ?? null,
     span: getFiniteNonNegativeNumberArg(args, 'span', 'frame_extract') ?? null,
     aroundCount: getFiniteNonNegativeNumberArg(args, 'aroundCount', 'frame_extract') ?? null,
+    ranges: readFrameProbeRanges(args, 'frame_extract'),
     affected: args.affected === true,
+    afterOp: getString(args, 'afterOp')?.trim() || null,
     limit: getFiniteNonNegativeNumberArg(args, 'limit', 'frame_extract') ?? null,
     // The bridge exists to put the picture in front of the model; a path alone
     // is unreadable to it.
     inline: true,
   };
+}
+
+/**
+ * Read the `ranges` sampler argument: the `affectedRanges` an apply handed back,
+ * passed through to the probe unchanged.
+ *
+ * Shape is checked here rather than left to the probe so a malformed hand-back
+ * fails with the field name in the message instead of an IPC-level rejection.
+ */
+function readFrameProbeRanges(args: CodexJsonObject, toolName: string): FrameProbeRange[] | null {
+  const value = args.ranges;
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(
+      `OpenReelio ${toolName} requires ranges to be a non-empty array of { startSec, endSec }.`,
+    );
+  }
+
+  return value.map((entry) => {
+    const range = asObject(entry);
+    const startSec = range ? asFiniteNumber(range.startSec) : null;
+    const endSec = range ? asFiniteNumber(range.endSec) : null;
+    if (startSec === null || endSec === null) {
+      throw new Error(
+        `OpenReelio ${toolName} requires every ranges entry to be { startSec, endSec } in seconds.`,
+      );
+    }
+    return { startSec, endSec };
+  });
 }
 
 function readNumberArrayArg(args: CodexJsonObject, key: string, toolName: string): number[] | null {
@@ -2460,17 +2540,44 @@ async function executeApprovedCommand(
  * follow-up — so their absence is normal and must not be mistaken for "the edit
  * changed nothing".
  */
-function readAffectedRanges(result: AgentPlanResult): unknown {
+function readAffectedRanges(result: AgentPlanResult): unknown[] | undefined {
   const ranges = (result as unknown as Record<string, unknown>).affectedRanges;
   return Array.isArray(ranges) && ranges.length > 0 ? ranges : undefined;
 }
 
 /**
+ * The op this apply ended at, which `afterOp` pins the hand-off to.
+ *
+ * `operationIds` is the executor's own ordered list, so it is read first; the
+ * per-step ids are the fallback for a result that only reports them there.
+ */
+function readLastOperationId(result: AgentPlanResult): string | undefined {
+  for (let index = result.operationIds.length - 1; index >= 0; index -= 1) {
+    const operationId = result.operationIds[index]?.trim();
+    if (operationId) {
+      return operationId;
+    }
+  }
+
+  for (let index = result.stepResults.length - 1; index >= 0; index -= 1) {
+    const operationId = result.stepResults[index]?.operationId?.trim();
+    if (operationId) {
+      return operationId;
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Tell the agent where to look now that the edit is applied.
  *
- * The fallback is spelled out as a request the frame probe accepts: `between`
- * is rejected without an explicit `COLSxROWS` grid, so the recovery path an
- * agent reads under pressure must not name it.
+ * When the apply reported the ranges it touched, they are inlined so the agent
+ * can hand them straight back rather than re-deriving them — and `afterOp` is
+ * offered alongside `affected` so a user edit landing in between cannot be
+ * mistaken for this one. The fallback is spelled out as a request the frame
+ * probe accepts: `between` is rejected without an explicit `COLSxROWS` grid, so
+ * the recovery path an agent reads under pressure must not name it.
  */
 function buildInspectionNextStep(
   result: AgentPlanResult,
@@ -2480,10 +2587,20 @@ function buildInspectionNextStep(
     return undefined;
   }
   const tool = toolIdFor(runtimeId, 'frame_extract');
-  const look = `Look at what changed: ${tool} { affected: true, grid: 'auto', labelCells: true }.`;
-  return readAffectedRanges(result)
-    ? look
-    : `${look} If no hand-off is recorded, sample the edited seconds instead: { atCuts: true, grid: 'auto' }, or { around: <edited time>, span: 1, grid: 'auto' }.`;
+  const editedSeconds =
+    "sample the edited seconds instead: { atCuts: true, grid: 'auto' }, or { around: <edited time>, span: 1, grid: 'auto' }.";
+
+  const ranges = readAffectedRanges(result);
+  if (!ranges) {
+    return `Look at what changed: ${tool} { affected: true, grid: 'auto', labelCells: true }. If no hand-off is recorded, ${editedSeconds}`;
+  }
+
+  const operationId = readLastOperationId(result);
+  const handOff = operationId
+    ? ` Or let the probe read the hand-off itself: { affected: true, afterOp: '${operationId}', grid: 'auto', labelCells: true }.`
+    : '';
+
+  return `Look at what changed: ${tool} { ranges: ${JSON.stringify(ranges)}, grid: 'auto', labelCells: true }.${handOff} If neither is accepted, ${editedSeconds}`;
 }
 
 async function validateCommandToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {

--- a/src/agents/external/adapters/openreelioCodexTools.ts
+++ b/src/agents/external/adapters/openreelioCodexTools.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 
 import {
   commands,
@@ -11,15 +12,18 @@ import {
   type PlanRiskLevel,
   type ProjectInfo,
   type ProjectStateDto,
+  type RenderLifecycleEvent,
   type SemanticTemporalEditAction,
   type SemanticTemporalEditPlan,
   type SemanticTemporalEditPlanOptions,
   type StockMediaImportResult,
   type StockMediaSearchResult,
+  type TimelineFrameProbeRequestDto,
   type TranscriptionOptionsDto,
   type TranscriptionResultDto,
   type TranscriptionStatusDto,
 } from '@/bindings';
+import type { RenderCompleteEvent } from '@/components/features/export/types';
 
 import { hasActiveTimeRemap, type TimeRemapCurve } from '@/types';
 import { TEXT_PRESETS } from '@/data/textPresets';
@@ -770,6 +774,124 @@ const STOCK_MEDIA_IMPORT_SCHEMA: CodexJsonObject = {
   additionalProperties: false,
 };
 
+const FRAME_EXTRACT_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  properties: {
+    time: {
+      type: 'number',
+      description: 'Timeline time in seconds for a single still.',
+    },
+    times: {
+      type: 'array',
+      items: { type: 'number' },
+      description:
+        'Timeline times in seconds: one still each, or the cells of a contact sheet when grid is set.',
+    },
+    grid: {
+      type: 'string',
+      description:
+        "Contact sheet layout as COLSxROWS, or 'auto' to size it from the samples. A sheet is ONE image, so it is the cheap way to look at many moments.",
+    },
+    between: {
+      type: 'array',
+      items: { type: 'number' },
+      description:
+        '[start, end] timeline seconds a grid samples uniformly. Uniform sampling lands on no edit event, so prefer an event sampler when one fits.',
+    },
+    cellWidth: {
+      type: 'number',
+      description: 'Contact sheet cell width in pixels; raise it when reading burned-in text.',
+    },
+    cellHeight: {
+      type: 'number',
+      description: 'Contact sheet cell height in pixels.',
+    },
+    labelCells: {
+      type: 'boolean',
+      description: "Burn each cell's index and timecode into the contact sheet.",
+    },
+    mode: {
+      type: 'string',
+      enum: ['composite', 'fast'],
+      description:
+        "'composite' (default) renders the whole stack — captions, text, transforms, blends — exactly as export does; 'fast' is the cheap topmost-clip-only look that shows none of the edit.",
+    },
+    maxWidth: {
+      type: 'number',
+      description: 'Maximum output width in pixels. Aspect ratio is preserved and never upscaled.',
+    },
+    file: {
+      type: 'string',
+      description:
+        'Rendered video inside the project directory to read instead of the timeline, such as the outputPath returned by openreelio.render_proxy. Cells then map back as fileSec.',
+    },
+    atCuts: {
+      type: 'boolean',
+      description: 'Sample both sides of every cut.',
+    },
+    atTransitions: {
+      type: 'boolean',
+      description: 'Sample the start, cut and end of every two-input transition.',
+    },
+    atCaptions: {
+      type: 'boolean',
+      description: 'Sample the middle of every caption and text span.',
+    },
+    atMarkers: {
+      type: 'boolean',
+      description: 'Sample every sequence marker.',
+    },
+    perShot: {
+      type: 'boolean',
+      description: 'Sample the middle of every shot the export draws — the coverage sweep.',
+    },
+    around: {
+      type: 'number',
+      description: 'Sample a window centred on this timeline time, in seconds.',
+    },
+    span: {
+      type: 'number',
+      description: 'Half-width of the around window in seconds.',
+    },
+    aroundCount: {
+      type: 'number',
+      description: 'Number of samples the around window produces.',
+    },
+    affected: {
+      type: 'boolean',
+      description:
+        'Sample exactly the timeline ranges the last applied edit changed. Errors when no edit recorded a hand-off; fall back to atCuts or between around the edited time.',
+    },
+    limit: {
+      type: 'number',
+      description:
+        'Largest number of sampler times to keep. At most 12 separate stills come back inline, so pass grid for anything wider.',
+    },
+  },
+  additionalProperties: false,
+};
+
+const RENDER_PROXY_SCHEMA: CodexJsonObject = {
+  type: 'object',
+  required: ['start', 'end'],
+  properties: {
+    start: {
+      type: 'number',
+      description: 'Range start in timeline seconds. Must be non-negative and below end.',
+    },
+    end: {
+      type: 'number',
+      description: 'Range end in timeline seconds.',
+    },
+    preset: {
+      type: 'string',
+      description:
+        'Render preset id. Defaults to proxy_480p, which the desktop host serves with its fast 720p draft preset. Pass a desktop preset id such as mp4_draft, youtube_1080p, or prores for a specific format.',
+    },
+  },
+  additionalProperties: false,
+};
+
 export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
   {
     namespace: 'openreelio',
@@ -879,8 +1001,22 @@ export const OPENREELIO_CODEX_DYNAMIC_TOOLS: CodexDynamicToolSpec[] = [
     namespace: 'openreelio',
     name: 'preview_describe',
     description:
-      'Read preview/playback state and whether raw frame inspection is available through the OpenReelio bridge.',
+      'Read preview/playback state and which media inspection paths the OpenReelio bridge exposes.',
     inputSchema: EMPTY_OBJECT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'frame_extract',
+    description:
+      'Look at the edit. Returns pictures of the composited timeline — captions, text, transforms and blends, exactly what export produces — as stills or one labelled contact sheet, plus the JSON that maps every cell back to its timecode and the reason it was sampled. Do not compute the times yourself: use affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, or around. At most 12 separate stills come back inline; a contact sheet is one image.',
+    inputSchema: FRAME_EXTRACT_SCHEMA,
+  },
+  {
+    namespace: 'openreelio',
+    name: 'render_proxy',
+    description:
+      'Render a fast draft of one timeline range into the project cache and wait for it to finish. Use it only for motion and pacing questions a still cannot answer, then inspect the returned outputPath with openreelio.frame_extract. Full-quality renders are for delivery, not for checking work.',
+    inputSchema: RENDER_PROXY_SCHEMA,
   },
   {
     namespace: 'openreelio',
@@ -980,6 +1116,15 @@ export function buildOpenReelioCodexDeveloperInstructions(
     '- Do not use shell or filesystem tools to mutate OpenReelio project state; OpenReelio edits must go through the command log.',
     '- Shell and filesystem tools are secondary; prefer OpenReelio tools for video-editing state and mutations.',
     '',
+    'Look at the edit before you report on it:',
+    "- After every openreelio.plan_apply or openreelio.command_execute, call openreelio.frame_extract with affected: true, grid: 'auto', labelCells: true, and look at the picture before you say what changed. If affected reports no recorded hand-off, sample the seconds you edited instead: atCuts: true, or between: [start, end] around the edited time.",
+    '- For caption or text edits, inspect with atCaptions: true and cellWidth: 640 so the burned-in words are legible.',
+    "- Before finishing a task, sweep the whole cut once with perShot: true, grid: 'auto', limit: 24.",
+    "- Do not compute inspection times yourself. frame_extract samples the edit's own events (affected, atCuts, atTransitions, atCaptions, atMarkers, perShot, around); uniform between sampling lands on no event and is for whole-timeline overviews only.",
+    '- frame_extract shows the composited edit by default. Only pass mode: "fast" when you deliberately want the raw footage without captions, text or effects.',
+    "- Use openreelio.render_proxy only for motion or pacing questions a still cannot answer, then inspect its outputPath with openreelio.frame_extract { file: outputPath, atCuts: true, grid: 'auto' }. Never full-render to check your work.",
+    '- Never claim a cut, caption, overlay, or transition looks right without having extracted a frame that shows it.',
+    '',
     'Available OpenReelio dynamic tools:',
     OPENREELIO_CODEX_DYNAMIC_TOOLS.map((tool) => `- openreelio.${tool.name}`).join('\n'),
   ].join('\n');
@@ -1058,6 +1203,14 @@ export async function handleOpenReelioCodexDynamicToolCall(
         return toolResponse(await buildDiagnosticsResponse());
       case 'preview_describe':
         return toolResponse(await buildPreviewDescription());
+      case 'frame_extract': {
+        const result = await extractFramesToolCall(toolCall.arguments);
+        return toolResponseWithImages(result.value, result.images, result.value.status === 'ok');
+      }
+      case 'render_proxy': {
+        const result = await renderProxyToolCall(toolCall.arguments, context);
+        return toolResponse(result, result.status === 'ok');
+      }
       case 'command_schema':
         return toolResponse(buildCommandSchema());
       case 'command_validate': {
@@ -1105,14 +1258,27 @@ export async function handleOpenReelioCodexDynamicToolCall(
 }
 
 /**
+ * One picture a tool produced, in the raw form MCP carries it: base64 bytes
+ * with no `data:` URI prefix, plus their media type.
+ */
+export interface OpenReelioToolCallImage {
+  data: string;
+  mimeType: string;
+}
+
+/**
  * Result of invoking an OpenReelio dynamic tool via {@link executeOpenReelioAgentToolCall}.
  *
  * `text` is a JSON-encoded payload suitable for an MCP `tools/call` text result;
- * `isError` mirrors the tool's failure state.
+ * `isError` mirrors the tool's failure state. `images` carries any pictures the
+ * tool produced as separate content blocks — they must never be folded into
+ * `text`, because a base64 blob in a text field is unreadable to the model and
+ * costs a fortune in tokens.
  */
 export interface OpenReelioAgentToolCallResult {
   text: string;
   isError: boolean;
+  images?: OpenReelioToolCallImage[];
 }
 
 /**
@@ -1161,22 +1327,50 @@ export async function executeOpenReelioAgentToolCall(
     };
   }
 
+  const images = collectToolCallResponseImages(response);
+
   return {
     text: flattenToolCallResponseText(response),
     isError: !response.success,
+    ...(images.length > 0 ? { images } : {}),
   };
 }
 
 /**
- * Collapse a dynamic-tool response's content items into a single text payload.
- * Text items are concatenated; non-text items (e.g. images) are represented by
- * their JSON so no information is silently dropped.
+ * Collapse a dynamic-tool response's TEXT content items into a single payload.
+ *
+ * Image items are skipped outright rather than JSON-stringified: they are
+ * carried separately by {@link collectToolCallResponseImages}, and serialising a
+ * `data:` URL here would inline a base64 blob into the model's text context.
  */
 function flattenToolCallResponseText(response: CodexDynamicToolCallResponse): string {
-  const parts = response.contentItems.map((item) =>
-    isCodexDynamicToolCallOutputTextItem(item) ? item.text : JSON.stringify(item),
-  );
-  return parts.join('\n');
+  return response.contentItems
+    .filter(isCodexDynamicToolCallOutputTextItem)
+    .map((item) => item.text)
+    .join('\n');
+}
+
+/**
+ * Recover the raw base64 blocks behind a response's `inputImage` data URLs, so
+ * an MCP host that speaks `{ type: "image", data, mimeType }` can carry them.
+ * An item whose URL is not a base64 data URL is dropped: there is nothing to
+ * hand an MCP client, and its paths are already named in the text payload.
+ */
+function collectToolCallResponseImages(
+  response: CodexDynamicToolCallResponse,
+): OpenReelioToolCallImage[] {
+  const images: OpenReelioToolCallImage[] = [];
+  for (const item of response.contentItems) {
+    if (isCodexDynamicToolCallOutputTextItem(item)) {
+      continue;
+    }
+    const match = /^data:([^;,]+);base64,(.+)$/s.exec(item.imageUrl);
+    if (!match) {
+      continue;
+    }
+    images.push({ mimeType: match[1], data: match[2] });
+  }
+  return images;
 }
 
 function normalizeOpenReelioDynamicToolCall(
@@ -1463,13 +1657,398 @@ async function buildPreviewDescription(): Promise<CodexJsonObject> {
       panY: previewState.panY,
     },
     mediaInspection: {
-      rawFrameAccess: true,
+      frameExtraction: 'openreelio.frame_extract',
+      rangeRender: 'openreelio.render_proxy',
       transcriptAccess: transcriptionAvailable,
       waveformAccess: false,
       message:
-        'Use openreelio.clip_analyze for indexed frame samples, openreelio.clip_describe for semantic clip-local frame evidence, and openreelio.transcription_generate for speech-to-text subtitle timing. Waveform inspection is not exposed through this Codex bridge yet.',
+        'Use openreelio.frame_extract to actually see the composited edit as stills or a contact sheet, openreelio.render_proxy for a draft of a range when motion matters, openreelio.clip_analyze for indexed frame samples, openreelio.clip_describe for semantic clip-local frame evidence, and openreelio.transcription_generate for speech-to-text subtitle timing. Waveform inspection is not exposed through this bridge yet.',
     },
   };
+}
+
+/** Outcome of a `frame_extract` call: the JSON to show, and the pictures to attach. */
+interface FrameExtractToolCallResult {
+  value: CodexJsonObject & { status: string };
+  images: OpenReelioToolCallImage[];
+}
+
+/**
+ * Timeline frame probe: the bridge's eyes on the composited edit.
+ *
+ * Always asks for the bytes inline — the whole point is that the model sees the
+ * frame, not a path it cannot open — and returns the probe's own report
+ * verbatim so the timecodes and sampler reasons match the CLI's.
+ */
+async function extractFramesToolCall(
+  args: CodexJsonObject | null,
+): Promise<FrameExtractToolCallResult> {
+  const request = buildFrameProbeRequest(args ?? {});
+
+  const result = await commands.extractTimelineFrames(request);
+  if (result.status === 'error') {
+    return {
+      value: { status: 'error', message: result.error },
+      images: [],
+    };
+  }
+
+  const images: OpenReelioToolCallImage[] = [];
+  const references: CodexJsonObject[] = [];
+  for (const image of result.data.images) {
+    references.push({ path: image.path, mimeType: image.mimeType });
+    if (image.data) {
+      images.push({ data: image.data, mimeType: image.mimeType });
+    }
+  }
+
+  return {
+    value: {
+      status: 'ok',
+      imageCount: images.length,
+      images: references,
+      payload: stripInlineImageBytes(result.data.payload),
+    },
+    images,
+  };
+}
+
+/** Translate tool arguments into the frame-probe request DTO. */
+function buildFrameProbeRequest(args: CodexJsonObject): TimelineFrameProbeRequestDto {
+  const between = readNumberArrayArg(args, 'between', 'frame_extract');
+  if (between && between.length !== 2) {
+    throw new Error('OpenReelio frame_extract requires between to be [start, end].');
+  }
+
+  return {
+    time: getFiniteNumberArg(args, 'time', 'frame_extract') ?? null,
+    times: readNumberArrayArg(args, 'times', 'frame_extract'),
+    grid: getString(args, 'grid')?.trim() || null,
+    between,
+    cellWidth: getFiniteNonNegativeNumberArg(args, 'cellWidth', 'frame_extract') ?? null,
+    cellHeight: getFiniteNonNegativeNumberArg(args, 'cellHeight', 'frame_extract') ?? null,
+    labelCells: args.labelCells === true,
+    mode: getString(args, 'mode')?.trim() || null,
+    maxWidth: getFiniteNonNegativeNumberArg(args, 'maxWidth', 'frame_extract') ?? null,
+    file: getString(args, 'file')?.trim() || null,
+    atCuts: args.atCuts === true,
+    atTransitions: args.atTransitions === true,
+    atCaptions: args.atCaptions === true,
+    atMarkers: args.atMarkers === true,
+    perShot: args.perShot === true,
+    around: getFiniteNumberArg(args, 'around', 'frame_extract') ?? null,
+    span: getFiniteNonNegativeNumberArg(args, 'span', 'frame_extract') ?? null,
+    aroundCount: getFiniteNonNegativeNumberArg(args, 'aroundCount', 'frame_extract') ?? null,
+    affected: args.affected === true,
+    limit: getFiniteNonNegativeNumberArg(args, 'limit', 'frame_extract') ?? null,
+    // The bridge exists to put the picture in front of the model; a path alone
+    // is unreadable to it.
+    inline: true,
+  };
+}
+
+function readNumberArrayArg(args: CodexJsonObject, key: string, toolName: string): number[] | null {
+  const value = args[key];
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'number')) {
+    throw new Error(`OpenReelio ${toolName} requires ${key} to be an array of numbers.`);
+  }
+  return value as number[];
+}
+
+/**
+ * Drop any inline image bytes from a probe report before it is serialised as
+ * text. The report names paths rather than bytes today, so this is a guard
+ * rather than a transformation: an image block is recognised by carrying both a
+ * `mimeType` and a `data` string, and only that `data` is removed.
+ */
+function stripInlineImageBytes(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripInlineImageBytes);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const source = value as Record<string, unknown>;
+  const stripped: Record<string, unknown> = {};
+  const isImageBlock = typeof source.mimeType === 'string' && typeof source.data === 'string';
+  for (const [key, entry] of Object.entries(source)) {
+    if (isImageBlock && key === 'data') {
+      continue;
+    }
+    stripped[key] = stripInlineImageBytes(entry);
+  }
+  return stripped;
+}
+
+/**
+ * How long the bridge waits for a draft render before giving up and cancelling
+ * the job. A range draft is minutes at worst; anything longer is a stuck
+ * encoder, and leaving the agent blocked on it helps nobody.
+ */
+const RENDER_PROXY_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * The same budget for a Claude session, kept under the loopback MCP server's
+ * own 300s `tools/call` timeout (`MCP_CALL_TIMEOUT`).
+ *
+ * Past that point the backend answers Claude with a timeout error and discards
+ * whatever the frontend eventually says, so a longer wait here would not buy
+ * the agent an answer — it would only hide the outcome behind a response nobody
+ * reads.
+ */
+const RENDER_PROXY_MCP_TIMEOUT_MS = 4.5 * 60 * 1000;
+
+/** The wait budget for the runtime this call came from. */
+function resolveRenderProxyTimeoutMs(context: OpenReelioCodexToolContext): number {
+  return context.runtimeId === 'claude_code'
+    ? RENDER_PROXY_MCP_TIMEOUT_MS
+    : RENDER_PROXY_TIMEOUT_MS;
+}
+
+/** Preset id the tool documents, matching the CLI's `--proxy` shorthand. */
+const RENDER_PROXY_DEFAULT_PRESET = 'proxy_480p';
+
+/**
+ * Preset the desktop render command is actually given for a proxy request.
+ *
+ * `ExportPreset::from_legacy_id` — the only preset table `render_range` knows —
+ * has no `proxy_480p` arm; that id lives in the CLI's own table. Until the
+ * desktop path learns it, a proxy request is served by the host's fast draft
+ * preset and the substitution is reported rather than hidden.
+ */
+const RENDER_PROXY_HOST_PRESET = 'mp4_draft';
+
+/** Preset ids that mean "a fast draft to look at", not a specific format. */
+const RENDER_PROXY_PRESET_ALIASES = new Set(['proxy', 'proxy_480p']);
+
+/** Terminal state of a range render, as the bridge reports it. */
+interface RenderProxyOutcome {
+  status: 'ok' | 'failed' | 'cancelled' | 'timeout';
+  outputPath?: string;
+  durationSec?: number;
+  fileSize?: number;
+  encodingTimeSec?: number;
+  message?: string;
+}
+
+/** Distinguishes one bridge render from the next within a millisecond. */
+let renderProxyOutputSequence = 0;
+
+/**
+ * Render one timeline range to a draft file inside the project and wait for it.
+ *
+ * The output lands in the project's own cache directory, which is both an
+ * allowed export root and inside the directory `frame_extract --file` confines
+ * to — so the render the agent just made is a render it can immediately look at.
+ */
+async function renderProxyToolCall(
+  args: CodexJsonObject | null,
+  context: OpenReelioCodexToolContext,
+): Promise<CodexJsonObject> {
+  if (!args) {
+    throw new Error('OpenReelio render_proxy requires object arguments.');
+  }
+
+  const start = getFiniteNonNegativeNumberArg(args, 'start', 'render_proxy', true) ?? 0;
+  const end = getFiniteNonNegativeNumberArg(args, 'end', 'render_proxy', true) ?? 0;
+  if (end <= start) {
+    return {
+      status: 'error',
+      message: `OpenReelio render_proxy requires end (${end}) to be greater than start (${start}).`,
+    };
+  }
+
+  const requestedPreset = getString(args, 'preset')?.trim() || RENDER_PROXY_DEFAULT_PRESET;
+  const warnings: string[] = [];
+  let preset = requestedPreset;
+  if (RENDER_PROXY_PRESET_ALIASES.has(requestedPreset.toLowerCase())) {
+    preset = RENDER_PROXY_HOST_PRESET;
+    warnings.push(
+      `The desktop render path does not accept the '${requestedPreset}' preset, so this draft was rendered with '${RENDER_PROXY_HOST_PRESET}' instead.`,
+    );
+  }
+
+  const [projectInfo, projectState] = await Promise.all([
+    readOptionalProjectInfo(),
+    readOptionalProjectState(),
+  ]);
+  const projectPath = projectInfo?.path?.trim();
+  if (!projectPath) {
+    return {
+      status: 'error',
+      message:
+        'OpenReelio render_proxy needs an open project with a directory on disk. Read openreelio.project_state first.',
+    };
+  }
+
+  const sequenceId = projectState?.activeSequenceId;
+  if (!sequenceId) {
+    return {
+      status: 'error',
+      message:
+        'OpenReelio render_proxy needs an active sequence. Read openreelio.timeline_snapshot first.',
+    };
+  }
+
+  const outputPath = buildAgentRenderOutputPath(projectPath);
+  const render = await startRangeRenderAndWait({
+    sequenceId,
+    outputPath,
+    preset,
+    start,
+    end,
+    timeoutMs: resolveRenderProxyTimeoutMs(context),
+  });
+
+  return {
+    status: render.outcome.status,
+    jobId: render.jobId,
+    sequenceId,
+    preset,
+    requestedPreset,
+    start,
+    end,
+    outputPath: render.outcome.outputPath ?? outputPath,
+    durationSec: render.outcome.durationSec,
+    fileSize: render.outcome.fileSize,
+    encodingTimeSec: render.outcome.encodingTimeSec,
+    message: render.outcome.message,
+    warnings: warnings.length > 0 ? warnings : undefined,
+    nextStep:
+      render.outcome.status === 'ok'
+        ? "Look at the render: openreelio.frame_extract { file: outputPath, atCuts: true, grid: 'auto' }."
+        : undefined,
+  };
+}
+
+/** Build the cache path a bridge-initiated render writes to. */
+function buildAgentRenderOutputPath(projectPath: string): string {
+  const separator = projectPath.includes('\\') && !projectPath.includes('/') ? '\\' : '/';
+  const root = projectPath.replace(/[\\/]+$/, '');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  renderProxyOutputSequence += 1;
+  return [
+    root,
+    '.openreelio',
+    'cache',
+    'renders',
+    'agent',
+    `proxy-${stamp}-${renderProxyOutputSequence}.mp4`,
+  ].join(separator);
+}
+
+interface RangeRenderRequest {
+  sequenceId: string;
+  outputPath: string;
+  preset: string;
+  start: number;
+  end: number;
+  timeoutMs: number;
+}
+
+/**
+ * Start a range render and resolve once it reaches a terminal state.
+ *
+ * The desktop render registry is cancel-only — there is no status to poll — so
+ * completion is observed through events. Both subscriptions are established
+ * before the render is started, and a terminal event that arrives before the
+ * job id is known is buffered rather than lost.
+ *
+ * `render-complete` carries the measurements worth reporting; `render-lifecycle`
+ * is what separates a failure from a cancellation, which the flat
+ * `render-error` event cannot do.
+ */
+async function startRangeRenderAndWait(
+  request: RangeRenderRequest,
+): Promise<{ jobId: string | null; outcome: RenderProxyOutcome }> {
+  const buffered = new Map<string, RenderProxyOutcome>();
+  let jobId: string | null = null;
+  let settle: ((outcome: RenderProxyOutcome) => void) | null = null;
+  const terminal = new Promise<RenderProxyOutcome>((resolve) => {
+    settle = resolve;
+  });
+
+  const deliver = (eventJobId: string, outcome: RenderProxyOutcome): void => {
+    if (jobId === null) {
+      if (!buffered.has(eventJobId)) {
+        buffered.set(eventJobId, outcome);
+      }
+      return;
+    }
+    if (eventJobId === jobId) {
+      settle?.(outcome);
+    }
+  };
+
+  const unlisteners = await Promise.all([
+    listen<RenderCompleteEvent>('render-complete', (event) => {
+      deliver(event.payload.jobId, {
+        status: 'ok',
+        outputPath: event.payload.outputPath,
+        durationSec: event.payload.durationSec,
+        fileSize: event.payload.fileSize,
+        encodingTimeSec: event.payload.encodingTimeSec,
+      });
+    }),
+    listen<RenderLifecycleEvent>('render-lifecycle', (event) => {
+      const { state } = event.payload;
+      if (state !== 'failed' && state !== 'cancelled') {
+        return;
+      }
+      deliver(event.payload.jobId, {
+        status: state,
+        message: event.payload.message ?? undefined,
+      });
+    }),
+  ]);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const started = await commands.renderRange(
+      request.sequenceId,
+      request.outputPath,
+      request.preset,
+      null,
+      request.start,
+      request.end,
+    );
+    if (started.status === 'error') {
+      return { jobId: null, outcome: { status: 'failed', message: started.error } };
+    }
+
+    jobId = started.data.jobId;
+    const early = buffered.get(jobId);
+    if (early) {
+      return { jobId, outcome: early };
+    }
+
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), request.timeoutMs);
+    });
+    const settled = await Promise.race([terminal, timeout]);
+    if (settled === 'timeout') {
+      await commands.cancelRender(jobId);
+      return {
+        jobId,
+        outcome: {
+          status: 'timeout',
+          message: `The range render did not finish within ${Math.round(
+            request.timeoutMs / 1000,
+          )}s and was cancelled. Render a shorter range.`,
+        },
+      };
+    }
+    return { jobId, outcome: settled };
+  } finally {
+    clearTimeout(timer);
+    for (const unlisten of unlisteners) {
+      unlisten();
+    }
+  }
 }
 
 async function insertMediaToolCall(
@@ -1709,9 +2288,33 @@ async function executeApprovedCommand(
     commandType,
     approval: buildApprovalExecutionSummary(execution),
     result: execution.result,
+    affectedRanges: readAffectedRanges(execution.result),
+    nextStep: buildInspectionNextStep(execution.result),
     targeting: payloadNormalization.notes.length > 0 ? payloadNormalization.notes : undefined,
     refresh,
   };
+}
+
+/**
+ * Surface the timeline ranges an apply reports it changed, when it reports any.
+ *
+ * The desktop plan executor does not carry them yet — that is a backend
+ * follow-up — so their absence is normal and must not be mistaken for "the edit
+ * changed nothing".
+ */
+function readAffectedRanges(result: AgentPlanResult): unknown {
+  const ranges = (result as unknown as Record<string, unknown>).affectedRanges;
+  return Array.isArray(ranges) && ranges.length > 0 ? ranges : undefined;
+}
+
+/** Tell the agent where to look now that the edit is applied. */
+function buildInspectionNextStep(result: AgentPlanResult): string | undefined {
+  if (!result.success) {
+    return undefined;
+  }
+  return readAffectedRanges(result)
+    ? "Look at what changed: openreelio.frame_extract { affected: true, grid: 'auto', labelCells: true }."
+    : "Look at what changed: openreelio.frame_extract { affected: true, grid: 'auto', labelCells: true }. If no hand-off is recorded, sample the edited seconds instead with atCuts or between.";
 }
 
 async function validateCommandToolCall(args: CodexJsonObject | null): Promise<CodexJsonObject> {
@@ -1871,6 +2474,8 @@ async function applyApprovedPlan(
     planId: validation.plan.id,
     approval: buildApprovalExecutionSummary(execution),
     result: execution.result,
+    affectedRanges: readAffectedRanges(execution.result),
+    nextStep: buildInspectionNextStep(execution.result),
     targeting: validation.normalizationNotes.length > 0 ? validation.normalizationNotes : undefined,
     refresh,
   };
@@ -4312,6 +4917,34 @@ function toolResponse(value: unknown, success = true): CodexDynamicToolCallRespo
     contentItems: [
       {
         type: 'inputText',
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+    success,
+  };
+}
+
+/**
+ * Build a dynamic-tool response that carries pictures alongside its JSON.
+ *
+ * Images come first so the host renders them before the text that explains
+ * them, and each is a `data:` URL because that is the only image form the Codex
+ * app-server dynamic-tool protocol accepts. `value` must already be free of
+ * base64 bytes: the picture travels once, as a picture.
+ */
+function toolResponseWithImages(
+  value: unknown,
+  images: readonly OpenReelioToolCallImage[],
+  success = true,
+): CodexDynamicToolCallResponse {
+  return {
+    contentItems: [
+      ...images.map((image) => ({
+        type: 'inputImage' as const,
+        imageUrl: `data:${image.mimeType};base64,${image.data}`,
+      })),
+      {
+        type: 'inputText' as const,
         text: JSON.stringify(value, null, 2),
       },
     ],

--- a/src/agents/external/openreelioMcpBridge.test.ts
+++ b/src/agents/external/openreelioMcpBridge.test.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { Event, UnlistenFn } from '@tauri-apps/api/event';
-import { describe, expect, it, vi } from 'vitest';
+import { listen, type Event, type UnlistenFn } from '@tauri-apps/api/event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   OpenReelioMcpBridge,
@@ -14,6 +14,17 @@ import type { OpenReelioAgentToolCallResult } from './adapters/openreelioCodexTo
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
+
+// The tool handler listens for render events through the real Tauri event API;
+// the bridge's own subscriptions are injected separately.
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(listen).mockReset();
+});
 
 type BridgeListen = NonNullable<OpenReelioMcpBridgeDependencies['listen']>;
 type PayloadHandler = (event: Event<unknown>) => void;
@@ -150,6 +161,56 @@ describe('OpenReelioMcpBridge', () => {
         images: [{ data: 'Zm9vYmFy', mimeType: 'image/jpeg' }],
       },
     });
+  });
+
+  it('should stop a draft render the backend has stopped waiting for', async () => {
+    const store = new Map<string, PayloadHandler>();
+    const { listen: bridgeListen } = makeRecordingListen(store);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    // The render never reports a terminal state: only the cancel path can end it.
+    vi.mocked(listen).mockImplementation(() => Promise.resolve<UnlistenFn>(() => undefined));
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_project_info') {
+        return Promise.resolve({ id: 'project-1', name: 'Demo', path: '/workspace/demo' });
+      }
+      if (command === 'get_project_state') {
+        return Promise.resolve({ activeSequenceId: 'seq-1', assets: [], sequences: [] });
+      }
+      if (command === 'render_range') {
+        return Promise.resolve({ jobId: 'job-7', outputPath: 'ignored', status: 'started' });
+      }
+      if (command === 'cancel_render') {
+        return Promise.resolve({ jobId: 'job-7', cancelled: true });
+      }
+      return Promise.reject(new Error(`unexpected command '${command}'`));
+    });
+
+    const bridge = new OpenReelioMcpBridge({ listen: bridgeListen, respond });
+    await bridge.registerMcpSession('server-1', SESSION_CONTEXT);
+    store.get('openreelio:mcp:call')?.(
+      makeEvent<OpenReelioMcpCallEvent>({
+        callId: 'call-render',
+        serverId: 'server-1',
+        sessionId: 'session-1',
+        tool: 'render_proxy',
+        args: { start: 0, end: 5 },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'render_range')).toBe(true);
+    });
+
+    store.get('openreelio:mcp:cancel')?.(
+      makeEvent<OpenReelioMcpCancelEvent>({ callId: 'call-render', serverId: 'server-1' }),
+    );
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(invoke).mock.calls.some(([name]) => name === 'cancel_render')).toBe(true);
+    });
+    // Rust already answered Claude, so the late result is dropped rather than
+    // sent to a call id the backend no longer knows.
+    expect(respond).not.toHaveBeenCalled();
   });
 
   it('should ignore a cancel for a call that is no longer in flight', async () => {

--- a/src/agents/external/openreelioMcpBridge.test.ts
+++ b/src/agents/external/openreelioMcpBridge.test.ts
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core';
 import type { Event, UnlistenFn } from '@tauri-apps/api/event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -8,6 +9,11 @@ import {
   type OpenReelioMcpCancelEvent,
   type OpenReelioMcpSessionContext,
 } from './openreelioMcpBridge';
+import type { OpenReelioAgentToolCallResult } from './adapters/openreelioCodexTools';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
 
 type BridgeListen = NonNullable<OpenReelioMcpBridgeDependencies['listen']>;
 type PayloadHandler = (event: Event<unknown>) => void;
@@ -87,6 +93,63 @@ describe('OpenReelioMcpBridge', () => {
     expect(callId).toBe('call-1');
     expect(response.isError).toBe(true);
     expect(response.text).toContain('unknown-server');
+  });
+
+  it('should forward a tool result to the backend without an images field when there are none', async () => {
+    const store = new Map<string, PayloadHandler>();
+    const { listen } = makeRecordingListen(store);
+    vi.mocked(invoke).mockResolvedValue(null);
+    // No `respond` dependency: this exercises the real backend hand-off.
+    const bridge = new OpenReelioMcpBridge({ listen });
+
+    await bridge.registerMcpSession('server-1', SESSION_CONTEXT);
+    store.get('openreelio:mcp:call')?.(
+      makeEvent<OpenReelioMcpCallEvent>({
+        callId: 'call-1',
+        serverId: 'unknown-server',
+        sessionId: null,
+        tool: 'project_state',
+        args: {},
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('respond_openreelio_mcp_call', expect.anything());
+    });
+
+    const [, args] = vi.mocked(invoke).mock.calls[0] as [string, { response: unknown }];
+    expect(args.response).toEqual({ text: expect.any(String), isError: true });
+    expect(args.response).not.toHaveProperty('images');
+  });
+
+  it('should forward the pictures a tool produced alongside its text', async () => {
+    const store = new Map<string, PayloadHandler>();
+    const { listen } = makeRecordingListen(store);
+    vi.mocked(invoke).mockResolvedValue(null);
+    const bridge = new OpenReelioMcpBridge({ listen });
+
+    await bridge.registerMcpSession('server-1', SESSION_CONTEXT);
+    // `defaultRespond` is private, so it is reached through the bridge's own
+    // respond path with a result that carries images.
+    const respond = (
+      bridge as unknown as {
+        respond: (callId: string, response: OpenReelioAgentToolCallResult) => Promise<void>;
+      }
+    ).respond;
+
+    await respond('call-2', {
+      text: '{"status":"ok"}',
+      isError: false,
+      images: [{ data: 'Zm9vYmFy', mimeType: 'image/jpeg' }],
+    });
+
+    expect(invoke).toHaveBeenCalledWith('respond_openreelio_mcp_call', {
+      callId: 'call-2',
+      response: {
+        text: '{"status":"ok"}',
+        isError: false,
+        images: [{ data: 'Zm9vYmFy', mimeType: 'image/jpeg' }],
+      },
+    });
   });
 
   it('should ignore a cancel for a call that is no longer in flight', async () => {

--- a/src/agents/external/openreelioMcpBridge.ts
+++ b/src/agents/external/openreelioMcpBridge.ts
@@ -6,10 +6,7 @@ import {
   executeOpenReelioAgentToolCall,
   type OpenReelioAgentToolCallResult,
 } from './adapters/openreelioCodexTools';
-import type {
-  ExternalAgentApprovalDecision,
-  ExternalAgentApprovalDecisionProvider,
-} from './types';
+import type { ExternalAgentApprovalDecision, ExternalAgentApprovalDecisionProvider } from './types';
 
 /**
  * Tauri event name carrying loopback MCP tool-call requests from the Claude
@@ -59,10 +56,7 @@ export interface OpenReelioMcpSessionContext {
 
 type TauriListen = <T>(event: string, handler: (event: Event<T>) => void) => Promise<UnlistenFn>;
 
-type RespondMcpCall = (
-  callId: string,
-  response: OpenReelioAgentToolCallResult,
-) => Promise<void>;
+type RespondMcpCall = (callId: string, response: OpenReelioAgentToolCallResult) => Promise<void>;
 
 async function defaultRespond(
   callId: string,
@@ -71,6 +65,9 @@ async function defaultRespond(
   const result = await commands.respondOpenreelioMcpCall(callId, {
     text: response.text,
     isError: response.isError,
+    // Pictures travel as their own MCP content blocks. Omitted entirely when
+    // there are none, so every text-only tool serialises exactly as before.
+    ...(response.images && response.images.length > 0 ? { images: response.images } : {}),
   });
   if (result.status === 'error') {
     throw new Error(result.error);
@@ -113,10 +110,7 @@ export class OpenReelioMcpBridge {
    * the bridge is receiving before Claude spawns and issues its first tool call.
    * Safe to call repeatedly for the same `serverId`.
    */
-  async registerMcpSession(
-    serverId: string,
-    context: OpenReelioMcpSessionContext,
-  ): Promise<void> {
+  async registerMcpSession(serverId: string, context: OpenReelioMcpSessionContext): Promise<void> {
     this.sessions.set(serverId, context);
     await this.ensureSubscribed();
   }

--- a/src/agents/external/openreelioMcpBridge.ts
+++ b/src/agents/external/openreelioMcpBridge.ts
@@ -3,6 +3,7 @@ import { listen, type Event, type UnlistenFn } from '@tauri-apps/api/event';
 import { commands } from '@/bindings';
 
 import {
+  cancelInflightAgentRender,
   executeOpenReelioAgentToolCall,
   type OpenReelioAgentToolCallResult,
 } from './adapters/openreelioCodexTools';
@@ -16,9 +17,10 @@ const OPENREELIO_MCP_CALL_EVENT = 'openreelio:mcp:call';
 
 /**
  * Tauri event name signalling that a pending `tools/call` was cancelled by the
- * backend (its 300s timeout elapsed or its session was deregistered with calls
- * in flight). Rust has already answered Claude with a timeout error, so the
- * frontend must stop waiting on approval and skip its own late response.
+ * backend (its timeout elapsed — 300s for most tools, 900s for `render_proxy` —
+ * or its session was deregistered with calls in flight). Rust has already
+ * answered Claude with a timeout error, so the frontend must stop waiting on
+ * approval, stop any work the call started, and skip its own late response.
  */
 const OPENREELIO_MCP_CANCEL_EVENT = 'openreelio:mcp:cancel';
 
@@ -157,7 +159,16 @@ export class OpenReelioMcpBridge {
     }
   }
 
+  /**
+   * Stop work the backend has stopped waiting for.
+   *
+   * Two things can be in flight: a pending approval, which the wrapped provider
+   * resolves as `'cancel'`, and a draft render, which keeps encoding until
+   * `cancel_render` reaches it. Both are released here — the approval race
+   * alone would leave the encoder running for a call nobody will read.
+   */
   private handleCancel(payload: OpenReelioMcpCancelEvent): void {
+    cancelInflightAgentRender(payload.callId);
     this.inflightCalls.get(payload.callId)?.cancel();
   }
 
@@ -207,6 +218,8 @@ export class OpenReelioMcpBridge {
           runtimeId: 'claude_code',
           sessionId: context.sessionId,
           sessionKnown: true,
+          // Lets a cancel reach work this call started, not just its approval.
+          callId: payload.callId,
           approvalDecisionProvider: wrapApprovalProviderWithCancellation(
             context.approvalDecisionProvider,
             cancellation,

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -363,6 +363,34 @@ function matchesResolveGenerationJobPath(path: string): boolean {
   );
 }
 
+/**
+ * The frame probe answers at the top level rather than under `data`: its report
+ * is the CLI's own JSON, passed through verbatim so both surfaces describe one
+ * artifact.
+ */
+function matchesFrameExtractPath(path: string): boolean {
+  return (
+    path === 'status' ||
+    path === 'imageCount' ||
+    /^images(?:\[\d+\])?(?:\.(?:path|mimeType))?$/.test(path) ||
+    path === 'payload' ||
+    /^payload\.(?:status|mode|count)$/.test(path) ||
+    /^payload\.warnings(?:\[\d+\])?$/.test(path) ||
+    /^payload\.frames(?:\[\d+\])?(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path) ||
+    /^payload\.sheet(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path) ||
+    /^payload\.sheet\.cells(?:\[\d+\])?(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path) ||
+    /^payload\.sampler(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path)
+  );
+}
+
+function matchesRenderProxyPath(path: string): boolean {
+  return (
+    /^(?:status|jobId|sequenceId|preset|requestedPreset|start|end|outputPath|durationSec|fileSize|encodingTimeSec|message|nextStep)$/.test(
+      path,
+    ) || /^warnings(?:\[\d+\])?$/.test(path)
+  );
+}
+
 export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
   get_timeline_info: {
     summary:
@@ -497,6 +525,18 @@ export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
       'returns submitted generation metadata under data.* including data.jobId, data.pendingTimeline.*, and data.nextAction',
     examples: ['data.jobId', 'data.pendingTimeline.markerId', 'data.nextAction'],
     validatePath: matchesGenerateTimelineMediaPath,
+  },
+  frame_extract: {
+    summary:
+      'returns the pictures themselves as image content blocks, plus a JSON report naming payload.mode (timeline/grid/file/asset), payload.frames[n].path/timelineSec/source/reason for stills, payload.sheet.path/cols/rows/cells[n] for a contact sheet, payload.sampler.* for why each time was chosen, and images[n].path/mimeType for the files on disk',
+    examples: ['payload.frames[0].timelineSec', 'payload.sheet.cells[0].reason', 'images[0].path'],
+    validatePath: matchesFrameExtractPath,
+  },
+  render_proxy: {
+    summary:
+      'returns the finished draft render under status (ok/failed/cancelled/timeout) with outputPath, jobId, durationSec, fileSize, encodingTimeSec, optional warnings[n], and a nextStep pointing at frame_extract',
+    examples: ['outputPath', 'jobId', 'durationSec'],
+    validatePath: matchesRenderProxyPath,
   },
   resolve_generation_job: {
     summary:

--- a/src/agents/toolOutputContracts.ts
+++ b/src/agents/toolOutputContracts.ts
@@ -363,34 +363,6 @@ function matchesResolveGenerationJobPath(path: string): boolean {
   );
 }
 
-/**
- * The frame probe answers at the top level rather than under `data`: its report
- * is the CLI's own JSON, passed through verbatim so both surfaces describe one
- * artifact.
- */
-function matchesFrameExtractPath(path: string): boolean {
-  return (
-    path === 'status' ||
-    path === 'imageCount' ||
-    /^images(?:\[\d+\])?(?:\.(?:path|mimeType))?$/.test(path) ||
-    path === 'payload' ||
-    /^payload\.(?:status|mode|count)$/.test(path) ||
-    /^payload\.warnings(?:\[\d+\])?$/.test(path) ||
-    /^payload\.frames(?:\[\d+\])?(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path) ||
-    /^payload\.sheet(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path) ||
-    /^payload\.sheet\.cells(?:\[\d+\])?(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path) ||
-    /^payload\.sampler(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(path)
-  );
-}
-
-function matchesRenderProxyPath(path: string): boolean {
-  return (
-    /^(?:status|jobId|sequenceId|preset|requestedPreset|start|end|outputPath|durationSec|fileSize|encodingTimeSec|message|nextStep)$/.test(
-      path,
-    ) || /^warnings(?:\[\d+\])?$/.test(path)
-  );
-}
-
 export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
   get_timeline_info: {
     summary:
@@ -525,18 +497,6 @@ export const TOOL_OUTPUT_CONTRACTS: Record<string, ToolOutputContract> = {
       'returns submitted generation metadata under data.* including data.jobId, data.pendingTimeline.*, and data.nextAction',
     examples: ['data.jobId', 'data.pendingTimeline.markerId', 'data.nextAction'],
     validatePath: matchesGenerateTimelineMediaPath,
-  },
-  frame_extract: {
-    summary:
-      'returns the pictures themselves as image content blocks, plus a JSON report naming payload.mode (timeline/grid/file/asset), payload.frames[n].path/timelineSec/source/reason for stills, payload.sheet.path/cols/rows/cells[n] for a contact sheet, payload.sampler.* for why each time was chosen, and images[n].path/mimeType for the files on disk',
-    examples: ['payload.frames[0].timelineSec', 'payload.sheet.cells[0].reason', 'images[0].path'],
-    validatePath: matchesFrameExtractPath,
-  },
-  render_proxy: {
-    summary:
-      'returns the finished draft render under status (ok/failed/cancelled/timeout) with outputPath, jobId, durationSec, fileSize, encodingTimeSec, optional warnings[n], and a nextStep pointing at frame_extract',
-    examples: ['outputPath', 'jobId', 'durationSec'],
-    validatePath: matchesRenderProxyPath,
   },
   resolve_generation_job: {
     summary:


### PR DESCRIPTION
### **User description**
## Summary

TypeScript half of bridge eyes, on top of #864. The in-app external-agent bridge (Codex app-server and Claude Code headless) had 23 text-only tools and no way to see the edit it was making.

- **`frame_extract`** runs the shared frame-probe engine through the `extract_timeline_frames` IPC and returns the stills as real images: Codex `inputImage` data URLs, and MCP image blocks for Claude Code through the response `images` channel that never passes through the text flattener. Text metadata follows without any base64. All 22 request fields (samplers, `ranges`, `afterOp`, `file`, grid options) are exposed with integer/minimum constraints matching the Rust DTO.
- **`render_proxy`** renders a range (≤ 5 min) with the canvas-fitted `proxy_480p` preset into the project frame cache, awaits `render-complete` / `render-lifecycle` with a deadline armed before the first await, cancels on timeout or when the bridge call is cancelled, and reports an output path only for a finished file.
- **Perception loop in the developer instructions**: after every `plan_apply`, hand the returned `affectedRanges` back as `ranges` with `grid: auto`; captions with `atCaptions` + 640-wide cells; a per-shot sweep before finishing; render only for motion a still cannot show. A test mirrors the probe validator and proves every recipe in the instructions and every `nextStep` hint is one the engine accepts.
- `preview_describe` no longer claims raw frame access; tool ids in results are host-aware (`mcp__openreelio__*` for Claude).
- `chore(lint)`: ESLint/Prettier ignore `.claude/**` so agent worktrees inside the repo no longer fail the pre-commit hook.

## Verification
- `npx vitest run src/agents` 1523+ passed (16 files / 197 in `src/agents/external`), `npm run type-check`, eslint and prettier clean on the touched files
- Two adversarial review passes (14 findings) fixed with tests before opening

Follow-ups tracked: hoist `verify` into core + IPC + bridge tool; prune `.openreelio/cache/renders/agent`; samplers on rendered files via a declared range.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Exposes `extract_timeline_frames` and `render_proxy` tools to in-app agents.

- Implements inline base64 image support for Claude and Codex bridges.

- Adds a perception loop to developer instructions for automated edit inspection.

- Introduces bounded draft rendering with automatic cancellation on tool timeout.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Agent["Agent (Claude/Codex)"] -- "Tool Call" --> Bridge["TS Agent Bridge"]
  Bridge -- "IPC: extract_timeline_frames" --> RustCore["Rust frame_probe"]
  Bridge -- "IPC: render_range" --> RustRender["Rust Render Engine"]
  RustCore -- "Base64 JPEGs" --> Bridge
  RustRender -- "MP4 Draft" --> Cache[".openreelio/cache/"]
  Bridge -- "Image Content Blocks" --> Agent
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openreelioCodexTools.ts</strong><dd><code>Implementation of agent bridge tools for frame extraction and </code><br><code>rendering</code></dd></summary>
<hr>

src/agents/external/adapters/openreelioCodexTools.ts

<ul><li>Implements <code>frame_extract</code> and <code>render_proxy</code> tool handlers.<br> <li> Adds JSON schemas for frame extraction parameters including samplers <br>and grids.<br> <li> Manages render timeouts and cancellation logic for agent-initiated <br>background jobs.<br> <li> Updates developer instructions to include the visual perception loop.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/865/files#diff-78b40377e0e9fccbf98b98f67b7c52e322184ae79113f5293cc6ad0e085d548d">+941/-16</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openreelioMcpBridge.ts</strong><dd><code>MCP bridge updates for image support and job cancellation</code></dd></summary>
<hr>

src/agents/external/openreelioMcpBridge.ts

<ul><li>Updates the MCP bridge to support returning image content blocks to <br>Claude.<br> <li> Integrates <code>cancelInflightAgentRender</code> to stop encoders when a tool call <br>is cancelled.<br> <li> Passes <code>callId</code> through the context to track active work.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/865/files#diff-fa1af01d9e1a4b2a5f72e9dbdde1b6c3ca1f5ce706e2a4e0bf85d1fb0ef648b2">+22/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openreelioCodexTools.test.ts</strong><dd><code>Unit tests for agent visual perception tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents/external/adapters/openreelioCodexTools.test.ts

<ul><li>Comprehensive test suite for the new <code>frame_extract</code> and <code>render_proxy</code> <br>tools.<br> <li> Validates that instruction recipes are accepted by the frame probe <br>logic.<br> <li> Tests timeout, cancellation, and error handling for draft renders.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/865/files#diff-dbddd9684a80fddb0cd0666bb874696f9feb4429a9bdeaa31bb01beb32cce7b2">+1068/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openreelioMcpBridge.test.ts</strong><dd><code>Tests for MCP bridge image and cancellation handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents/external/openreelioMcpBridge.test.ts

<ul><li>Adds tests for forwarding images to the MCP backend.<br> <li> Verifies that cancelling an MCP call triggers a render cancellation in <br>the frontend.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/865/files#diff-f4f1389951e5658bfb6aaa0027e66a43eae4a47eb30f60bbbd409e524dab430e">+126/-2</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eslint.config.js</strong><dd><code>Ignore agent worktrees in ESLint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

eslint.config.js

<ul><li>Adds <code>.claude/**</code> to the ignore list to prevent linting agent-created <br>worktrees.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/865/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.prettierignore</strong><dd><code>Ignore agent worktrees in Prettier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.prettierignore

<ul><li>Ignores <code>.claude/</code> directory to avoid formatting conflicts in agent <br>worktrees.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/865/files#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

