### PR TITLE
fix(render): burn caption background boxes into the ASS border colour so boxed packs render

### DIFF
--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -8765,14 +8765,27 @@ fn vertical_caption_ass_script_with_style(text: &str, style: serde_json::Value) 
 }
 
 /// Renders `script` over black and returns the frame as 8-bit grayscale.
-///
-/// The script is written into the directory FFmpeg runs in so the filtergraph
-/// can name it without escaping a Windows drive letter.
 fn render_ass_over_black(
     ffmpeg_path: &std::path::Path,
     script: &str,
     width: u32,
     height: u32,
+) -> Option<Vec<u8>> {
+    render_ass_over_color(ffmpeg_path, script, width, height, "black")
+}
+
+/// Renders `script` over a flat `color` and returns the frame as 8-bit grayscale.
+///
+/// The script is written into the directory FFmpeg runs in so the filtergraph
+/// can name it without escaping a Windows drive letter. A backing other than
+/// black is what makes a *dark* decoration measurable: a black box over black
+/// is indistinguishable from no box at all.
+fn render_ass_over_color(
+    ffmpeg_path: &std::path::Path,
+    script: &str,
+    width: u32,
+    height: u32,
+    color: &str,
 ) -> Option<Vec<u8>> {
     let dir = tempfile::tempdir().expect("temp dir");
     std::fs::write(dir.path().join("overlay.ass"), script).expect("write script");
@@ -8785,7 +8798,7 @@ fn render_ass_over_black(
             "-f",
             "lavfi",
             "-i",
-            &format!("color=c=black:s={width}x{height}:d=2"),
+            &format!("color=c={color}:s={width}x{height}:d=2"),
             "-vf",
             "subtitles=overlay.ass",
             "-ss",
@@ -8818,6 +8831,76 @@ fn render_ass_over_black(
 
 /// Threshold above which a grayscale sample counts as text rather than backing.
 const CAPTION_INK_THRESHOLD: u8 = 96;
+
+/// Below this a grayscale sample counts as backing rather than bright canvas.
+///
+/// A 70%-opaque black box over white lands near 76; the canvas itself is 255.
+const CAPTION_BACKING_THRESHOLD: u8 = 128;
+
+/// Share of a row that must read dark before the row counts as backed.
+///
+/// A caption is far narrower than the canvas, so the row *mean* stays bright
+/// even where the box is solid. Coverage measures the box instead of averaging
+/// it away.
+const CAPTION_BACKING_ROW_COVERAGE: f64 = 0.2;
+
+/// Mean sample value of a rectangle, inclusive of both ends of both ranges.
+fn region_mean_luminance(frame: &[u8], width: u32, rows: (u32, u32), columns: (u32, u32)) -> f64 {
+    let mut total = 0.0;
+    let mut count = 0.0;
+
+    for row in rows.0..=rows.1 {
+        for column in columns.0..=columns.1 {
+            total += f64::from(frame[(row * width + column) as usize]);
+            count += 1.0;
+        }
+    }
+
+    total / count
+}
+
+/// Row ranges where enough of the row reads dark, grouped into bands.
+///
+/// The inverse of [`text_row_bands`]: over a bright backing it finds the *dark*
+/// decorations - a caption's background box - rather than the light glyphs.
+fn backed_row_bands(frame: &[u8], width: u32, height: u32) -> Vec<(u32, u32)> {
+    let mut bands: Vec<(u32, u32)> = Vec::new();
+
+    for row in 0..height {
+        let start = (row * width) as usize;
+        let dark = frame[start..start + width as usize]
+            .iter()
+            .filter(|value| **value < CAPTION_BACKING_THRESHOLD)
+            .count();
+        let is_backed = dark as f64 / f64::from(width) >= CAPTION_BACKING_ROW_COVERAGE;
+
+        match (is_backed, bands.last_mut()) {
+            (true, Some(band)) if band.1 + 1 == row => band.1 = row,
+            (true, _) => bands.push((row, row)),
+            (false, _) => {}
+        }
+    }
+
+    bands
+}
+
+/// Horizontal extent of the dark samples inside `rows`, as (leftmost, rightmost).
+fn backing_column_extent(frame: &[u8], width: u32, rows: (u32, u32)) -> Option<(u32, u32)> {
+    let mut extent: Option<(u32, u32)> = None;
+
+    for row in rows.0..=rows.1 {
+        for column in 0..width {
+            if frame[(row * width + column) as usize] < CAPTION_BACKING_THRESHOLD {
+                extent = Some(match extent {
+                    Some((left, right)) => (left.min(column), right.max(column)),
+                    None => (column, column),
+                });
+            }
+        }
+    }
+
+    extent
+}
 
 /// Row ranges carrying text, grouped into the bands they form.
 ///
@@ -8858,6 +8941,84 @@ fn text_column_extent(frame: &[u8], width: u32, height: u32) -> Option<(u32, u32
     }
 
     extent
+}
+
+/// Feature: Caption burn-in
+/// Scenario: a caption styled with a translucent black box burns that box in
+///
+/// Given a caption whose style carries `backgroundColor` rgba(0,0,0,180)
+/// When the export's ASS script is burned in by libass over a white backing
+/// Then the band behind the text is dark, and the same band of the same
+///      caption without a box stays white
+///
+/// The unit tests can only assert what the script *says*. libass draws a
+/// `BorderStyle: 3` box in the OutlineColour column and reserves BackColour for
+/// the drop shadow, so a script that named the box in BackColour parsed fine,
+/// asserted fine, and burned in as bare white text over the footage. Only
+/// measuring pixels behind the caption catches that.
+#[test]
+fn test_a_boxed_caption_burns_a_dark_band_behind_its_text() {
+    let Some(ffmpeg_path) = available_ffmpeg_path() else {
+        return;
+    };
+
+    let (width, height) = (1080u32, 1920u32);
+    let boxed = vertical_caption_ass_script_with_style(
+        "Boxed caption",
+        serde_json::json!({
+            "fontFamily": "Arial",
+            "fontSize": 64,
+            "color": { "r": 255, "g": 255, "b": 255, "a": 255 },
+            "backgroundColor": { "r": 0, "g": 0, "b": 0, "a": 180 },
+        }),
+    );
+    let bare = vertical_caption_ass_script_with_style(
+        "Boxed caption",
+        serde_json::json!({
+            "fontFamily": "Arial",
+            "fontSize": 64,
+            "color": { "r": 255, "g": 255, "b": 255, "a": 255 },
+        }),
+    );
+
+    let Some(with_box) = render_ass_over_color(&ffmpeg_path, &boxed, width, height, "white") else {
+        skip_without_ffmpeg("ffmpeg could not burn the ASS overlay in");
+        return;
+    };
+    let without_box = render_ass_over_color(&ffmpeg_path, &bare, width, height, "white")
+        .expect("the control render must succeed once the first one did");
+
+    let bands = backed_row_bands(&with_box, width, height);
+    let band = bands
+        .iter()
+        .max_by_key(|(top, bottom)| bottom - top)
+        .copied()
+        .unwrap_or_else(|| panic!("a boxed caption must darken rows, got bands {bands:?}"));
+
+    assert!(
+        band.1 - band.0 >= 64,
+        "the box must cover at least the type it backs, got rows {band:?}"
+    );
+    assert!(
+        band.0 > height / 2 && band.1 < height - 80,
+        "a bottom-preset box must sit low in frame and clear the edge, got rows {band:?}"
+    );
+
+    let columns = backing_column_extent(&with_box, width, band).expect("the box has an extent");
+    let boxed_mean = region_mean_luminance(&with_box, width, band, columns);
+    let bare_mean = region_mean_luminance(&without_box, width, band, columns);
+    assert!(
+        boxed_mean < 160.0,
+        "the caption band must read dark behind the text, got mean {boxed_mean:.1}"
+    );
+    assert!(
+        bare_mean > 240.0,
+        "the same band without a box must stay white, got mean {bare_mean:.1}"
+    );
+    assert!(
+        bare_mean - boxed_mean > 80.0,
+        "the box must change the picture, got {bare_mean:.1} without and {boxed_mean:.1} with"
+    );
 }
 
 /// Feature: Caption burn-in

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -5842,8 +5842,7 @@ fn append_ass_text_style_and_event(
         "outline_color",
         "#000000",
         decoration_alpha("outline_opacity", 1.0),
-    )
-    .unwrap_or_else(AssColor::transparent_black);
+    );
     let outline_width = if effect.get_param("outline_color").is_some() {
         effect_int_param(effect, "outline_width", 2).clamp(0, 100) as f64
     } else {
@@ -5884,9 +5883,17 @@ fn append_ass_text_style_and_event(
     } else {
         outline_width
     };
-    let back_color = background_color
-        .or(shadow_color)
+    // `BorderStyle: 3` draws its opaque box in the *OutlineColour* column and
+    // uses BackColour only for the drop-shadow box behind it. Writing the box
+    // colour to BackColour therefore painted it nowhere unless the style also
+    // carried a shadow offset, and left the box column fully transparent: a
+    // boxed caption burned in as bare white text over the footage. The box
+    // replaces the outline in this border style, so nothing is lost by giving
+    // it the column, and the shadow keeps its own.
+    let border_color = background_color
+        .or(outline_color)
         .unwrap_or_else(AssColor::transparent_black);
+    let back_color = shadow_color.unwrap_or_else(AssColor::transparent_black);
     let alignment = anchor.alignment();
     let (margin_l, margin_r, margin_v) = anchor.margin_columns();
 
@@ -5894,7 +5901,7 @@ fn append_ass_text_style_and_event(
         "Style: {style_name},{font_family},{font_size:.2},{},{},{},{},{},{},{},0,{scale_x_percent:.2},{scale_y_percent:.2},{letter_spacing},0,{border_style},{style_outline_width:.2},{shadow_size:.2},{alignment},{margin_l},{margin_r},{margin_v},1\n",
         primary.ass_value(),
         primary.ass_value(),
-        outline_color.ass_value(),
+        border_color.ass_value(),
         back_color.ass_value(),
         if bold { -1 } else { 0 },
         if italic { -1 } else { 0 },
@@ -8755,6 +8762,156 @@ mod tests {
             script.contains(r"\bord24.00"),
             "Expected dialogue override to preserve background padding. Got: {script}"
         );
+    }
+
+    /// Builds the ASS script for one caption carrying `style` at the default anchor.
+    fn caption_ass_script_for_style(style: serde_json::Value) -> String {
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut track = Track::new_caption("Captions");
+        let mut clip = Clip::new("caption-asset")
+            .with_source_range(0.0, 2.0)
+            .place_at(0.0);
+        clip.label = Some("Boxed".to_string());
+        clip.caption_style = Some(style);
+        track.add_clip(clip);
+        sequence.add_track(track);
+
+        build_ass_text_overlay_script(&sequence, &HashMap::new())
+            .expect("script result")
+            .expect("script exists")
+    }
+
+    /// Column indices of the `[V4+ Styles]` `Format:` line this exporter writes.
+    mod ass_style_column {
+        /// `OutlineColour`, which `BorderStyle: 3` draws its opaque box in.
+        pub const BORDER_COLOUR: usize = 5;
+        /// `BackColour`, which carries the drop shadow.
+        pub const BACK_COLOUR: usize = 6;
+        /// `BorderStyle`: 1 for outline plus shadow, 3 for an opaque box.
+        pub const BORDER_STYLE: usize = 15;
+    }
+
+    /// Splits the script's single `Style:` line into its columns.
+    fn ass_style_columns(script: &str) -> Vec<String> {
+        script
+            .lines()
+            .find(|line| line.starts_with("Style: "))
+            .expect("the script carries a style line")
+            .split(',')
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Reads the `OutlineColour` and `BackColour` columns out of a `Style:` line.
+    fn ass_border_and_back_colour(script: &str) -> (String, String) {
+        let columns = ass_style_columns(script);
+        (
+            columns[ass_style_column::BORDER_COLOUR].clone(),
+            columns[ass_style_column::BACK_COLOUR].clone(),
+        )
+    }
+
+    /// Reads the visible alpha of an `&HAABBGGRR` colour, where `0xFF` is invisible.
+    fn ass_colour_visible_alpha(raw: &str) -> u8 {
+        let hex = raw.trim().trim_start_matches("&H");
+        assert_eq!(hex.len(), 8, "an ASS colour is eight hex digits: {raw}");
+        255 - u8::from_str_radix(&hex[0..2], 16).expect("the alpha byte parses")
+    }
+
+    #[test]
+    fn a_boxed_caption_writes_its_box_colour_to_the_ass_border_column() {
+        // libass draws a `BorderStyle: 3` box in the OutlineColour column and
+        // reserves BackColour for the drop-shadow box behind it. Writing the
+        // box colour to BackColour left the box column fully transparent, so a
+        // boxed caption burned in as bare text over the footage.
+        let script = caption_ass_script_for_style(serde_json::json!({
+            "color": { "r": 255, "g": 255, "b": 255, "a": 255 },
+            "backgroundColor": { "r": 0, "g": 0, "b": 0, "a": 180 },
+            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 120 },
+            "shadowOffset": 2.0,
+        }));
+
+        let (border, back) = ass_border_and_back_colour(&script);
+        // Alpha is inverted in ASS: 180/255 visible becomes 0x4B opaque-from-255.
+        assert_eq!(
+            border, "&H4B000000",
+            "the box colour must reach the border column. Got: {script}"
+        );
+        assert_eq!(
+            back, "&H87000000",
+            "the shadow colour must keep the back column. Got: {script}"
+        );
+        assert!(
+            script.contains(",3,10.00,2.00,"),
+            "a box must select BorderStyle 3 and keep its shadow. Got: {script}"
+        );
+    }
+
+    #[test]
+    fn an_outlined_caption_still_writes_its_outline_to_the_ass_border_column() {
+        // The border column is shared: without a box it carries the outline,
+        // exactly as it did before boxes were routed through it.
+        let script = caption_ass_script_for_style(serde_json::json!({
+            "color": { "r": 255, "g": 255, "b": 255, "a": 255 },
+            "outlineColor": { "r": 0, "g": 0, "b": 0, "a": 255 },
+            "outlineWidth": 4.0,
+        }));
+
+        let (border, back) = ass_border_and_back_colour(&script);
+        assert_eq!(border, "&H00000000", "Got: {script}");
+        assert_eq!(
+            back, "&HFF000000",
+            "no shadow leaves the back column transparent. Got: {script}"
+        );
+        assert!(
+            script.contains(",1,4.00,0.00,"),
+            "an outline must stay on BorderStyle 1. Got: {script}"
+        );
+    }
+
+    #[test]
+    fn every_curated_pack_with_a_background_burns_a_visible_box() {
+        use crate::core::style::caption_packs::CAPTION_PACKS;
+
+        // `boxed-contrast`, `broadcast-lower` and `high-contrast-accessible`
+        // are the packs whose whole point is the box. Walking the table rather
+        // than naming them keeps a future boxed pack from shipping unchecked.
+        let boxed: Vec<&str> = CAPTION_PACKS
+            .iter()
+            .filter(|pack| pack.style().background_color.is_some())
+            .map(|pack| pack.id)
+            .collect();
+        assert!(
+            boxed.contains(&"boxed-contrast")
+                && boxed.contains(&"broadcast-lower")
+                && boxed.contains(&"high-contrast-accessible"),
+            "the boxed packs must still be boxed, got {boxed:?}"
+        );
+
+        for pack in CAPTION_PACKS
+            .iter()
+            .filter(|pack| pack.style().background_color.is_some())
+        {
+            let style =
+                serde_json::to_value(pack.style()).expect("a pack style serializes to JSON");
+            let script = caption_ass_script_for_style(style);
+            let columns = ass_style_columns(&script);
+
+            assert_eq!(
+                columns[ass_style_column::BORDER_STYLE],
+                "3",
+                "pack '{}' must select BorderStyle 3. Got: {script}",
+                pack.id
+            );
+            let alpha = ass_colour_visible_alpha(&columns[ass_style_column::BORDER_COLOUR]);
+            assert!(
+                alpha >= 128,
+                "pack '{}' must draw a box the footage cannot swallow, got alpha {alpha}",
+                pack.id
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## Summary

Found by two independent agents judging real footage through the CLI: after applying `boxed-contrast` (or any explicit `backgroundColor`), both the composite still and the proxy render showed plain white text with no box — `verify` still passed. Root cause: the ASS style builder wrote the background colour into `BackColour` and left `OutlineColour` at transparent black, but libass draws a `BorderStyle: 3` box in the `OutlineColour` column; `BackColour` only tints the drop-shadow box. The box was drawn every time — in a fully transparent colour.

- One-line mapping fix in the ASS style builder (`src-tauri/src/core/render/export.rs`): the border column carries the box when there is one and the outline otherwise; the shadow keeps `BackColour`.
- Every surface that burns captions through the ASS script (frame extract composite, proxy/full renders, cached preview segments) is fixed at once.
- Tests: a pixel-measuring integration test renders a boxed caption over white through the real exporter and asserts the dark band (fails on the old mapping); unit tests pin the column mapping, the outline case, and walk every curated pack that declares a background.

Note: ASS `BorderStyle: 3` cannot draw a box and an outline at once; a style carrying both renders only the box (previously blank). A validation warning for that combination is a follow-up.

## Verification
- `cargo test -p openreelio --lib` 4647; `cargo test -p openreelio-cli` 201 + 195 (ffmpeg-gated tests executed); clippy (CI command) clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes caption background box rendering in ASS.

- Maps background color to ASS `OutlineColour` column.

- Ensures `BorderStyle: 3` renders opaque boxes correctly.

- Adds pixel-measuring integration tests for box visibility.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Caption Style"] -- "backgroundColor exists" --> B["Set BorderStyle: 3"]
  B -- "Map to ASS" --> C["OutlineColour = Background"]
  C -- "Map to ASS" --> D["BackColour = Shadow"]
  D -- "libass Render" --> E["Visible Opaque Box"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration.rs</strong><dd><code>Add integration tests for caption box rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/tests/integration.rs

<ul><li>Added <code>render_ass_over_color</code> to support rendering against non-black <br>backgrounds.<br> <li> Implemented <code>test_a_boxed_caption_burns_a_dark_band_behind_its_text</code> to <br>verify box rendering via pixel analysis.<br> <li> Added helper functions for calculating region mean luminance and <br>detecting backed row bands.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/871/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+164/-3</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Fix ASS style mapping for background boxes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/core/render/export.rs

<ul><li>Re-mapped <code>backgroundColor</code> to the <code>OutlineColour</code> column in ASS styles <br>when <code>BorderStyle: 3</code> is used.<br> <li> Reserved <code>BackColour</code> specifically for drop shadows.<br> <li> Added unit tests to verify ASS column mapping and curated caption pack <br>styles.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/871/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+162/-5</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed exported captions with background boxes so their dark or translucent backing renders correctly behind the text.
  - Improved caption styling to preserve the distinction between background boxes, outlines, and shadows.
  - Captions without background boxes continue to render without unintended dark bands or filled areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->