### PR TITLE
fix(preview): clamp cached-frame offsets to the segment's last stored frame

### DIFF
--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -2776,12 +2776,11 @@ fn run_frame_extract_tool(
         sequence_id,
     );
 
-    extract_inline_frames(args, project.as_ref()).map_err(|error| {
+    extract_inline_frames(args, project.as_ref()).inspect_err(|_error| {
         // Nothing usable came back, so this call's directory is residue: FFmpeg
         // and the sequence-bounds check both run after the mkdir, and an empty
         // entry per failed probe is how the cache grows fastest.
         output.discard();
-        error
     })
 }
 

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -2365,7 +2365,7 @@ fn test_render_reports_only_unrenderable_motion_as_unrendered() {
         return;
     }
 
-    fn is_motion_warning(warning: &String) -> bool {
+    fn is_motion_warning(warning: &str) -> bool {
         warning.contains("Motion keyframes") && warning.contains("not yet rendered")
     }
 
@@ -2373,7 +2373,7 @@ fn test_render_reports_only_unrenderable_motion_as_unrendered() {
         return;
     };
     assert!(
-        !panning.iter().any(is_motion_warning),
+        !panning.iter().any(|warning| is_motion_warning(warning)),
         "a pan renders, so it must not be reported as unrendered: {panning:?}"
     );
 
@@ -2381,7 +2381,7 @@ fn test_render_reports_only_unrenderable_motion_as_unrendered() {
         return;
     };
     assert!(
-        rotating.iter().any(is_motion_warning),
+        rotating.iter().any(|warning| is_motion_warning(warning)),
         "motion that turns the picture is still unrendered and must be reported: {rotating:?}"
     );
 }

--- a/src-tauri/src/core/render/frame_probe/timeline.rs
+++ b/src-tauri/src/core/render/frame_probe/timeline.rs
@@ -1028,8 +1028,8 @@ fn find_segment_for_time(
 /// length is not a whole number of frames: a 0-5s segment at 25fps holds its
 /// last frame at 4.96s, and the seconds clamp would ask for 4.98s.
 ///
-/// Mirrors `cacheFrameOffsetSec` in `src/utils/cacheFrameSource.ts`, which still
-/// carries the seconds clamp on the GUI's preview path.
+/// Mirrors `cacheFrameOffsetSec` in `src/utils/cacheFrameSource.ts`; the two
+/// surfaces must agree about which frame of the file an instant addresses.
 fn cache_frame_offset_sec(segment: &RenderCacheSegment, time_sec: f64, fps: f64) -> f64 {
     if !fps.is_finite() || fps <= 0.0 {
         let duration_sec = (segment.end_sec - segment.start_sec).max(0.0);

--- a/src/utils/cacheFrameSource.test.ts
+++ b/src/utils/cacheFrameSource.test.ts
@@ -175,6 +175,18 @@ describe('cacheFrameOffsetSec', () => {
     expect(frameIndexAt(cacheFrameOffsetSec(segment, 5, NTSC_FPS), NTSC_FPS)).toBe(149);
   });
 
+  it('should clamp to the last stored frame rather than half a frame of wall clock', () => {
+    // A 0-5s segment at 25fps holds frames 0..124, the last of them at 4.96s.
+    // Clamping to the segment's length less half a frame would ask for 4.98s,
+    // which rounds to frame 125 — one past the end of the file.
+    const segment = createSegment({ startSec: 0, endSec: 5 });
+
+    const offset = cacheFrameOffsetSec(segment, 5, 25);
+
+    expect(offset).toBeCloseTo(4.96, 9);
+    expect(frameIndexAt(offset, 25)).toBe(124);
+  });
+
   it('should address through the frame grid so an NTSC segment start keeps its phase', () => {
     // Segment bounds are whole seconds but the renderer snaps its window to
     // round(t * fps) and rebases the file to zero, so file frame 0 sits up to

--- a/src/utils/cacheFrameSource.ts
+++ b/src/utils/cacheFrameSource.ts
@@ -25,9 +25,11 @@ import type { CacheSegmentStatusDto, RenderCacheStatus } from '@/bindings';
 /**
  * Slack subtracted from a segment's end when the frame rate is unusable.
  *
- * Only a fallback: with a real frame rate the end clamp is half a frame (see
- * {@link cacheFrameOffsetSec}), because the decoder addresses by nearest frame
- * and errors out of range rather than saturating.
+ * Only a fallback: with a real frame rate the end clamp is the segment's final
+ * stored frame (see {@link cacheFrameOffsetSec}), because the decoder addresses
+ * by nearest frame and errors out of range rather than saturating. Without a
+ * frame rate there is no frame count to clamp to, so a sliver of a second is
+ * taken off the segment's wall-clock length instead.
  */
 export const CACHE_SEGMENT_END_EPSILON_SEC = 0.001;
 
@@ -154,13 +156,20 @@ export function cacheFrameAssetId(sequenceId: string, segment: CacheSegmentStatu
  * Differencing the two grid positions instead reproduces exactly the frame the
  * renderer wrote.
  *
- * ## Why the end clamp is half a frame
+ * ## Why the end clamp is the segment's final stored frame
  *
  * The decoder addresses by *nearest* frame and treats an out-of-range index as
- * an error rather than saturating at the last one. Anything inside the final
- * half-frame of a segment therefore rounds one frame past the end of the file,
- * and the resulting failure would retire the whole segment as unplayable. The
- * clamp keeps the request on the last frame the file actually holds.
+ * an error rather than saturating at the last one, and a failed decode retires
+ * the whole segment as unplayable. The file holds
+ * `round(endSec * fps) - round(startSec * fps)` frames numbered from zero, so
+ * the clamp is the offset of the last of them. Clamping to wall-clock seconds
+ * instead — the segment's length less half a frame — lands past that frame
+ * whenever the length is not a whole number of frames: a 0-5s segment at 25fps
+ * holds its last frame at 4.96s, and the seconds clamp would ask for 4.98s.
+ *
+ * Mirrors `cache_frame_offset_sec` in
+ * `src-tauri/src/core/render/frame_probe/timeline.rs`; the two surfaces must
+ * agree about which frame of the file an instant addresses.
  *
  * @param segment - Segment covering `timeSec`
  * @param timeSec - Timeline time in seconds
@@ -173,22 +182,20 @@ export function cacheFrameOffsetSec(
   timeSec: number,
   fps: number,
 ): number {
-  const durationSec = Math.max(0, segment.endSec - segment.startSec);
-
   if (!Number.isFinite(fps) || fps <= 0) {
+    const durationSec = Math.max(0, segment.endSec - segment.startSec);
     const fallbackLastSec = Math.max(0, durationSec - CACHE_SEGMENT_END_EPSILON_SEC);
     return Math.min(Math.max(0, timeSec - segment.startSec), fallbackLastSec);
   }
 
   const frameSec = 1 / fps;
-  // A segment shorter than one frame holds a single frame at offset zero, so
-  // there is nothing to address but the start of the file.
-  if (durationSec < frameSec) {
-    return 0;
-  }
-
-  const gridOffsetFrames = Math.round(timeSec * fps) - Math.round(segment.startSec * fps);
-  const lastAddressableSec = Math.max(0, durationSec - frameSec / 2);
+  const startFrame = Math.round(segment.startSec * fps);
+  // What the renderer wrote: the same grid difference the offset itself is
+  // built from, so a segment holding a single frame — or none at all — clamps
+  // every request onto the start of the file.
+  const storedFrames = Math.round(segment.endSec * fps) - startFrame;
+  const lastAddressableSec = Math.max(0, storedFrames - 1) * frameSec;
+  const gridOffsetFrames = Math.round(timeSec * fps) - startFrame;
 
   return Math.min(Math.max(0, gridOffsetFrames * frameSec), lastAddressableSec);
 }


### PR DESCRIPTION
### **User description**
## Summary

- `cacheFrameOffsetSec` in the preview path clamped end-of-segment requests to `durationSec - frameSec/2` (4.98 s for a 0-5 s segment at 25 fps) while the last stored frame is at 4.96 s, so the resident decoder could be asked for a frame past the file. It now mirrors the Rust `cache_frame_offset_sec` exactly (last stored frame index from the frame grid); new test pins the 25 fps case.
- `chore(lint)`: two clippy findings that fail `cargo clippy --locked --all-targets --features dev-full -- -D warnings` on rustc 1.92 (`ptr_arg` in a CLI test helper, `manual_inspect` in the MCP frame path). CI is on 1.88 so these were latent; after the fix the dev-full command is fully clean on 1.92.

## Verification
- `npx vitest run src/utils/cacheFrameSource.test.ts src/components/preview/TimelinePreviewPlayer.test.tsx` 41 passed; `npm run type-check`, eslint, prettier clean
- `cargo clippy --locked --all-targets --features dev-full -- -D warnings` clean on 1.92; `cargo test -p openreelio-cli mcp` 74+2


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Fixes preview frame clamping to match stored frames.

- Aligns TypeScript and Rust frame offset logic.

- Resolves Rust clippy lints for version 1.92.

- Adds test case for 25fps frame clamping.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Frontend (TypeScript)"
    A["cacheFrameOffsetSec"] -- "Aligns with" --> B["Frame Grid Logic"]
  end
  subgraph "Backend (Rust)"
    C["cache_frame_offset_sec"] -- "Matches" --> B
    D["CLI Commands"] -- "Fixes" --> E["Clippy Lints"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacheFrameSource.test.ts</strong><dd><code>Add test for 25fps frame clamping accuracy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/cacheFrameSource.test.ts

<ul><li>Added a new test case to verify that frame clamping at 25 fps <br>correctly targets the last stored frame (4.96s) instead of a <br>wall-clock calculation (4.98s).</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/868/files#diff-9627360ce3838ec7f37028edbcebc439d116b0bccc1cb4f36475d0e1e387700f">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cacheFrameSource.ts</strong><dd><code>Align frame offset clamping with stored frame grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/cacheFrameSource.ts

<ul><li>Updated <code>cacheFrameOffsetSec</code> to calculate the last addressable second <br>based on the actual number of stored frames in the grid.<br> <li> Improved documentation explaining why the end clamp must mirror the <br>Rust implementation to avoid decoder errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/868/files#diff-d98aec954477034b3bf14a13fee5e305013ebf945560de39a2128d573ca45707">+25/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp.rs</strong><dd><code>Fix manual_inspect clippy lint in MCP tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/src/commands/mcp.rs

<ul><li>Replaced <code>map_err</code> with <code>inspect_err</code> in <code>run_frame_extract_tool</code> to satisfy <br>Rust 1.92 clippy lints regarding side-effect only error mapping.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/868/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>integration.rs</strong><dd><code>Fix ptr_arg clippy lint in integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/tests/integration.rs

<ul><li>Changed <code>&String</code> to <code>&str</code> in a test helper function to satisfy <code>ptr_arg</code> <br>clippy lint.<br> <li> Updated iterator calls to explicitly use closures for the modified <br>helper.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/868/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timeline.rs</strong><dd><code>Update documentation for cross-language logic parity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/frame_probe/timeline.rs

<ul><li>Updated comments to reflect that the TypeScript implementation now <br>correctly mirrors the Rust logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/868/files#diff-fe6c96132c346db806eb00e5ee7c7627218ccdfd2c64ce02b993fa787807ab6e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

