### PR TITLE
fix(cli): keep the frame probe off the main-thread stack so the MCP server survives a contact sheet

### DIFF
--- a/crates/openreelio-cli/src/commands/frame.rs
+++ b/crates/openreelio-cli/src/commands/frame.rs
@@ -301,6 +301,17 @@ pub fn run_extract_with_project(
     extract_with_project(args, Some(project))
 }
 
+/// Resolves FFmpeg, opens the project if the plan needs it, and runs the probe.
+///
+/// Every `plan.run` here is handed to `block_on` boxed. `block_on` drives the
+/// future on the calling thread, and an unoptimised build of Tokio's entry
+/// chain stores it by value in several frames on the way in — so the cost in
+/// stack is a multiple of the future's own size, not the size itself. The
+/// composite-still state machine is tens of kilobytes wide, which multiplied out
+/// to roughly 650 KiB of stack before the future's body was entered; on the MCP
+/// server, which reaches this through its own JSON-RPC dispatch, that overflowed
+/// the 1 MiB Windows main thread and killed the process. Boxed, only a pointer
+/// is copied through those frames.
 fn extract_with_project(
     args: ExtractArgs,
     project: Option<&ActiveProject>,
@@ -317,7 +328,7 @@ fn extract_with_project(
     let runner = FFmpegRunner::new(ffmpeg_info);
 
     if !plan.needs_project() {
-        return Ok(runtime.block_on(plan.run(&runner, None))?);
+        return Ok(runtime.block_on(Box::pin(plan.run(&runner, None)))?);
     }
 
     let opened;
@@ -333,5 +344,5 @@ fn extract_with_project(
         state: &project.state,
     };
 
-    Ok(runtime.block_on(plan.run(&runner, Some(&probe_project)))?)
+    Ok(runtime.block_on(Box::pin(plan.run(&runner, Some(&probe_project))))?)
 }

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -237,7 +237,11 @@ pub fn run_start_render(args: StartArgs) -> anyhow::Result<serde_json::Value> {
         .enable_all()
         .build()
         .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))?;
-    let result = runtime.block_on(async move {
+    // Boxed for the same reason `frame::extract_with_project` boxes its probe:
+    // `block_on` copies the future it is given through several of its own frames
+    // in an unoptimised build, so an export state machine costs a multiple of
+    // its size in stack. Only a pointer travels through those frames now.
+    let result = runtime.block_on(Box::pin(async move {
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
         // Ctrl-C must reach FFmpeg: without this the CLI would exit while the
         // child keeps encoding into a half-written output file.
@@ -279,7 +283,7 @@ pub fn run_start_render(args: StartArgs) -> anyhow::Result<serde_json::Value> {
         }
 
         export
-    });
+    }));
 
     let result = result.map_err(|error| match error {
         openreelio_core::render::ExportError::Cancelled => {

--- a/crates/openreelio-cli/src/commands/verify.rs
+++ b/crates/openreelio-cli/src/commands/verify.rs
@@ -164,8 +164,12 @@ pub(crate) fn run_verify(path: &Path, request: VerifyRequest) -> anyhow::Result<
         .build()
         .map_err(|error| anyhow::anyhow!("Failed to create Tokio runtime: {error}"))?;
 
+    // Boxed for the same reason `frame::extract_with_project` boxes its probe:
+    // `block_on` copies the future it is given through several of its own frames
+    // in an unoptimised build, so a wide state machine costs a multiple of its
+    // size in stack. Only a pointer travels through those frames now.
     let report = runtime
-        .block_on(plan.run(&project.state, runner.as_ref()))
+        .block_on(Box::pin(plan.run(&project.state, runner.as_ref())))
         .map_err(|error| anyhow::anyhow!("{error}"))?;
 
     let exit_code = i32::from(report.exit_code());

--- a/crates/openreelio-cli/src/main.rs
+++ b/crates/openreelio-cli/src/main.rs
@@ -28,6 +28,26 @@ mod validate;
 use clap::Parser;
 use commands::Cli;
 
+/// Stack size handed to the thread every CLI verb runs on.
+///
+/// The process main thread is sized by the OS from the executable header, which
+/// is 1 MiB on Windows — the smallest of the three platforms we ship, and small
+/// enough that the frame probe walked off the end of it. Driving a future with
+/// `block_on` costs far more stack than the future itself: an unoptimised build
+/// of Tokio's entry chain stores the future by value in several frames, so the
+/// 41 KiB `FrameProbePlan::run` state machine cost roughly 650 KiB of stack
+/// before its body was even entered, and the composite-still chain below it
+/// (contact sheet, windowed export, FFmpeg invocation) added ~370 KiB more.
+/// A `frame extract` with a sampler and an auto grid therefore peaked around
+/// 1.3 MiB, and the MCP server — whose JSON-RPC dispatch adds another ~32 KiB
+/// under the same call — died on it with an unrecoverable stack overflow.
+///
+/// Boxing the future at the `block_on` boundary (see `commands::frame`) removes
+/// the amplification and is the actual fix. This is the second line of defence:
+/// no future anywhere below a CLI verb may ever be able to kill the process,
+/// because on Windows a stack overflow is not a panic that can be caught.
+const WORKER_STACK_SIZE_BYTES: usize = 64 * 1024 * 1024;
+
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -48,5 +68,23 @@ fn main() -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    commands::execute(cli)
+    run_on_worker_thread(cli)
+}
+
+/// Runs the parsed command on a thread with an explicitly sized stack.
+///
+/// A panic on the worker is re-raised on the main thread so the process still
+/// reports it exactly as it did when the work ran here: the same message on
+/// stderr from the default hook, and the same non-zero exit.
+fn run_on_worker_thread(cli: Cli) -> anyhow::Result<()> {
+    let worker = std::thread::Builder::new()
+        .name("openreelio-cli".to_string())
+        .stack_size(WORKER_STACK_SIZE_BYTES)
+        .spawn(move || commands::execute(cli))
+        .map_err(|error| anyhow::anyhow!("Failed to start the CLI worker thread: {error}"))?;
+
+    match worker.join() {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -8536,11 +8536,29 @@ fn test_command_execute_resolves_a_text_preset_into_concrete_values() {
 /// server reads until stdin closes — so the requests go in, stdin is dropped,
 /// and the process is left to exit on its own.
 fn run_mcp_stdio(project_path: &str, requests: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    run_mcp_stdio_session(project_path, false, requests).0
+}
+
+/// The same transport, keeping stderr and optionally granting `--allow-write`.
+///
+/// The server writes nothing to stdout when it dies, so a caller that got fewer
+/// responses than it sent has to be able to say why — a stack overflow, for one,
+/// is reported by the runtime on stderr and nowhere else.
+fn run_mcp_stdio_session(
+    project_path: &str,
+    allow_write: bool,
+    requests: &[serde_json::Value],
+) -> (Vec<serde_json::Value>, String) {
     use std::io::Write;
     use std::process::Stdio;
 
+    let mut args = vec!["mcp", "--stdio", "--project", project_path];
+    if allow_write {
+        args.push("--allow-write");
+    }
+
     let mut child = Command::new(cli_bin())
-        .args(["mcp", "--stdio", "--project", project_path])
+        .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -8562,19 +8580,19 @@ fn run_mcp_stdio(project_path: &str, requests: &[serde_json::Value]) -> Vec<serd
 
     let output = child.wait_with_output().expect("MCP server output");
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    stdout
+    let responses = stdout
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
             serde_json::from_str(line).unwrap_or_else(|error| {
-                panic!(
-                    "MCP server wrote a non-JSON line: {error}\nline: {line}\nstderr: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                )
+                panic!("MCP server wrote a non-JSON line: {error}\nline: {line}\nstderr: {stderr}")
             })
         })
-        .collect()
+        .collect();
+
+    (responses, stderr)
 }
 
 fn mcp_request(id: u32, method: &str, params: serde_json::Value) -> serde_json::Value {
@@ -8719,6 +8737,195 @@ fn test_mcp_frame_extract_refuses_a_render_outside_the_project() {
     assert!(
         message.contains("project directory"),
         "the refusal must say what the scope is: {message}"
+    );
+}
+
+/// The handshake every MCP client sends before its first `tools/call`.
+///
+/// `notifications/initialized` carries no id and draws no response, so a caller
+/// counting responses counts one fewer than it sent.
+fn mcp_handshake() -> Vec<serde_json::Value> {
+    vec![
+        mcp_request(
+            1,
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "integration-test", "version": "0" }
+            }),
+        ),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    ]
+}
+
+/// A project with one clip on the timeline and one caption over it.
+///
+/// The caption is what `atCaptions` samples, and it is also what forces every
+/// still here through the composite renderer: the fast path cannot draw one.
+///
+/// The source is longer than the ten seconds `timeline insert` gives a clip
+/// whose asset carries no probed duration. `perShot` samples the middle of the
+/// shot, and over a clip whose source range runs past the end of its media that
+/// midpoint renders nothing at all — a fixture failure that has nothing to say
+/// about what these tests are guarding.
+fn create_project_with_clip_and_caption(name: &str) -> Option<(tempfile::TempDir, String)> {
+    let (dir, path, _asset_id) = create_project_with_timeline_clip(name, 12)?;
+
+    let caption = run_cli_ok(&[
+        "caption",
+        "add",
+        "--path",
+        &path,
+        "--text",
+        "Sampled caption",
+        "--start",
+        "0.5",
+        "--end",
+        "2.0",
+    ]);
+    assert_eq!(caption["status"], "ok");
+
+    Some((dir, path))
+}
+
+/// Feeds one `openreelio.frame.extract` call through a full MCP session.
+///
+/// Each call gets its own server process, which is the point: the crash this
+/// guards against killed the process outright, and sharing one session would let
+/// the first failure hide every later call behind a missing response.
+fn mcp_frame_extract(
+    project_path: &str,
+    arguments: serde_json::Value,
+    label: &str,
+) -> serde_json::Value {
+    let mut requests = mcp_handshake();
+    requests.push(mcp_request(
+        2,
+        "tools/call",
+        serde_json::json!({ "name": "openreelio.frame.extract", "arguments": arguments }),
+    ));
+
+    let (responses, stderr) = run_mcp_stdio_session(project_path, true, &requests);
+    assert_eq!(
+        responses.len(),
+        2,
+        "{label}: expected the initialize result and the tool result, got {}.\nstderr: {stderr}",
+        responses.len()
+    );
+
+    let content = responses[1]["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{label} failed: {}\nstderr: {stderr}", responses[1]));
+
+    // An MCP-connected vision agent gets the picture itself, not a path it has
+    // no tool to read.
+    let image = content
+        .iter()
+        .find(|block| block["type"] == "image")
+        .unwrap_or_else(|| panic!("{label} returned no image block: {}", responses[1]));
+    assert_eq!(image["mimeType"], "image/jpeg", "{label}");
+    assert!(
+        image["data"].as_str().expect("image data").len() > 1000,
+        "{label} must carry real image bytes"
+    );
+
+    let text = content
+        .iter()
+        .find(|block| block["type"] == "text")
+        .unwrap_or_else(|| panic!("{label} returned no metadata block: {}", responses[1]));
+    let payload: serde_json::Value =
+        serde_json::from_str(text["text"].as_str().expect("text block"))
+            .expect("frame extract payload");
+    assert_eq!(payload["status"], "ok", "{label}");
+    payload
+}
+
+/// A sampler with an auto grid used to kill the MCP server outright.
+///
+/// `block_on` drives the frame probe on the calling thread and, unoptimised,
+/// copies the future through several frames of Tokio's own entry chain — so a
+/// state machine of tens of kilobytes cost hundreds of kilobytes of stack.
+/// Reached through the JSON-RPC dispatch, which ran on the process main thread
+/// that Windows sizes at 1 MiB, the composite-still path walked off the end of
+/// it: the server died with `has overflowed its stack` and answered nothing at
+/// all. The CLI's own `frame extract` sat just under the same limit, and the
+/// in-process tests never saw it because a Rust test thread gets a far larger
+/// stack than the real main thread does.
+///
+/// Every assertion below is therefore secondary. What is being tested is that
+/// the real binary answers at all.
+#[test]
+fn test_mcp_frame_extract_serves_a_sampled_grid_over_stdio() {
+    let Some((_dir, path)) = create_project_with_clip_and_caption("mcp_frame_sampler_test") else {
+        return;
+    };
+
+    let payload = mcp_frame_extract(
+        &path,
+        serde_json::json!({
+            "atCaptions": true,
+            "grid": "auto",
+            "labelCells": true,
+            "cellWidth": 640
+        }),
+        "atCaptions with an auto grid",
+    );
+
+    assert_eq!(payload["mode"], "grid");
+    assert_eq!(payload["sampler"]["kinds"][0], "atCaptions");
+    assert!(
+        !payload["sheet"]["cells"]
+            .as_array()
+            .expect("cells array")
+            .is_empty(),
+        "the caption must have produced at least one cell: {payload}"
+    );
+}
+
+/// The same call shape through the other two grid selectors.
+///
+/// `perShot` derives its own times the way `atCaptions` does; `between` with an
+/// explicit grid derives none. Both reach the identical composite-render chain,
+/// so both would have died the same way.
+#[test]
+fn test_mcp_frame_extract_serves_per_shot_and_between_grids_over_stdio() {
+    let Some((_dir, path)) = create_project_with_clip_and_caption("mcp_frame_grids_test") else {
+        return;
+    };
+
+    let per_shot = mcp_frame_extract(
+        &path,
+        serde_json::json!({
+            "perShot": true,
+            "grid": "auto",
+            "labelCells": true,
+            "cellWidth": 640
+        }),
+        "perShot with an auto grid",
+    );
+    assert_eq!(per_shot["mode"], "grid");
+    assert_eq!(per_shot["sampler"]["kinds"][0], "perShot");
+
+    let between = mcp_frame_extract(
+        &path,
+        serde_json::json!({
+            "between": [0.0, 3.0],
+            "grid": "4x2",
+            "labelCells": true,
+            "cellWidth": 640
+        }),
+        "between with a 4x2 grid",
+    );
+    assert_eq!(between["mode"], "grid");
+    assert_eq!(between["sheet"]["cols"], 4);
+    assert_eq!(between["sheet"]["rows"], 2);
+    assert_eq!(
+        between["sheet"]["cells"]
+            .as_array()
+            .expect("cells array")
+            .len(),
+        8
     );
 }
 

--- a/src-tauri/src/ipc/commands/frame_probe.rs
+++ b/src-tauri/src/ipc/commands/frame_probe.rs
@@ -111,7 +111,13 @@ pub async fn extract_timeline_frames(
         path: &project_path,
         state: &project_state,
     };
-    let payload = match plan.run(&runner, Some(&probe_project)).await {
+    // Boxed to keep the probe's own state machine off this command's future.
+    // Nothing here calls `block_on`, so the stack amplification that overflowed
+    // the CLI's main thread cannot arise on this path — a Tauri command is a
+    // spawned task, and its future already lives on the heap. What boxing buys
+    // is that the probe's tens of kilobytes stop being inlined into every
+    // `extract_timeline_frames` future, whatever the request asked for.
+    let payload = match Box::pin(plan.run(&runner, Some(&probe_project))).await {
         Ok(payload) => payload,
         Err(error) => {
             // Nothing usable came back, so this call's entry is residue: an


### PR DESCRIPTION
### **User description**
## Summary

Found by running a headless Codex agent against the MCP server on a real project: its first `openreelio.frame.extract` with `atCaptions` + `grid: "auto"` killed the server (`thread main has overflowed its stack`), and every later call failed with "Transport closed".

**Root cause (measured on the real debug binary):** the frame-probe future is 41.6 KiB, but an unoptimised `Runtime::block_on` moves it by value through several of its own entry frames, costing ~650 KiB of stack before the body runs; the composite chain adds ~370 KiB. Total ≈ 1.3 MiB against the 1 MiB Windows main thread. The identical CLI command landed just under; the MCP JSON-RPC dispatch frames (+32 KiB) tipped it over. Not recursion, not a huge future — a knife-edge nobody measured because test threads have bigger stacks.

- `Box::pin` the probe/verify/render futures at every `block_on` (sufficient on its own — verified with the worker stack forced to 1 MiB).
- Every CLI verb, including the MCP stdio loop, runs on a 64 MiB worker thread; panics are re-raised so exit codes and stderr are unchanged.
- The Tauri IPC probe is boxed as well (it runs on 2 MiB tokio workers without `block_on`, so it was never at risk; boxing stops the state machine from being inlined into every command future).
- Three ffmpeg-gated integration tests drive the real binary over MCP stdio (`atCaptions`+auto grid, `perShot`+auto grid, `between`+`4x2`) and assert an inline image block — they fail on the previous binary.

Release builds were probably never affected (smaller frames); the fix removes the dependency on that margin.

## Verification
- clippy (CI command) clean; `cargo test -p openreelio frame_probe` 179; CLI `mcp` 84+4, `frame` 2+53, `render` 11+38, `verify` 8+12; new stdio tests 3/3


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixes stack overflow by boxing large futures.

- Moves CLI execution to a dedicated worker thread.

- Increases worker thread stack size to 64MiB.

- Adds integration tests for MCP server stability.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Main["main thread"] -- "spawn with 64MB stack" --> Worker["worker thread"]
  Worker -- "block_on(Box::pin(future))" --> Future["boxed future"]
  Future -- "prevents" --> Overflow["stack overflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frame.rs</strong><dd><code>Box frame extraction futures to save stack space</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/src/commands/frame.rs

<ul><li>Wraps the <code>plan.run</code> future in <code>Box::pin</code> before calling <code>runtime.block_on</code>.<br> <li> Prevents stack amplification caused by Tokio's <code>block_on</code> moving large <br>futures by value.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/872/files#diff-c47708a90f60cf6fc8376a523d5213a7be6f80c06e26671b9e0f6820f783fda2">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>render.rs</strong><dd><code>Box render futures during block_on execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/src/commands/render.rs

<ul><li>Boxes the render execution future within <code>runtime.block_on</code>.<br> <li> Includes documentation explaining the necessity of boxing for <br>unoptimized builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/872/files#diff-280e1b2f4fcfd0aff373db2f4103f98a471444033d18d9ad282608a80355019f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>verify.rs</strong><dd><code>Box verification futures to prevent overflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/src/commands/verify.rs

<ul><li>Implements <code>Box::pin</code> for the verification plan future.<br> <li> Reduces stack footprint during synchronous runtime execution.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/872/files#diff-6230a47e8099d60c3f943e67c7aa6969829e0e53bbca8aca67c7820c956c75f6">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Execute CLI commands on a large-stack worker thread</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/src/main.rs

<ul><li>Introduces <code>WORKER_STACK_SIZE_BYTES</code> set to 64 MiB.<br> <li> Replaces direct command execution with <code>run_on_worker_thread</code>.<br> <li> Ensures panics on the worker thread are re-raised on the main thread.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/872/files#diff-d6359047dcea3ad778ecf80792cce8e77581b5207d6639e711286e69b07c6d10">+39/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frame_probe.rs</strong><dd><code>Box probe futures in Tauri IPC commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/ipc/commands/frame_probe.rs

<ul><li>Boxes the <code>plan.run</code> future in the Tauri IPC layer.<br> <li> Prevents large state machines from being inlined into the command <br>future.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/872/files#diff-4660d1df8327ba7254c4ecf4a16b53baba0b9ea902ead3d333a521fd9e7c085c">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration.rs</strong><dd><code>Add MCP integration tests for complex frame extraction</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/openreelio-cli/tests/integration.rs

<ul><li>Adds comprehensive integration tests for MCP server over stdio.<br> <li> Tests <code>atCaptions</code>, <code>perShot</code>, and <code>between</code> grid extractions.<br> <li> Enhances MCP test utilities to capture and report stderr on failure.</ul>


</details>


  </td>
  <td><a href="https://github.com/openreelio/openreelio/pull/872/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+214/-7</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

