### PR TITLE
test(core): poll for worker-pool completion instead of sleeping a fixed 50 ms

### DIFF
--- a/src-tauri/src/core/performance/parallel.rs
+++ b/src-tauri/src/core/performance/parallel.rs
@@ -805,6 +805,28 @@ mod tests {
         assert!(retrieved.is_some());
     }
 
+    /// Polls the pool until at least `count` tasks have completed.
+    ///
+    /// A fixed sleep is not enough on a loaded CI runner: the simulated work
+    /// is scheduled on the runtime and can finish well after 50 ms, which made
+    /// the completion assertions below flaky. Polling with a generous deadline
+    /// keeps the tests fast when the runtime is idle and correct when it is not.
+    async fn wait_for_completed(pool: &WorkerPool, count: usize) -> Vec<ParallelTask> {
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+        loop {
+            let completed = pool.get_tasks_by_status(TaskStatus::Completed).await;
+            if completed.len() >= count {
+                return completed;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "expected {count} completed task(s), found {}",
+                completed.len()
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+    }
+
     #[tokio::test]
     async fn test_worker_pool_get_tasks_by_status() {
         let pool = WorkerPool::new();
@@ -813,10 +835,7 @@ mod tests {
         let task = ParallelTask::new(TaskType::Rendering, TaskPriority::Normal);
         pool.submit(task).await.unwrap();
 
-        // Wait for completion
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-        let completed = pool.get_tasks_by_status(TaskStatus::Completed).await;
+        let completed = wait_for_completed(&pool, 1).await;
         assert!(!completed.is_empty());
     }
 
@@ -824,10 +843,10 @@ mod tests {
     async fn test_worker_pool_cleanup() {
         let pool = WorkerPool::new();
 
-        // Submit and wait for task
+        // Submit and wait for the task to complete
         let task = ParallelTask::new(TaskType::Compute, TaskPriority::Normal);
         pool.submit(task).await.unwrap();
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        wait_for_completed(&pool, 1).await;
 
         // Cleanup
         let cleaned = pool.cleanup_completed().await;


### PR DESCRIPTION
### **User description**
## Summary

`test_worker_pool_cleanup` (and its sibling `test_worker_pool_get_tasks_by_status`) asserted that the simulated task had completed after a fixed 50 ms sleep. On a loaded CI runner the runtime can schedule the work later than that, which failed the Rust Tests job on #869 for a change that never touches this module. The tests now poll for the completed task with a five-second deadline, so they stay fast when the runtime is idle and correct when it is not.

## Verification
- `cargo test -p openreelio --features gui --lib performance::parallel` 22 passed; clippy clean


___

### **PR Type**
Tests


___

### **Description**
- Replaces fixed 50ms sleeps with polling logic.

- Implements `wait_for_completed` helper with 5s deadline.

- Fixes flaky worker pool integration tests.

- Improves CI reliability under heavy load.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Test["Worker Pool Test"] -- "Submit Task" --> Pool["WorkerPool"]
  Test -- "Poll (wait_for_completed)" --> Pool
  Pool -- "Status: Completed" --> Test
  Test -- "Assert" --> Result["Success"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parallel.rs</strong><dd><code>Replace fixed sleeps with polling in worker pool tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/performance/parallel.rs

<ul><li>Added a <code>wait_for_completed</code> helper function that polls the worker pool <br>for a specific number of completed tasks with a 5-second timeout.<br> <li> Updated <code>test_worker_pool_get_tasks_by_status</code> to use the new polling <br>helper instead of a fixed 50ms sleep.<br> <li> Updated <code>test_worker_pool_cleanup</code> to use the polling helper, ensuring <br>tasks are finished before cleanup assertions run.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/870/files#diff-def5882a8c5459253ce5625caec2c39c24ceb2e5e366cb119a12b9789361647a">+25/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by waiting for background tasks to complete before validating results.
  * Added a timeout assertion to clearly report when task completion takes too long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->