### PR TITLE
fix(captions): transcribe the audio a sequence really renders, in a chosen window, onto the frame grid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,9 @@ jobs:
       # they need a binary, so the `Run tests` step above never ran them and the
       # properties they measure - zoom frame counts and geometry, still and
       # animated image handling, the adjustment-layer refusal, filtergraph
-      # injection, and the audio loudness/peak measurement against a synthesized
-      # tone of known level - went unexercised in CI.
+      # injection, the audio loudness/peak measurement against a synthesized
+      # tone of known level, and the transcription mixdown finding the sound of
+      # an A/V clip on a video track - went unexercised in CI.
       #
       # They run against the BUNDLED FFmpeg, not apt's: the assertions were
       # measured against the exact build the app ships (9.x), and most of them
@@ -277,11 +278,11 @@ jobs:
       # `REQUIRE_FFMPEG_TESTS` turns their quiet skips into failures, so a missing
       # bundled binary fails the job instead of passing vacuously.
       #
-      # Each module runs as its own invocation rather than as one call with
-      # three filters. libtest reports a filter that matches nothing as a pass,
+      # Each module runs as its own invocation rather than as one call listing
+      # every filter. libtest reports a filter that matches nothing as a pass,
       # and with the modules pooled a rename in one of them was still covered by
-      # the other two: the run stayed green while a whole module went
-      # unexercised. Per-module runs move that guard onto each module.
+      # the others: the run stayed green while a whole module went unexercised.
+      # Per-module runs move that guard onto each module.
       - name: Run src-tauri ffmpeg-backed tests
         working-directory: src-tauri
         shell: bash
@@ -291,19 +292,22 @@ jobs:
           OPENREELIO_FFPROBE_PATH: ${{ github.workspace }}/src-tauri/binaries/ffprobe
         run: |
           set -euo pipefail
-          for module in \
+          # One invocation per filter, because libtest prints one `test result`
+          # line per run: pooled filters share a single line, so a module that
+          # was renamed away to nothing still rides in on the others. Run them
+          # separately, and require each one to have run something.
+          for filter in \
             core::analysis::audio::tests:: \
+            core::captions::audio::ffmpeg_backed_tests:: \
             core::effects::filter_builder::tests:: \
-            core::render::export::tests::
-          do
-            log="${RUNNER_TEMP}/ffmpeg-tests-$(echo "${module}" | tr ':' '-').log"
-            cargo test --locked --features dev-full --lib -- --ignored \
-              "${module}" 2>&1 | tee "${log}"
+            core::render::export::tests:: ; do
+            log="${RUNNER_TEMP}/ffmpeg-tests-$(printf '%s' "$filter" | tr -c 'a-zA-Z0-9' '-').log"
+            cargo test --locked --features dev-full --lib -- --ignored "$filter" 2>&1 | tee "$log"
             # A renamed or moved test would leave this filter matching nothing,
-            # which libtest still reports as a pass. Require that this module
+            # which libtest still reports as a pass. Require that this filter
             # ran at least one test of its own.
-            grep -qE 'test result: ok\. [1-9][0-9]* passed' "${log}" \
-              || { echo "No ffmpeg-backed test ran for ${module}"; exit 1; }
+            grep -qE 'test result: ok\. [1-9][0-9]* passed' "$log" \
+              || { echo "No ffmpeg-backed test ran for filter ${filter}"; exit 1; }
           done
 
   # ==========================================================================

--- a/crates/openreelio-cli/src/commands/caption.rs
+++ b/crates/openreelio-cli/src/commands/caption.rs
@@ -10,6 +10,7 @@ use openreelio_core::commands::*;
 use openreelio_core::style::{resolve_caption_layers, resolve_caption_pack, resolve_caption_style};
 use openreelio_core::timeline::{Clip, Sequence, TrackKind};
 use openreelio_core::ActiveProject;
+use openreelio_core::Ratio;
 use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
 
@@ -196,6 +197,19 @@ pub enum CaptionAction {
         /// Ignored for SRT/VTT input, which is always timeline-relative.
         #[arg(long)]
         source_clip: Option<String>,
+
+        /// Keep the file's raw cue times instead of snapping them to the
+        /// sequence frame grid.
+        ///
+        /// Snapping is on by default: subtitle files carry millisecond times,
+        /// which land between frames and make every composite and render warn
+        /// about each cue. Each cue is rounded on its own — cues that overlap in
+        /// the file still overlap after the import, because a held lyric or a
+        /// rolling VTT means those overlaps. Export validation reports them as
+        /// one warning per caption track, with a count, rather than treating
+        /// them as an error.
+        #[arg(long)]
+        no_snap: bool,
     },
 
     /// Export captions to SRT or VTT format
@@ -814,6 +828,28 @@ pub(crate) fn map_segments_for_source_clip(
     Ok(info)
 }
 
+/// Counts what the frame grid will do to an import: cues moved, cues dropped.
+///
+/// The command is planned, and the plan reports both as it makes them. Planning
+/// is pure arithmetic, so this costs nothing, and it reports the numbers the
+/// import will actually produce rather than a guess made before the readability
+/// rules run.
+pub(crate) fn count_snapped_cues(
+    command: &ImportGeneratedCaptionsCommand,
+    fps: &Ratio,
+    snap_to_frames: bool,
+) -> anyhow::Result<(usize, usize)> {
+    if !snap_to_frames {
+        return Ok((0, 0));
+    }
+
+    let plan = command
+        .plan(fps, true)
+        .map_err(|error| anyhow::anyhow!("Caption import failed: {}", error))?;
+
+    Ok((plan.snapped_cues, plan.dropped_cues))
+}
+
 pub(crate) fn ensure_caption_track(
     project: &mut ActiveProject,
     sequence_id: &str,
@@ -1286,7 +1322,9 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             position_json,
             sequence,
             source_clip,
+            no_snap,
         } => {
+            let snap_to_frames = !no_snap;
             let subtitle_path = std::fs::canonicalize(&file).map_err(|e| {
                 anyhow::anyhow!("Subtitle file '{}' not found: {}", file.display(), e)
             })?;
@@ -1315,7 +1353,12 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
             // records nothing — there is nowhere to look.
             let mut edit = super::EditRecorder::begin(&project, &seq_id);
 
+            let sequence_fps = get_sequence(&project, &seq_id)?.format.fps.clone();
             let mut created_ids = Vec::new();
+            let mut snapped_cues = 0usize;
+            // Cues the frame grid gave up on rather than drag off their own
+            // time. Only the generated path can produce them.
+            let mut dropped_cues = 0usize;
             if matches!(format, CaptionFileFormat::TranscriptJson) {
                 let mut segments: Vec<GeneratedCaptionSegment> = captions
                     .iter()
@@ -1349,7 +1392,21 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
 
                 let cmd = ImportGeneratedCaptionsCommand::new(&seq_id, &track_id, segments)
                     .with_style(style.clone())
-                    .with_position(position.clone());
+                    .with_position(position.clone())
+                    .snap_to_frames(snap_to_frames);
+                match count_snapped_cues(&cmd, &sequence_fps, snap_to_frames) {
+                    Ok((moved, dropped)) => {
+                        snapped_cues = moved;
+                        dropped_cues = dropped;
+                    }
+                    Err(error) => {
+                        if created_track {
+                            let cmd = RemoveTrackCommand::new(&seq_id, &track_id);
+                            let _ = project.executor.execute(Box::new(cmd), &mut project.state);
+                        }
+                        return Err(error);
+                    }
+                }
 
                 match edit.execute(&mut project, Box::new(cmd)) {
                     Ok(result) => {
@@ -1364,6 +1421,29 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
                     }
                 }
             } else {
+                // SRT and VTT carry millisecond times, so the same grid applies
+                // here — but these cues are placed one command at a time, and
+                // `CreateCaption` deliberately honours the times it is given.
+                // Snapping therefore happens on the way in.
+                //
+                // Only the snap: a subtitle file is free to overlap its cues,
+                // and unlike the generated path nothing has de-overlapped these.
+                // Running the ordering pass here would serialize a held cue with
+                // everything underneath it, so the file is reproduced as written,
+                // on the frame grid.
+                let mut captions = captions;
+                if snap_to_frames {
+                    let mut times = captions
+                        .iter()
+                        .map(|caption| (caption.start_sec, caption.end_sec))
+                        .collect::<Vec<_>>();
+                    snapped_cues = snap_cue_times_to_frame_grid(&mut times, &sequence_fps);
+                    for (caption, (start_sec, end_sec)) in captions.iter_mut().zip(times) {
+                        caption.start_sec = start_sec;
+                        caption.end_sec = end_sec;
+                    }
+                }
+
                 for caption in captions {
                     let cmd = CreateCaptionCommand::new(
                         &seq_id,
@@ -1426,6 +1506,8 @@ pub fn execute(action: CaptionAction) -> anyhow::Result<()> {
                 "language": language,
                 "source": subtitle_path.display().to_string(),
                 "sequenceId": seq_id,
+                "snappedCues": snapped_cues,
+                "droppedCues": dropped_cues,
                 "affectedRanges": affected_ranges,
             }))
         }

--- a/crates/openreelio-cli/src/commands/help_json.rs
+++ b/crates/openreelio-cli/src/commands/help_json.rs
@@ -480,7 +480,8 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "position": { "type": "string", "required": false, "desc": "Position preset: top, center, bottom. A vertical anchor only; the margin comes from --style-pack when one is named, else 5%" },
                     "position-json": { "type": "string", "required": false, "desc": "Caption position JSON object applied to all cues" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID" },
-                    "source-clip": { "type": "string", "required": false, "desc": "Clip ID to map SOURCE-relative transcript times onto the timeline (transcript-json only). A transcript produced from a source asset counts from the start of the file, so a trimmed, moved or sped-up clip drifts; naming the hosting clip remaps every cue to its timeline position. Omitted, cues are imported as-is - correct only when the times are already timeline-relative. Ignored for SRT/VTT, which always are" }
+                    "source-clip": { "type": "string", "required": false, "desc": "Clip ID to map SOURCE-relative transcript times onto the timeline (transcript-json only). A transcript produced from a source asset counts from the start of the file, so a trimmed, moved or sped-up clip drifts; naming the hosting clip remaps every cue to its timeline position. Omitted, cues are imported as-is - correct only when the times are already timeline-relative. Ignored for SRT/VTT, which always are" },
+                    "no-snap": { "type": "boolean", "required": false, "desc": "Keep the file's raw cue times instead of snapping each boundary to the sequence frame grid. Snapping is on by default: subtitle files carry millisecond times, which land between frames and make every composite and render warn about each cue. The response reports how many cues moved as snappedCues, and how many were dropped rather than dragged off their own time as droppedCues" }
                 },
                 "example": "openreelio-cli caption import --path ./project --file transcript.json --format transcript-json --source-clip clip_001"
             },
@@ -505,11 +506,14 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "language": { "type": "string", "required": false, "desc": "Language code, or auto for detection" },
                     "model": { "type": "string", "required": false, "desc": "Whisper model, or auto to use the best installed model. Prefer any model except large: large keeps Whisper's heuristic word timings instead of DTW-aligned ones" },
                     "translate": { "type": "boolean", "required": false, "desc": "Translate recognized speech to English when supported" },
+                    "start": { "type": "number", "required": false, "desc": "First ASSET second to transcribe. Everything outside the range is never decoded, so captioning a 90-second excerpt of a long talk costs the excerpt. Segment times stay absolute" },
+                    "end": { "type": "number", "required": false, "desc": "Last ASSET second to transcribe; must be greater than --start" },
                     "output": { "type": "string", "required": false, "desc": "Write transcript JSON to this file in addition to stdout" },
                     "import": { "type": "boolean", "required": false, "desc": "Import generated captions into the active or selected sequence" },
                     "track": { "type": "string", "required": false, "desc": "Caption track ID for import" },
                     "sequence": { "type": "string", "required": false, "desc": "Sequence ID for import" },
                     "replace-existing": { "type": "boolean", "required": false, "desc": "Replace existing captions on the target caption track during import" },
+                    "no-snap": { "type": "boolean", "required": false, "desc": "Keep raw cue times on import instead of snapping each boundary to the sequence frame grid. Snapping is on by default; the response reports how many cues moved as snappedCues, and how many were dropped rather than dragged off their own time as droppedCues" },
                     "source-clip": { "type": "string", "required": false, "desc": "Clip ID to map SOURCE-relative transcript times onto the timeline during import. Transcribing an asset counts from the start of the file, so a trimmed, moved or sped-up clip drifts; naming the hosting clip remaps every segment to its timeline position. When the asset sits on the target sequence as exactly one clip, that clip is resolved automatically and the mapping is applied" }
                 },
                 "example": "openreelio-cli transcription generate --path ./project --asset asset_001 --language auto --model auto --import --source-clip clip_001"
@@ -522,10 +526,13 @@ pub(crate) fn build_schema() -> serde_json::Value {
                     "language": { "type": "string", "required": false, "desc": "Language code, or auto for detection" },
                     "model": { "type": "string", "required": false, "desc": "Whisper model, or auto to use the best installed model. Prefer any model except large: large keeps Whisper's heuristic word timings instead of DTW-aligned ones" },
                     "translate": { "type": "boolean", "required": false, "desc": "Translate recognized speech to English when supported" },
+                    "start": { "type": "number", "required": false, "desc": "First TIMELINE second to transcribe. Clips outside the range are never opened, so transcribing a stretch of a long sequence costs that stretch. Segment times stay absolute" },
+                    "end": { "type": "number", "required": false, "desc": "Last TIMELINE second to transcribe; must be greater than --start" },
                     "output": { "type": "string", "required": false, "desc": "Write transcript JSON to this file in addition to stdout" },
                     "import": { "type": "boolean", "required": false, "desc": "Import generated captions into the selected sequence" },
                     "track": { "type": "string", "required": false, "desc": "Caption track ID for import" },
-                    "replace-existing": { "type": "boolean", "required": false, "desc": "Replace existing captions on the target caption track during import" }
+                    "replace-existing": { "type": "boolean", "required": false, "desc": "Replace existing captions on the target caption track during import" },
+                    "no-snap": { "type": "boolean", "required": false, "desc": "Keep raw cue times on import instead of snapping each boundary to the sequence frame grid. Snapping is on by default; the response reports how many cues moved as snappedCues, and how many were dropped rather than dragged off their own time as droppedCues" }
                 },
                 "example": "openreelio-cli transcription generate-sequence --path ./project --sequence seq_001 --language auto --model auto --import"
             },

--- a/crates/openreelio-cli/src/commands/mcp.rs
+++ b/crates/openreelio-cli/src/commands/mcp.rs
@@ -51,6 +51,7 @@ use crate::{
 #[cfg(test)]
 use base64::Engine as _;
 use clap::Args;
+use openreelio_core::captions::audio::AudioWindow;
 #[cfg(test)]
 use openreelio_core::commands::SplitClipCommand;
 use openreelio_core::commands::{get_text_data, is_text_clip, InsertMediaCommand};
@@ -702,7 +703,17 @@ fn all_tool_schemas(state: &McpServerState) -> Vec<Value> {
                         "enum": ["auto", "tiny", "base", "small", "medium", "large", "large-v3", "large-v3-turbo", "large-v3-turbo-q5_0", "large-v3-turbo-q8_0", "large-v3-q5_0"],
                         "description": "Whisper model to use. Defaults to auto, which selects the best installed model. Every model except large produces DTW-aligned word timings; large (ggml-large.bin) keeps the cheaper heuristic ones because its filename does not pin a version."
                     },
-                    "translate": { "type": "boolean" }
+                    "translate": { "type": "boolean" },
+                    "start": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "First second to transcribe. Asset seconds in asset mode, timeline seconds in sequenceAudio mode. Everything outside the range is never decoded, so captioning a 90-second excerpt of a long talk costs the excerpt. Segment times stay absolute."
+                    },
+                    "end": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Last second to transcribe, in the same clock as start. Must be greater than start."
+                    }
                 },
                 "additionalProperties": false
             }),
@@ -1337,6 +1348,11 @@ fn generate_transcription(state: &McpServerState, arguments: Value) -> Result<Va
         optional_string_argument(&arguments, "model")?.unwrap_or_else(|| "auto".to_string());
     let translate = optional_bool_argument(&arguments, "translate")?.unwrap_or(false);
     let sequence_audio = optional_bool_argument(&arguments, "sequenceAudio")?.unwrap_or(false);
+    let window = AudioWindow::new(
+        optional_non_negative_number(&arguments, "start")?,
+        optional_non_negative_number(&arguments, "end")?,
+    )
+    .map_err(|error| ToolError::InvalidArguments(error.to_string()))?;
     let project = super::load_project(project_path).map_err(|error| {
         ToolError::Execution(format!(
             "Failed to open project '{}': {error}",
@@ -1357,6 +1373,7 @@ fn generate_transcription(state: &McpServerState, arguments: Value) -> Result<Va
                 &language,
                 &model,
                 translate,
+                window,
             )
             .map_err(|error| ToolError::Execution(error.to_string()))?,
         )
@@ -1366,7 +1383,7 @@ fn generate_transcription(state: &McpServerState, arguments: Value) -> Result<Va
         confine_asset_media(&project, &asset_id)?;
         serde_json::to_value(
             transcription::generate_asset_transcription(
-                &project, &asset_id, &language, &model, translate,
+                &project, &asset_id, &language, &model, translate, window,
             )
             .map_err(|error| ToolError::Execution(error.to_string()))?,
         )
@@ -5259,6 +5276,50 @@ mod tests {
             "the surface's own spelling of the sequence argument"
         );
         assert_eq!(names.asset, "assetId");
+    }
+
+    /// Feature: ranged transcription
+    /// Scenario: the MCP surface advertises the same window the CLI takes
+    ///
+    /// The unknown-argument guard builds its table from the advertised schemas,
+    /// so a range the schema does not declare is refused before it reaches the
+    /// tool no matter how the tool is written.
+    #[test]
+    fn transcription_generate_should_advertise_a_time_range() {
+        let state = McpServerState {
+            project: Some(PathBuf::from("unused")),
+            ..Default::default()
+        };
+        let tools = build_tools(&state);
+        let properties = tools
+            .iter()
+            .find(|tool| tool["name"] == "openreelio.transcription.generate")
+            .and_then(|tool| tool["inputSchema"]["properties"].as_object())
+            .expect("transcription.generate advertises an object schema");
+
+        assert!(properties.contains_key("start"));
+        assert!(properties.contains_key("end"));
+    }
+
+    /// Feature: ranged transcription
+    /// Scenario: an impossible window is refused before any work is done
+    #[test]
+    fn transcription_generate_should_refuse_an_end_before_its_start() {
+        let state = McpServerState {
+            project: Some(PathBuf::from("unused")),
+            ..Default::default()
+        };
+
+        let error = generate_transcription(
+            &state,
+            serde_json::json!({ "assetId": "asset_1", "start": 5.0, "end": 3.0 }),
+        )
+        .expect_err("an end before its start is not a range");
+
+        assert!(
+            matches!(error, ToolError::InvalidArguments(ref message) if message.contains("must be greater than")),
+            "{error:?}"
+        );
     }
 
     #[test]

--- a/crates/openreelio-cli/src/commands/render.rs
+++ b/crates/openreelio-cli/src/commands/render.rs
@@ -1,13 +1,14 @@
 //! Render and export commands.
 
-use crate::ffmpeg_env::ensure_ffmpeg;
+use crate::ffmpeg_env::{ensure_ffmpeg, ensure_ffmpeg_optional};
 use crate::output;
 use crate::validate;
 use clap::Subcommand;
 use openreelio_core::ffmpeg::FFmpegRunner;
 use openreelio_core::render::{
-    build_render_graph, build_render_plan, validate_export_settings, AudioCodec, ExportEngine,
-    ExportPreset, ExportProgress, ExportSettings, HdrMode, VideoCodec,
+    build_render_graph_with_audio_info, build_render_plan, clear_transient_probes,
+    probe_sequence_audio_info, validate_export_settings, AudioCodec, ExportEngine, ExportPreset,
+    ExportProgress, ExportSettings, HdrMode, VideoCodec,
 };
 use openreelio_core::timeline::Canvas;
 use std::path::PathBuf;
@@ -47,7 +48,14 @@ pub enum RenderAction {
     /// List available render presets
     Presets,
 
-    /// Output the renderer-agnostic graph for preview/export tooling
+    /// Output the renderer-agnostic graph for preview/export tooling.
+    ///
+    /// Costs one FFprobe per unique asset on the sequence the first time it sees
+    /// a file: whether a clip carries sound is a property of the media, not of
+    /// the metadata an extension-based import guessed. Repeat runs in the same
+    /// process reuse the measurement for a file whose size and modification time
+    /// have not changed. Without FFmpeg the stored metadata is all there is, and
+    /// the graph still builds.
     Graph {
         /// Project directory path
         #[arg(long)]
@@ -107,9 +115,25 @@ pub fn execute(action: RenderAction) -> anyhow::Result<()> {
         }
 
         RenderAction::Graph { path, sequence } => {
+            // The graph tells an agent what a render of this sequence will
+            // contain, so its audio layers have to be the ones the render will
+            // actually mix. Whether a video asset carries sound is a property of
+            // the file, not of the metadata an extension-based import guessed,
+            // so it is measured here — one FFprobe per unique asset. Without
+            // FFmpeg the stored metadata is all there is, and the graph still
+            // builds rather than failing an introspection command.
+            ensure_ffmpeg_optional();
+
+            // An agent asks for the graph to decide what to do next, so this is
+            // a request, not a poll. In the long-lived MCP server a file that
+            // was locked when an earlier command probed it would otherwise be
+            // reported as carrying no audio for the rest of the session.
+            clear_transient_probes();
+
             let project = super::load_project(&path)?;
             let seq_id = super::resolve_sequence_id(&project, sequence)?;
-            let graph = build_render_graph(&project.state, &seq_id)
+            let audio_info = probe_sequence_audio_info(&project.state, &seq_id);
+            let graph = build_render_graph_with_audio_info(&project.state, &seq_id, &audio_info)
                 .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
 
             output::print_json_pretty(&graph)
@@ -187,6 +211,13 @@ pub fn run_start_render(args: StartArgs) -> anyhow::Result<serde_json::Value> {
 
     validate_render_range(start, end)?;
 
+    // A render is user-initiated, so it must not be answered out of the window
+    // that suppresses re-probing after a failure that reached no verdict. A
+    // one-shot CLI process starts with an empty window, but the MCP server is
+    // long-lived: without this, a file that was locked when an earlier analysis
+    // probed it would render mute for the rest of the session.
+    clear_transient_probes();
+
     let preset_id = if proxy {
         PROXY_PRESET_ID.to_string()
     } else {
@@ -210,12 +241,19 @@ pub fn run_start_render(args: StartArgs) -> anyhow::Result<serde_json::Value> {
     let effects = project.state.effects.clone();
     let settings =
         build_export_settings(&preset_id, output_path, &sequence.format.canvas, start, end)?;
-    let graph = build_render_graph(&project.state, &seq_id)
-        .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
 
-    // Validation measures transformed clips with FFprobe, so the resolved
-    // binaries have to be registered before it runs — see `ffmpeg_env`.
+    // Validation measures transformed clips with FFprobe, and so does the audio
+    // probe below, so the resolved binaries have to be registered first — see
+    // `ffmpeg_env`.
     let ffmpeg_info = ensure_ffmpeg()?;
+
+    // The same measured audio presence `render graph` reports. Building the plan
+    // from the stored metadata instead would have `render start` plan a silent
+    // render for a sequence `render graph` says has sound — an A/V file imported
+    // from its extension carries no audio metadata at all.
+    let audio_info = probe_sequence_audio_info(&project.state, &seq_id);
+    let graph = build_render_graph_with_audio_info(&project.state, &seq_id, &audio_info)
+        .map_err(|error| anyhow::anyhow!("Failed to build render graph: {}", error))?;
 
     let validation = validate_export_settings(&sequence, &assets, &effects, &settings);
     if !validation.is_valid {
@@ -232,6 +270,10 @@ pub fn run_start_render(args: StartArgs) -> anyhow::Result<serde_json::Value> {
         ));
     }
     let plan_hash = render_plan.plan_hash.clone();
+    // Reported so an agent can see, without a second command, that the render it
+    // asked for carries the layers `render graph` said it would.
+    let planned_video_layers = render_plan.video_layers.len();
+    let planned_audio_layers = render_plan.audio_layers.len();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -301,6 +343,8 @@ pub fn run_start_render(args: StartArgs) -> anyhow::Result<serde_json::Value> {
         "fileSize": result.file_size,
         "encodingTimeSec": result.encoding_time_sec,
         "planHash": plan_hash,
+        "videoLayerCount": planned_video_layers,
+        "audioLayerCount": planned_audio_layers,
         "warnings": validation.warnings,
     }))
 }

--- a/crates/openreelio-cli/src/commands/transcription.rs
+++ b/crates/openreelio-cli/src/commands/transcription.rs
@@ -6,7 +6,8 @@ use clap::Subcommand;
 use openreelio_core::assets::AssetKind;
 use openreelio_core::captions::{
     audio::{
-        extract_audio_for_transcription, load_audio_samples, mix_sequence_audio_for_transcription,
+        extract_audio_range_for_transcription, load_audio_samples,
+        mix_sequence_audio_for_transcription, AudioWindow,
     },
     whisper::{
         default_models_dir, download_whisper_model_blocking, is_whisper_available,
@@ -17,6 +18,7 @@ use openreelio_core::commands::{
     GeneratedCaptionSegment, ImportGeneratedCaptionsCommand, RemoveTrackCommand,
 };
 use openreelio_core::ActiveProject;
+use openreelio_core::Ratio;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
@@ -59,6 +61,14 @@ pub enum TranscriptionAction {
         #[arg(long)]
         translate: bool,
 
+        /// First ASSET second to transcribe; the rest of the file is never decoded
+        #[arg(long)]
+        start: Option<f64>,
+
+        /// Last ASSET second to transcribe; segment times stay absolute
+        #[arg(long)]
+        end: Option<f64>,
+
         /// Write transcript JSON to this file in addition to stdout
         #[arg(long)]
         output: Option<PathBuf>,
@@ -78,6 +88,10 @@ pub enum TranscriptionAction {
         /// Replace existing captions on the target caption track during import
         #[arg(long)]
         replace_existing: bool,
+
+        /// Keep raw cue times on import instead of snapping them to the frame grid
+        #[arg(long)]
+        no_snap: bool,
 
         /// Clip ID to map SOURCE-relative transcript times onto the timeline
         /// during import.
@@ -115,6 +129,14 @@ pub enum TranscriptionAction {
         #[arg(long)]
         translate: bool,
 
+        /// First TIMELINE second to transcribe; clips outside are never decoded
+        #[arg(long)]
+        start: Option<f64>,
+
+        /// Last TIMELINE second to transcribe; segment times stay absolute
+        #[arg(long)]
+        end: Option<f64>,
+
         /// Write transcript JSON to this file in addition to stdout
         #[arg(long)]
         output: Option<PathBuf>,
@@ -130,6 +152,10 @@ pub enum TranscriptionAction {
         /// Replace existing captions on the target caption track during import
         #[arg(long)]
         replace_existing: bool,
+
+        /// Keep raw cue times on import instead of snapping them to the frame grid
+        #[arg(long)]
+        no_snap: bool,
     },
 }
 
@@ -215,16 +241,21 @@ pub fn execute(action: TranscriptionAction) -> anyhow::Result<()> {
             language,
             model,
             translate,
+            start,
+            end,
             output,
             import_to_timeline,
             track,
             sequence,
             replace_existing,
+            no_snap,
             source_clip,
         } => {
             let mut project = super::load_project(&path)?;
-            let transcription =
-                generate_asset_transcription(&project, &asset, &language, &model, translate)?;
+            let window = parse_window(start, end)?;
+            let transcription = generate_asset_transcription(
+                &project, &asset, &language, &model, translate, window,
+            )?;
             let mut response = serde_json::to_value(&transcription)?;
 
             if let Some(output_path) = output {
@@ -239,6 +270,7 @@ pub fn execute(action: TranscriptionAction) -> anyhow::Result<()> {
                     sequence,
                     track,
                     replace_existing,
+                    !no_snap,
                     &transcription,
                     source_clip,
                     Some(&asset),
@@ -255,19 +287,24 @@ pub fn execute(action: TranscriptionAction) -> anyhow::Result<()> {
             language,
             model,
             translate,
+            start,
+            end,
             output,
             import_to_timeline,
             track,
             replace_existing,
+            no_snap,
         } => {
             let mut project = super::load_project(&path)?;
             let sequence_id = super::resolve_sequence_id(&project, sequence)?;
+            let window = parse_window(start, end)?;
             let transcription = generate_sequence_transcription(
                 &project,
                 &sequence_id,
                 &language,
                 &model,
                 translate,
+                window,
             )?;
             let mut response = serde_json::to_value(&transcription)?;
 
@@ -285,6 +322,7 @@ pub fn execute(action: TranscriptionAction) -> anyhow::Result<()> {
                     Some(sequence_id),
                     track,
                     replace_existing,
+                    !no_snap,
                     &TranscriptionCliOutput {
                         status: transcription.status.clone(),
                         asset_id: "sequence-audio".to_string(),
@@ -428,6 +466,7 @@ pub(crate) fn generate_asset_transcription(
     language: &str,
     model: &str,
     translate: bool,
+    window: AudioWindow,
 ) -> anyhow::Result<TranscriptionCliOutput> {
     if !is_whisper_available() {
         return Err(anyhow::anyhow!(
@@ -475,7 +514,7 @@ pub(crate) fn generate_asset_transcription(
     ));
     let _guard = TempFileGuard(temp_path.clone());
 
-    extract_audio_for_transcription(&asset_path, &temp_path, None)
+    extract_audio_range_for_transcription(&asset_path, &temp_path, window, None)
         .map_err(|error| anyhow::anyhow!("Audio extraction failed: {}", error))?;
     let samples = load_audio_samples(&temp_path)
         .map_err(|error| anyhow::anyhow!("Failed to load extracted audio: {}", error))?;
@@ -492,6 +531,10 @@ pub(crate) fn generate_asset_transcription(
         .map_err(|error| anyhow::anyhow!("Transcription failed: {}", error))?;
     let full_text = result.full_text();
     let subtitle_segments = subtitle_ready_segments(&result.segments);
+    // Whisper saw only the window, so its clock starts at zero. Times are put
+    // back on the asset's own clock here, which is what makes a ranged run
+    // interchangeable with a full one.
+    let offset_sec = window.start();
     let segments = subtitle_segments
         .into_iter()
         .filter_map(|segment| {
@@ -501,8 +544,8 @@ pub(crate) fn generate_asset_transcription(
             }
 
             Some(TranscriptionSegmentJson {
-                start_time: segment.start_time,
-                end_time: segment.end_time,
+                start_time: segment.start_time + offset_sec,
+                end_time: segment.end_time + offset_sec,
                 text,
             })
         })
@@ -527,6 +570,7 @@ pub(crate) fn generate_sequence_transcription(
     language: &str,
     model: &str,
     translate: bool,
+    window: AudioWindow,
 ) -> anyhow::Result<SequenceTranscriptionCliOutput> {
     if !is_whisper_available() {
         return Err(anyhow::anyhow!(
@@ -563,8 +607,9 @@ pub(crate) fn generate_sequence_transcription(
     ));
     let _guard = TempFileGuard(temp_path.clone());
 
-    mix_sequence_audio_for_transcription(&project.state, sequence_id, &temp_path, None)
-        .map_err(|error| anyhow::anyhow!("Sequence audio mixdown failed: {}", error))?;
+    let mixdown =
+        mix_sequence_audio_for_transcription(&project.state, sequence_id, &temp_path, window, None)
+            .map_err(|error| anyhow::anyhow!("Sequence audio mixdown failed: {}", error))?;
     let samples = load_audio_samples(&temp_path)
         .map_err(|error| anyhow::anyhow!("Failed to load mixed sequence audio: {}", error))?;
     let engine = WhisperEngine::new(&model_path)
@@ -580,11 +625,14 @@ pub(crate) fn generate_sequence_transcription(
         .map_err(|error| anyhow::anyhow!("Transcription failed: {}", error))?;
     let full_text = result.full_text();
     let subtitle_segments = subtitle_ready_segments(&result.segments);
+    // The mixdown starts at the window, so Whisper's clock does too. Rebasing
+    // here keeps the segments on the sequence's clock, ready to import as-is.
+    let offset_sec = mixdown.start_sec;
     let segments = subtitle_segments
         .into_iter()
         .map(|segment| TranscriptionSegmentJson {
-            start_time: segment.start_time,
-            end_time: segment.end_time,
+            start_time: segment.start_time + offset_sec,
+            end_time: segment.end_time + offset_sec,
             text: segment.text,
         })
         .collect::<Vec<_>>();
@@ -607,6 +655,7 @@ fn import_generated_captions(
     sequence: Option<String>,
     track: Option<String>,
     replace_existing: bool,
+    snap_to_frames: bool,
     transcription: &TranscriptionCliOutput,
     source_clip: Option<String>,
     source_asset_id: Option<&str>,
@@ -639,8 +688,26 @@ fn import_generated_captions(
 
     let (track_id, created_track) =
         super::caption::ensure_caption_track(project, &sequence_id, track.as_deref())?;
+    let fps = sequence_fps(project, &sequence_id)?;
     let command = ImportGeneratedCaptionsCommand::new(&sequence_id, &track_id, segments)
-        .replace_existing(replace_existing);
+        .replace_existing(replace_existing)
+        .snap_to_frames(snap_to_frames);
+    // Planning can still refuse the segments, and by now the caption track may
+    // be one this call created. It goes back the same way an import failure
+    // takes it, or the project keeps an empty track nobody asked for.
+    let (snapped_cues, dropped_cues) =
+        match super::caption::count_snapped_cues(&command, &fps, snap_to_frames) {
+            Ok(counts) => counts,
+            Err(error) => {
+                if created_track {
+                    let rollback = RemoveTrackCommand::new(&sequence_id, &track_id);
+                    let _ = project
+                        .executor
+                        .execute(Box::new(rollback), &mut project.state);
+                }
+                return Err(error);
+            }
+        };
 
     match project
         .executor
@@ -653,7 +720,9 @@ fn import_generated_captions(
                 "opId": result.op_id,
                 "createdIds": result.created_ids,
                 "deletedIds": result.deleted_ids,
-                "replaceExisting": replace_existing
+                "replaceExisting": replace_existing,
+                "snappedCues": snapped_cues,
+                "droppedCues": dropped_cues
             });
             if let serde_json::Value::Object(map) = &mut payload {
                 map.extend(mapping_info);
@@ -670,6 +739,21 @@ fn import_generated_captions(
             Err(anyhow::anyhow!("Caption import failed: {}", error))
         }
     }
+}
+
+/// Builds the decode window from the CLI's `--start`/`--end` pair.
+fn parse_window(start: Option<f64>, end: Option<f64>) -> anyhow::Result<AudioWindow> {
+    AudioWindow::new(start, end).map_err(|error| anyhow::anyhow!("{}", error))
+}
+
+/// The frame rate the caption grid is defined against.
+fn sequence_fps(project: &ActiveProject, sequence_id: &str) -> anyhow::Result<Ratio> {
+    project
+        .state
+        .sequences
+        .get(sequence_id)
+        .map(|sequence| sequence.format.fps.clone())
+        .ok_or_else(|| anyhow::anyhow!("Sequence '{}' not found", sequence_id))
 }
 
 fn write_json_file<T: Serialize>(path: &Path, output: &T) -> anyhow::Result<()> {
@@ -702,5 +786,149 @@ impl Drop for TempFileGuard {
         if self.0.exists() {
             let _ = std::fs::remove_file(&self.0);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openreelio_core::timeline::TrackKind;
+
+    /// A transcription whose every cue is blank once trimmed.
+    ///
+    /// Whisper emits these — a segment of pure silence comes back as a space —
+    /// and the caption command refuses them, which is the failure this import
+    /// has to unwind cleanly.
+    fn blank_transcription() -> TranscriptionCliOutput {
+        TranscriptionCliOutput {
+            status: "ok".to_string(),
+            asset_id: "asset".to_string(),
+            asset_name: "asset.mp4".to_string(),
+            language: "en".to_string(),
+            model: "tiny".to_string(),
+            duration_sec: 2.0,
+            segment_count: 2,
+            full_text: String::new(),
+            segments: vec![
+                TranscriptionSegmentJson {
+                    start_time: 0.0,
+                    end_time: 1.0,
+                    text: " ".to_string(),
+                },
+                TranscriptionSegmentJson {
+                    start_time: 1.0,
+                    end_time: 2.0,
+                    text: "\n".to_string(),
+                },
+            ],
+        }
+    }
+
+    /// A transcription whose cue boundaries all land between frames.
+    ///
+    /// The times are off the 24, 25, 30 and 60 fps grids alike, so the import
+    /// has to move both cues whatever format a fresh project starts on.
+    fn off_grid_transcription() -> TranscriptionCliOutput {
+        TranscriptionCliOutput {
+            status: "ok".to_string(),
+            asset_id: "asset".to_string(),
+            asset_name: "asset.mp4".to_string(),
+            language: "en".to_string(),
+            model: "tiny".to_string(),
+            duration_sec: 5.049,
+            segment_count: 2,
+            full_text: "First line Second line".to_string(),
+            segments: vec![
+                TranscriptionSegmentJson {
+                    start_time: 0.137,
+                    end_time: 2.418,
+                    text: "First line".to_string(),
+                },
+                TranscriptionSegmentJson {
+                    start_time: 2.511,
+                    end_time: 5.049,
+                    text: "Second line".to_string(),
+                },
+            ],
+        }
+    }
+
+    /// How many caption tracks the project's active sequence carries.
+    fn caption_track_count(project: &ActiveProject) -> usize {
+        let sequence_id = project
+            .state
+            .active_sequence_id
+            .clone()
+            .expect("a new project has an active sequence");
+        project.state.sequences[&sequence_id]
+            .tracks
+            .iter()
+            .filter(|track| track.kind == TrackKind::Caption)
+            .count()
+    }
+
+    #[test]
+    fn a_refused_import_leaves_no_caption_track_behind() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut project = ActiveProject::create("Blank Import", dir.path().join("project"))
+            .expect("create project");
+        assert_eq!(caption_track_count(&project), 0);
+
+        let error = import_generated_captions(
+            &mut project,
+            None,
+            None,
+            false,
+            true,
+            &blank_transcription(),
+            None,
+            None,
+        )
+        .expect_err("blank cues cannot become captions");
+
+        assert!(
+            error.to_string().contains("text cannot be empty"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            caption_track_count(&project),
+            0,
+            "the track this import created has to go back with it"
+        );
+    }
+
+    #[test]
+    fn an_import_reports_the_frame_grid_counts_as_two_separate_numbers() {
+        // The grid produces two independent counts, and an agent reads them to
+        // tell a re-timing from a loss. Reporting the pair as one value says
+        // neither.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut project = ActiveProject::create("Grid Import", dir.path().join("project"))
+            .expect("create project");
+
+        let payload = import_generated_captions(
+            &mut project,
+            None,
+            None,
+            false,
+            true,
+            &off_grid_transcription(),
+            None,
+            None,
+        )
+        .expect("off-grid cues import");
+
+        assert_eq!(
+            payload["snappedCues"], 2,
+            "both cues sit between frames: {payload}"
+        );
+        assert_eq!(
+            payload["droppedCues"], 0,
+            "nothing had to be given up here: {payload}"
+        );
+        assert!(
+            payload["snappedCues"].is_u64() && payload["droppedCues"].is_u64(),
+            "each count is its own number: {payload}"
+        );
     }
 }

--- a/crates/openreelio-cli/tests/integration.rs
+++ b/crates/openreelio-cli/tests/integration.rs
@@ -12581,3 +12581,403 @@ fn test_command_execute_resolves_the_active_sequence_for_a_format_change() {
     assert_eq!(sheet["sampler"]["kinds"][0], "affected");
     assert!(sheet_path.exists());
 }
+
+// =============================================================================
+// Sequence audio: what renders is what transcribes
+// =============================================================================
+
+/// Seconds every clip in a fixture project is trimmed to.
+///
+/// Two seconds is a whole number of frames at 24, 25 and 30 fps, so a caption or
+/// render check can change the sequence rate without the clip itself drawing a
+/// frame-alignment warning. It also fits inside the four-second fixture.
+const FIXTURE_CLIP_SEC: f64 = 2.0;
+
+/// Trims every clip on the sequence to a frame-aligned length.
+///
+/// `timeline insert` gives a clip whatever length the asset advertises, which is
+/// the file's real duration when the import probed it and a default when it did
+/// not. Neither is guaranteed to land on the frame grid, and an off-grid *clip*
+/// draws the same alignment warning an off-grid caption does — which would make
+/// a caption test pass or fail for reasons that have nothing to do with
+/// captions. Trimming pins it.
+fn trim_all_clips_to_fixture_length(path: &str) {
+    let clips = run_cli_ok(&["timeline", "clips", "--path", path]);
+    let out = FIXTURE_CLIP_SEC.to_string();
+    for clip in clips["clips"].as_array().expect("clips") {
+        run_cli_ok(&[
+            "timeline",
+            "trim",
+            "--path",
+            path,
+            "--clip",
+            clip["id"].as_str().unwrap(),
+            "--track",
+            clip["trackId"].as_str().unwrap(),
+            "--source-in",
+            "0",
+            "--source-out",
+            &out,
+        ]);
+    }
+}
+
+/// Imports an A/V fixture and puts it on the sequence's first (video) track.
+///
+/// This is the shape a headless agent produces: `asset import` records the file
+/// and `timeline insert` drops it on the video track. Its embedded audio still
+/// reaches the render.
+///
+/// Deliberately agnostic about what `asset import` records. An extension-only
+/// import produces one clip carrying its own sound; an import that probes can
+/// produce a picture clip plus a linked audio clip, and gives clips the file's
+/// real length. Callers must not assume either, which is why every clip is
+/// trimmed to [`FIXTURE_CLIP_SEC`] here and why the assertions below count
+/// "at least one audio layer for this asset" rather than exactly one.
+fn project_with_av_clip_on_video_track(
+    name: &str,
+) -> Option<(tempfile::TempDir, String, String, String)> {
+    let (dir, path, asset_id) =
+        create_project_with_media(name, "av_source.mp4", create_sample_video_with_audio)?;
+
+    let tracks = run_cli_ok(&["timeline", "tracks", "--path", &path]);
+    let track_id = tracks["tracks"][0]["id"].as_str().unwrap().to_string();
+    assert_eq!(tracks["tracks"][0]["kind"], "Video", "{tracks}");
+
+    run_cli_ok(&[
+        "timeline", "insert", "--path", &path, "--asset", &asset_id, "--track", &track_id, "--at",
+        "0.0",
+    ]);
+    trim_all_clips_to_fixture_length(&path);
+
+    Some((dir, path, asset_id, track_id))
+}
+
+/// Whether a local Whisper model is installed, so a transcription can run.
+fn whisper_ready() -> bool {
+    let status = run_cli_ok(&["transcription", "status"]);
+    status["ready"].as_bool().unwrap_or(false)
+}
+
+/// The audio layers a graph reports for one asset.
+fn audio_layers_for_asset<'a>(
+    graph: &'a serde_json::Value,
+    asset_id: &str,
+) -> Vec<&'a serde_json::Value> {
+    graph["audioLayers"]
+        .as_array()
+        .expect("audioLayers")
+        .iter()
+        .filter(|layer| layer["assetId"] == serde_json::json!(asset_id))
+        .collect()
+}
+
+#[test]
+fn test_render_graph_reports_the_audio_of_an_av_clip_on_a_video_track() {
+    let Some((_dir, path, asset_id, _track_id)) =
+        project_with_av_clip_on_video_track("graph_av_audio")
+    else {
+        eprintln!("Skipping render graph audio test: ffmpeg unavailable");
+        return;
+    };
+
+    let graph = run_cli_ok(&["render", "graph", "--path", &path]);
+
+    // "At least one", not "exactly one": whether the import probed decides
+    // whether the file arrives as a single A/V clip or as a picture clip with a
+    // linked audio clip. Either way the render has sound, and that is the claim.
+    assert!(
+        !audio_layers_for_asset(&graph, &asset_id).is_empty(),
+        "an A/V clip on the video track renders with sound, so the graph has to say so: {graph}"
+    );
+}
+
+#[test]
+fn test_render_start_plans_the_same_audio_render_graph_reports() {
+    let Some((dir, path, asset_id, _track_id)) =
+        project_with_av_clip_on_video_track("start_av_audio")
+    else {
+        eprintln!("Skipping render start audio test: ffmpeg unavailable");
+        return;
+    };
+
+    let graph = run_cli_ok(&["render", "graph", "--path", &path]);
+    let expected = audio_layers_for_asset(&graph, &asset_id).len();
+    assert!(expected > 0, "{graph}");
+
+    let output_path = dir.path().join("audio_agreement.mp4");
+    let result = run_cli_ok(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--proxy",
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+
+    // `render start` reports how many layers the plan it rendered carries.
+    // Building that plan from the stored metadata instead of the probe would
+    // report no audio layers at all for a render `render graph` says has sound.
+    let planned = result["audioLayerCount"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("render start must report its layer counts: {result}"));
+    assert_eq!(planned as usize, expected, "{result}");
+}
+
+#[test]
+fn test_transcription_generate_sequence_accepts_an_av_clip_on_a_video_track() {
+    let Some((_dir, path, _asset_id, _track_id)) =
+        project_with_av_clip_on_video_track("seq_transcribe_av")
+    else {
+        eprintln!("Skipping sequence transcription test: ffmpeg unavailable");
+        return;
+    };
+
+    if !whisper_ready() {
+        // The model check runs before the mixdown, so with no model installed
+        // this run cannot say anything about the mixdown at all — asserting
+        // that it did not complain about audio would pass no matter what the
+        // mixdown does. All this branch honestly proves is where the run
+        // stopped; the mixdown itself is covered by the core-side
+        // `mixdown_captures_the_sound_of_an_av_clip_on_a_video_track`.
+        let (_stdout, stderr) =
+            run_cli_err(&["transcription", "generate-sequence", "--path", &path]);
+        // Either refusal is a stop before the mixdown: "not available" is a
+        // build without the `whisper` feature, "not installed" a build with it
+        // and no model file.
+        assert!(
+            stderr.contains("is not installed") || stderr.contains("is not available"),
+            "without a model the run must stop before the mixdown: {stderr}"
+        );
+        eprintln!("Skipping sequence transcription test: no Whisper model installed");
+        return;
+    }
+
+    let result = run_cli_ok(&["transcription", "generate-sequence", "--path", &path]);
+    assert_eq!(result["status"], "ok", "{result}");
+}
+
+#[test]
+fn test_transcription_rejects_a_range_that_describes_nothing() {
+    let dir = create_temp_project("transcribe_range");
+    let path = project_path(&dir, "transcribe_range");
+
+    // Validation happens before Whisper is consulted, so this holds with or
+    // without an installed model.
+    let (_stdout, stderr) = run_cli_err(&[
+        "transcription",
+        "generate-sequence",
+        "--path",
+        &path,
+        "--start",
+        "5",
+        "--end",
+        "3",
+    ]);
+    assert!(
+        stderr.contains("must be greater than"),
+        "an end before its start is not a range: {stderr}"
+    );
+}
+
+// =============================================================================
+// Caption frame-grid snapping
+// =============================================================================
+
+/// Puts the project's sequence on a 24 fps grid, where a frame is 1/24 s.
+fn set_sequence_to_24fps(path: &str) {
+    run_cli_ok(&[
+        "command",
+        "execute",
+        "--path",
+        path,
+        "--type",
+        "SetSequenceFormat",
+        "--payload",
+        r#"{"fps":24}"#,
+    ]);
+}
+
+/// Whether a time sits on a 24 fps frame boundary.
+fn is_on_24fps_grid(seconds: f64) -> bool {
+    let frames = seconds * 24.0;
+    (frames - frames.round()).abs() < 1e-6
+}
+
+/// Two cues whose millisecond boundaries all fall between 24 fps frames.
+const OFF_GRID_SRT: &str =
+    "1\n00:00:00,137 --> 00:00:02,418\nFirst line\n\n2\n00:00:02,511 --> 00:00:05,049\nSecond line\n";
+
+#[test]
+fn test_caption_import_snaps_cues_to_the_sequence_frame_grid() {
+    let dir = create_temp_project("caption_snap");
+    let path = project_path(&dir, "caption_snap");
+    set_sequence_to_24fps(&path);
+
+    let subtitle_file = dir.path().join("captions.srt");
+    std::fs::write(&subtitle_file, OFF_GRID_SRT).unwrap();
+
+    let result = run_cli_ok(&[
+        "caption",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        subtitle_file.to_str().unwrap(),
+    ]);
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["snappedCues"], 2, "{result}");
+
+    let list = run_cli_ok(&["caption", "list", "--path", &path]);
+    let captions = list["captions"].as_array().expect("captions");
+    assert_eq!(captions.len(), 2);
+    for caption in captions {
+        let start = caption["startSec"].as_f64().unwrap();
+        let end = caption["endSec"].as_f64().unwrap();
+        assert!(is_on_24fps_grid(start), "start {start} off grid: {list}");
+        assert!(is_on_24fps_grid(end), "end {end} off grid: {list}");
+        assert!(end - start >= 1.0 / 24.0 - 1e-9, "{list}");
+    }
+    assert!(
+        captions[1]["startSec"].as_f64().unwrap() >= captions[0]["endSec"].as_f64().unwrap(),
+        "{list}"
+    );
+}
+
+/// A held cue with two dialogue cues running underneath it, the shape a music
+/// or forced-narrative subtitle track takes.
+const OVERLAPPING_SRT: &str = "1\n00:00:00,001 --> 00:00:10,002\n\u{266a}\n\n\
+     2\n00:00:01,003 --> 00:00:03,004\nFirst line\n\n\
+     3\n00:00:03,005 --> 00:00:05,006\nSecond line\n";
+
+#[test]
+fn test_caption_import_reproduces_an_overlapping_subtitle_file() {
+    let dir = create_temp_project("caption_overlap");
+    let path = project_path(&dir, "caption_overlap");
+    set_sequence_to_24fps(&path);
+
+    let subtitle_file = dir.path().join("overlapping.srt");
+    std::fs::write(&subtitle_file, OVERLAPPING_SRT).unwrap();
+
+    let result = run_cli_ok(&[
+        "caption",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        subtitle_file.to_str().unwrap(),
+    ]);
+    assert_eq!(result["status"], "ok", "{result}");
+
+    let list = run_cli_ok(&["caption", "list", "--path", &path]);
+    let captions = list["captions"].as_array().expect("captions");
+    assert_eq!(captions.len(), 3, "{list}");
+
+    let cue = |text: &str| -> (f64, f64) {
+        let found = captions
+            .iter()
+            .find(|caption| caption["text"] == serde_json::json!(text))
+            .unwrap_or_else(|| panic!("cue '{text}' missing: {list}"));
+        (
+            found["startSec"].as_f64().unwrap(),
+            found["endSec"].as_f64().unwrap(),
+        )
+    };
+
+    let (held_start, held_end) = cue("\u{266a}");
+    let (first_start, first_end) = cue("First line");
+    let (second_start, second_end) = cue("Second line");
+
+    // Every boundary is on the grid, and none moved by more than half a frame.
+    for (start, end) in [
+        (held_start, held_end),
+        (first_start, first_end),
+        (second_start, second_end),
+    ] {
+        assert!(is_on_24fps_grid(start), "start {start} off grid: {list}");
+        assert!(is_on_24fps_grid(end), "end {end} off grid: {list}");
+    }
+    assert!((held_start - 0.0).abs() < 1e-9, "{list}");
+    assert!((held_end - 10.0).abs() < 1e-9, "{list}");
+
+    // The dialogue keeps the times the file gave it. Serializing these behind
+    // the held cue would flush both past ten seconds as one-frame flashes.
+    assert!((first_start - 1.0).abs() < 1e-9, "{list}");
+    assert!((first_end - 3.0).abs() < 1e-9, "{list}");
+    assert!((second_start - 3.0).abs() < 1e-9, "{list}");
+    assert!((second_end - 5.0).abs() < 1e-9, "{list}");
+    assert!(first_start < held_end && second_end < held_end, "{list}");
+}
+
+#[test]
+fn test_caption_import_keeps_raw_times_with_no_snap() {
+    let dir = create_temp_project("caption_no_snap");
+    let path = project_path(&dir, "caption_no_snap");
+    set_sequence_to_24fps(&path);
+
+    let subtitle_file = dir.path().join("captions.srt");
+    std::fs::write(&subtitle_file, OFF_GRID_SRT).unwrap();
+
+    let result = run_cli_ok(&[
+        "caption",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        subtitle_file.to_str().unwrap(),
+        "--no-snap",
+    ]);
+    assert_eq!(result["snappedCues"], 0, "{result}");
+
+    let list = run_cli_ok(&["caption", "list", "--path", &path]);
+    let start = list["captions"][0]["startSec"].as_f64().unwrap();
+    assert!((start - 0.137).abs() < 1e-9, "{list}");
+}
+
+#[test]
+fn test_snapped_captions_draw_no_frame_alignment_warnings() {
+    let Some((dir, path, _asset_id, _track_id)) =
+        project_with_av_clip_on_video_track("caption_snap_render")
+    else {
+        eprintln!("Skipping caption alignment test: ffmpeg unavailable");
+        return;
+    };
+    set_sequence_to_24fps(&path);
+
+    let subtitle_file = dir.path().join("captions.srt");
+    std::fs::write(&subtitle_file, OFF_GRID_SRT).unwrap();
+    run_cli_ok(&[
+        "caption",
+        "import",
+        "--path",
+        &path,
+        "--file",
+        subtitle_file.to_str().unwrap(),
+    ]);
+
+    let output_path = dir.path().join("aligned.mp4");
+    let result = run_cli_ok(&[
+        "render",
+        "start",
+        "--path",
+        &path,
+        "--proxy",
+        "--output",
+        output_path.to_str().unwrap(),
+    ]);
+
+    let warnings = result["warnings"].as_array().cloned().unwrap_or_default();
+    let alignment: Vec<&serde_json::Value> = warnings
+        .iter()
+        .filter(|warning| {
+            warning
+                .to_string()
+                .contains("not aligned to sequence frame boundaries")
+        })
+        .collect();
+    assert!(
+        alignment.is_empty(),
+        "snapped cues sit on the grid, so nothing should warn: {alignment:?}"
+    );
+}

--- a/distribution/skills/skills/openreelio/captions/REFERENCE.md
+++ b/distribution/skills/skills/openreelio/captions/REFERENCE.md
@@ -25,12 +25,32 @@ Import and export:
 
 ```bash
 openreelio-cli caption import --path ./demo --file subs.srt \
-                              [--format srt|vtt|transcript-json] [--language en]
+                              [--format srt|vtt|transcript-json] [--language en] [--no-snap]
 openreelio-cli caption export --path ./demo --format srt --output subs.srt
 ```
 
 `--format` is auto-detected from the file extension on import when omitted.
 Export supports `srt` and `vtt`.
+
+Imported cue boundaries are snapped to the sequence frame grid: each start and
+end goes to the nearest frame, and every cue keeps at least one frame. Subtitle
+files carry millisecond times, which otherwise land between frames and make
+every composite and render warn about each cue. The response reports how many
+cues moved as `snappedCues` and how many were given up on as `droppedCues`; pass
+`--no-snap` to keep the file's raw times.
+
+Each cue of an `srt` or `vtt` file is rounded on its own, and nothing else about
+it changes. A file whose cues overlap — a held `♪` under a song, a rolling VTT
+where a line is still on screen when the next arrives — imports with those
+overlaps intact, on the grid, so `droppedCues` is always `0` for those two
+formats. Cues are only put in order and pulled clear of one another on the
+generated path — `--format transcript-json` here, and `--import` on
+`transcription generate`/`generate-sequence` — where they were already
+de-overlapped before rounding could nudge two of them back together; that
+ordering pass is the one that drops a cue, when keeping it clear of its
+neighbours would displace it by more than two frames — dropped rather than
+dragged off its own time. `droppedCues` can therefore be non-zero on those
+paths, and only on those.
 
 ## Caption style packs
 
@@ -244,15 +264,32 @@ openreelio-cli transcription status
 openreelio-cli transcription install --model large-v3-turbo [--force]
 openreelio-cli transcription generate --path ./demo --asset <ASSET_ID> \
                                       [--language auto] [--model auto] [--import] \
-                                      [--track <TRACK_ID>] [--replace-existing] [--translate]
-openreelio-cli transcription generate-sequence --path ./demo [--sequence <SEQ_ID>] --import
+                                      [--track <TRACK_ID>] [--replace-existing] [--translate] \
+                                      [--start <SEC>] [--end <SEC>] [--no-snap]
+openreelio-cli transcription generate-sequence --path ./demo [--sequence <SEQ_ID>] --import \
+                                      [--start <SEC>] [--end <SEC>] [--no-snap]
 ```
 
 `transcription status` returns `{featureAvailable, ready, modelsDir,
 defaultModel, installedCount, models[…]}`. `--import` writes the result straight
 into a caption track; without it, use `--output <FILE>` and import later.
 `generate-sequence` transcribes the audible mix of a sequence instead of a single
-asset.
+asset — every clip that reaches the render with sound, including the embedded
+audio of an A/V file sitting on a *video* track, which is what a plain
+`timeline insert` produces. `render graph` lists the same audio layers, so an
+empty `audioLayers` there means the sequence really is silent.
+
+`--start`/`--end` bound the decode: asset seconds for `generate`, timeline
+seconds for `generate-sequence`. Nothing outside the window is opened, so
+transcribing 90 seconds of a 14-minute talk costs 90 seconds. Segment times come
+back absolute, so a ranged run imports exactly like a full one.
+
+Cues imported by `--import` are snapped to the sequence frame grid, the same way
+`caption import` does, and are additionally kept in order and clear of one
+another. The response reports `snappedCues` and `droppedCues` — a cue that the
+ordering pass would have to displace by more than two frames to keep clear of
+its neighbours is dropped rather than dragged off its own time. `--no-snap`
+keeps Whisper's raw millisecond times.
 
 **Caption cue boundaries come from DTW-aligned word timings.** Cue starts and
 ends — including on a cue short enough to need no splitting — are derived from
@@ -283,6 +320,14 @@ otherwise span a pause is released after at most 350 ms per syllable-ish unit,
 except the segment's last word, whose end anchors the tail cue; and starts are
 snapped to the nearest short-time-energy onset within 80 ms when that neither
 reorders nor starves a neighbour.
+
+Grid snapping runs after all of that, on import rather than on transcription: it
+moves each boundary by up to half a frame so the cue clips sit on the sequence's
+frame grid, which is what silences the per-cue alignment warnings. Because these
+cues left the readability pass already ordered and clear of one another, a
+second pass then pushes apart any two that rounding landed on the same frame. It
+does not make the timings more accurate — a boundary is only ever as good as the
+word timing under it.
 
 Accuracy is indicative, not contractual: on English and Korean test clips whose
 speech is preceded by silence, the leading cue edge landed on the hand-measured

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -922,7 +922,7 @@ openreelio-cli caption add    --path ./demo --text "Hello" --start 0.5 --end 3.0
 openreelio-cli caption update --path ./demo --id <CAPTION_ID> --text "Updated" [--style-pack <PACK_ID>]
 openreelio-cli caption list   --path ./demo
 openreelio-cli caption remove --path ./demo --id <CAPTION_ID>
-openreelio-cli caption import --path ./demo --file subs.srt [--format srt|vtt|transcript-json]
+openreelio-cli caption import --path ./demo --file subs.srt [--format srt|vtt|transcript-json] [--no-snap]
 openreelio-cli caption export --path ./demo --format srt --output subs.srt
 
 openreelio-cli text add       --path ./demo --text "Title" --start 0 [--duration 3] [--preset <PRESET_ID>]
@@ -1064,9 +1064,36 @@ caption track.
 ```bash
 openreelio-cli transcription status
 openreelio-cli transcription install --model large-v3-turbo-q5_0
-openreelio-cli transcription generate --path ./demo --asset <ASSET_ID> --import
-openreelio-cli transcription generate-sequence --path ./demo --import
+openreelio-cli transcription generate --path ./demo --asset <ASSET_ID> --import [--start 60 --end 150]
+openreelio-cli transcription generate-sequence --path ./demo --import [--start 60 --end 150]
 ```
+
+`generate-sequence` mixes down every clip that reaches the render with sound,
+including the embedded audio of an A/V file sitting on a **video** track — the
+shape a plain `timeline insert` produces. `render graph` reports the same audio
+layers the mixdown and the export will use, so an empty `audioLayers` means the
+render really is silent.
+
+`audioLayers` lists every clip that *has* sound, muted ones included — muting is
+a property of the layer, not a reason to leave it out, and the export still opens
+the input to apply the gain. Read `audio.muted` on each layer before concluding
+that a sequence will be audible; the transcription mixdown is the one caller that
+drops muted layers outright.
+
+`--start`/`--end` bound the work: asset seconds for `generate`, timeline seconds
+for `generate-sequence`. Only that window is decoded, so transcribing 90 seconds
+of a 14-minute talk costs 90 seconds. Reported segment times stay absolute, so a
+ranged run imports exactly like a full one.
+
+Imported cues are snapped to the sequence frame grid — nearest frame, always at
+least one frame long. Without it a transcriber's millisecond times land between
+frames and every composite and render warns about each cue. Generated cues, which
+the readability pass already de-overlapped, are additionally kept in order and
+clear of one another; an SRT or VTT file imported with `caption import` is
+reproduced as written, overlaps and all. The response reports `snappedCues` and
+`droppedCues` — a generated cue that would have to move more than two frames to
+stay clear of its neighbours is dropped rather than dragged off its own time.
+Pass `--no-snap` to keep the raw times.
 
 **Caption cue boundaries come from DTW-aligned word timings.** Instead of
 Whisper's cheap heuristic token timestamps, whisper.cpp aligns tokens by dynamic

--- a/src-tauri/src/core/assets/metadata.rs
+++ b/src-tauri/src/core/assets/metadata.rs
@@ -28,7 +28,11 @@ use crate::core::{CoreError, CoreResult, Ratio};
 /// Two things read it. [`probe_measured_nothing`] is one. The other is the
 /// frontend: `src/utils/errorMessages.ts` matches this same wording to ask for
 /// a retry instead of blaming the file, so the prefix is user-visible text and
-/// changing it means changing that pattern and its test too.
+/// changing it means changing that pattern and its test too. That pattern is
+/// anchored and case-sensitive, for the reason this side matches on
+/// `starts_with`: it accepts the prefix at the start of the message, or
+/// directly after the `FFprobe error: ` that [`CoreError`]'s `Display` puts in
+/// front of it, and nowhere else.
 pub const PROBE_MEASURED_NOTHING_PREFIX: &str = "FFprobe reported nothing";
 
 /// Whether `error` means the probe finished without measuring anything.

--- a/src-tauri/src/core/assets/metadata.rs
+++ b/src-tauri/src/core/assets/metadata.rs
@@ -12,6 +12,46 @@ use crate::core::process::configure_std_command;
 use crate::core::{CoreError, CoreResult, Ratio};
 
 // =============================================================================
+// Probe Failure Classification
+// =============================================================================
+
+/// Marks the [`CoreError::FFprobeError`] a probe that reached no verdict carries.
+///
+/// FFprobe can exit successfully and still leave nothing to read - a truncated
+/// or empty stdout, output no version of the JSON schema this understands. That
+/// is not the same failure as FFprobe looking at a file and rejecting it: the
+/// second says something permanent about the bytes, the first says only that
+/// this run produced no measurement. Callers that would otherwise register an
+/// asset from defaults need to tell the two apart, so the message *starts* with
+/// this prefix.
+///
+/// Two things read it. [`probe_measured_nothing`] is one. The other is the
+/// frontend: `src/utils/errorMessages.ts` matches this same wording to ask for
+/// a retry instead of blaming the file, so the prefix is user-visible text and
+/// changing it means changing that pattern and its test too.
+pub const PROBE_MEASURED_NOTHING_PREFIX: &str = "FFprobe reported nothing";
+
+/// Whether `error` means the probe finished without measuring anything.
+///
+/// True for a probe whose output could not be read (see
+/// [`PROBE_MEASURED_NOTHING_PREFIX`]) and for one that could not be launched at
+/// all: neither looked at the file, so neither licenses a caller to invent the
+/// frame size, duration or codec it failed to report. A failure FFprobe *did*
+/// reach about the content is not covered - something looked, and one
+/// unreadable file must not stop a workspace scan.
+///
+/// The prefix is matched at the start of the message, not anywhere in it: every
+/// producer writes it there, and a substring match would also fire on a verdict
+/// that merely quotes an inner error carrying the same words.
+pub fn probe_measured_nothing(error: &CoreError) -> bool {
+    match error {
+        CoreError::FFprobeUnavailable(_) => true,
+        CoreError::FFprobeError(message) => message.starts_with(PROBE_MEASURED_NOTHING_PREFIX),
+        _ => false,
+    }
+}
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -129,13 +169,19 @@ impl MetadataExtractor {
             return Err(CoreError::FileNotFound(path.to_string_lossy().to_string()));
         }
 
-        // Run FFprobe
+        // Run FFprobe.
+        //
+        // `-v error` rather than `-v quiet`: the JSON still comes back on
+        // stdout, but a refusal now says *why* on stderr. Callers that decide
+        // whether a failure is worth remembering — see
+        // `crate::core::render::probe_asset_audio_info` — have nothing to
+        // classify when the message is empty.
         let mut command = Command::new(resolved_ffprobe_path());
         configure_std_command(&mut command);
         let output = command
             .args([
                 "-v",
-                "quiet",
+                "error",
                 "-print_format",
                 "json",
                 "-show_streams",
@@ -143,7 +189,7 @@ impl MetadataExtractor {
             ])
             .arg(path)
             .output()
-            .map_err(|e| CoreError::FFprobeError(format!("Failed to run ffprobe: {}", e)))?;
+            .map_err(|e| CoreError::FFprobeUnavailable(format!("Failed to run ffprobe: {}", e)))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -159,8 +205,15 @@ impl MetadataExtractor {
 
     /// Parse FFprobe JSON output into MediaMetadata
     fn parse_ffprobe_output(json: &str) -> CoreResult<MediaMetadata> {
+        // Unreadable output is not a verdict about the file: FFprobe exited
+        // successfully and still said nothing this can be built from. It is
+        // marked with `PROBE_MEASURED_NOTHING_PREFIX` so callers that would
+        // otherwise fall back to invented defaults can tell it apart from a
+        // refusal FFprobe actually reached about the bytes.
         let output: FFprobeOutput = serde_json::from_str(json).map_err(|e| {
-            CoreError::FFprobeError(format!("Failed to parse ffprobe output: {}", e))
+            CoreError::FFprobeError(format!(
+                "{PROBE_MEASURED_NOTHING_PREFIX}: failed to parse ffprobe output: {e}"
+            ))
         })?;
 
         let mut metadata = MediaMetadata::default();
@@ -372,7 +425,7 @@ impl MetadataExtractor {
             ])
             .arg(path)
             .output()
-            .map_err(|e| CoreError::FFprobeError(format!("Failed to run ffprobe: {}", e)))?;
+            .map_err(|e| CoreError::FFprobeUnavailable(format!("Failed to run ffprobe: {}", e)))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -705,6 +758,38 @@ mod tests {
         let json = "invalid json";
         let result = MetadataExtractor::parse_ffprobe_output(json);
         assert!(result.is_err());
+    }
+
+    /// Feature: probe failure classification
+    /// Scenario: FFprobe exits successfully with output nothing can be read from
+    ///
+    /// Given output that does not parse
+    /// When a caller asks whether the probe measured anything
+    /// Then it is told no, so it does not register an asset from defaults the
+    /// probe never reported; a verdict FFprobe did reach about the file is
+    /// still reported as a measurement that happened.
+    #[test]
+    fn a_probe_whose_output_cannot_be_read_measured_nothing() {
+        let unreadable = MetadataExtractor::parse_ffprobe_output("invalid json")
+            .expect_err("unreadable output is a failure");
+        assert!(probe_measured_nothing(&unreadable));
+
+        assert!(probe_measured_nothing(&CoreError::FFprobeUnavailable(
+            "Failed to run ffprobe: program not found".to_string()
+        )));
+        assert!(!probe_measured_nothing(&CoreError::FFprobeError(
+            "FFprobe failed: Invalid data found when processing input".to_string()
+        )));
+
+        // A verdict that merely quotes the marker further along is still a
+        // verdict: FFprobe looked at the file and had something to say about
+        // it, so the caller may keep the defaults.
+        assert!(
+            !probe_measured_nothing(&CoreError::FFprobeError(
+                "FFprobe failed: FFprobe reported nothing decodable".to_string()
+            )),
+            "the marker only marks when the message starts with it"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/src-tauri/src/core/captions/audio.rs
+++ b/src-tauri/src/core/captions/audio.rs
@@ -3,6 +3,7 @@
 //! Provides audio extraction functionality for transcription using FFmpeg.
 //! Extracts audio as 16kHz mono WAV format suitable for Whisper.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use thiserror::Error;
@@ -10,7 +11,8 @@ use thiserror::Error;
 use crate::core::ffmpeg::resolved_ffmpeg_path;
 use crate::core::process::configure_std_command;
 use crate::core::project::ProjectState;
-use crate::core::render::build_render_graph;
+use crate::core::render::{build_render_graph_with_audio_info, probe_sequence_audio_info};
+use crate::core::timeline::AudioSettings;
 
 // =============================================================================
 // Error Types
@@ -35,6 +37,10 @@ pub enum AudioExtractionError {
     #[error("Output directory does not exist: {0}")]
     OutputDirNotFound(String),
 
+    /// Requested time range does not describe anything decodable
+    #[error("Invalid range: {0}")]
+    InvalidRange(String),
+
     /// IO error during file operations
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
@@ -43,11 +49,92 @@ pub enum AudioExtractionError {
 /// Result type for audio extraction operations
 pub type AudioResult<T> = Result<T, AudioExtractionError>;
 
+/// A window of media or timeline time, in seconds.
+///
+/// Transcribing a 90-second excerpt of a 14-minute talk used to decode the whole
+/// talk: the window is cut *before* Whisper runs, so the decode, the mixdown and
+/// the inference all cost only the stretch under review. Segment timestamps stay
+/// absolute — callers add [`Self::start`] back onto what Whisper reports.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct AudioWindow {
+    start_sec: Option<f64>,
+    end_sec: Option<f64>,
+}
+
+impl AudioWindow {
+    /// The whole file or timeline.
+    pub const FULL: Self = Self {
+        start_sec: None,
+        end_sec: None,
+    };
+
+    /// Builds a window, rejecting bounds that describe nothing decodable.
+    pub fn new(start_sec: Option<f64>, end_sec: Option<f64>) -> AudioResult<Self> {
+        if let Some(start) = start_sec {
+            if !start.is_finite() || start < 0.0 {
+                return Err(AudioExtractionError::InvalidRange(format!(
+                    "Range start {start} must be a finite, non-negative number of seconds"
+                )));
+            }
+        }
+        if let Some(end) = end_sec {
+            if !end.is_finite() || end <= 0.0 {
+                return Err(AudioExtractionError::InvalidRange(format!(
+                    "Range end {end} must be a finite, positive number of seconds"
+                )));
+            }
+        }
+        if let (Some(start), Some(end)) = (start_sec, end_sec) {
+            if end <= start {
+                return Err(AudioExtractionError::InvalidRange(format!(
+                    "Range end {end} must be greater than range start {start}"
+                )));
+            }
+        }
+
+        Ok(Self { start_sec, end_sec })
+    }
+
+    /// Whether this window covers everything, so nothing needs trimming.
+    pub fn is_full(&self) -> bool {
+        self.start_sec.is_none() && self.end_sec.is_none()
+    }
+
+    /// The first second the window keeps; zero when it is open at the front.
+    pub fn start(&self) -> f64 {
+        self.start_sec.unwrap_or(0.0)
+    }
+
+    /// The declared end, if any.
+    pub fn end(&self) -> Option<f64> {
+        self.end_sec
+    }
+
+    /// The end of the window once the total length it applies to is known.
+    pub fn resolved_end(&self, total_sec: f64) -> f64 {
+        match self.end_sec {
+            Some(end) => end.min(total_sec),
+            None => total_sec,
+        }
+    }
+}
+
 /// Result metadata for sequence audio mixdown.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceAudioMixdownResult {
-    /// Sequence duration in seconds.
+    /// Length of the WAV that was actually written, measured from its own
+    /// header rather than assumed from the window.
+    ///
+    /// The two normally agree — the mixdown is capped with `-t` at the window's
+    /// length — but they part company whenever the mix runs short: a layer
+    /// whose source ends early, a decoder that gave up mid-file. Callers report
+    /// this to the user and slice transcripts against it, so it has to describe
+    /// the file, not the request. Falls back to the requested length when the
+    /// header cannot be read.
     pub duration_sec: f64,
+    /// Timeline second the mixdown starts at; add it to Whisper's segment times
+    /// to put them back on the sequence's clock.
+    pub start_sec: f64,
     /// Number of audible timeline audio layers mixed into the output.
     pub layer_count: usize,
 }
@@ -84,6 +171,21 @@ pub fn extract_audio_for_transcription(
     output_path: &Path,
     ffmpeg_path: Option<&str>,
 ) -> AudioResult<()> {
+    extract_audio_range_for_transcription(input_path, output_path, AudioWindow::FULL, ffmpeg_path)
+}
+
+/// Extracts one window of a media file's audio as 16kHz mono WAV.
+///
+/// The window is applied on the FFmpeg command line, so only the requested
+/// stretch is ever decoded. `window` is in *source* seconds; the WAV it writes
+/// starts at zero, and callers add [`AudioWindow::start`] back onto the
+/// timestamps Whisper reports.
+pub fn extract_audio_range_for_transcription(
+    input_path: &Path,
+    output_path: &Path,
+    window: AudioWindow,
+    ffmpeg_path: Option<&str>,
+) -> AudioResult<()> {
     // Validate input file exists
     if !input_path.exists() {
         return Err(AudioExtractionError::InputNotFound(
@@ -106,10 +208,21 @@ pub fn extract_audio_for_transcription(
         .unwrap_or_else(resolved_ffmpeg_path);
     let mut cmd = Command::new(ffmpeg);
     configure_std_command(&mut cmd);
+
+    // `-ss` in front of `-i` seeks the demuxer instead of decoding and throwing
+    // frames away, which is what keeps a 90-second excerpt of a 14-minute talk
+    // from costing the whole talk.
+    let start_sec = window.start();
+    if start_sec > 0.0 {
+        cmd.args(["-ss", &format_filter_seconds(start_sec)]);
+    }
+    cmd.arg("-i").arg(input_path);
+    if let Some(end_sec) = window.end() {
+        cmd.args(["-t", &format_filter_seconds((end_sec - start_sec).max(0.0))]);
+    }
+
     let output = cmd
         .args([
-            "-i",
-            input_path.to_str().unwrap_or_default(),
             "-ar",
             "16000", // 16kHz sample rate (required by Whisper)
             "-ac",
@@ -129,11 +242,84 @@ pub fn extract_audio_for_transcription(
     Ok(())
 }
 
+/// How far in front of a layer's in point its input is seeked.
+///
+/// An input `-ss` is a *demuxer* seek: FFmpeg lands on the packet at or before
+/// the requested second and starts decoding there. For a video container that
+/// is a keyframe well ahead of the request, so the audio the window wants is
+/// always inside what gets decoded. A bare audio container has no such slack —
+/// an m4a's AAC frames carry an encoder delay and an mp3's bit reservoir needs
+/// the frames before the one you land on — so seeking straight to the in point
+/// dropped the first tens of milliseconds and shifted every transcript
+/// timestamp in the window by that much.
+///
+/// A quarter of a second is longer than any of those priming intervals and
+/// cheap: it is decoded, then thrown away by the `atrim` that follows.
+const MIXDOWN_SEEK_HANDLE_SEC: f64 = 0.25;
+
+/// One clip's contribution to a transcription mixdown, already narrowed to the
+/// requested window.
+struct MixdownLayer {
+    asset_path: PathBuf,
+    /// Placement inside the mixdown, relative to the window's start.
+    output_in_sec: f64,
+    output_out_sec: f64,
+    source_in_sec: f64,
+    source_out_sec: f64,
+    /// Seconds of the clip's own head and tail the window cut away, used to
+    /// carry over what is left of its fade envelope.
+    trimmed_head_sec: f64,
+    trimmed_tail_sec: f64,
+    speed: f64,
+    reverse: bool,
+    audio: AudioSettings,
+}
+
+impl MixdownLayer {
+    /// How many source seconds this layer reads, after the window trimmed it.
+    fn source_span_sec(&self) -> f64 {
+        (self.source_out_sec - self.source_in_sec).max(0.0)
+    }
+
+    /// Where the input's own `-ss` seeks to.
+    ///
+    /// A handle before the wanted stretch, never before the file's start.
+    fn seek_sec(&self) -> f64 {
+        (self.source_in_sec - MIXDOWN_SEEK_HANDLE_SEC).max(0.0)
+    }
+
+    /// How far into the seeked input the wanted stretch begins.
+    ///
+    /// The whole handle, except on a clip whose in point is closer to the start
+    /// of the file than the handle is long.
+    fn seek_handle_sec(&self) -> f64 {
+        self.source_in_sec - self.seek_sec()
+    }
+
+    /// How much of the input the demuxer is asked to read: the handle in front,
+    /// the wanted stretch, and one more handle behind it so a decoder that
+    /// under-reads the tail still has the last sample of the window.
+    fn decoded_span_sec(&self) -> f64 {
+        self.seek_handle_sec() + self.source_span_sec() + MIXDOWN_SEEK_HANDLE_SEC
+    }
+}
+
 /// Renders the audible audio layers of a sequence to a 16kHz mono WAV for transcription.
+///
+/// Every clip that reaches the render with sound is mixed, including the
+/// embedded audio of a clip sitting on a *video* track — the shape a headless
+/// `timeline insert` of an A/V file produces. Audio presence is measured with
+/// FFprobe rather than read from the stored asset metadata, because an asset
+/// imported from its file extension carries none.
+///
+/// `window` is in timeline seconds. Clips outside it are never opened, and the
+/// ones inside are trimmed to their overlap, so the decode costs only the
+/// stretch being transcribed.
 pub fn mix_sequence_audio_for_transcription(
     state: &ProjectState,
     sequence_id: &str,
     output_path: &Path,
+    window: AudioWindow,
     ffmpeg_path: Option<&str>,
 ) -> AudioResult<SequenceAudioMixdownResult> {
     if let Some(parent) = output_path.parent() {
@@ -144,12 +330,22 @@ pub fn mix_sequence_audio_for_transcription(
         }
     }
 
-    let graph = build_render_graph(state, sequence_id)
+    let audio_info = probe_sequence_audio_info(state, sequence_id);
+    let graph = build_render_graph_with_audio_info(state, sequence_id, &audio_info)
         .map_err(|error| AudioExtractionError::FFmpegFailed(error.to_string()))?;
     if graph.duration_sec <= 0.0 {
         return Err(AudioExtractionError::FFmpegFailed(
             "Sequence duration is empty; nothing to transcribe".to_string(),
         ));
+    }
+
+    let window_start = window.start();
+    let window_end = window.resolved_end(graph.duration_sec);
+    if window_end <= window_start {
+        return Err(AudioExtractionError::InvalidRange(format!(
+            "Range {window_start}s-{window_end}s lies outside the sequence, which is {:.3}s long",
+            graph.duration_sec
+        )));
     }
 
     let mut audible_layers = Vec::new();
@@ -169,7 +365,10 @@ pub fn mix_sequence_audio_for_transcription(
         if !asset_path.exists() {
             return Err(AudioExtractionError::InputNotFound(asset.uri.clone()));
         }
-        audible_layers.push((layer, asset_path.to_path_buf()));
+        if let Some(narrowed) = narrow_layer_to_window(layer, asset_path, window_start, window_end)
+        {
+            audible_layers.push(narrowed);
+        }
     }
 
     if audible_layers.is_empty() {
@@ -183,29 +382,11 @@ pub fn mix_sequence_audio_for_transcription(
         .unwrap_or_else(resolved_ffmpeg_path);
     let mut cmd = Command::new(ffmpeg);
     configure_std_command(&mut cmd);
-    cmd.arg("-y").arg("-hide_banner");
-
-    for (_, asset_path) in &audible_layers {
-        cmd.arg("-i").arg(asset_path);
-    }
-
-    let filter_complex = build_sequence_mixdown_filter(&audible_layers);
-    let duration_arg = format_filter_seconds(graph.duration_sec);
-    cmd.args([
-        "-filter_complex",
-        &filter_complex,
-        "-map",
-        "[aout]",
-        "-t",
-        &duration_arg,
-        "-ar",
-        "16000",
-        "-ac",
-        "1",
-        "-c:a",
-        "pcm_s16le",
-        output_path.to_str().unwrap_or_default(),
-    ]);
+    cmd.args(build_sequence_mixdown_args(
+        &audible_layers,
+        window_end - window_start,
+        output_path,
+    ));
 
     let output = cmd.output()?;
     if !output.status.success() {
@@ -214,22 +395,165 @@ pub fn mix_sequence_audio_for_transcription(
     }
 
     Ok(SequenceAudioMixdownResult {
-        duration_sec: graph.duration_sec,
+        duration_sec: written_wav_duration_sec(output_path, window_end - window_start),
+        start_sec: window_start,
         layer_count: audible_layers.len(),
     })
 }
 
-fn build_sequence_mixdown_filter(
-    audible_layers: &[(&crate::core::render::AudioRenderLayer, std::path::PathBuf)],
-) -> String {
+/// How long the mixdown FFmpeg just wrote actually runs.
+///
+/// Read from the WAV's own header — sample count over sample rate — which costs
+/// one file open and no FFprobe. `requested_sec` stands in when the header
+/// cannot be read or claims a zero sample rate, so a caller still gets the
+/// length it asked for rather than a zero.
+fn written_wav_duration_sec(path: &Path, requested_sec: f64) -> f64 {
+    match hound::WavReader::open(path) {
+        Ok(reader) => {
+            let sample_rate = reader.spec().sample_rate;
+            if sample_rate == 0 {
+                return requested_sec;
+            }
+            f64::from(reader.duration()) / f64::from(sample_rate)
+        }
+        Err(error) => {
+            tracing::debug!(
+                "Falling back to the requested mixdown length: {} could not be measured: {}",
+                path.display(),
+                error
+            );
+            requested_sec
+        }
+    }
+}
+
+/// Cuts a layer down to its overlap with the window, or drops it entirely.
+///
+/// The source range is narrowed by the same fraction as the timeline range, so
+/// FFmpeg decodes only the seconds the window keeps. A reversed clip plays its
+/// source backwards, so its timeline head maps to the *end* of the source range
+/// and the fractions are mirrored.
+fn narrow_layer_to_window(
+    layer: &crate::core::render::AudioRenderLayer,
+    asset_path: &Path,
+    window_start: f64,
+    window_end: f64,
+) -> Option<MixdownLayer> {
+    let clip_start = layer.timeline_in_sec;
+    let clip_end = layer.timeline_out_sec;
+    let kept_start = clip_start.max(window_start);
+    let kept_end = clip_end.min(window_end);
+    if kept_end <= kept_start {
+        return None;
+    }
+
+    let clip_duration = clip_end - clip_start;
+    let head_fraction = ((kept_start - clip_start) / clip_duration).clamp(0.0, 1.0);
+    let tail_fraction = ((kept_end - clip_start) / clip_duration).clamp(0.0, 1.0);
+    let source_span = layer.source_out_sec - layer.source_in_sec;
+    let (source_in_sec, source_out_sec) = if layer.reverse {
+        (
+            layer.source_out_sec - tail_fraction * source_span,
+            layer.source_out_sec - head_fraction * source_span,
+        )
+    } else {
+        (
+            layer.source_in_sec + head_fraction * source_span,
+            layer.source_in_sec + tail_fraction * source_span,
+        )
+    };
+    if source_out_sec <= source_in_sec {
+        return None;
+    }
+
+    let speed = if layer.speed.is_finite() && layer.speed > 0.0 {
+        layer.speed as f64
+    } else {
+        1.0
+    };
+
+    Some(MixdownLayer {
+        asset_path: asset_path.to_path_buf(),
+        output_in_sec: kept_start - window_start,
+        output_out_sec: kept_end - window_start,
+        source_in_sec,
+        source_out_sec,
+        trimmed_head_sec: kept_start - clip_start,
+        trimmed_tail_sec: clip_end - kept_end,
+        speed,
+        reverse: layer.reverse,
+        audio: layer.audio.clone(),
+    })
+}
+
+/// Builds the FFmpeg arguments for one transcription mixdown.
+///
+/// Every layer gets its own `-ss`/`-t` in front of its `-i`, so FFmpeg seeks the
+/// demuxer and reads only the stretch the window kept — the same reason
+/// [`extract_audio_range_for_transcription`] does it. Without them a ranged
+/// `generate-sequence` still decoded every input end to end and let `atrim`
+/// throw the rest away, so transcribing ninety seconds of a fourteen-minute talk
+/// cost the whole talk.
+///
+/// The seek lands [`MIXDOWN_SEEK_HANDLE_SEC`] *before* the layer's in point and
+/// reads a handle past its out point; the filtergraph's `atrim` then cuts the
+/// handles off. Seeking straight to the in point loses the head of a bare audio
+/// container, which is a shift of the whole window's timestamps rather than a
+/// dropped sample.
+fn build_sequence_mixdown_args(
+    audible_layers: &[MixdownLayer],
+    output_duration_sec: f64,
+    output_path: &Path,
+) -> Vec<OsString> {
+    let mut args: Vec<OsString> = vec!["-y".into(), "-hide_banner".into()];
+
+    for layer in audible_layers {
+        // A layer that already starts at the head of its file gets no `-ss` at
+        // all. `-ss 0` is not free: measured against the bundled FFmpeg, asking
+        // an m4a to seek to zero still costs one AAC frame (23 ms) of head,
+        // while simply not seeking reads the file from its first sample.
+        let seek_sec = layer.seek_sec();
+        if seek_sec > 0.0 {
+            args.push("-ss".into());
+            args.push(format_filter_seconds(seek_sec).into());
+        }
+        args.push("-t".into());
+        args.push(format_filter_seconds(layer.decoded_span_sec()).into());
+        args.push("-i".into());
+        args.push(layer.asset_path.clone().into_os_string());
+    }
+
+    args.push("-filter_complex".into());
+    args.push(build_sequence_mixdown_filter(audible_layers).into());
+    args.push("-map".into());
+    args.push("[aout]".into());
+    args.push("-t".into());
+    args.push(format_filter_seconds(output_duration_sec).into());
+    args.push("-ar".into());
+    args.push("16000".into());
+    args.push("-ac".into());
+    args.push("1".into());
+    args.push("-c:a".into());
+    args.push("pcm_s16le".into());
+    args.push(output_path.as_os_str().to_os_string());
+
+    args
+}
+
+fn build_sequence_mixdown_filter(audible_layers: &[MixdownLayer]) -> String {
     let mut filters = Vec::new();
 
-    for (index, (layer, _)) in audible_layers.iter().enumerate() {
+    for (index, layer) in audible_layers.iter().enumerate() {
+        // The input's own `-ss` landed a handle in front of the layer's in
+        // point and rebased that input's timestamps to zero, so the wanted
+        // stretch starts one handle in. This is the cut that throws the handles
+        // away; `asetpts` below then puts the surviving audio back at zero.
+        let trim_start_sec = layer.seek_handle_sec();
         let mut chain = vec![
             format!(
                 "[{index}:a]atrim=start={}:end={}",
-                format_filter_seconds(layer.source_in_sec),
-                format_filter_seconds(layer.source_out_sec)
+                format_filter_seconds(trim_start_sec),
+                format_filter_seconds(trim_start_sec + layer.source_span_sec())
             ),
             "asetpts=PTS-STARTPTS".to_string(),
             "aresample=16000".to_string(),
@@ -240,24 +564,24 @@ fn build_sequence_mixdown_filter(
             chain.push("areverse".to_string());
         }
 
-        let speed = if layer.speed.is_finite() && layer.speed > 0.0 {
-            layer.speed as f64
-        } else {
-            1.0
-        };
-        for tempo in atempo_chain(speed) {
+        for tempo in atempo_chain(layer.speed) {
             chain.push(format!("atempo={}", format_filter_seconds(tempo)));
         }
 
-        let clip_duration = (layer.timeline_out_sec - layer.timeline_in_sec).max(0.0);
-        let fade_in = layer.audio.fade_in_sec.clamp(0.0, clip_duration);
+        // The fade envelope belongs to the whole clip. When the window cut the
+        // clip's head or tail away, what survives is whatever is left of each
+        // ramp: a clip whose fade-in finished before the window opened fades no
+        // more.
+        let clip_duration = (layer.output_out_sec - layer.output_in_sec).max(0.0);
+        let fade_in = (layer.audio.fade_in_sec - layer.trimmed_head_sec).clamp(0.0, clip_duration);
         if fade_in > 0.0 {
             chain.push(format!(
                 "afade=t=in:st=0:d={}",
                 format_filter_seconds(fade_in)
             ));
         }
-        let fade_out = layer.audio.fade_out_sec.clamp(0.0, clip_duration);
+        let fade_out =
+            (layer.audio.fade_out_sec - layer.trimmed_tail_sec).clamp(0.0, clip_duration);
         if fade_out > 0.0 {
             let fade_start = (clip_duration - fade_out).max(0.0);
             chain.push(format!(
@@ -270,7 +594,7 @@ fn build_sequence_mixdown_filter(
         let volume = db_to_linear(layer.audio.volume_db);
         chain.push(format!("volume={}", format_filter_seconds(volume)));
 
-        let delay_ms = (layer.timeline_in_sec.max(0.0) * 1000.0).round() as u64;
+        let delay_ms = (layer.output_in_sec.max(0.0) * 1000.0).round() as u64;
         if delay_ms > 0 {
             chain.push(format!("adelay={delay_ms}:all=1"));
         }
@@ -488,6 +812,7 @@ pub fn load_audio_samples_i16(wav_path: &Path) -> AudioResult<Vec<i16>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::render::AudioRenderLayer;
     use std::fs::File;
     use std::io::Write;
     use tempfile::TempDir;
@@ -646,5 +971,502 @@ mod tests {
         assert_eq!(format_filter_seconds(1.5), "1.5");
         assert_eq!(format_filter_seconds(0.0), "0");
         assert_eq!(format_filter_seconds(f64::NAN), "0");
+    }
+
+    /// An audio layer covering `[timeline_in, timeline_out]` of a source range
+    /// of the same length, playing forward at 1x.
+    fn layer(timeline_in_sec: f64, timeline_out_sec: f64, source_in_sec: f64) -> AudioRenderLayer {
+        AudioRenderLayer {
+            track_id: "track".to_string(),
+            track_index: 0,
+            clip_id: "clip".to_string(),
+            asset_id: "asset".to_string(),
+            timeline_in_sec,
+            timeline_out_sec,
+            timeline_in_frame: 0,
+            timeline_out_frame: 0,
+            duration_frames: 0,
+            source_in_sec,
+            source_out_sec: source_in_sec + (timeline_out_sec - timeline_in_sec),
+            source_in_frame: 0,
+            source_out_frame: 0,
+            speed: 1.0,
+            reverse: false,
+            audio: AudioSettings::default(),
+            effects: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn audio_window_rejects_bounds_that_describe_nothing() {
+        assert!(AudioWindow::new(Some(-1.0), None).is_err());
+        assert!(AudioWindow::new(None, Some(0.0)).is_err());
+        assert!(AudioWindow::new(Some(5.0), Some(5.0)).is_err());
+        assert!(AudioWindow::new(Some(6.0), Some(5.0)).is_err());
+        assert!(AudioWindow::new(Some(f64::NAN), None).is_err());
+    }
+
+    #[test]
+    fn audio_window_reports_its_bounds() {
+        assert!(AudioWindow::FULL.is_full());
+        assert_eq!(AudioWindow::FULL.start(), 0.0);
+        assert_eq!(AudioWindow::FULL.resolved_end(9.0), 9.0);
+
+        let window = AudioWindow::new(Some(2.0), Some(5.0)).expect("window");
+        assert!(!window.is_full());
+        assert_eq!(window.start(), 2.0);
+        assert_eq!(window.end(), Some(5.0));
+        // A window reaching past the material it applies to stops at the end.
+        assert_eq!(window.resolved_end(4.0), 4.0);
+        assert_eq!(window.resolved_end(9.0), 5.0);
+    }
+
+    #[test]
+    fn narrow_layer_drops_a_clip_the_window_never_reaches() {
+        let clip = layer(0.0, 2.0, 0.0);
+        assert!(narrow_layer_to_window(&clip, Path::new("a.wav"), 5.0, 8.0).is_none());
+        // Touching the window's edge is not overlap.
+        assert!(narrow_layer_to_window(&clip, Path::new("a.wav"), 2.0, 8.0).is_none());
+    }
+
+    #[test]
+    fn narrow_layer_trims_source_and_placement_to_the_window() {
+        // Clip 10s-20s of the timeline, playing source 30s-40s. The window
+        // 12s-18s keeps the middle six seconds of both.
+        let clip = layer(10.0, 20.0, 30.0);
+        let narrowed =
+            narrow_layer_to_window(&clip, Path::new("a.wav"), 12.0, 18.0).expect("overlap");
+
+        assert!((narrowed.source_in_sec - 32.0).abs() < 1e-9);
+        assert!((narrowed.source_out_sec - 38.0).abs() < 1e-9);
+        // Placement is relative to the window, which is where the mixdown's
+        // own clock starts.
+        assert!((narrowed.output_in_sec - 0.0).abs() < 1e-9);
+        assert!((narrowed.output_out_sec - 6.0).abs() < 1e-9);
+        assert!((narrowed.trimmed_head_sec - 2.0).abs() < 1e-9);
+        assert!((narrowed.trimmed_tail_sec - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn narrow_layer_mirrors_the_source_range_of_a_reversed_clip() {
+        // Played backwards, the clip's timeline head is the source's tail.
+        let mut clip = layer(10.0, 20.0, 30.0);
+        clip.reverse = true;
+        let narrowed =
+            narrow_layer_to_window(&clip, Path::new("a.wav"), 12.0, 18.0).expect("overlap");
+
+        assert!((narrowed.source_in_sec - 32.0).abs() < 1e-9);
+        assert!((narrowed.source_out_sec - 38.0).abs() < 1e-9);
+
+        let narrowed =
+            narrow_layer_to_window(&clip, Path::new("a.wav"), 0.0, 12.0).expect("overlap");
+        assert!((narrowed.source_in_sec - 38.0).abs() < 1e-9);
+        assert!((narrowed.source_out_sec - 40.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mixdown_filter_offsets_a_clip_by_its_position_inside_the_window() {
+        let clip = layer(10.0, 20.0, 30.0);
+        let narrowed =
+            narrow_layer_to_window(&clip, Path::new("a.wav"), 8.0, 18.0).expect("overlap");
+        let filter = build_sequence_mixdown_filter(std::slice::from_ref(&narrowed));
+
+        // Two seconds into the window, not ten seconds into the sequence.
+        assert!(filter.contains("adelay=2000:all=1"), "{filter}");
+        // The input's own `-ss` seeked a 0.25s handle in front of source second
+        // 30 and rebased that input to zero, so the eight seconds the window
+        // kept start one handle in rather than at zero.
+        assert!(filter.contains("atrim=start=0.25:end=8.25"), "{filter}");
+    }
+
+    #[test]
+    fn mixdown_args_seek_each_input_to_the_stretch_the_window_kept() {
+        // Two clips, each reading a different part of its source. Without a
+        // per-input `-ss` FFmpeg would decode both files end to end and let
+        // `atrim` discard the rest, which is what made a ranged
+        // `generate-sequence` cost the whole talk.
+        let first =
+            narrow_layer_to_window(&layer(10.0, 20.0, 30.0), Path::new("a.mp4"), 12.0, 18.0)
+                .expect("overlap");
+        let second =
+            narrow_layer_to_window(&layer(14.0, 24.0, 100.0), Path::new("b.mp4"), 12.0, 18.0)
+                .expect("overlap");
+
+        let args = build_sequence_mixdown_args(&[first, second], 6.0, Path::new("out.wav"))
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        let input_positions = args
+            .iter()
+            .enumerate()
+            .filter(|(_, arg)| arg.as_str() == "-i")
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        assert_eq!(input_positions.len(), 2, "{args:?}");
+
+        // `-ss <in - handle> -t <handle + span + handle>` sits immediately in
+        // front of each `-i`: the handle is decoded and then trimmed off, so a
+        // bare audio container's priming frames cannot eat the head of the
+        // window.
+        assert_eq!(args[input_positions[0] - 4], "-ss");
+        assert_eq!(args[input_positions[0] - 3], "31.75");
+        assert_eq!(args[input_positions[0] - 2], "-t");
+        assert_eq!(args[input_positions[0] - 1], "6.5");
+        assert_eq!(args[input_positions[0] + 1], "a.mp4");
+
+        assert_eq!(args[input_positions[1] - 4], "-ss");
+        assert_eq!(args[input_positions[1] - 3], "99.75");
+        assert_eq!(args[input_positions[1] - 2], "-t");
+        assert_eq!(args[input_positions[1] - 1], "4.5");
+        assert_eq!(args[input_positions[1] + 1], "b.mp4");
+
+        // The output still runs for the window's own length.
+        assert_eq!(args.last().map(String::as_str), Some("out.wav"));
+        assert!(args.windows(2).any(|pair| pair == ["-map", "[aout]"]));
+    }
+
+    #[test]
+    fn mixdown_filter_keeps_only_the_part_of_a_fade_the_window_left() {
+        // A one-second fade-in whose first 0.4s the window cut away still has
+        // 0.6s to run; a fade the window cut away entirely runs no more.
+        let mut clip = layer(10.0, 20.0, 30.0);
+        clip.audio.fade_in_sec = 1.0;
+        let narrowed =
+            narrow_layer_to_window(&clip, Path::new("a.wav"), 10.4, 20.0).expect("overlap");
+        let filter = build_sequence_mixdown_filter(std::slice::from_ref(&narrowed));
+        assert!(filter.contains("afade=t=in:st=0:d=0.6"), "{filter}");
+
+        let narrowed =
+            narrow_layer_to_window(&clip, Path::new("a.wav"), 12.0, 20.0).expect("overlap");
+        let filter = build_sequence_mixdown_filter(std::slice::from_ref(&narrowed));
+        assert!(!filter.contains("afade=t=in"), "{filter}");
+    }
+}
+
+#[cfg(test)]
+mod ffmpeg_backed_tests {
+    //! Tests that put a real FFmpeg behind the transcription mixdown.
+    //!
+    //! They are `#[ignore]`d because they need a binary the machine may not
+    //! have; `require_or_skip_ffmpeg` turns the skip into a failure when
+    //! `REQUIRE_FFMPEG_TESTS` is set, so a CI job that installs FFmpeg cannot
+    //! report green without having run them.
+
+    use super::*;
+    use crate::core::assets::{Asset, AudioInfo, VideoInfo};
+    use crate::core::test_ffmpeg::{
+        require_or_skip_ffmpeg, require_or_skip_ffprobe, skip_without_ffmpeg,
+    };
+    use crate::core::timeline::{Clip, ClipPlace, ClipRange, Sequence, SequenceFormat, Track};
+
+    /// Writes a four-second A/V file: black picture with a 440 Hz tone.
+    ///
+    /// Returns `false` when FFmpeg could not produce it, which is the same
+    /// "skip quietly" answer a missing binary gives.
+    fn write_av_fixture(ffmpeg: &Path, path: &Path) -> bool {
+        let mut cmd = Command::new(ffmpeg);
+        configure_std_command(&mut cmd);
+        let output = cmd
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:s=160x90:r=25:d=4",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440:sample_rate=44100:duration=4",
+                "-pix_fmt",
+                "yuv420p",
+                "-shortest",
+            ])
+            .arg(path)
+            .output();
+
+        matches!(output, Ok(output) if output.status.success()) && path.exists()
+    }
+
+    /// A project holding `asset_path` as one clip on the sequence's video track.
+    ///
+    /// The asset carries no audio metadata, which is exactly what the CLI's
+    /// `asset import` records for a file it never opened. Whether the mixdown
+    /// finds the sound therefore depends on it probing rather than trusting the
+    /// stored guess.
+    fn state_with_av_clip_on_a_video_track(asset_path: &Path) -> ProjectState {
+        let mut asset = Asset::new_video(
+            "fixture",
+            &asset_path.to_string_lossy(),
+            VideoInfo::default(),
+        );
+        asset.id = "asset-av".to_string();
+        assert!(
+            asset.audio.is_none(),
+            "the fixture stands in for an unprobed import"
+        );
+        state_with_clip_on_a_video_track(asset)
+    }
+
+    /// A project holding `asset` as one four-second clip on the video track.
+    fn state_with_clip_on_a_video_track(asset: Asset) -> ProjectState {
+        let mut state = ProjectState::new("Mixdown Test");
+        state.sequences.clear();
+
+        let asset_id = asset.id.clone();
+        state.assets.insert(asset_id.clone(), asset);
+
+        let mut clip = Clip::new(&asset_id);
+        clip.id = "clip-av".to_string();
+        clip.place = ClipPlace::new(0.0, 4.0);
+        clip.range = ClipRange::new(0.0, 4.0);
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+        let mut video_track = Track::new("Video 1", crate::core::timeline::TrackKind::Video);
+        video_track.id = "video-track".to_string();
+        video_track.clips.push(clip);
+        sequence.tracks.push(video_track);
+
+        state.active_sequence_id = Some(sequence.id.clone());
+        state.sequences.insert(sequence.id.clone(), sequence);
+        state
+    }
+
+    /// The loudest sample in a mixdown, as a fraction of full scale.
+    fn peak_amplitude(samples: &[f32]) -> f32 {
+        samples
+            .iter()
+            .fold(0.0_f32, |peak, sample| peak.max(sample.abs()))
+    }
+
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn mixdown_captures_the_sound_of_an_av_clip_on_a_video_track() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        // The mixdown measures audio presence with FFprobe, which is resolved
+        // separately from the FFmpeg handed in above.
+        if require_or_skip_ffprobe().is_none() {
+            return;
+        }
+        let Ok(dir) = tempfile::tempdir() else {
+            skip_without_ffmpeg("a temporary directory could not be created");
+            return;
+        };
+
+        let source_path = dir.path().join("av_source.mp4");
+        if !write_av_fixture(&ffmpeg, &source_path) {
+            skip_without_ffmpeg("FFmpeg could not build the A/V fixture");
+            return;
+        }
+
+        let state = state_with_av_clip_on_a_video_track(&source_path);
+        let output_path = dir.path().join("mixdown.wav");
+        let result = mix_sequence_audio_for_transcription(
+            &state,
+            "seq-1",
+            &output_path,
+            AudioWindow::FULL,
+            ffmpeg.to_str(),
+        )
+        .expect("the embedded audio of a video-track clip has to reach the mixdown");
+
+        assert_eq!(result.layer_count, 1);
+        assert!((result.duration_sec - 4.0).abs() < 0.5, "{result:?}");
+
+        let samples = load_audio_samples(&output_path).expect("mixdown is a 16 kHz mono WAV");
+        assert!(!samples.is_empty(), "the mixdown wrote no samples");
+        let peak = peak_amplitude(&samples);
+        assert!(
+            peak > 0.1,
+            "a 440 Hz tone must not transcribe as silence: peak {peak}"
+        );
+    }
+
+    /// Where the marked fixture's silence sits, in source seconds.
+    const MARK_START_SEC: f64 = 1.5;
+    /// How long that silence lasts.
+    const MARK_DURATION_SEC: f64 = 0.5;
+    /// The window the ranged mixdown reads, in timeline seconds.
+    const MARK_WINDOW_START_SEC: f64 = 1.0;
+    const MARK_WINDOW_END_SEC: f64 = 3.0;
+    /// How far the mark may move before the window is judged to have shifted.
+    ///
+    /// The bug this bounds moved a bare `.m4a`'s head by 10-40 ms, so the bound
+    /// has to be tighter than that. It is measured against the *unwindowed*
+    /// mixdown of the same fixture rather than against 1.5 s outright: a lossy
+    /// codec rounds the edges of a silent stretch by a few milliseconds, and
+    /// that offset is a property of the file, identical in both mixdowns.
+    const MARK_TOLERANCE_SEC: f64 = 0.005;
+
+    /// Writes a four-second tone with a marked silence at 1.5-2.0 s.
+    ///
+    /// `extra_args` decides the container: an mp4 also gets a picture, an m4a
+    /// carries nothing but the AAC stream whose priming this is here to catch.
+    /// Returns `false` when FFmpeg could not produce it, which is the same
+    /// "skip quietly" answer a missing binary gives.
+    fn write_marked_fixture(ffmpeg: &Path, path: &Path, with_picture: bool) -> bool {
+        let mut cmd = Command::new(ffmpeg);
+        configure_std_command(&mut cmd);
+        cmd.args(["-y", "-hide_banner", "-loglevel", "error"]);
+        if with_picture {
+            cmd.args(["-f", "lavfi", "-i", "color=c=black:s=160x90:r=25:d=4"]);
+        }
+        cmd.args([
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:sample_rate=44100:duration=4",
+            "-af",
+            "volume=enable='between(t,1.5,2)':volume=0",
+        ]);
+        if with_picture {
+            cmd.args(["-pix_fmt", "yuv420p", "-shortest"]);
+        }
+        let output = cmd.arg(path).output();
+
+        matches!(output, Ok(output) if output.status.success()) && path.exists()
+    }
+
+    /// The first silent stretch FFmpeg finds in a WAV, as (start, duration).
+    ///
+    /// `None` when the file has no stretch long enough to count, which is what a
+    /// mixdown that lost the mark would produce.
+    fn first_silence(ffmpeg: &Path, wav_path: &Path) -> Option<(f64, f64)> {
+        let mut cmd = Command::new(ffmpeg);
+        configure_std_command(&mut cmd);
+        let output = cmd
+            .args(["-hide_banner", "-nostats", "-i"])
+            .arg(wav_path)
+            .args(["-af", "silencedetect=noise=-50dB:d=0.2", "-f", "null", "-"])
+            .output()
+            .ok()?;
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let start = find_labelled_value(&stderr, "silence_start:")?;
+        let duration = find_labelled_value(&stderr, "silence_duration:")?;
+        Some((start, duration))
+    }
+
+    /// Reads the number `label` introduces in FFmpeg's own log lines.
+    fn find_labelled_value(log: &str, label: &str) -> Option<f64> {
+        log.split(label)
+            .nth(1)?
+            .split_whitespace()
+            .next()?
+            .parse()
+            .ok()
+    }
+
+    /// Mixes the fixture over `window` and returns where the mark landed.
+    fn mark_position(
+        ffmpeg: &Path,
+        state: &ProjectState,
+        output_path: &Path,
+        window: AudioWindow,
+    ) -> Option<(f64, f64)> {
+        mix_sequence_audio_for_transcription(state, "seq-1", output_path, window, ffmpeg.to_str())
+            .expect("mixdown");
+        first_silence(ffmpeg, output_path)
+    }
+
+    /// Feature: ranged transcription of a sequence
+    /// Scenario: the window is read from the right place in the source
+    ///
+    /// Given a four-second source with a marked silence at 1.5-2.0 s
+    /// When seconds 1-3 of the timeline are mixed down for transcription
+    /// Then the mark sits 0.5 s into the mixdown, within a few milliseconds of
+    /// where the unwindowed mixdown of the same file puts it.
+    ///
+    /// Run for a bare `.m4a` as well as an `.mp4`: an mp4's video keyframes give
+    /// a demuxer seek all the slack it needs, while a bare AAC stream has none,
+    /// and seeking straight to the in point cost it 10-40 ms of head — a shift
+    /// of every timestamp in the window, not a dropped sample.
+    #[test]
+    #[ignore = "requires FFmpeg"]
+    fn a_windowed_mixdown_reads_the_window_from_the_right_place() {
+        let Some(ffmpeg) = require_or_skip_ffmpeg() else {
+            return;
+        };
+        // The mixdown measures audio presence with FFprobe, which is resolved
+        // separately from the FFmpeg handed in above.
+        if require_or_skip_ffprobe().is_none() {
+            return;
+        }
+        let Ok(dir) = tempfile::tempdir() else {
+            skip_without_ffmpeg("a temporary directory could not be created");
+            return;
+        };
+
+        for (name, with_picture) in [("marked.mp4", true), ("marked.m4a", false)] {
+            let source_path = dir.path().join(name);
+            if !write_marked_fixture(&ffmpeg, &source_path, with_picture) {
+                skip_without_ffmpeg(&format!("FFmpeg could not build the {name} fixture"));
+                return;
+            }
+
+            let uri = source_path.to_string_lossy().into_owned();
+            let mut asset = if with_picture {
+                Asset::new_video("fixture", &uri, VideoInfo::default())
+            } else {
+                Asset::new_audio("fixture", &uri, AudioInfo::default())
+            };
+            asset.id = "asset-av".to_string();
+            let state = state_with_clip_on_a_video_track(asset);
+
+            let Some((whole_start, whole_duration)) = mark_position(
+                &ffmpeg,
+                &state,
+                &dir.path().join(format!("{name}.whole.wav")),
+                AudioWindow::FULL,
+            ) else {
+                panic!("{name}: the unwindowed mixdown lost the marked silence");
+            };
+            assert!(
+                (whole_duration - MARK_DURATION_SEC).abs() < 0.05,
+                "{name}: the mark is {whole_duration}s long, not {MARK_DURATION_SEC}s"
+            );
+
+            let window = AudioWindow::new(Some(MARK_WINDOW_START_SEC), Some(MARK_WINDOW_END_SEC))
+                .expect("window");
+            let Some((window_start, window_duration)) = mark_position(
+                &ffmpeg,
+                &state,
+                &dir.path().join(format!("{name}.window.wav")),
+                window,
+            ) else {
+                panic!("{name}: the windowed mixdown lost the marked silence");
+            };
+
+            let expected = whole_start - MARK_WINDOW_START_SEC;
+            assert!(
+                (window_start - expected).abs() <= MARK_TOLERANCE_SEC,
+                "{name}: the mark landed at {window_start}s, but the window starts at \
+                 {MARK_WINDOW_START_SEC}s and the whole file puts the mark at {whole_start}s, \
+                 so it belongs at {expected}s"
+            );
+            assert!(
+                (window_duration - MARK_DURATION_SEC).abs() < 0.05,
+                "{name}: the windowed mark is {window_duration}s long, not {MARK_DURATION_SEC}s"
+            );
+            // The mark is inside the window rather than at its edge, so a
+            // mixdown that silently returned the wrong stretch could not pass.
+            assert!(
+                window_start > 0.1
+                    && window_start + window_duration
+                        < MARK_WINDOW_END_SEC - MARK_WINDOW_START_SEC - 0.1,
+                "{name}: the mark has to sit inside the window for this to mean anything"
+            );
+            assert!(
+                (MARK_START_SEC - MARK_WINDOW_START_SEC - expected).abs() < 0.05,
+                "{name}: the reference mixdown itself is off; the mark should be near \
+                 {MARK_START_SEC}s of the source"
+            );
+        }
     }
 }

--- a/src-tauri/src/core/commands/affected.rs
+++ b/src-tauri/src/core/commands/affected.rs
@@ -180,7 +180,11 @@ pub fn affected_ranges(
             // themselves; the edit that uses the asset does.
             StateChange::AssetAdded { .. }
             | StateChange::AssetModified { .. }
-            | StateChange::AssetRemoved { .. } => {}
+            | StateChange::AssetRemoved { .. }
+            // Reports how many cues the frame grid moved. The cues
+            // themselves arrive as `CaptionCreated`, which is what marks
+            // the affected span; this carries no range of its own.
+            | StateChange::CaptionsSnappedToFrameGrid { .. } => {}
         }
     }
 

--- a/src-tauri/src/core/commands/caption.rs
+++ b/src-tauri/src/core/commands/caption.rs
@@ -4,13 +4,15 @@
 //! Currently captions are represented as `Clip` entries inside `TrackKind::Caption` tracks,
 //! with `Clip.label` used as the caption text.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::core::{
     commands::{Command, CommandResult, StateChange},
     project::ProjectState,
-    timeline::{Clip, ClipPlace, ClipRange},
-    ClipId, CoreError, CoreResult, SequenceId, TimeSec, TrackId,
+    timeline::{Clip, ClipPlace, ClipRange, TimelineClock},
+    ClipId, CoreError, CoreResult, Ratio, SequenceId, TimeSec, TrackId,
 };
 
 const CAPTION_ASSET_ID: &str = "caption";
@@ -24,6 +26,152 @@ const MIN_CAPTION_DURATION_SEC: TimeSec = 0.3;
 
 fn is_valid_time_sec(value: TimeSec) -> bool {
     value.is_finite() && value >= 0.0
+}
+
+/// Moves cue boundaries onto the sequence's frame grid, in place.
+///
+/// A transcriber reports times to the millisecond, and nothing in the caption
+/// path rounded them, so every imported cue landed between two frames. Each one
+/// then drew a `Clip '…' is not aligned to sequence frame boundaries` warning
+/// from every composite and render — forty-one of them on a single talk, enough
+/// to bury the warnings that mattered.
+///
+/// Each cue is snapped on its own and nothing else about it changes:
+///
+/// * each boundary goes to the nearest frame;
+/// * a cue that would collapse — both boundaries rounding to the same frame —
+///   is given one frame of length, because a zero-length caption clip is not a
+///   caption.
+///
+/// Cues are **not** compared with each other. A subtitle file is allowed to
+/// overlap its cues, and many do: a held `♪` under a whole song, a rolling
+/// VTT where every line is still on screen when the next arrives. Serializing
+/// those would push every later cue past the held one and rewrite the file into
+/// something it never was. Callers that need cues in order and clear of one
+/// another call [`keep_cues_ordered_and_non_overlapping`] afterwards; the
+/// generated-captions import does, because its cues were already de-overlapped
+/// before rounding could nudge two of them back together.
+///
+/// `cues` need not arrive sorted, and their order is untouched.
+///
+/// Returns how many cues moved.
+pub fn snap_cue_times_to_frame_grid(cues: &mut [(TimeSec, TimeSec)], fps: &Ratio) -> usize {
+    let clock = TimelineClock::new(fps.clone());
+    let mut moved = 0usize;
+
+    for cue in cues.iter_mut() {
+        let (start_sec, end_sec) = *cue;
+
+        let start_frame = clock.seconds_to_nearest_frame(start_sec);
+        let end_frame = clock.seconds_to_nearest_frame(end_sec).max(start_frame + 1);
+
+        let snapped = (
+            clock.frame_to_seconds(start_frame),
+            clock.frame_to_seconds(end_frame),
+        );
+        if snapped.0 != start_sec || snapped.1 != end_sec {
+            moved += 1;
+        }
+        *cue = snapped;
+    }
+
+    moved
+}
+
+/// How far the ordering pass may push a generated cue off its own time.
+///
+/// The pass separates two cues that rounding put on the same frame by moving
+/// the later one forward, and every push raises the floor for the cue after it.
+/// A run of cues packed tighter than the frame grid therefore fans out
+/// linearly: the twentieth cue of such a run would be nineteen frames late even
+/// though rounding moved it by half a frame. Past this many frames the cue is
+/// dropped instead — a caption that is nearly a tenth of a second adrift from
+/// the speech is worse than one that is missing, and the caller is told how many
+/// went rather than left to discover a silent re-timing.
+const MAX_SNAP_DISPLACEMENT_FRAMES: i64 = 2;
+
+/// What [`keep_cues_ordered_and_non_overlapping`] did to a cue list.
+///
+/// Only the losses are reported. How many cues this pass nudged is not a
+/// separate number to hand back: [`ImportGeneratedCaptionsCommand::plan`]
+/// compares the final times against the ones it started rounding from, so a cue
+/// this pass pushed off the grid to clear its neighbour is already counted in
+/// that method's `snappedCues`, alongside the cues plain rounding moved.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CueOrderingOutcome {
+    /// Indices, in the caller's own order, of the cues the pass gave up on
+    /// rather than push more than [`MAX_SNAP_DISPLACEMENT_FRAMES`] off their own
+    /// time. Their slots in `cues` are left untouched; the caller removes them.
+    pub dropped: Vec<usize>,
+}
+
+/// Restores cue ordering and non-overlap on the frame grid, in place.
+///
+/// Opt-in, and only correct for a cue list that was already ordered and clear of
+/// overlap before it was snapped — rounding two neighbours a fraction of a frame
+/// apart can put them back on top of each other, and this is the pass that
+/// separates them again. Run on cues that genuinely overlap it would serialize
+/// them, which is why [`snap_cue_times_to_frame_grid`] no longer does it.
+///
+/// Walking the cues in time order restores three invariants in one pass:
+///
+/// * every cue lasts at least one frame;
+/// * no cue ends after the next one starts (touching is allowed — it is exactly
+///   what the overlap clamp in [`ImportGeneratedCaptionsCommand::enforce_readability`]
+///   already produces);
+/// * ordering survives. Two cues less than a frame apart both want the frame the
+///   earlier one had to keep whole; the later one is pushed off it rather than
+///   dropped, which moves a cue's start by under a frame but never loses a line.
+///
+/// The push is bounded. Each cue is placed relative to where rounding wanted it,
+/// and one that would have to move more than [`MAX_SNAP_DISPLACEMENT_FRAMES`] to
+/// stay clear of its neighbours is dropped instead of dragged along; without
+/// that bound a run of cues packed tighter than the frame grid fans out, each
+/// one later than the last. Dropped cues are named in the outcome.
+///
+/// Each surviving cue is written back to the slot it came in, so the caller's
+/// order is untouched.
+pub fn keep_cues_ordered_and_non_overlapping(
+    cues: &mut [(TimeSec, TimeSec)],
+    fps: &Ratio,
+) -> CueOrderingOutcome {
+    let clock = TimelineClock::new(fps.clone());
+    let mut outcome = CueOrderingOutcome::default();
+
+    let mut order = (0..cues.len()).collect::<Vec<_>>();
+    order.sort_by(|left, right| {
+        cues[*left]
+            .0
+            .total_cmp(&cues[*right].0)
+            .then_with(|| cues[*left].1.total_cmp(&cues[*right].1))
+    });
+
+    // The first frame the next cue may start on. Advancing it as cues are placed
+    // is what keeps the pass single and the result non-overlapping.
+    let mut earliest_start_frame = 0i64;
+
+    for index in order {
+        let (start_sec, end_sec) = cues[index];
+
+        let wanted_start_frame = clock.seconds_to_nearest_frame(start_sec);
+        let start_frame = wanted_start_frame.max(earliest_start_frame);
+        if start_frame - wanted_start_frame > MAX_SNAP_DISPLACEMENT_FRAMES {
+            // Dropped rather than dragged: the floor stays where it is, so this
+            // cue does not push the next one any further either.
+            outcome.dropped.push(index);
+            continue;
+        }
+        let end_frame = clock.seconds_to_nearest_frame(end_sec).max(start_frame + 1);
+
+        let snapped = (
+            clock.frame_to_seconds(start_frame),
+            clock.frame_to_seconds(end_frame),
+        );
+        earliest_start_frame = end_frame;
+        cues[index] = snapped;
+    }
+
+    outcome
 }
 
 fn normalize_caption_text(text: String) -> Option<String> {
@@ -172,6 +320,21 @@ impl Command for CreateCaptionCommand {
 // ImportGeneratedCaptionsCommand
 // =============================================================================
 
+/// A generated-caption import as planned, before anything is placed.
+///
+/// The counts are what the caller reports: a snap rewrites times the caller
+/// supplied, and a drop loses a line outright, so neither may happen silently.
+#[derive(Clone, Debug)]
+pub struct GeneratedCaptionPlan {
+    /// The cues that will be placed, in time order.
+    pub segments: Vec<GeneratedCaptionSegment>,
+    /// How many of them the frame grid moved.
+    pub snapped_cues: usize,
+    /// How many cues the grid dropped rather than push more than
+    /// [`MAX_SNAP_DISPLACEMENT_FRAMES`] off their own time.
+    pub dropped_cues: usize,
+}
+
 /// A single segment produced by speech-to-text or another caption generator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -215,10 +378,21 @@ pub struct ImportGeneratedCaptionsCommand {
     pub position: Option<serde_json::Value>,
     #[serde(default)]
     pub replace_existing: bool,
+    /// Whether cue boundaries are moved onto the sequence's frame grid.
+    ///
+    /// On by default: a transcriber's millisecond times otherwise land between
+    /// frames and make every composite and render warn about each cue. Turn it
+    /// off to keep the raw times.
+    #[serde(default = "default_snap_to_frames")]
+    pub snap_to_frames: bool,
     #[serde(skip)]
     created_caption_ids: Vec<ClipId>,
     #[serde(skip)]
     removed_clips: Vec<(usize, Clip)>,
+}
+
+fn default_snap_to_frames() -> bool {
+    true
 }
 
 impl ImportGeneratedCaptionsCommand {
@@ -230,6 +404,7 @@ impl ImportGeneratedCaptionsCommand {
             style: None,
             position: None,
             replace_existing: false,
+            snap_to_frames: true,
             created_caption_ids: Vec::new(),
             removed_clips: Vec::new(),
         }
@@ -248,6 +423,87 @@ impl ImportGeneratedCaptionsCommand {
     pub fn replace_existing(mut self, replace_existing: bool) -> Self {
         self.replace_existing = replace_existing;
         self
+    }
+
+    /// Keeps the cues' raw times instead of snapping them to the frame grid.
+    pub fn snap_to_frames(mut self, snap_to_frames: bool) -> Self {
+        self.snap_to_frames = snap_to_frames;
+        self
+    }
+
+    /// Resolves the cues this import will place, without touching the project.
+    ///
+    /// Validation, ordering, the readability rules and — when `snap_to_frames`
+    /// — frame-grid snapping, in that order. `execute` runs exactly this, so a
+    /// caller can plan twice, with and without snapping, to report how many cues
+    /// the snap moved.
+    pub fn plan_segments(
+        &self,
+        fps: &Ratio,
+        snap_to_frames: bool,
+    ) -> CoreResult<Vec<GeneratedCaptionSegment>> {
+        Ok(self.plan(fps, snap_to_frames)?.segments)
+    }
+
+    /// Plans the import and reports what the frame grid did to it.
+    ///
+    /// Same arithmetic as [`Self::plan_segments`], with the two numbers the
+    /// caller has to be able to report: how many placed cues the grid moved, and
+    /// how many it gave up on. Counting by planning twice is not possible once
+    /// cues can be dropped — the two plans no longer line up cue for cue.
+    ///
+    /// Both counts are measured against the times [`Self::normalized_segments`]
+    /// produced, *after* validation, sorting and the readability re-timing —
+    /// not against the times the caller handed in. A cue that readability
+    /// already moved and that then lands on a frame boundary counts as
+    /// unsnapped, because neither the grid nor the ordering pass touched it. So
+    /// `snappedCues` answers "how many cues did putting this list on the frame
+    /// grid move" — counting both the cues rounding moved and the cues
+    /// [`keep_cues_ordered_and_non_overlapping`] then pushed further to keep
+    /// them clear of a neighbour — not "how many cues differ from where the
+    /// file put them".
+    pub fn plan(&self, fps: &Ratio, snap_to_frames: bool) -> CoreResult<GeneratedCaptionPlan> {
+        let segments = self.normalized_segments()?;
+        if !snap_to_frames {
+            return Ok(GeneratedCaptionPlan {
+                segments,
+                snapped_cues: 0,
+                dropped_cues: 0,
+            });
+        }
+
+        let unsnapped = segments
+            .iter()
+            .map(|segment| (segment.start_sec, segment.end_sec))
+            .collect::<Vec<_>>();
+        let mut times = unsnapped.clone();
+        snap_cue_times_to_frame_grid(&mut times, fps);
+        // These cues left `enforce_readability` ordered and clear of one
+        // another; rounding can put two neighbours back on the same frame,
+        // so the invariant is restored rather than assumed.
+        let outcome = keep_cues_ordered_and_non_overlapping(&mut times, fps);
+        let dropped = outcome.dropped.iter().copied().collect::<HashSet<usize>>();
+
+        let mut planned = Vec::with_capacity(segments.len() - dropped.len());
+        let mut snapped_cues = 0usize;
+        for (index, mut segment) in segments.into_iter().enumerate() {
+            if dropped.contains(&index) {
+                continue;
+            }
+            let (start_sec, end_sec) = times[index];
+            if start_sec != unsnapped[index].0 || end_sec != unsnapped[index].1 {
+                snapped_cues += 1;
+            }
+            segment.start_sec = start_sec;
+            segment.end_sec = end_sec;
+            planned.push(segment);
+        }
+
+        Ok(GeneratedCaptionPlan {
+            segments: planned,
+            snapped_cues,
+            dropped_cues: dropped.len(),
+        })
     }
 
     fn normalized_segments(&self) -> CoreResult<Vec<GeneratedCaptionSegment>> {
@@ -360,7 +616,23 @@ impl ImportGeneratedCaptionsCommand {
 
 impl Command for ImportGeneratedCaptionsCommand {
     fn execute(&mut self, state: &mut ProjectState) -> CoreResult<CommandResult> {
-        let segments = self.normalized_segments()?;
+        // The cue grid belongs to the sequence, so its rate is read before the
+        // mutable borrow the placement below needs.
+        let fps = state
+            .sequences
+            .get(&self.sequence_id)
+            .ok_or_else(|| CoreError::SequenceNotFound(self.sequence_id.clone()))?
+            .format
+            .fps
+            .clone();
+        // The plan reports what the grid did as it does it: how many cues it
+        // moved, and how many it dropped rather than push off their own time.
+        let plan = self.plan(&fps, self.snap_to_frames)?;
+        let GeneratedCaptionPlan {
+            segments,
+            snapped_cues,
+            dropped_cues,
+        } = plan;
         self.created_caption_ids.clear();
         self.removed_clips.clear();
 
@@ -380,6 +652,12 @@ impl Command for ImportGeneratedCaptionsCommand {
 
         let op_id = ulid::Ulid::new().to_string();
         let mut result = CommandResult::new(&op_id);
+        if snapped_cues > 0 || dropped_cues > 0 {
+            result = result.with_change(StateChange::CaptionsSnappedToFrameGrid {
+                count: snapped_cues,
+                dropped: dropped_cues,
+            });
+        }
 
         if self.replace_existing {
             self.removed_clips = track.clips.iter().cloned().enumerate().collect();
@@ -757,8 +1035,13 @@ mod tests {
     use crate::core::timeline::{Sequence, SequenceFormat, Track};
 
     fn state_with_caption_track() -> (ProjectState, String, String) {
+        state_with_caption_track_at(SequenceFormat::youtube_1080())
+    }
+
+    /// A project holding one empty caption track in a sequence of this format.
+    fn state_with_caption_track_at(format: SequenceFormat) -> (ProjectState, String, String) {
         let mut state = ProjectState::new_empty("Test");
-        let mut sequence = Sequence::new("Sequence 1", SequenceFormat::youtube_1080());
+        let mut sequence = Sequence::new("Sequence 1", format);
         let track = Track::new_caption("Captions");
         let seq_id = sequence.id.clone();
         let track_id = track.id.clone();
@@ -766,6 +1049,227 @@ mod tests {
         state.active_sequence_id = Some(seq_id.clone());
         state.sequences.insert(seq_id.clone(), sequence);
         (state, seq_id, track_id)
+    }
+
+    /// 1920x1080 at exactly 24 fps, where one frame is 1/24 s.
+    fn format_24fps() -> SequenceFormat {
+        SequenceFormat::new(1920, 1080, 24, 1, 48_000)
+    }
+
+    /// Whether a time sits on the frame grid, to within a frame's rounding.
+    fn is_on_frame_grid(seconds: TimeSec, fps: &Ratio) -> bool {
+        let clock = TimelineClock::new(fps.clone());
+        let frame = clock.seconds_to_nearest_frame(seconds);
+        (clock.frame_to_seconds(frame) - seconds).abs() < 1e-9
+    }
+
+    #[test]
+    fn snap_cue_times_moves_every_boundary_onto_the_frame_grid() {
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(0.123, 1.987), (2.004, 3.5), (4.0, 4.9)];
+
+        let moved = snap_cue_times_to_frame_grid(&mut cues, &fps);
+
+        assert_eq!(moved, 3);
+        for (start_sec, end_sec) in &cues {
+            assert!(is_on_frame_grid(*start_sec, &fps), "start {start_sec}");
+            assert!(is_on_frame_grid(*end_sec, &fps), "end {end_sec}");
+            assert!(end_sec > start_sec);
+        }
+    }
+
+    #[test]
+    fn snap_cue_times_reports_nothing_moved_when_cues_are_already_aligned() {
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(0.0, 1.0), (1.0, 2.0)];
+
+        assert_eq!(snap_cue_times_to_frame_grid(&mut cues, &fps), 0);
+        assert_eq!(cues, vec![(0.0, 1.0), (1.0, 2.0)]);
+    }
+
+    #[test]
+    fn snap_cue_times_keeps_a_cue_at_least_one_frame_long() {
+        // Both boundaries round to frame 24; a cue that collapsed would take a
+        // caption clip's duration to zero.
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(1.0, 1.001)];
+
+        snap_cue_times_to_frame_grid(&mut cues, &fps);
+
+        assert_eq!(cues[0].0, 1.0);
+        assert!((cues[0].1 - 25.0 / 24.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn snap_cue_times_leaves_overlapping_cues_overlapping() {
+        // A held cue under a whole song, with dialogue running underneath it.
+        // Serializing these would push every line of dialogue past the held cue
+        // and turn each into a one-frame flash.
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(0.001, 600.002), (1.003, 3.004), (3.005, 5.006)];
+
+        snap_cue_times_to_frame_grid(&mut cues, &fps);
+
+        assert!((cues[0].0 - 0.0).abs() < 1e-9, "{cues:?}");
+        assert!((cues[0].1 - 600.0).abs() < 1e-9, "{cues:?}");
+        // The dialogue keeps its own place under the held cue.
+        assert!(cues[1].0 < cues[0].1, "{cues:?}");
+        assert!((cues[1].0 - 24.0 / 24.0).abs() < 1e-9, "{cues:?}");
+        assert!((cues[2].0 - 72.0 / 24.0).abs() < 1e-9, "{cues:?}");
+        for (start_sec, end_sec) in &cues {
+            assert!(is_on_frame_grid(*start_sec, &fps));
+            assert!(is_on_frame_grid(*end_sec, &fps));
+            assert!(end_sec - start_sec >= 1.0 / 24.0 - 1e-9, "{cues:?}");
+        }
+    }
+
+    #[test]
+    fn snap_cue_times_handles_cues_that_arrive_out_of_order() {
+        // A subtitle file can list cues in any order, and `caption import`
+        // hands them over as parsed. Snapping must not read the file's order as
+        // time order and push a later-listed early cue past a whole cue.
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(4.01, 5.01), (0.01, 1.01)];
+
+        snap_cue_times_to_frame_grid(&mut cues, &fps);
+
+        // Each cue stays in the slot it came in, snapped to its own frames.
+        assert!(is_on_frame_grid(cues[0].0, &fps));
+        assert!((cues[0].0 - 96.0 / 24.0).abs() < 1e-9, "{cues:?}");
+        assert!((cues[1].0 - 0.0).abs() < 1e-9, "{cues:?}");
+        assert!(cues[1].1 < cues[0].0, "{cues:?}");
+    }
+
+    #[test]
+    fn ordering_pass_keeps_neighbours_ordered_and_non_overlapping() {
+        // Two cues barely apart round onto the same pair of frames. The second
+        // is pushed off the frame the first had to keep, rather than dropped.
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(1.0, 1.004), (1.008, 1.02)];
+
+        snap_cue_times_to_frame_grid(&mut cues, &fps);
+        keep_cues_ordered_and_non_overlapping(&mut cues, &fps);
+
+        assert!(cues[0].1 > cues[0].0);
+        assert!(cues[1].1 > cues[1].0);
+        assert!(cues[1].0 >= cues[0].1, "{cues:?}");
+        for (start_sec, end_sec) in &cues {
+            assert!(is_on_frame_grid(*start_sec, &fps));
+            assert!(is_on_frame_grid(*end_sec, &fps));
+        }
+    }
+
+    #[test]
+    fn ordering_pass_reads_time_order_rather_than_slot_order() {
+        // The pass sorts by time before it walks, so a file that lists a late
+        // cue first is not read as "this one comes first".
+        let fps = Ratio::new(24, 1);
+        let mut cues = vec![(4.0, 5.0), (0.0, 1.0)];
+
+        assert_eq!(
+            keep_cues_ordered_and_non_overlapping(&mut cues, &fps),
+            CueOrderingOutcome::default()
+        );
+        assert_eq!(cues, vec![(4.0, 5.0), (0.0, 1.0)]);
+    }
+
+    #[test]
+    fn import_generated_captions_places_clips_on_the_frame_grid() {
+        let (mut state, seq_id, track_id) = state_with_caption_track_at(format_24fps());
+        let fps = Ratio::new(24, 1);
+        let segments = vec![
+            GeneratedCaptionSegment::new(0.137, 2.418, "First"),
+            GeneratedCaptionSegment::new(2.511, 5.049, "Second"),
+        ];
+
+        let mut cmd = ImportGeneratedCaptionsCommand::new(&seq_id, &track_id, segments);
+        cmd.execute(&mut state).expect("import");
+
+        let track = state
+            .get_sequence(&seq_id)
+            .unwrap()
+            .get_track(&track_id)
+            .unwrap();
+        assert_eq!(track.clips.len(), 2);
+        for clip in &track.clips {
+            assert!(is_on_frame_grid(clip.place.timeline_in_sec, &fps));
+            assert!(is_on_frame_grid(clip.place.timeline_out_sec(), &fps));
+            assert!(clip.place.duration_sec >= 1.0 / 24.0 - 1e-9);
+        }
+        assert!(track.clips[1].place.timeline_in_sec >= track.clips[0].place.timeline_out_sec());
+    }
+
+    #[test]
+    fn import_generated_captions_separates_cues_that_rounding_pushed_together() {
+        // Both cues want frame 24 once the readability rules and rounding are
+        // through. The generated path is the one that de-overlaps beforehand, so
+        // it is the one that runs the ordering pass and pushes the second off.
+        let (mut state, seq_id, track_id) = state_with_caption_track_at(format_24fps());
+        let segments = vec![
+            GeneratedCaptionSegment::new(1.0, 1.004, "First"),
+            GeneratedCaptionSegment::new(1.008, 1.02, "Second"),
+        ];
+
+        let mut cmd = ImportGeneratedCaptionsCommand::new(&seq_id, &track_id, segments);
+        cmd.execute(&mut state).expect("import");
+
+        let track = state
+            .get_sequence(&seq_id)
+            .unwrap()
+            .get_track(&track_id)
+            .unwrap();
+        assert_eq!(track.clips.len(), 2);
+        assert!(
+            track.clips[1].place.timeline_in_sec >= track.clips[0].place.timeline_out_sec(),
+            "{:?}",
+            track.clips
+        );
+        for clip in &track.clips {
+            assert!(clip.place.duration_sec >= 1.0 / 24.0 - 1e-9);
+        }
+    }
+
+    #[test]
+    fn import_generated_captions_keeps_raw_times_when_snapping_is_off() {
+        let (mut state, seq_id, track_id) = state_with_caption_track_at(format_24fps());
+        let segments = vec![GeneratedCaptionSegment::new(0.137, 2.418, "First")];
+
+        let mut cmd =
+            ImportGeneratedCaptionsCommand::new(&seq_id, &track_id, segments).snap_to_frames(false);
+        cmd.execute(&mut state).expect("import");
+
+        let track = state
+            .get_sequence(&seq_id)
+            .unwrap()
+            .get_track(&track_id)
+            .unwrap();
+        assert_eq!(track.clips[0].place.timeline_in_sec, 0.137);
+        assert!((track.clips[0].place.timeline_out_sec() - 2.418).abs() < 1e-9);
+    }
+
+    #[test]
+    fn plan_segments_reports_the_same_cues_the_import_places() {
+        let (mut state, seq_id, track_id) = state_with_caption_track_at(format_24fps());
+        let fps = Ratio::new(24, 1);
+        let segments = vec![
+            GeneratedCaptionSegment::new(0.137, 2.418, "First"),
+            GeneratedCaptionSegment::new(2.511, 5.049, "Second"),
+        ];
+
+        let mut cmd = ImportGeneratedCaptionsCommand::new(&seq_id, &track_id, segments);
+        let planned = cmd.plan_segments(&fps, true).expect("plan");
+        cmd.execute(&mut state).expect("import");
+
+        let track = state
+            .get_sequence(&seq_id)
+            .unwrap()
+            .get_track(&track_id)
+            .unwrap();
+        assert_eq!(planned.len(), track.clips.len());
+        for (segment, clip) in planned.iter().zip(&track.clips) {
+            assert_eq!(segment.start_sec, clip.place.timeline_in_sec);
+            assert!((segment.end_sec - clip.place.timeline_out_sec()).abs() < 1e-9);
+        }
     }
 
     #[test]
@@ -1022,5 +1526,105 @@ mod tests {
 
         let err = cmd.execute(&mut state).unwrap_err();
         assert!(matches!(err, CoreError::ValidationError(_)));
+    }
+
+    /// Feature: generated caption import on the frame grid
+    /// Scenario: a run of cues packed tighter than the frame grid
+    ///
+    /// Given ten cues 10 ms apart on a 24 fps grid, where one frame is 41.7 ms
+    /// When the ordering pass separates them
+    /// Then no surviving cue sits more than `MAX_SNAP_DISPLACEMENT_FRAMES` from
+    /// the frame rounding wanted for it: the pass drops the cues it would
+    /// otherwise have dragged, and names them, instead of fanning the whole run
+    /// out one frame further with every cue.
+    #[test]
+    fn ordering_pass_drops_a_cue_rather_than_fan_the_run_out() {
+        let fps = Ratio::new(24, 1);
+        let clock = TimelineClock::new(fps.clone());
+        let mut cues: Vec<(TimeSec, TimeSec)> = (0..10)
+            .map(|index| {
+                let start_sec = 1.0 + f64::from(index) * 0.01;
+                (start_sec, start_sec + 0.008)
+            })
+            .collect();
+        let wanted_frames = cues
+            .iter()
+            .map(|(start_sec, _)| clock.seconds_to_nearest_frame(*start_sec))
+            .collect::<Vec<_>>();
+
+        snap_cue_times_to_frame_grid(&mut cues, &fps);
+        let outcome = keep_cues_ordered_and_non_overlapping(&mut cues, &fps);
+
+        assert!(
+            !outcome.dropped.is_empty(),
+            "ten cues 10 ms apart cannot all hold a whole 41.7 ms frame"
+        );
+        assert!(
+            outcome.dropped.len() < cues.len(),
+            "the cap must not empty the run: {outcome:?}"
+        );
+
+        let mut previous_end_frame = i64::MIN;
+        for (index, (start_sec, end_sec)) in cues.iter().enumerate() {
+            if outcome.dropped.contains(&index) {
+                continue;
+            }
+            let start_frame = clock.seconds_to_nearest_frame(*start_sec);
+            let end_frame = clock.seconds_to_nearest_frame(*end_sec);
+            assert!(
+                start_frame - wanted_frames[index] <= MAX_SNAP_DISPLACEMENT_FRAMES,
+                "cue {index} was pushed {} frames off {}s: {cues:?}",
+                start_frame - wanted_frames[index],
+                1.0 + index as f64 * 0.01
+            );
+            assert!(end_frame > start_frame, "cue {index} collapsed: {cues:?}");
+            assert!(
+                start_frame >= previous_end_frame,
+                "cue {index} overlaps the one before it: {cues:?}"
+            );
+            previous_end_frame = end_frame;
+        }
+    }
+
+    /// Feature: generated caption import on the frame grid
+    /// Scenario: the import reports what the grid did
+    ///
+    /// Given a run of cues too tightly packed for the frame grid to keep whole
+    /// When they are imported with snapping on
+    /// Then the cues the grid dropped are absent from the track and counted in
+    /// the state change, so nothing is lost silently.
+    #[test]
+    fn import_generated_captions_reports_the_cues_the_grid_dropped() {
+        let (mut state, seq_id, track_id) = state_with_caption_track_at(format_24fps());
+        let segments = (0..10)
+            .map(|index| {
+                let start_sec = 1.0 + f64::from(index) * 0.01;
+                GeneratedCaptionSegment::new(start_sec, start_sec + 0.008, format!("Line {index}"))
+            })
+            .collect::<Vec<_>>();
+
+        let mut cmd = ImportGeneratedCaptionsCommand::new(&seq_id, &track_id, segments);
+        let plan = cmd.plan(&Ratio::new(24, 1), true).expect("plan");
+        assert!(plan.dropped_cues > 0, "the fixture has to exercise the cap");
+
+        let result = cmd.execute(&mut state).expect("import");
+
+        let dropped = result
+            .changes
+            .iter()
+            .find_map(|change| match change {
+                StateChange::CaptionsSnappedToFrameGrid { dropped, .. } => Some(*dropped),
+                _ => None,
+            })
+            .expect("the import has to report what the grid did");
+        assert_eq!(dropped, plan.dropped_cues);
+        assert_eq!(result.created_ids.len(), plan.segments.len());
+
+        let track = state
+            .get_sequence(&seq_id)
+            .expect("sequence")
+            .get_track(&track_id)
+            .expect("track");
+        assert_eq!(track.clips.len(), plan.segments.len());
     }
 }

--- a/src-tauri/src/core/commands/insert_media.rs
+++ b/src-tauri/src/core/commands/insert_media.rs
@@ -199,6 +199,16 @@ impl InsertMediaCommand {
             .ok_or_else(|| CoreError::AssetNotFound(self.asset_id.clone()))?;
         let asset_kind = asset.kind.clone();
         let asset_duration_sec = asset.duration_sec;
+        // Read from the *stored* metadata, deliberately: a command must replay
+        // identically from the op log, and an FFprobe here would make the same
+        // op produce a different timeline depending on whether the file is still
+        // on the machine. The consequence is that an asset recorded from its file
+        // extension — the CLI's `asset import` without a probe — is inserted with
+        // no linked audio clip even when the file has sound. Nothing downstream
+        // is silenced by that: the render graph, the export and the transcription
+        // mixdown all measure the file, so the clip's own audio is still mixed.
+        // Fixing it belongs with `asset import`, which is where the metadata goes
+        // missing.
         let asset_has_audio = asset.audio.is_some();
 
         let sequence = state

--- a/src-tauri/src/core/commands/traits.rs
+++ b/src-tauri/src/core/commands/traits.rs
@@ -94,6 +94,15 @@ pub enum StateChange {
     SequenceCreated { sequence_id: String },
     /// An existing sequence was modified
     SequenceModified { sequence_id: String },
+    /// Imported caption cues were moved onto the sequence's frame grid.
+    ///
+    /// Reported so a GUI can say "41 cues were nudged onto the frame grid, 2
+    /// dropped" rather than leaving a silent rewrite of the times the user
+    /// handed over. `count` is how many cues moved and `dropped` how many were
+    /// given up on because keeping them in order would have pushed them off
+    /// their own time; the change is only emitted when at least one cue was
+    /// moved or dropped.
+    CaptionsSnappedToFrameGrid { count: usize, dropped: usize },
     /// A new marker was created
     MarkerCreated { marker_id: String },
     /// A marker was deleted

--- a/src-tauri/src/core/error.rs
+++ b/src-tauri/src/core/error.rs
@@ -81,6 +81,13 @@ pub enum CoreError {
     #[error("FFprobe error: {0}")]
     FFprobeError(String),
 
+    /// FFprobe could not be started at all, so nothing was learned about the
+    /// file. Distinct from [`CoreError::FFprobeError`], which means FFprobe ran
+    /// and rejected what it read: a caller that remembers verdicts must not
+    /// remember this one, because the next call may find the binary installed.
+    #[error("FFprobe could not be run: {0}")]
+    FFprobeUnavailable(String),
+
     // =========================================================================
     // Timeline Errors
     // =========================================================================

--- a/src-tauri/src/core/ffmpeg/mod.rs
+++ b/src-tauri/src/core/ffmpeg/mod.rs
@@ -85,6 +85,59 @@ pub enum FFmpegError {
     Timeout,
 }
 
+impl FFmpegError {
+    /// Whether the failure means the child process never ran at all.
+    ///
+    /// A probe fails in two ways, and only one of them says anything about the
+    /// file: FFprobe ran and rejected what it read, or FFprobe could not be
+    /// started. The second still happens long after startup detection
+    /// succeeded - a binary uninstalled, quarantined by endpoint security, or
+    /// living on a volume mounted without execute permission - and reaches the
+    /// spawn as [`FFmpegError::ProcessError`] carrying
+    /// [`std::io::ErrorKind::NotFound`] or
+    /// [`std::io::ErrorKind::PermissionDenied`].
+    ///
+    /// That one arm is the whole rule. [`FFmpegError::NotFound`],
+    /// [`FFmpegError::NotFoundInSources`] and [`FFmpegError::InvalidOverride`]
+    /// are raised by the *resolver*, before an [`FFmpegRunner`] exists at all;
+    /// a caller holding a runner has already got past them, so they can never
+    /// come back out of [`FFmpegRunner::probe`] and listing them here would
+    /// only describe a case no caller can reach.
+    ///
+    /// Callers that otherwise fall back to unmeasured defaults use this to tell
+    /// a spawn that failed apart from a file FFprobe actually looked at. A
+    /// `ProcessError` raised while *waiting* on a child that did start is not
+    /// one of these; see [`FFmpegError::measured_nothing`] for the wider
+    /// question a caller deciding whether to invent a duration should ask.
+    pub fn is_launch_failure(&self) -> bool {
+        match self {
+            Self::ProcessError(error) => matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ),
+            _ => false,
+        }
+    }
+
+    /// Whether the failure left the caller knowing nothing about the file.
+    ///
+    /// A caller that falls back to defaults is claiming "FFprobe looked and
+    /// this is the best we can say". Three failures make that claim false:
+    /// FFprobe never started ([`FFmpegError::is_launch_failure`]);
+    /// [`FFmpegError::Timeout`], where the child was killed before it reported
+    /// anything; and [`FFmpegError::ParseError`], where output came back but
+    /// could not be read, so no field of it was ever available. Substituting a
+    /// default duration and frame size for any of these puts an invented
+    /// measurement on an asset the user believes was imported.
+    ///
+    /// [`FFmpegError::ProbeError`] and [`FFmpegError::InvalidInput`] are
+    /// deliberately excluded: FFprobe reached those about the file itself, and
+    /// they are the cases a fallback exists for.
+    pub fn measured_nothing(&self) -> bool {
+        self.is_launch_failure() || matches!(self, Self::Timeout | Self::ParseError(_))
+    }
+}
+
 pub type FFmpegResult<T> = Result<T, FFmpegError>;
 
 #[cfg(test)]
@@ -98,5 +151,78 @@ mod tests {
 
         let err = FFmpegError::ExecutionFailed("exit code 1".to_string());
         assert!(err.to_string().contains("exit code 1"));
+    }
+
+    /// Feature: FFmpeg error classification
+    /// Scenario: telling "never ran" apart from "ran and refused"
+    ///
+    /// Given the failures a probe spawn can come back with
+    /// When each is classified
+    /// Then only the ones where no child ever started count as launch
+    /// failures, so a caller may keep its fallback for everything FFprobe
+    /// actually looked at.
+    #[test]
+    fn only_failures_before_the_child_started_are_launch_failures() {
+        use std::io::{Error, ErrorKind};
+
+        for error in [
+            FFmpegError::ProcessError(Error::new(ErrorKind::NotFound, "program not found")),
+            FFmpegError::ProcessError(Error::new(ErrorKind::PermissionDenied, "access is denied")),
+        ] {
+            assert!(
+                error.is_launch_failure(),
+                "{error} means no FFprobe ever looked at the file"
+            );
+        }
+
+        for error in [
+            FFmpegError::ProbeError("FFprobe failed: Invalid data found".to_string()),
+            FFmpegError::InvalidInput("Input file does not exist: /gone.mp4".to_string()),
+            FFmpegError::ParseError("unexpected end of JSON".to_string()),
+            FFmpegError::Timeout,
+            FFmpegError::ProcessError(Error::new(ErrorKind::Interrupted, "wait interrupted")),
+        ] {
+            assert!(
+                !error.is_launch_failure(),
+                "{error} did not stop a child from starting"
+            );
+        }
+    }
+
+    /// Feature: FFmpeg error classification
+    /// Scenario: deciding when a default would be an invented measurement
+    ///
+    /// Given the failures a probe can come back with
+    /// When each is asked whether anything was learned about the file
+    /// Then the spawn failures, the watchdog kill and the unreadable output all
+    /// say no - an import must refuse rather than attach a default duration and
+    /// frame size, and a relink must refuse rather than clear the real ones -
+    /// while FFprobe's own verdicts on the file keep the fallback.
+    #[test]
+    fn a_probe_that_reported_nothing_cannot_be_answered_with_defaults() {
+        use std::io::{Error, ErrorKind};
+
+        for error in [
+            FFmpegError::ProcessError(Error::new(ErrorKind::NotFound, "program not found")),
+            FFmpegError::ProcessError(Error::new(ErrorKind::PermissionDenied, "access is denied")),
+            FFmpegError::Timeout,
+            FFmpegError::ParseError("unexpected end of JSON".to_string()),
+        ] {
+            assert!(
+                error.measured_nothing(),
+                "{error} measured nothing, so a default would be invented"
+            );
+        }
+
+        for error in [
+            FFmpegError::ProbeError("FFprobe failed: Invalid data found".to_string()),
+            FFmpegError::InvalidInput("Input file does not exist: /gone.mp4".to_string()),
+            FFmpegError::ProcessError(Error::new(ErrorKind::Interrupted, "wait interrupted")),
+        ] {
+            assert!(
+                !error.measured_nothing(),
+                "{error} is a verdict FFprobe reached, not a reason to refuse the import"
+            );
+        }
     }
 }

--- a/src-tauri/src/core/ffmpeg/resolver.rs
+++ b/src-tauri/src/core/ffmpeg/resolver.rs
@@ -287,16 +287,26 @@ fn resolved_cell() -> &'static RwLock<Option<ResolvedFFmpeg>> {
 /// managed installer writes its new binaries and then re-initializes, so this
 /// is the one place every route to a different build passes through — including
 /// an install that lands at the same path the analysis latch already wrote off.
+///
+/// Verdicts reached with the *previous* binaries are forgotten: a probe that
+/// refused a file under a stale or half-installed FFprobe says nothing about
+/// what the one being registered now can read, and remembering it would leave a
+/// project silent for the rest of the session.
 pub fn set_resolved_paths(ffmpeg: PathBuf, ffprobe: PathBuf) {
-    // A poisoned lock only means another thread panicked mid-write; the
-    // stored Option is still valid, so recover the guard instead of panicking.
-    let mut guard = resolved_cell()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(ResolvedFFmpeg { ffmpeg, ffprobe });
-    drop(guard);
+    {
+        // A poisoned lock only means another thread panicked mid-write; the
+        // stored Option is still valid, so recover the guard instead of
+        // panicking.
+        let mut guard = resolved_cell()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = Some(ResolvedFFmpeg { ffmpeg, ffprobe });
+    }
 
+    // Outside the guard: each cache has a lock of its own, and holding both at
+    // once is an ordering nobody else has to observe.
     crate::core::analysis::audio::clear_loudness_filter_latch();
+    crate::core::render::clear_negative_probes();
 }
 
 /// Returns the globally resolved paths, running lazy detection if needed.
@@ -524,6 +534,11 @@ mod tests {
     // deterministic.
     #[test]
     fn test_resolver_lazy_fallback_then_explicit_registration() {
+        // `set_resolved_paths` retires every remembered probe failure, so this
+        // test would otherwise wipe the cache out from under the audio-presence
+        // tests that assert a verdict is still remembered.
+        let _serialized = crate::core::render::probe_counter_guard();
+
         // Lazy path: with or without prior registration, the resolver must
         // always return a non-empty path for both binaries.
         let lazy_ffmpeg = resolved_ffmpeg_path();

--- a/src-tauri/src/core/jobs/worker.rs
+++ b/src-tauri/src/core/jobs/worker.rs
@@ -1237,8 +1237,9 @@ impl JobProcessor {
     async fn process_preview_render(&self, job: &Job) -> Result<serde_json::Value, String> {
         #[cfg(not(test))]
         use crate::core::render::{
-            build_render_graph, build_render_plan, validate_export_settings, ExportEngine,
-            ExportSettings,
+            build_render_graph_with_audio_info, build_render_plan, clear_transient_probes,
+            probe_assets_audio_info_off_runtime, sequence_probe_targets, validate_export_settings,
+            ExportEngine, ExportSettings,
         };
 
         // Validate required payload fields
@@ -1293,6 +1294,25 @@ impl JobProcessor {
 
         #[cfg(not(test))]
         {
+            // A render is something the user asked for once, not a status poll,
+            // so it must not be answered out of the window that suppresses
+            // re-probing after a failure that reached no verdict. A file that
+            // was locked or on a dropped share when the last poll ran is exactly
+            // what this render needs measured again.
+            clear_transient_probes();
+
+            // FFprobe is a process spawn, so the assets are read under the lock
+            // and measured after it is dropped. Every IPC command waits on this
+            // lock, and a preview render must not park them behind a child
+            // process.
+            let probe_targets = {
+                let app_state = self.app_handle.state::<crate::AppState>();
+                let guard = app_state.project.lock().await;
+                let project = guard.as_ref().ok_or("No project open")?;
+                sequence_probe_targets(&project.state, sequence_id)
+            };
+            let audio_probe = probe_assets_audio_info_off_runtime(probe_targets).await;
+
             let (sequence, assets, effects, render_graph) = {
                 // Get project state from AppState
                 let app_state = self.app_handle.state::<crate::AppState>();
@@ -1308,8 +1328,13 @@ impl JobProcessor {
 
                 // Clone required data to release the lock
                 let sequence = sequence.clone();
-                let render_graph = build_render_graph(&project.state, sequence_id)
-                    .map_err(|error| format!("Failed to build render graph: {}", error))?;
+                // Measurements the project still stands behind: an asset
+                // relinked while the probe ran is dropped rather than answered
+                // from the file it no longer points at.
+                let audio_info = audio_probe.measurements_for(&project.state);
+                let render_graph =
+                    build_render_graph_with_audio_info(&project.state, sequence_id, &audio_info)
+                        .map_err(|error| format!("Failed to build render graph: {}", error))?;
                 let assets = project.state.assets.clone();
                 let effects = project.state.effects.clone();
                 (sequence, assets, effects, render_graph)
@@ -1508,8 +1533,9 @@ impl JobProcessor {
         use crate::core::{
             fs::{export_allowed_roots, validate_scoped_output_path},
             render::{
-                build_render_graph, build_render_plan, validate_export_settings, ExportEngine,
-                ExportPreset, ExportSettings,
+                build_render_graph_with_audio_info, build_render_plan, clear_transient_probes,
+                probe_assets_audio_info_off_runtime, sequence_probe_targets,
+                validate_export_settings, ExportEngine, ExportPreset, ExportSettings,
             },
         };
 
@@ -1548,7 +1574,22 @@ impl JobProcessor {
 
         #[cfg(not(test))]
         {
+            // As in `process_preview_render`: an export is user-initiated, so
+            // the post-failure suppression window is dropped and every asset is
+            // asked about again.
+            clear_transient_probes();
+
             // 1. Get project state and validate inputs
+            // FFprobe is a process spawn: read the assets under the lock, then
+            // measure them after it is dropped. See `process_preview_render`.
+            let probe_targets = {
+                let app_state = self.app_handle.state::<crate::AppState>();
+                let guard = app_state.project.lock().await;
+                let project = guard.as_ref().ok_or("No project open")?;
+                sequence_probe_targets(&project.state, sequence_id)
+            };
+            let audio_probe = probe_assets_audio_info_off_runtime(probe_targets).await;
+
             let (sequence, assets, effects, render_graph, project_path) = {
                 let app_state = self.app_handle.state::<crate::AppState>();
                 let guard = app_state.project.lock().await;
@@ -1560,8 +1601,13 @@ impl JobProcessor {
                     .get(sequence_id)
                     .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
                     .clone();
-                let render_graph = build_render_graph(&project.state, sequence_id)
-                    .map_err(|error| format!("Failed to build render graph: {}", error))?;
+                // Measurements the project still stands behind: an asset
+                // relinked while the probe ran is dropped rather than answered
+                // from the file it no longer points at.
+                let audio_info = audio_probe.measurements_for(&project.state);
+                let render_graph =
+                    build_render_graph_with_audio_info(&project.state, sequence_id, &audio_info)
+                        .map_err(|error| format!("Failed to build render graph: {}", error))?;
 
                 // Clone needed data to release lock quickly
                 (

--- a/src-tauri/src/core/render/audio_presence.rs
+++ b/src-tauri/src/core/render/audio_presence.rs
@@ -1,0 +1,1080 @@
+//! One definition of which clips make a sound.
+//!
+//! The export argument builders and the render graph answer the same question —
+//! "does this clip put audio into the output?" — and used to answer it
+//! differently. The builders walk the sequence's tracks and accept a video-track
+//! clip's embedded audio; the graph only ever emitted an audio layer for a clip
+//! on an *audio* track. A talk imported as one A/V file and inserted on the
+//! video track — the default path for every agent — therefore rendered with
+//! sound while `render graph` reported `"audioLayers": []` and the transcription
+//! mixdown refused the sequence outright.
+//!
+//! [`clip_carries_audio`] is that single definition. Both the export builders
+//! and [`crate::core::render::graph::build_render_graph`] call it, so the graph
+//! cannot claim silence for a render that will have sound.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime};
+
+use crate::core::assets::{Asset, AssetKind, MediaMetadata};
+use crate::core::project::ProjectState;
+use crate::core::render::export::{
+    asset_has_playable_audio, clip_audio_is_suppressed_by_companion, AssetAudioInfo,
+};
+use crate::core::timeline::{Clip, Track};
+use crate::core::{CoreError, CoreResult};
+
+/// Whether this clip contributes an audio stream to a render of its sequence.
+///
+/// Two questions, in the order the export builders ask them:
+///
+/// 1. Does the asset carry audio this track can play? An audio asset always
+///    does; a video asset does when the probe — or, absent a probe, the stored
+///    asset metadata — found an audio stream. Anything else (images, text,
+///    adjustment layers, caption placeholders) does not.
+/// 2. Is that audio already on the timeline a second time? `DetachAudio` leaves
+///    the video clip in place and adds an audio-track clip over the same source
+///    range, and mixing both would double the sound.
+///
+/// Whether the clip is *silenced* is deliberately not part of the answer: the
+/// export still opens the input and applies the gain, while the transcription
+/// mixdown drops it. Callers apply `clip.audio.muted` and `clip.freeze_frame`
+/// themselves, exactly as they did before this predicate was hoisted.
+pub fn clip_carries_audio(
+    clip: &Clip,
+    track: &Track,
+    asset: &Asset,
+    audio_info: Option<&AssetAudioInfo>,
+    audio_companion_keys: &HashSet<String>,
+) -> bool {
+    asset_has_playable_audio(asset, &track.kind, audio_info)
+        && !clip_audio_is_suppressed_by_companion(clip, track, asset, audio_companion_keys)
+}
+
+/// Measures which of a sequence's assets actually carry an audio stream.
+///
+/// [`clip_carries_audio`] falls back to the *stored* asset metadata when it is
+/// given no probe result, and that metadata is frequently absent: the CLI's
+/// `asset import` records an asset from its file extension without opening the
+/// file, so an A/V mp4 is stored with no audio info at all. The export never hit
+/// this because it probes every unique asset before building its arguments;
+/// callers that need the same truth without an export engine — the transcription
+/// mixdown, `render graph` — call this instead.
+///
+/// One FFprobe per unique *video* asset, memoized for the life of the process —
+/// see [`probe_asset_audio_info`]. An asset that cannot be probed falls back to
+/// its stored metadata rather than failing the caller, which is what the export
+/// engine's own probe does.
+///
+/// This blocks on FFprobe. A caller on an async runtime must not hold a lock
+/// across it: read [`sequence_probe_targets`] under the lock, drop the guard,
+/// and await [`probe_assets_audio_info_off_runtime`] instead.
+pub fn probe_sequence_audio_info(
+    state: &ProjectState,
+    sequence_id: &str,
+) -> HashMap<String, AssetAudioInfo> {
+    probe_assets_audio_info(&sequence_probe_targets(state, sequence_id))
+}
+
+/// The assets of a sequence whose audio presence actually has to be measured.
+///
+/// Only *video* assets are returned. An audio asset is audible whatever a probe
+/// would say, and an image, subtitle, font or preset carries no sound at all —
+/// [`asset_has_playable_audio`] answers for both without opening the file, so
+/// probing them would spend an FFprobe on a question already settled. Assets
+/// left out of the map fall back to exactly that answer.
+///
+/// The assets are cloned so a caller can drop whatever lock it read the project
+/// under before [`probe_assets_audio_info`] starts spawning processes.
+pub fn sequence_probe_targets(state: &ProjectState, sequence_id: &str) -> Vec<Asset> {
+    let Some(sequence) = state.sequences.get(sequence_id) else {
+        return Vec::new();
+    };
+
+    let mut unique_asset_ids = HashSet::new();
+    for track in &sequence.tracks {
+        for clip in &track.clips {
+            if clip.enabled {
+                unique_asset_ids.insert(clip.asset_id.clone());
+            }
+        }
+    }
+
+    unique_asset_ids
+        .into_iter()
+        .filter_map(|asset_id| state.assets.get(&asset_id))
+        .filter(|asset| asset.kind == AssetKind::Video)
+        .cloned()
+        .collect()
+}
+
+/// Measures the assets [`sequence_probe_targets`] selected, keyed by asset id.
+pub fn probe_assets_audio_info(assets: &[Asset]) -> HashMap<String, AssetAudioInfo> {
+    assets
+        .iter()
+        .map(|asset| (asset.id.clone(), probe_asset_audio_info(asset)))
+        .collect()
+}
+
+/// Measurements, together with the file each asset pointed at when it was taken.
+///
+/// A probe deliberately runs with the project lock released, so the project can
+/// change while it runs. Relinking an asset — `UpdateAsset` pointing the same id
+/// at a different file — is the change the asset id alone cannot survive: the
+/// measurement is of the *old* file, and answering the new one with it reports
+/// audio a render will not produce, or silence for a render that has sound.
+///
+/// So the uri is carried alongside, and [`Self::measurements_for`] is what every
+/// caller uses to turn the pair back into a map once it has re-locked.
+#[derive(Clone, Debug, Default)]
+pub struct SequenceAudioProbe {
+    /// What was measured, keyed by asset id.
+    measurements: HashMap<String, AssetAudioInfo>,
+    /// The uri each of those assets carried when it was measured.
+    probed_uris: HashMap<String, String>,
+}
+
+impl SequenceAudioProbe {
+    /// Measurements that still describe the files `state` currently points at.
+    ///
+    /// An asset relinked while the probe ran is dropped rather than answered
+    /// from the old file's verdict. Dropping it is safe in a way answering it is
+    /// not: an asset absent from the map falls back to its own stored metadata,
+    /// which is what an unprobed asset has always done.
+    pub fn measurements_for(&self, state: &ProjectState) -> HashMap<String, AssetAudioInfo> {
+        self.measurements
+            .iter()
+            .filter(|(asset_id, _)| {
+                let probed_uri = self.probed_uris.get(*asset_id);
+                match (state.assets.get(*asset_id), probed_uri) {
+                    (Some(asset), Some(uri)) => &asset.uri == uri,
+                    // An asset that is gone is not looked up by the graph
+                    // either, and a measurement with no recorded uri cannot be
+                    // vouched for.
+                    _ => false,
+                }
+            })
+            .map(|(asset_id, info)| (asset_id.clone(), info.clone()))
+            .collect()
+    }
+}
+
+/// [`probe_assets_audio_info`], moved off the async runtime's worker threads.
+///
+/// FFprobe is a process spawn and a demuxer read — tens of milliseconds each,
+/// and unbounded when the file lives on a disconnected network share. Running
+/// it inside an async task stalls that task's whole worker thread, and running
+/// it while the task holds the project lock stalls every other IPC command too.
+///
+/// A join failure (the runtime shutting down, or the blocking task panicking)
+/// answers with no measurements, which is the same "nobody measured these"
+/// fallback [`crate::core::render::build_render_graph`] already handles.
+pub async fn probe_assets_audio_info_off_runtime(assets: Vec<Asset>) -> SequenceAudioProbe {
+    let probed_uris = assets
+        .iter()
+        .map(|asset| (asset.id.clone(), asset.uri.clone()))
+        .collect::<HashMap<_, _>>();
+
+    match tokio::task::spawn_blocking(move || probe_assets_audio_info(&assets)).await {
+        Ok(measurements) => SequenceAudioProbe {
+            measurements,
+            probed_uris,
+        },
+        Err(error) => {
+            tracing::warn!("Audio presence probe did not complete: {error}");
+            SequenceAudioProbe::default()
+        }
+    }
+}
+
+/// What a probe of one asset is remembered against: where the file is, and how
+/// it looked when it was measured.
+///
+/// Modification time and size together are what every incremental build system
+/// treats as "this file did not change", and they cost one `stat` against the
+/// several tens of milliseconds an FFprobe run costs. A file edited in place
+/// changes at least one of them and is measured again.
+type ProbeFingerprint = (PathBuf, Option<SystemTime>, u64);
+
+/// Upper bound on remembered probes.
+///
+/// A project's own assets are a handful; the cap only exists so a long-lived
+/// GUI session that opens project after project cannot grow this without end.
+/// Reaching it clears the cache rather than evicting cleverly — the next graph
+/// re-measures what it needs and nothing is ever wrong, only slower once.
+const PROBE_CACHE_CAPACITY: usize = 512;
+
+/// How long a probe failure that reached no verdict suppresses another probe
+/// of the same file.
+///
+/// These failures must not be remembered — a locked file is released, a share
+/// comes back, a permission is granted — but "not remembered" used to mean
+/// "re-probed by every caller", and a GUI builds a render graph on every status
+/// poll. That is a doomed FFprobe spawn several times a second for as long as
+/// the file stays locked, on exactly the poll-driven path this cache exists to
+/// keep cheap. The interval is short enough that a file freed while the user
+/// watches is picked up within one of their glances, and
+/// [`clear_negative_probes`] still cuts it short whenever the FFmpeg resolver
+/// publishes new paths.
+const NEGATIVE_PROBE_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// When each file last failed a probe that said nothing about its bytes.
+///
+/// Separate from [`probe_cache`] because these entries are not verdicts: they
+/// answer "was this asked recently", not "what is the answer", and they expire
+/// on their own after [`NEGATIVE_PROBE_RETRY_INTERVAL`].
+fn transient_probe_cache() -> &'static Mutex<HashMap<ProbeFingerprint, Instant>> {
+    static CACHE: OnceLock<Mutex<HashMap<ProbeFingerprint, Instant>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Probes remembered from earlier graphs in this process.
+///
+/// A `None` entry records that FFprobe could not measure this exact file: the
+/// verdict is remembered, but the *answer* is not, because the fallback reads
+/// the asset's own stored metadata and two assets may point at one path.
+fn probe_cache() -> &'static Mutex<HashMap<ProbeFingerprint, Option<AssetAudioInfo>>> {
+    static CACHE: OnceLock<Mutex<HashMap<ProbeFingerprint, Option<AssetAudioInfo>>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// FFprobe runs this process has actually spawned, so a test can prove that a
+/// second look at the same file did not spawn another one.
+#[cfg(test)]
+static PROBE_ATTEMPTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Serializes every test that reads [`PROBE_ATTEMPTS`] or depends on the probe
+/// cache surviving between two calls.
+///
+/// The counter and the cache are process-global, and `cargo test` runs the
+/// binary's tests on many threads. Anything that counts probes, or that asserts
+/// a remembered verdict is still remembered, has to hold this — including tests
+/// outside this module: [`clear_negative_probes`] is called by
+/// `crate::core::ffmpeg::set_resolved_paths`, so a resolver test registering
+/// paths would otherwise wipe the cache mid-assertion.
+///
+/// The guard is deliberately recovered from poisoning: a panicking test tells
+/// us nothing about whether the *next* one may run.
+#[cfg(test)]
+pub(crate) fn probe_counter_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    let guard = GUARD.get_or_init(|| Mutex::new(()));
+    guard
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Measures one asset, reusing an earlier measurement of the same file.
+///
+/// Every surface that builds a render graph probes, and a GUI builds one on
+/// every export, every preview-cache fill and every status poll. Without a cache
+/// that is one FFprobe per asset per graph, on files that have not changed since
+/// the last one — the cost the `render graph` help text warns about, paid over
+/// and over.
+///
+/// A file that cannot be `stat`ed is probed without being remembered: a missing
+/// or half-copied file that appears later must be measured then, not answered
+/// from a failure. A file that stats but that FFprobe *ran on and rejected* is
+/// remembered as unmeasurable — the same broken or non-media file on the
+/// timeline otherwise spawned a doomed FFprobe on every graph, which is exactly
+/// the poll-driven cost this cache exists to remove — and its answer still comes
+/// from the asking asset's own stored metadata.
+///
+/// A probe that failed for any other reason — FFprobe could not be started,
+/// FFprobe started but could not open the file — is never remembered as an
+/// answer: that says nothing about the bytes, and remembering it would freeze
+/// the whole timeline as unmeasurable for the life of the process even after a
+/// managed FFmpeg finishes installing or a locked file is released. It is only
+/// rate-limited, for [`NEGATIVE_PROBE_RETRY_INTERVAL`], so that a file held
+/// open elsewhere does not draw a fresh doomed spawn out of every status poll.
+/// See [`probe_failure_is_final`] for which verdicts count, and
+/// [`clear_negative_probes`], which the FFmpeg resolver calls when it publishes
+/// new paths.
+pub fn probe_asset_audio_info(asset: &Asset) -> AssetAudioInfo {
+    probe_asset_audio_info_with(asset, |uri| {
+        crate::core::assets::MetadataExtractor::extract(uri)
+    })
+}
+
+/// Verdicts FFprobe reaches about the *content* of a file it managed to open.
+///
+/// Matched case-insensitively against the diagnostic tail of FFprobe's own
+/// stderr lines (see [`probe_failure_is_final`]). Each one means the bytes were
+/// read and refused, so the identical bytes get the identical answer and the
+/// failure is worth remembering.
+///
+/// Kept deliberately short. `unknown format` is something FFprobe says when it
+/// is told a format with `-f`, which no probe here passes, and `not a valid`
+/// only ever appeared as part of a longer sentence this list cannot pin down —
+/// both were guesses at wordings rather than verdicts observed from the probes
+/// this cache remembers.
+///
+/// "The identical bytes get the identical answer" is what makes these safe to
+/// remember, and it is the *fingerprint*, not this list, that decides which
+/// bytes an answer belongs to. A file caught mid-copy earns one of these
+/// verdicts honestly — an empty file and a preallocated one with no `moov` atom
+/// yet are both genuinely unreadable at the instant FFprobe looks — and the
+/// verdict is only ever un-stuck because finishing the copy changes the size or
+/// the modification time and so asks under a new [`ProbeFingerprint`]. A copy
+/// that somehow ended with both unchanged would keep the stale verdict for the
+/// life of the process; no probe path here can tell that apart from a file that
+/// really is broken, and [`clear_negative_probes`] is the way out.
+const FINAL_PROBE_VERDICTS: [&str; 2] = ["invalid data found", "moov atom not found"];
+
+/// Whether a failed probe is worth remembering against the file.
+///
+/// The policy is an allow-list, not a deny-list: a failure is remembered only
+/// when FFprobe's own stderr names a verdict it reached about the content (see
+/// [`FINAL_PROBE_VERDICTS`]). Everything else is treated as transient and asked
+/// again, at most once per [`NEGATIVE_PROBE_RETRY_INTERVAL`].
+///
+/// Two kinds of failure hide behind the same [`CoreError::FFprobeError`]:
+/// FFprobe ran and rejected what it read, and FFprobe ran but could not *open*
+/// the file at all — a locked or still-copying file, a share that dropped, a
+/// permission that a later run may have. Only the first says anything permanent
+/// about the bytes. A deny-list would have to enumerate every phrasing of the
+/// second (`Permission denied`, `Input/output error`, `No such file or
+/// directory`, `Resource temporarily unavailable`, `Operation not permitted`,
+/// `Access is denied`, …) across platforms and locales, and anything it missed
+/// would be memoized as a permanent verdict for the life of the process.
+/// Erring the other way only costs a re-probe.
+///
+/// [`CoreError::FFprobeUnavailable`] — FFprobe could not be started — is never
+/// final for the same reason, and does not reach the allow-list.
+///
+/// Each stderr line is matched from its last `": "` onwards, which is where
+/// FFprobe puts the diagnostic and everything before which is the subject it is
+/// diagnosing — the demuxer tag, or the input path. Matching the whole line
+/// would let a *path* carry a verdict (`/clips/invalid data found/take1.mp4:
+/// Permission denied`) and memoize a transient failure for the life of the
+/// process. Lines are looked at one at a time because FFprobe reports the
+/// container diagnostic and the verdict on the file separately, and only the
+/// first of those carries `moov atom not found`.
+fn probe_failure_is_final(error: &CoreError) -> bool {
+    let CoreError::FFprobeError(message) = error else {
+        return false;
+    };
+    message.lines().any(|line| {
+        let diagnostic = line
+            .rsplit_once(": ")
+            .map_or(line, |(_subject, tail)| tail)
+            .to_ascii_lowercase();
+        FINAL_PROBE_VERDICTS
+            .iter()
+            .any(|verdict| diagnostic.contains(verdict))
+    })
+}
+
+/// [`probe_asset_audio_info`], with the measurement itself supplied.
+///
+/// The seam is what lets a test produce one specific failure — FFprobe missing
+/// versus FFprobe rejecting the file — without installing or removing binaries.
+fn probe_asset_audio_info_with<F>(asset: &Asset, extract: F) -> AssetAudioInfo
+where
+    F: FnOnce(&str) -> CoreResult<MediaMetadata>,
+{
+    probe_asset_audio_info_at(asset, Instant::now(), extract)
+}
+
+/// [`probe_asset_audio_info_with`], with the clock supplied too.
+///
+/// [`NEGATIVE_PROBE_RETRY_INTERVAL`] is otherwise only observable by waiting it
+/// out, which no test should do; passing the instant lets one prove both halves
+/// of the rule — suppressed inside the interval, probed again past it — in no
+/// time at all.
+fn probe_asset_audio_info_at<F>(asset: &Asset, now: Instant, extract: F) -> AssetAudioInfo
+where
+    F: FnOnce(&str) -> CoreResult<MediaMetadata>,
+{
+    let path = Path::new(&asset.uri);
+    let fingerprint = std::fs::metadata(path).ok().and_then(|metadata| {
+        metadata
+            .is_file()
+            .then(|| (path.to_path_buf(), metadata.modified().ok(), metadata.len()))
+    });
+
+    if let Some(key) = fingerprint.as_ref() {
+        if let Ok(cache) = probe_cache().lock() {
+            match cache.get(key) {
+                Some(Some(cached)) => return cached.clone(),
+                Some(None) => return AssetAudioInfo::from_asset(asset),
+                None => {}
+            }
+        }
+
+        if let Ok(mut recent) = transient_probe_cache().lock() {
+            match recent.get(key) {
+                Some(failed_at)
+                    if now.saturating_duration_since(*failed_at)
+                        < NEGATIVE_PROBE_RETRY_INTERVAL =>
+                {
+                    return AssetAudioInfo::from_asset(asset);
+                }
+                // Past the interval the question is open again, and the entry
+                // is dropped now rather than left for a sweep that never runs.
+                Some(_) => {
+                    recent.remove(key);
+                }
+                None => {}
+            }
+        }
+    }
+
+    #[cfg(test)]
+    PROBE_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    let (probed, remember) = match extract(&asset.uri) {
+        Ok(metadata) => (Some(AssetAudioInfo::from_media_metadata(&metadata)), true),
+        Err(error) => {
+            let remember = probe_failure_is_final(&error);
+            tracing::debug!(
+                asset_id = %asset.id,
+                remembered = remember,
+                "Falling back to stored audio metadata: {}",
+                error
+            );
+            (None, remember)
+        }
+    };
+
+    if let Some(key) = fingerprint {
+        if remember {
+            if let Ok(mut cache) = probe_cache().lock() {
+                if cache.len() >= PROBE_CACHE_CAPACITY {
+                    cache.clear();
+                }
+                cache.insert(key, probed.clone());
+            }
+        } else if probed.is_none() {
+            if let Ok(mut recent) = transient_probe_cache().lock() {
+                if recent.len() >= PROBE_CACHE_CAPACITY {
+                    recent.clear();
+                }
+                recent.insert(key, now);
+            }
+        }
+    }
+
+    probed.unwrap_or_else(|| AssetAudioInfo::from_asset(asset))
+}
+
+/// Forgets every remembered *failure*, keeping the successful measurements.
+///
+/// A failure is only remembered once FFprobe has actually run, but the reasons a
+/// run refuses a file are not all permanent: an FFprobe too old for a container,
+/// or one resolved from a half-written managed download, rejects media a newly
+/// registered binary reads fine. The FFmpeg resolver calls this whenever it
+/// publishes paths, so a session that opened a project before FFmpeg finished
+/// installing measures its media on the next graph instead of reporting silence
+/// until it is restarted.
+pub fn clear_negative_probes() {
+    if let Ok(mut cache) = probe_cache().lock() {
+        cache.retain(|_, probed| probed.is_some());
+    }
+    // The failures that were only being rate-limited are dropped outright: new
+    // binaries are exactly the event [`NEGATIVE_PROBE_RETRY_INTERVAL`] is
+    // waiting for.
+    clear_transient_probes();
+}
+
+/// Forgets the rate-limited failures only, keeping every verdict FFprobe
+/// reached — the successful measurements and the refusals alike.
+///
+/// [`NEGATIVE_PROBE_RETRY_INTERVAL`] exists to keep *polling* cheap: a GUI
+/// rebuilds a render graph several times a second, and one locked file must not
+/// turn that into a stream of doomed FFprobe spawns. A user asking for an
+/// export or a preview render is not a poll. It happens once, because they said
+/// so, and it is exactly the moment a file that was locked or on a dropped
+/// share a few seconds ago is worth asking about again — answering it from a
+/// suppression window would silently render a clip mute.
+///
+/// Every path a user or an agent asks a question through calls this before it
+/// probes: the `start_render`, `render_range`, `batch_render`,
+/// `export_audio_only` and `validate_export` IPC commands, the preview- and
+/// final-render job handlers, and the CLI's `render start` and `render graph`
+/// (which the MCP server shares, and that process is long-lived enough for a
+/// window to still be open). The polled paths — cache status and cache fill -
+/// deliberately do not, because they are the polling this window exists to
+/// bound.
+///
+/// The remembered verdicts are deliberately left alone: they are about bytes
+/// that have not changed, and re-measuring them is the cost this cache exists
+/// to remove. [`clear_negative_probes`] is the wider reset, for when the FFmpeg
+/// resolver publishes binaries that may reach different verdicts.
+pub fn clear_transient_probes() {
+    if let Ok(mut recent) = transient_probe_cache().lock() {
+        recent.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::assets::{AudioInfo, VideoInfo};
+    use crate::core::timeline::{Clip, ClipPlace, ClipRange, Sequence, SequenceFormat, TrackKind};
+
+    /// How many FFprobe runs this process has spawned so far.
+    fn probe_attempts() -> usize {
+        PROBE_ATTEMPTS.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// A video asset over a real file, so the probe reaches its fingerprint.
+    fn asset_over(path: &std::path::Path) -> Asset {
+        let mut asset = Asset::new_video("subject", &path.to_string_lossy(), VideoInfo::default());
+        asset.id = "asset-1".to_string();
+        asset.audio = None;
+        asset
+    }
+
+    /// A one-clip sequence over `asset`, on a video track.
+    fn state_with_one_clip(asset: Asset) -> ProjectState {
+        let mut state = ProjectState::new("Audio Presence Test");
+        state.sequences.clear();
+
+        let mut clip = Clip::new(&asset.id);
+        clip.id = "clip-1".to_string();
+        clip.place = ClipPlace::new(0.0, 4.0);
+        clip.range = ClipRange::new(0.0, 4.0);
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+        let mut track = Track::new("Video 1", TrackKind::Video);
+        track.id = "track-1".to_string();
+        track.clips.push(clip);
+        sequence.tracks.push(track);
+
+        state.assets.insert(asset.id.clone(), asset);
+        state.active_sequence_id = Some(sequence.id.clone());
+        state.sequences.insert(sequence.id.clone(), sequence);
+        state
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: an asset whose kind already answers the question
+    ///
+    /// Given an audio asset and an image asset on a sequence
+    /// When the probe targets are collected
+    /// Then neither is offered to FFprobe, because `asset_has_playable_audio`
+    /// answers "always" and "never" for them without opening the file.
+    #[test]
+    fn assets_that_are_not_video_are_never_probed() {
+        let _serialized = probe_counter_guard();
+
+        for asset in [
+            Asset::new_audio("audio", "does-not-matter.wav", AudioInfo::default()),
+            Asset::new_image("image", "does-not-matter.png", 1920, 1080),
+        ] {
+            let mut asset = asset;
+            asset.id = "asset-1".to_string();
+            let kind = format!("{:?}", asset.kind);
+            let state = state_with_one_clip(asset);
+
+            assert!(
+                sequence_probe_targets(&state, "seq-1").is_empty(),
+                "a {kind} asset must not be handed to FFprobe"
+            );
+
+            let before = probe_attempts();
+            let audio_info = probe_sequence_audio_info(&state, "seq-1");
+            assert_eq!(
+                probe_attempts(),
+                before,
+                "a {kind} asset must not spawn an FFprobe"
+            );
+            assert!(
+                audio_info.is_empty(),
+                "an unprobed asset stays out of the map so the kind-based answer stands"
+            );
+        }
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: a file that stats but that FFprobe cannot read
+    ///
+    /// Given a video asset pointing at a file with no media in it
+    /// When the sequence is probed twice
+    /// Then FFprobe runs once: the failure is remembered against the same
+    /// (path, mtime, size) fingerprint a success would be, so a status poll on a
+    /// broken clip stops re-spawning a doomed probe.
+    #[test]
+    fn a_probe_that_fails_is_remembered() {
+        let _serialized = probe_counter_guard();
+
+        let Ok(dir) = tempfile::tempdir() else {
+            eprintln!("Skipping test: a temporary directory could not be created");
+            return;
+        };
+        let path = dir.path().join("not-really-a-video.mp4");
+        if std::fs::write(&path, b"this is not a media file").is_err() {
+            eprintln!("Skipping test: the fixture could not be written");
+            return;
+        }
+
+        let mut asset = Asset::new_video("broken", &path.to_string_lossy(), VideoInfo::default());
+        asset.id = "asset-1".to_string();
+        asset.audio = None;
+        let state = state_with_one_clip(asset);
+
+        // A test about what FFprobe *decided* has nothing to say on a machine
+        // where it cannot be launched at all — that is the other failure, and
+        // it is deliberately not remembered.
+        if crate::core::test_ffmpeg::require_or_skip_ffprobe().is_none() {
+            return;
+        }
+
+        let before = probe_attempts();
+        let first = probe_sequence_audio_info(&state, "seq-1");
+        let after_first = probe_attempts();
+        assert_eq!(
+            after_first,
+            before + 1,
+            "the first look at an unmeasured file has to probe it"
+        );
+
+        let second = probe_sequence_audio_info(&state, "seq-1");
+        assert_eq!(
+            probe_attempts(),
+            after_first,
+            "the second look must be answered from the remembered failure"
+        );
+
+        // The remembered failure still answers from the *asking* asset's stored
+        // metadata rather than from a cached copy of someone else's.
+        assert_eq!(first.get("asset-1").map(|info| info.has_audio), Some(false));
+        assert_eq!(
+            second.get("asset-1").map(|info| info.has_audio),
+            Some(false)
+        );
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: an asset relinked while the probe ran
+    ///
+    /// Given a probe taken against one file
+    /// When the asset is pointed at a different file before the caller re-locks
+    /// Then the old file's measurement is dropped rather than reported for the
+    /// new one, and an asset still pointing where it did keeps its measurement.
+    #[test]
+    fn a_relinked_asset_does_not_keep_the_old_file_s_verdict() {
+        let probe = SequenceAudioProbe {
+            measurements: HashMap::from([
+                (
+                    "relinked".to_string(),
+                    AssetAudioInfo {
+                        has_audio: true,
+                        source_dimensions: None,
+                        source_duration_sec: None,
+                    },
+                ),
+                (
+                    "unchanged".to_string(),
+                    AssetAudioInfo {
+                        has_audio: true,
+                        source_dimensions: None,
+                        source_duration_sec: None,
+                    },
+                ),
+            ]),
+            probed_uris: HashMap::from([
+                ("relinked".to_string(), "with-audio.mp4".to_string()),
+                ("unchanged".to_string(), "still-here.mp4".to_string()),
+            ]),
+        };
+
+        let mut state = ProjectState::new("Relink Test");
+        for (id, uri) in [
+            ("relinked", "silent-replacement.mp4"),
+            ("unchanged", "still-here.mp4"),
+        ] {
+            let mut asset = Asset::new_video(id, uri, VideoInfo::default());
+            asset.id = id.to_string();
+            state.assets.insert(asset.id.clone(), asset);
+        }
+
+        let resolved = probe.measurements_for(&state);
+        assert!(
+            !resolved.contains_key("relinked"),
+            "the measurement was of the file this asset no longer points at"
+        );
+        assert_eq!(
+            resolved.get("unchanged").map(|info| info.has_audio),
+            Some(true),
+            "an asset that did not move keeps what was measured for it"
+        );
+
+        // An asset removed outright is not answered either.
+        state.assets.remove("unchanged");
+        assert!(probe.measurements_for(&state).is_empty());
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: FFprobe could not be started
+    ///
+    /// Given a probe that fails because the binary could not be run
+    /// When the same asset is probed again
+    /// Then it is measured again rather than answered from the failure, because
+    /// nothing was ever learned about the file — a managed FFmpeg that finishes
+    /// installing mid-session must not find the whole timeline written off.
+    #[test]
+    fn a_probe_that_could_not_run_is_not_remembered() {
+        let _serialized = probe_counter_guard();
+
+        let Ok(dir) = tempfile::tempdir() else {
+            eprintln!("Skipping test: a temporary directory could not be created");
+            return;
+        };
+        let path = dir.path().join("unreachable-ffprobe.mp4");
+        if std::fs::write(&path, b"contents are never read").is_err() {
+            eprintln!("Skipping test: the fixture could not be written");
+            return;
+        }
+        let asset = asset_over(&path);
+
+        let base = Instant::now();
+        let attempts = std::cell::Cell::new(0usize);
+        let probe = |now: Instant| {
+            probe_asset_audio_info_at(&asset, now, |_| {
+                attempts.set(attempts.get() + 1);
+                Err(CoreError::FFprobeUnavailable(
+                    "Failed to run ffprobe: program not found".to_string(),
+                ))
+            })
+        };
+
+        probe(base);
+        probe(base + NEGATIVE_PROBE_RETRY_INTERVAL);
+        assert_eq!(
+            attempts.get(),
+            2,
+            "a probe that never ran must be retried, not remembered"
+        );
+
+        // And once FFprobe is available, the file is measured rather than
+        // answered from the earlier non-verdict.
+        let measured =
+            probe_asset_audio_info_at(&asset, base + NEGATIVE_PROBE_RETRY_INTERVAL * 2, |_| {
+                Ok(MediaMetadata {
+                    audio: Some(AudioInfo::default()),
+                    ..MediaMetadata::default()
+                })
+            });
+        assert!(
+            measured.has_audio,
+            "the first successful run decides, not the failures before it"
+        );
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: FFprobe ran and refused the file
+    ///
+    /// Given a probe that fails with FFprobe's own verdict
+    /// When the same asset is probed again
+    /// Then FFprobe is not run a second time: the identical bytes get the
+    /// identical answer, and that is the poll-driven cost this cache removes.
+    #[test]
+    fn a_probe_that_ffprobe_refused_is_remembered() {
+        let _serialized = probe_counter_guard();
+
+        let Ok(dir) = tempfile::tempdir() else {
+            eprintln!("Skipping test: a temporary directory could not be created");
+            return;
+        };
+        let path = dir.path().join("refused-by-ffprobe.mp4");
+        if std::fs::write(&path, b"this is not a media file").is_err() {
+            eprintln!("Skipping test: the fixture could not be written");
+            return;
+        }
+        let asset = asset_over(&path);
+
+        let attempts = std::cell::Cell::new(0usize);
+        let probe = || {
+            probe_asset_audio_info_with(&asset, |_| {
+                attempts.set(attempts.get() + 1);
+                Err(CoreError::FFprobeError(
+                    "FFprobe failed: Invalid data found when processing input".to_string(),
+                ))
+            })
+        };
+
+        probe();
+        probe();
+        assert_eq!(
+            attempts.get(),
+            1,
+            "FFprobe's own verdict on unchanged bytes is asked for once"
+        );
+
+        // ...until the resolver publishes new binaries, which retires every
+        // verdict the old ones reached.
+        clear_negative_probes();
+        probe();
+        assert_eq!(
+            attempts.get(),
+            2,
+            "re-registered FFmpeg paths reopen the question"
+        );
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: FFprobe ran but could not open the file
+    ///
+    /// Given a probe that fails because the file could not be opened
+    /// When the same asset is probed again
+    /// Then it is measured again: FFprobe reached no verdict on the bytes, and
+    /// a lock, a dropped share or a permission that a later run has must not be
+    /// written off for the life of the process.
+    #[test]
+    fn a_probe_that_could_not_open_the_file_is_not_remembered() {
+        let _serialized = probe_counter_guard();
+
+        let Ok(dir) = tempfile::tempdir() else {
+            eprintln!("Skipping test: a temporary directory could not be created");
+            return;
+        };
+        let path = dir.path().join("locked-by-someone-else.mp4");
+        if std::fs::write(&path, b"contents are never read").is_err() {
+            eprintln!("Skipping test: the fixture could not be written");
+            return;
+        }
+        let asset = asset_over(&path);
+
+        let base = Instant::now();
+
+        for stderr in [
+            "Permission denied",
+            "Input/output error",
+            "No such file or directory",
+            "Resource temporarily unavailable",
+            "Operation not permitted",
+            "Access is denied. (os error 5)",
+            // A path that reads like a verdict must not become one: only the
+            // diagnostic after the last ": " is classified.
+            "/clips/invalid data found/take1.mp4: Permission denied",
+        ] {
+            clear_negative_probes();
+
+            let attempts = std::cell::Cell::new(0usize);
+            let probe = |now: Instant| {
+                probe_asset_audio_info_at(&asset, now, |_| {
+                    attempts.set(attempts.get() + 1);
+                    Err(CoreError::FFprobeError(format!("FFprobe failed: {stderr}")))
+                })
+            };
+
+            probe(base);
+            probe(base + NEGATIVE_PROBE_RETRY_INTERVAL);
+            assert_eq!(
+                attempts.get(),
+                2,
+                "`{stderr}` says nothing about the bytes and must be retried"
+            );
+        }
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: a file that is locked while the GUI polls
+    ///
+    /// Given a probe that failed without reaching a verdict
+    /// When the same asset is probed again straight away
+    /// Then FFprobe is not spawned again until the retry interval has passed,
+    /// so a status poll several times a second cannot turn one locked file into
+    /// a stream of doomed FFprobe spawns.
+    #[test]
+    fn a_failure_without_a_verdict_is_rate_limited_not_repeated() {
+        let _serialized = probe_counter_guard();
+
+        let Ok(dir) = tempfile::tempdir() else {
+            eprintln!("Skipping test: a temporary directory could not be created");
+            return;
+        };
+        let path = dir.path().join("held-open-elsewhere.mp4");
+        if std::fs::write(&path, b"contents are never read").is_err() {
+            eprintln!("Skipping test: the fixture could not be written");
+            return;
+        }
+        let asset = asset_over(&path);
+        clear_negative_probes();
+
+        let base = Instant::now();
+        let attempts = std::cell::Cell::new(0usize);
+        let probe = |now: Instant| {
+            probe_asset_audio_info_at(&asset, now, |_| {
+                attempts.set(attempts.get() + 1);
+                Err(CoreError::FFprobeError(
+                    "FFprobe failed: Permission denied".to_string(),
+                ))
+            })
+        };
+
+        probe(base);
+        assert_eq!(attempts.get(), 1, "the first poll has to ask");
+
+        probe(base + NEGATIVE_PROBE_RETRY_INTERVAL / 2);
+        assert_eq!(
+            attempts.get(),
+            1,
+            "a poll inside the interval is answered from the stored metadata"
+        );
+
+        probe(base + NEGATIVE_PROBE_RETRY_INTERVAL);
+        assert_eq!(
+            attempts.get(),
+            2,
+            "past the interval the file is asked about again"
+        );
+
+        // A resolver publishing new binaries reopens the question immediately,
+        // without waiting the interval out.
+        clear_negative_probes();
+        probe(base + NEGATIVE_PROBE_RETRY_INTERVAL);
+        assert_eq!(
+            attempts.get(),
+            3,
+            "re-registered FFmpeg paths cut the interval short"
+        );
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: a user asks for a render while a file is inside the
+    /// suppression window
+    ///
+    /// Given one file suppressed after a failure that reached no verdict, one
+    /// FFprobe refused outright, and one measured successfully
+    /// When the export and proxy job paths drop the rate limit
+    /// Then only the suppressed file is asked about again: a render the user
+    /// asked for re-asks about a file that may have been released, and still
+    /// pays nothing to re-measure bytes FFprobe has already ruled on.
+    #[test]
+    fn a_user_render_reopens_only_the_rate_limited_failures() {
+        let _serialized = probe_counter_guard();
+
+        let Ok(dir) = tempfile::tempdir() else {
+            eprintln!("Skipping test: a temporary directory could not be created");
+            return;
+        };
+        let locked = dir.path().join("locked.mp4");
+        let refused = dir.path().join("refused.mp4");
+        let measured = dir.path().join("measured.mp4");
+        if [&locked, &refused, &measured]
+            .iter()
+            .any(|path| std::fs::write(path, b"contents are never read").is_err())
+        {
+            eprintln!("Skipping test: the fixtures could not be written");
+            return;
+        }
+
+        clear_negative_probes();
+
+        let base = Instant::now();
+        let attempts = std::cell::Cell::new(0usize);
+        let probe = |path: &std::path::Path, now: Instant| {
+            let asset = asset_over(path);
+            let outcome = if path == locked.as_path() {
+                Err(CoreError::FFprobeError(
+                    "FFprobe failed: Permission denied".to_string(),
+                ))
+            } else if path == refused.as_path() {
+                Err(CoreError::FFprobeError(
+                    "FFprobe failed: Invalid data found when processing input".to_string(),
+                ))
+            } else {
+                Ok(MediaMetadata {
+                    audio: Some(AudioInfo::default()),
+                    ..MediaMetadata::default()
+                })
+            };
+            probe_asset_audio_info_at(&asset, now, |_| {
+                attempts.set(attempts.get() + 1);
+                outcome
+            });
+        };
+
+        for path in [&locked, &refused, &measured] {
+            probe(path, base);
+        }
+        assert_eq!(attempts.get(), 3, "each file has to be asked about once");
+
+        // Well inside the retry interval, so only the explicit reset can
+        // reopen the suppressed file.
+        let during_render = base + NEGATIVE_PROBE_RETRY_INTERVAL / 2;
+        clear_transient_probes();
+        for path in [&locked, &refused, &measured] {
+            probe(path, during_render);
+        }
+        assert_eq!(
+            attempts.get(),
+            4,
+            "the render re-asks about the suppressed file and nothing else"
+        );
+
+        // And the reset is not a one-off: the failure it just re-asked about
+        // went back into the rate limit rather than becoming a verdict.
+        for path in [&locked, &refused, &measured] {
+            probe(path, during_render);
+        }
+        assert_eq!(
+            attempts.get(),
+            4,
+            "polls after the render are suppressed again"
+        );
+    }
+
+    /// Feature: audio presence probing
+    /// Scenario: which failures are worth remembering
+    ///
+    /// Given the failures a probe can come back with
+    /// When each is classified
+    /// Then only FFprobe's verdicts on the content are final, so a policy that
+    /// is an allow-list cannot silently memoize a new phrasing of "could not
+    /// open this file".
+    #[test]
+    fn only_content_verdicts_are_treated_as_final() {
+        for message in [
+            "FFprobe failed: Invalid data found when processing input",
+            "FFprobe failed: moov atom not found",
+            // What a truncated MP4 really produces: the demuxer's line, then
+            // the verdict on the file. Either line on its own is enough.
+            "FFprobe failed: [mov,mp4,m4a,3gp,3g2,mj2 @ 0x1] moov atom not found\n\
+             C:\\clips\\subject.mp4: Invalid data found when processing input",
+        ] {
+            assert!(
+                probe_failure_is_final(&CoreError::FFprobeError(message.to_string())),
+                "`{message}` is a verdict on the bytes and must be remembered"
+            );
+        }
+
+        for message in [
+            "FFprobe failed: Permission denied",
+            "FFprobe failed: Input/output error",
+            "FFprobe failed: No such file or directory",
+            "FFprobe failed: Resource temporarily unavailable",
+            "FFprobe failed: Operation not permitted",
+            "FFprobe failed: Access is denied. (os error 5)",
+            // A path that reads like a verdict is still only a path: the
+            // diagnostic is what follows the last ": ".
+            "FFprobe failed: /clips/invalid data found/take1.mp4: Permission denied",
+            // Wordings that were guessed at rather than observed, and that
+            // FFprobe does not produce for a probe with no `-f`.
+            "FFprobe failed: Unknown format",
+            "FFprobe failed: subject.mp4: not a valid input file",
+            // The empty stderr `-v quiet` used to produce: nothing to classify,
+            // so nothing to memoize.
+            "FFprobe failed: ",
+        ] {
+            assert!(
+                !probe_failure_is_final(&CoreError::FFprobeError(message.to_string())),
+                "`{message}` is about this process, not these bytes"
+            );
+        }
+
+        assert!(
+            !probe_failure_is_final(&CoreError::FFprobeUnavailable(
+                "Failed to run ffprobe: program not found".to_string()
+            )),
+            "a probe that never ran is never final"
+        );
+    }
+}

--- a/src-tauri/src/core/render/export.rs
+++ b/src-tauri/src/core/render/export.rs
@@ -91,7 +91,17 @@ fn track_included_in_media_collection(track: &Track) -> bool {
     track.contributes_to_output()
 }
 
-pub(super) fn asset_has_playable_audio(
+/// Whether this asset carries audio the given track can play.
+///
+/// An audio asset always does. A video asset does when the probe found an audio
+/// stream; with no probe result the answer falls back to the *stored* asset
+/// metadata on a picture track, and to "assume yes" on an audio track, where the
+/// clip exists only because something put the sound there. Every other asset
+/// kind — images, text, adjustment layers — carries none.
+///
+/// Prefer [`crate::core::render::clip_carries_audio`], which also asks whether
+/// the same sound is already on the timeline as a detached companion.
+pub fn asset_has_playable_audio(
     asset: &Asset,
     track_kind: &TrackKind,
     audio_info: Option<&AssetAudioInfo>,
@@ -130,7 +140,13 @@ fn create_audio_companion_key(clip: &Clip) -> String {
     .join("|")
 }
 
-pub(super) fn collect_audio_companion_keys(
+/// Identifies the audio-track clips that already carry a video clip's own sound.
+///
+/// `DetachAudio` leaves the video clip in place and adds an audio-track clip
+/// over the same source range. The key is the pair's shared identity — asset,
+/// placement, source range, speed — so the video clip's embedded audio can be
+/// suppressed and the sound mixed exactly once.
+pub fn collect_audio_companion_keys(
     sequence: &Sequence,
     assets: &HashMap<String, Asset>,
     audio_info: &HashMap<String, AssetAudioInfo>,
@@ -162,7 +178,12 @@ pub(super) fn collect_audio_companion_keys(
     keys
 }
 
-pub(super) fn clip_audio_is_suppressed_by_companion(
+/// Whether this clip's embedded audio is already on the timeline separately.
+///
+/// True only for a video clip on a picture track whose detached companion — see
+/// [`collect_audio_companion_keys`] — is present, in which case mixing its
+/// embedded audio too would double the sound.
+pub fn clip_audio_is_suppressed_by_companion(
     clip: &Clip,
     track: &Track,
     asset: &Asset,
@@ -194,13 +215,13 @@ fn sequence_has_exportable_audio(
                     return false;
                 };
 
-                asset_has_playable_audio(asset, &track.kind, audio_info.get(&clip.asset_id))
-                    && !clip_audio_is_suppressed_by_companion(
-                        clip,
-                        track,
-                        asset,
-                        &audio_companion_keys,
-                    )
+                crate::core::render::clip_carries_audio(
+                    clip,
+                    track,
+                    asset,
+                    audio_info.get(&clip.asset_id),
+                    &audio_companion_keys,
+                )
             })
         })
 }
@@ -2283,6 +2304,35 @@ impl AssetAudioInfo {
                 .video_duration_sec
                 .filter(|duration| duration.is_finite() && *duration > 0.0)
                 .or(Some(media_info.duration_sec))
+                .filter(|duration| duration.is_finite() && *duration > 0.0),
+        }
+    }
+
+    /// Create from an FFprobe [`crate::core::assets::MediaMetadata`] result.
+    ///
+    /// The same measurement [`Self::from_media_info`] describes, from the probe
+    /// the asset pipeline runs. Every field comes from the probe: filling in only
+    /// `has_audio` and taking the rest from the stored metadata would give a
+    /// measured file the dimensions and length an extension-based import guessed,
+    /// which for such an import is nothing at all.
+    pub fn from_media_metadata(metadata: &crate::core::assets::MediaMetadata) -> Self {
+        Self {
+            has_audio: metadata.audio.is_some(),
+            source_dimensions: metadata
+                .video
+                .as_ref()
+                .map(|video| {
+                    crate::core::ffmpeg::display_dimensions(
+                        video.width,
+                        video.height,
+                        metadata.rotation_deg,
+                    )
+                })
+                .filter(|(width, height)| *width > 0 && *height > 0),
+            source_duration_sec: metadata
+                .video_duration_sec
+                .filter(|duration| duration.is_finite() && *duration > 0.0)
+                .or(Some(metadata.duration_sec))
                 .filter(|duration| duration.is_finite() && *duration > 0.0),
         }
     }
@@ -7896,19 +7946,33 @@ fn validate_caption_track_qc(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
+    // One warning per track, not one per pair. Overlapping cues are legal and
+    // ordinary — a held lyric under a whole song, a rolling VTT where each line
+    // is still up when the next arrives — and the import preserves them
+    // deliberately. A file like that produced one warning per neighbouring
+    // pair, which buried every other finding the export had to report.
+    let mut overlapping_pairs = 0usize;
+    let mut first_overlap: Option<(&str, &str)> = None;
     for pair in enabled_caption_clips.windows(2) {
         let previous = pair[0];
         let next = pair[1];
         if previous.place.overlaps(&next.place) {
-            validation.add_clip_warning(
-                sequence_id,
-                &next.id,
-                format!(
-                    "Caption clips '{}' and '{}' overlap on track '{}'",
-                    previous.id, next.id, track.name
-                ),
-            );
+            overlapping_pairs += 1;
+            if first_overlap.is_none() {
+                first_overlap = Some((previous.id.as_str(), next.id.as_str()));
+            }
         }
+    }
+
+    if let Some((first, second)) = first_overlap {
+        validation.add_clip_warning(
+            sequence_id,
+            second,
+            format!(
+                "{overlapping_pairs} overlapping caption pairs on track '{}'; first: {first}/{second}",
+                track.name
+            ),
+        );
     }
 }
 
@@ -10438,6 +10502,60 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("overlap")));
+    }
+
+    /// Feature: export validation of a caption track
+    /// Scenario: a subtitle file whose cues deliberately overlap
+    ///
+    /// Given four captions that each overlap the next
+    /// When the sequence is validated for export
+    /// Then one warning covers the whole track, carrying the number of
+    /// overlapping pairs and naming the first — a held lyric or a rolling VTT
+    /// otherwise produced a warning per pair and buried everything else.
+    #[test]
+    fn overlapping_captions_warn_once_for_the_whole_track() {
+        use crate::core::timeline::{Clip, SequenceFormat, Track};
+
+        let mut sequence = Sequence::new("Test", SequenceFormat::youtube_1080());
+        let mut caption_track = Track::new_caption("Captions");
+        for index in 0..4 {
+            let mut caption = Clip::new(&format!("caption_{index}"))
+                .with_source_range(0.0, 2.0)
+                .place_at(f64::from(index));
+            caption.id = format!("cap-{index}");
+            caption.label = Some(format!("Line {index}"));
+            caption_track.add_clip(caption);
+        }
+        sequence.add_track(caption_track);
+
+        let validation = validate_export_settings(
+            &sequence,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ExportSettings::default(),
+        );
+
+        let overlap_warnings = validation
+            .warnings
+            .iter()
+            .filter(|warning| warning.contains("overlapping caption pairs"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            overlap_warnings.len(),
+            1,
+            "one warning per track, not per pair: {:?}",
+            validation.warnings
+        );
+        assert!(
+            overlap_warnings[0].starts_with("3 overlapping caption pairs on track 'Captions'; "),
+            "{}",
+            overlap_warnings[0]
+        );
+        assert!(
+            overlap_warnings[0].contains("first: cap-0/cap-1"),
+            "{}",
+            overlap_warnings[0]
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/render/ffmpeg_plan.rs
+++ b/src-tauri/src/core/render/ffmpeg_plan.rs
@@ -18,14 +18,14 @@ use crate::core::{
 };
 
 use super::{
+    audio_presence::clip_carries_audio,
     export::{
         append_animated_video_transform_composition, append_ass_text_overlay,
         append_black_video_gap, append_drawtext_text_overlays, append_master_audio_output,
         append_timeline_video_output, append_video_stream_normalization,
         append_video_transform_composition, append_window_frame_cap, append_window_silence_audio,
-        append_windowed_output_duration_arg, apply_audio_mix_settings, asset_has_playable_audio,
-        build_audio_trim_filter, build_video_trim_filter, clip_audio_is_suppressed_by_companion,
-        clip_composition_is_motion_only, clip_needs_transform_composition,
+        append_windowed_output_duration_arg, apply_audio_mix_settings, build_audio_trim_filter,
+        build_video_trim_filter, clip_composition_is_motion_only, clip_needs_transform_composition,
         collect_audio_companion_keys, collect_drawtext_text_overlays, collect_enabled_clips_sorted,
         effective_source_dimensions, generated_text_visual_end_sec, hdr_metadata_for_asset,
         is_text_clip, output_video_dimensions, output_video_fps, output_video_pixel_format,
@@ -227,14 +227,13 @@ pub(super) fn build_sequence_ffmpeg_args(
         let validated_path = validate_local_input_path(&asset.uri, "Asset file")
             .map_err(ExportError::InvalidSettings)?;
 
-        let clip_has_audio =
-            asset_has_playable_audio(asset, &track.kind, ctx.audio_info.get(&clip.asset_id))
-                && !clip_audio_is_suppressed_by_companion(
-                    clip,
-                    track,
-                    asset,
-                    &audio_companion_keys,
-                );
+        let clip_has_audio = clip_carries_audio(
+            clip,
+            track,
+            asset,
+            ctx.audio_info.get(&clip.asset_id),
+            &audio_companion_keys,
+        );
 
         // Recorded before the window has any say, because the question it
         // answers is about the *sequence*: whether a full render of it would
@@ -827,14 +826,13 @@ pub(super) fn build_audio_only_ffmpeg_args(
             ExportError::InvalidSettings(format!("Asset not found: {}", clip.asset_id))
         })?;
 
-        let clip_has_audio =
-            asset_has_playable_audio(asset, &track.kind, ctx.audio_info.get(&clip.asset_id))
-                && !clip_audio_is_suppressed_by_companion(
-                    clip,
-                    track,
-                    asset,
-                    &audio_companion_keys,
-                );
+        let clip_has_audio = clip_carries_audio(
+            clip,
+            track,
+            asset,
+            ctx.audio_info.get(&clip.asset_id),
+            &audio_companion_keys,
+        );
 
         if !clip_has_audio {
             continue;

--- a/src-tauri/src/core/render/frame_probe/timeline.rs
+++ b/src-tauri/src/core/render/frame_probe/timeline.rs
@@ -28,13 +28,14 @@ use crate::core::ffmpeg::{FFmpegRunner, FrameExtractOptions};
 use crate::core::render::cache::transition_effect_reach_sec;
 use crate::core::render::export::effective_blend_mode_for_clip;
 use crate::core::render::{
-    build_render_graph, build_render_plan, clip_needs_transform_composition, clip_source_time_at,
-    is_text_clip, manifest_for_profile, preview_profile_hash, probed_image_dimensions,
-    profile_cache_dir, refresh_manifest_plan_fingerprints, resolve_cached_segment_path,
-    scaled_frame_dimensions, source_dimensions_from_audio_info, source_durations_from_audio_info,
-    track_included_in_export, validate_export_settings_with_dimensions, ExportEngine,
-    ExportSettings, ExportValidation, FrameExportSettings, ImageFormat, RenderCacheConfig,
-    RenderCacheManifest, RenderCacheSegment, RenderGraph, SourceDimensionMap,
+    build_render_graph_with_audio_info, build_render_plan, clip_needs_transform_composition,
+    clip_source_time_at, is_text_clip, manifest_for_profile, preview_profile_hash,
+    probed_image_dimensions, profile_cache_dir, refresh_manifest_plan_fingerprints,
+    resolve_cached_segment_path, scaled_frame_dimensions, source_dimensions_from_audio_info,
+    source_durations_from_audio_info, track_included_in_export,
+    validate_export_settings_with_dimensions, AssetAudioInfo, ExportEngine, ExportSettings,
+    ExportValidation, FrameExportSettings, ImageFormat, RenderCacheConfig, RenderCacheManifest,
+    RenderCacheSegment, RenderGraph, SourceDimensionMap,
 };
 use crate::core::timeline::{BlendMode, Canvas, Clip, Sequence, TrackKind};
 use serde::Serialize;
@@ -417,6 +418,15 @@ struct TimelineFrameContext<'a> {
     /// shared measurement a 4x4 contact sheet over five assets meant 160 FFprobe
     /// spawns instead of five.
     source_dimensions: SourceDimensionMap,
+    /// Audio presence measured once for the whole invocation.
+    ///
+    /// The render graph decides whether a clip contributes sound from this. An
+    /// A/V file imported without a probe stores no audio metadata, so building
+    /// the graph without these measurements would describe a silent render of a
+    /// sequence the export gives sound to - the same divergence the graph and
+    /// the export builders were unified to end. Empty until
+    /// [`Self::measure_sources`] has run, which every entry point does first.
+    audio_info: HashMap<String, AssetAudioInfo>,
     /// Export validation for this sequence, run once for the whole invocation.
     ///
     /// Nothing validation inspects changes between frames of the same sequence,
@@ -452,6 +462,7 @@ impl<'a> TimelineFrameContext<'a> {
             graph: None,
             cache: None,
             source_dimensions: SourceDimensionMap::new(),
+            audio_info: HashMap::new(),
             validation: None,
             per_frame_warnings: Vec::new(),
         }
@@ -482,6 +493,7 @@ impl<'a> TimelineFrameContext<'a> {
             .await;
         self.source_dimensions = source_dimensions_from_audio_info(&audio_info);
         let source_durations = source_durations_from_audio_info(&audio_info);
+        self.audio_info = audio_info;
 
         // Validated against the profile the stills are actually produced with —
         // the lossless preview-cache profile at the sequence canvas — and with
@@ -519,12 +531,21 @@ impl<'a> TimelineFrameContext<'a> {
     }
 
     /// Builds the sequence's render graph, reusing it across frames.
+    ///
+    /// Built from the audio presence [`Self::measure_sources`] measured, so a
+    /// still and a render of the same sequence describe the same clips as
+    /// audible. Reading the stored asset metadata instead would report an
+    /// unprobed A/V import as silent here and as audible there.
     fn graph(&mut self) -> FrameProbeResult<&RenderGraph> {
         if self.graph.is_none() {
-            let graph =
-                build_render_graph(self.project.state, self.sequence_id).map_err(|error| {
-                    FrameProbeError::new(format!("Failed to build render graph: {}", error))
-                })?;
+            let graph = build_render_graph_with_audio_info(
+                self.project.state,
+                self.sequence_id,
+                &self.audio_info,
+            )
+            .map_err(|error| {
+                FrameProbeError::new(format!("Failed to build render graph: {}", error))
+            })?;
             self.graph = Some(graph);
         }
 
@@ -1219,6 +1240,7 @@ mod tests {
     use super::*;
     use crate::core::assets::VideoInfo;
     use crate::core::effects::{EffectType, ParamValue};
+    use crate::core::project::ProjectState;
     use crate::core::timeline::{SequenceFormat, Track};
 
     fn segment(index: u32, start_sec: f64, end_sec: f64) -> RenderCacheSegment {
@@ -1606,5 +1628,112 @@ mod tests {
             .reasons(),
             vec!["canvas fit"]
         );
+    }
+
+    /// An FFmpeg runner that is never asked to run anything.
+    ///
+    /// The graph is pure arithmetic over the project state; only the extraction
+    /// that follows it touches a binary.
+    fn unused_runner() -> FFmpegRunner {
+        FFmpegRunner::new(crate::core::ffmpeg::FFmpegInfo {
+            ffmpeg_path: PathBuf::from("ffmpeg"),
+            ffprobe_path: PathBuf::from("ffprobe"),
+            version: "test".to_string(),
+            is_bundled: false,
+            source: crate::core::ffmpeg::FFmpegSource::System,
+        })
+    }
+
+    /// A sequence whose only clip is an A/V file nobody probed.
+    ///
+    /// This is what the CLI's `asset import` records: the kind comes from the
+    /// extension and the file is never opened, so `asset.audio` is `None` even
+    /// though the file has a soundtrack.
+    fn state_with_an_unprobed_av_clip() -> ProjectState {
+        let mut state = ProjectState::new("Frame Probe Graph Test");
+        state.sequences.clear();
+
+        let mut asset = Asset::new_video("talk", "talk.mp4", VideoInfo::default());
+        asset.id = "asset-av".to_string();
+        assert!(asset.audio.is_none(), "the import never opened the file");
+        state.assets.insert(asset.id.clone(), asset);
+
+        let mut clip = crate::core::timeline::Clip::new("asset-av");
+        clip.id = "clip-av".to_string();
+        clip.place = crate::core::timeline::ClipPlace::new(0.0, 4.0);
+        clip.range = crate::core::timeline::ClipRange::new(0.0, 4.0);
+
+        let mut sequence =
+            crate::core::timeline::Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+        let mut track = Track::new("Video 1", TrackKind::Video);
+        track.id = "video-track".to_string();
+        track.clips.push(clip);
+        sequence.tracks.push(track);
+
+        state.active_sequence_id = Some(sequence.id.clone());
+        state.sequences.insert(sequence.id.clone(), sequence);
+        state
+    }
+
+    /// Feature: stills describe the edit a render produces
+    /// Scenario: an A/V asset that was imported without a probe
+    ///
+    /// Given a sequence whose only clip is an unprobed A/V file
+    /// When the frame-probe context builds the graph it composites from
+    /// Then it is the same graph a render validates — audio layer and all —
+    /// rather than the silent one the stored asset metadata describes.
+    #[test]
+    fn the_frame_probe_graph_is_the_render_graph_for_an_unprobed_av_asset() {
+        let state = state_with_an_unprobed_av_clip();
+        let project = FrameProbeProject {
+            path: Path::new("."),
+            state: &state,
+        };
+        let sequence = state.sequences.get("seq-1").expect("sequence");
+
+        // What `measure_sources` stores after FFprobe has opened the file.
+        let mut measured = HashMap::new();
+        measured.insert(
+            "asset-av".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                source_dimensions: Some((1920, 1080)),
+                source_duration_sec: Some(4.0),
+            },
+        );
+
+        let runner = unused_runner();
+        let mut context = TimelineFrameContext::new(
+            &runner,
+            &project,
+            sequence,
+            "seq-1",
+            ImageFormat::Png,
+            1920,
+            TimelineMode::Composite,
+        );
+        context.audio_info = measured.clone();
+
+        let probed_graph =
+            crate::core::render::build_render_graph_with_audio_info(&state, "seq-1", &measured)
+                .expect("render graph");
+        assert_eq!(
+            context.graph().expect("frame probe graph"),
+            &probed_graph,
+            "a still and a render of one sequence must describe the same edit"
+        );
+        assert_eq!(
+            probed_graph.audio_layers.len(),
+            1,
+            "the clip's embedded audio is what the render carries"
+        );
+
+        // The measurement is what makes the difference: without it the same
+        // sequence reports silence, which is the graph this used to build.
+        assert!(crate::core::render::build_render_graph(&state, "seq-1")
+            .expect("render graph")
+            .audio_layers
+            .is_empty());
     }
 }

--- a/src-tauri/src/core/render/graph.rs
+++ b/src-tauri/src/core/render/graph.rs
@@ -4,10 +4,16 @@
 //! project state into deterministic audio and visual layer lists that a future
 //! GPU compositor, software reference renderer, or export renderer can share.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use specta::Type;
 
+use crate::core::render::{
+    audio_presence::clip_carries_audio,
+    export::{collect_audio_companion_keys, AssetAudioInfo},
+};
 use crate::core::{
     captions::{CAPTION_CUSTOM_DEFAULT_Y_PERCENT, CAPTION_DEFAULT_VERTICAL_MARGIN_PERCENT},
     commands::{get_text_data, is_text_clip},
@@ -406,7 +412,25 @@ impl TextRenderSpec {
 }
 
 /// Builds a renderer-agnostic graph for the sequence.
+///
+/// Audio presence is read from the assets' *stored* metadata. When the caller
+/// can afford one FFprobe per asset — the transcription mixdown, `render graph`
+/// — [`build_render_graph_with_audio_info`] measures it instead, which is the
+/// only way to see the audio of a file imported without a probe.
 pub fn build_render_graph(state: &ProjectState, sequence_id: &str) -> CoreResult<RenderGraph> {
+    build_render_graph_with_audio_info(state, sequence_id, &HashMap::new())
+}
+
+/// Builds the graph with measured audio-stream presence for the sequence's assets.
+///
+/// `audio_info` comes from [`crate::core::render::probe_sequence_audio_info`];
+/// assets missing from it fall back to their stored metadata, exactly as the
+/// export's argument builders do.
+pub fn build_render_graph_with_audio_info(
+    state: &ProjectState,
+    sequence_id: &str,
+    audio_info: &HashMap<String, AssetAudioInfo>,
+) -> CoreResult<RenderGraph> {
     let sequence = state
         .sequences
         .get(sequence_id)
@@ -415,9 +439,17 @@ pub fn build_render_graph(state: &ProjectState, sequence_id: &str) -> CoreResult
     let mut visual_layers = Vec::new();
     let mut audio_layers = Vec::new();
     let clock = TimelineClock::new(sequence.format.fps.clone());
+    let audio_companion_keys = collect_audio_companion_keys(sequence, &state.assets, audio_info);
 
     for (track_index, track) in sequence.tracks.iter().enumerate().rev() {
-        if track.muted || !track.visible {
+        // Picture and sound leave a track on different conditions: hiding a
+        // video track removes its picture but keeps its sound, which is what
+        // `Track::contributes_to_output` — the export's own filter — says.
+        // Deciding both here with one `!track.visible` would have the graph
+        // report silence for a render that still carries the audio.
+        let contributes_audio = track.contributes_to_output();
+        let contributes_picture = !track.muted && track.visible;
+        if !contributes_audio && !contributes_picture {
             continue;
         }
 
@@ -426,32 +458,57 @@ pub fn build_render_graph(state: &ProjectState, sequence_id: &str) -> CoreResult
                 continue;
             }
 
-            match track.kind {
-                TrackKind::Audio => {
-                    let timeline_in_frame =
-                        clock.seconds_to_nearest_frame(clip.place.timeline_in_sec);
-                    let timeline_out_frame =
-                        clock.seconds_to_nearest_frame(clip.place.timeline_out_sec());
-                    audio_layers.push(AudioRenderLayer {
-                        track_id: track.id.clone(),
-                        track_index,
-                        clip_id: clip.id.clone(),
-                        asset_id: clip.asset_id.clone(),
-                        timeline_in_sec: clip.place.timeline_in_sec,
-                        timeline_out_sec: clip.place.timeline_out_sec(),
-                        timeline_in_frame,
-                        timeline_out_frame,
-                        duration_frames: (timeline_out_frame - timeline_in_frame).max(0),
-                        source_in_sec: clip.range.source_in_sec,
-                        source_out_sec: clip.range.source_out_sec,
-                        source_in_frame: clock.seconds_to_nearest_frame(clip.range.source_in_sec),
-                        source_out_frame: clock.seconds_to_nearest_frame(clip.range.source_out_sec),
-                        speed: clip.speed,
-                        reverse: clip.reverse,
-                        audio: clip.audio.clone(),
-                        effects: clip.effects.clone(),
-                    });
+            // Every clip that reaches the output with sound gets an audio
+            // layer, whichever track it sits on. A single A/V file dropped on
+            // the video track — the shape every headless import produces — is
+            // the common case, and it used to produce no audio layer at all.
+            //
+            // A freeze frame holds one picture and plays nothing, and the
+            // audio-only argument builder skips it for that reason.
+            if contributes_audio && !clip.freeze_frame {
+                if let Some(asset) = state.assets.get(&clip.asset_id) {
+                    if clip_carries_audio(
+                        clip,
+                        track,
+                        asset,
+                        audio_info.get(&clip.asset_id),
+                        &audio_companion_keys,
+                    ) {
+                        let timeline_in_frame =
+                            clock.seconds_to_nearest_frame(clip.place.timeline_in_sec);
+                        let timeline_out_frame =
+                            clock.seconds_to_nearest_frame(clip.place.timeline_out_sec());
+                        audio_layers.push(AudioRenderLayer {
+                            track_id: track.id.clone(),
+                            track_index,
+                            clip_id: clip.id.clone(),
+                            asset_id: clip.asset_id.clone(),
+                            timeline_in_sec: clip.place.timeline_in_sec,
+                            timeline_out_sec: clip.place.timeline_out_sec(),
+                            timeline_in_frame,
+                            timeline_out_frame,
+                            duration_frames: (timeline_out_frame - timeline_in_frame).max(0),
+                            source_in_sec: clip.range.source_in_sec,
+                            source_out_sec: clip.range.source_out_sec,
+                            source_in_frame: clock
+                                .seconds_to_nearest_frame(clip.range.source_in_sec),
+                            source_out_frame: clock
+                                .seconds_to_nearest_frame(clip.range.source_out_sec),
+                            speed: clip.speed,
+                            reverse: clip.reverse,
+                            audio: clip.audio.clone(),
+                            effects: clip.effects.clone(),
+                        });
+                    }
                 }
+            }
+
+            if !contributes_picture {
+                continue;
+            }
+
+            match track.kind {
+                TrackKind::Audio => {}
                 TrackKind::Video | TrackKind::Overlay | TrackKind::Caption => {
                     let source = if let Some(compound_sequence_id) = &clip.compound_sequence_id {
                         VisualRenderSource::Compound {
@@ -793,6 +850,7 @@ fn normalize_caption_axis(value: f64, fallback: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::core::{
+        assets::{Asset, AudioInfo, VideoInfo},
         commands::TEXT_ASSET_PREFIX,
         effects::{Effect, EffectType, ParamValue},
         project::ProjectState,
@@ -810,6 +868,27 @@ mod tests {
     fn add_sequence(state: &mut ProjectState, sequence: Sequence) {
         state.active_sequence_id = Some(sequence.id.clone());
         state.sequences.insert(sequence.id.clone(), sequence);
+    }
+
+    /// Registers an audio-only asset under a known id.
+    ///
+    /// Audio presence is a property of the asset now, so a clip whose asset the
+    /// project never heard of contributes nothing — which is also what the
+    /// export's argument builders do with it (they fail on it outright).
+    fn add_audio_asset(state: &mut ProjectState, asset_id: &str) {
+        let mut asset = Asset::new_audio(asset_id, "audio.wav", AudioInfo::default());
+        asset.id = asset_id.to_string();
+        state.assets.insert(asset_id.to_string(), asset);
+    }
+
+    /// Registers a video asset under a known id, with or without an audio stream.
+    fn add_video_asset(state: &mut ProjectState, asset_id: &str, has_audio: bool) {
+        let mut asset = Asset::new_video(asset_id, "video.mp4", VideoInfo::default());
+        asset.id = asset_id.to_string();
+        if has_audio {
+            asset.audio = Some(AudioInfo::default());
+        }
+        state.assets.insert(asset_id.to_string(), asset);
     }
 
     #[test]
@@ -1004,6 +1083,7 @@ mod tests {
         sequence.tracks.push(video_track);
         sequence.tracks.push(audio_track);
         add_sequence(&mut state, sequence);
+        add_audio_asset(&mut state, "asset-audio");
 
         let graph = build_render_graph(&state, "seq-1").expect("render graph");
 
@@ -1014,6 +1094,146 @@ mod tests {
         assert_eq!(graph.audio_layers[0].timeline_in_frame, 60);
         assert_eq!(graph.audio_layers[0].timeline_out_frame, 180);
         assert_eq!(graph.audio_layers[0].duration_frames, 120);
+    }
+
+    #[test]
+    fn build_render_graph_emits_an_audio_layer_for_an_av_clip_on_a_video_track() {
+        // The shape every headless `timeline insert` of an A/V file produces.
+        // The export mixes its embedded audio, so the graph has to report it.
+        let mut state = ProjectState::new("Render Graph Test");
+        state.sequences.clear();
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+
+        let mut video_track = Track::new("Video 1", TrackKind::Video);
+        video_track.id = "video-track".to_string();
+        video_track
+            .clips
+            .push(clip_with_timing("av-clip", "asset-av", 0.0, 2.0));
+        sequence.tracks.push(video_track);
+        add_sequence(&mut state, sequence);
+        add_video_asset(&mut state, "asset-av", true);
+
+        let graph = build_render_graph(&state, "seq-1").expect("render graph");
+
+        assert_eq!(graph.visual_layers.len(), 1);
+        assert_eq!(graph.audio_layers.len(), 1);
+        assert_eq!(graph.audio_layers[0].clip_id, "av-clip");
+        assert_eq!(graph.audio_layers[0].track_id, "video-track");
+    }
+
+    #[test]
+    fn build_render_graph_omits_an_audio_layer_for_a_silent_video_clip() {
+        let mut state = ProjectState::new("Render Graph Test");
+        state.sequences.clear();
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+
+        let mut video_track = Track::new("Video 1", TrackKind::Video);
+        video_track.id = "video-track".to_string();
+        video_track
+            .clips
+            .push(clip_with_timing("silent-clip", "asset-silent", 0.0, 2.0));
+        sequence.tracks.push(video_track);
+        add_sequence(&mut state, sequence);
+        add_video_asset(&mut state, "asset-silent", false);
+
+        let graph = build_render_graph(&state, "seq-1").expect("render graph");
+
+        assert_eq!(graph.visual_layers.len(), 1);
+        assert!(graph.audio_layers.is_empty());
+    }
+
+    #[test]
+    fn build_render_graph_reads_measured_audio_presence_over_stored_metadata() {
+        // `asset import` records an mp4 from its extension without opening it,
+        // so the stored metadata says "no audio" for a file that has some. A
+        // caller that probes gets the truth; one that does not sees the guess.
+        let mut state = ProjectState::new("Render Graph Test");
+        state.sequences.clear();
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+
+        let mut video_track = Track::new("Video 1", TrackKind::Video);
+        video_track.id = "video-track".to_string();
+        video_track
+            .clips
+            .push(clip_with_timing("av-clip", "asset-unprobed", 0.0, 2.0));
+        sequence.tracks.push(video_track);
+        add_sequence(&mut state, sequence);
+        add_video_asset(&mut state, "asset-unprobed", false);
+
+        assert!(build_render_graph(&state, "seq-1")
+            .expect("render graph")
+            .audio_layers
+            .is_empty());
+
+        let mut audio_info = HashMap::new();
+        audio_info.insert(
+            "asset-unprobed".to_string(),
+            AssetAudioInfo {
+                has_audio: true,
+                ..AssetAudioInfo::from_asset(&state.assets["asset-unprobed"])
+            },
+        );
+        let graph =
+            build_render_graph_with_audio_info(&state, "seq-1", &audio_info).expect("render graph");
+
+        assert_eq!(graph.audio_layers.len(), 1);
+        assert_eq!(graph.audio_layers[0].clip_id, "av-clip");
+    }
+
+    #[test]
+    fn build_render_graph_keeps_a_hidden_video_track_audible() {
+        // `contributes_to_output` says a hidden video track still carries its
+        // sound. Deciding picture and sound together would have the graph
+        // report silence for a render that has audio.
+        let mut state = ProjectState::new("Render Graph Test");
+        state.sequences.clear();
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+
+        let mut video_track = Track::new("Video 1", TrackKind::Video);
+        video_track.id = "video-track".to_string();
+        video_track.visible = false;
+        video_track
+            .clips
+            .push(clip_with_timing("av-clip", "asset-av", 0.0, 2.0));
+        sequence.tracks.push(video_track);
+        add_sequence(&mut state, sequence);
+        add_video_asset(&mut state, "asset-av", true);
+
+        let graph = build_render_graph(&state, "seq-1").expect("render graph");
+
+        assert!(graph.visual_layers.is_empty());
+        assert_eq!(graph.audio_layers.len(), 1);
+    }
+
+    #[test]
+    fn build_render_graph_drops_the_audio_of_a_muted_track() {
+        let mut state = ProjectState::new("Render Graph Test");
+        state.sequences.clear();
+
+        let mut sequence = Sequence::new("Sequence", SequenceFormat::youtube_1080());
+        sequence.id = "seq-1".to_string();
+
+        let mut video_track = Track::new("Video 1", TrackKind::Video);
+        video_track.id = "video-track".to_string();
+        video_track.muted = true;
+        video_track
+            .clips
+            .push(clip_with_timing("av-clip", "asset-av", 0.0, 2.0));
+        sequence.tracks.push(video_track);
+        add_sequence(&mut state, sequence);
+        add_video_asset(&mut state, "asset-av", true);
+
+        let graph = build_render_graph(&state, "seq-1").expect("render graph");
+
+        assert!(graph.audio_layers.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/core/render/mod.rs
+++ b/src-tauri/src/core/render/mod.rs
@@ -7,6 +7,7 @@
 //! - `export`: Video export engine and settings
 //! - `hdr`: HDR workflow support (color spaces, tonemapping, metadata)
 
+pub mod audio_presence;
 pub mod cache;
 pub mod executor;
 pub(crate) mod export;
@@ -48,6 +49,13 @@ pub mod smart;
 mod transform_layout;
 pub(crate) mod transition_stitch;
 
+#[cfg(test)]
+pub(crate) use audio_presence::probe_counter_guard;
+pub use audio_presence::{
+    clear_negative_probes, clear_transient_probes, clip_carries_audio, probe_assets_audio_info,
+    probe_assets_audio_info_off_runtime, probe_sequence_audio_info, sequence_probe_targets,
+    SequenceAudioProbe,
+};
 pub use executor::{
     execute_ffmpeg_invocation, execute_ffmpeg_output, FfmpegExecutionResult, FfmpegOutput,
 };
@@ -57,7 +65,8 @@ pub use ffmpeg_graph::{
     FfmpegInvocationError,
 };
 pub use graph::{
-    build_render_graph, AudioRenderLayer, RenderGraph, VisualRenderLayer, VisualRenderSource,
+    build_render_graph, build_render_graph_with_audio_info, AudioRenderLayer, RenderGraph,
+    VisualRenderLayer, VisualRenderSource,
 };
 pub use hardware::{
     detect_available_decoders, detect_available_encoders, is_hardware_encoder,

--- a/src-tauri/src/core/render/plan.rs
+++ b/src-tauri/src/core/render/plan.rs
@@ -120,8 +120,19 @@ impl RenderPlanValidation {
         }
     }
 
+    /// Records one validation failure, once.
+    ///
+    /// A clip that is both a picture and a sound — an A/V file on a video track,
+    /// which is what every headless import produces — is built into a video
+    /// layer *and* an audio layer, and both walk the same clip's effect list. A
+    /// missing or unsupported effect on it therefore reached this twice, and the
+    /// report read as two problems where there is one. Identical messages
+    /// collapse; genuinely different ones do not.
     fn add_error(&mut self, error: impl Into<String>) {
-        self.errors.push(error.into());
+        let error = error.into();
+        if !self.errors.iter().any(|existing| existing == &error) {
+            self.errors.push(error);
+        }
         self.is_valid = false;
     }
 }
@@ -454,6 +465,37 @@ mod tests {
         assert_eq!(plan.video_layers[0].clip_id, "clip-1");
         assert_eq!(plan.video_layers[0].timeline_out_frame, 150);
         assert!(!plan.plan_hash.is_empty());
+    }
+
+    #[test]
+    fn render_plan_reports_one_clip_s_missing_effect_once() {
+        // An A/V clip on a video track becomes a video layer *and* an audio
+        // layer, and both walk the same effect list. The report has to describe
+        // one problem, not two.
+        let (mut state, mut assets) = graph_state();
+        let mut asset = video_asset("asset-1");
+        asset.audio = Some(crate::core::assets::AudioInfo::default());
+        assets.insert("asset-1".to_string(), asset.clone());
+        state.assets.insert("asset-1".to_string(), asset);
+        let sequence = state.sequences.get_mut("seq-1").expect("sequence");
+        sequence.tracks[0].clips[0]
+            .effects
+            .push("missing-effect".to_string());
+
+        let graph = build_render_graph(&state, "seq-1").expect("graph");
+        assert_eq!(graph.visual_layers.len(), 1);
+        assert_eq!(graph.audio_layers.len(), 1);
+
+        let plan = build_render_plan(&graph, &assets, &HashMap::new(), &ExportSettings::default());
+
+        assert!(!plan.validation.is_valid);
+        let mentions = plan
+            .validation
+            .errors
+            .iter()
+            .filter(|error| error.contains("missing-effect"))
+            .count();
+        assert_eq!(mentions, 1, "{:?}", plan.validation.errors);
     }
 
     #[test]

--- a/src-tauri/src/core/test_ffmpeg.rs
+++ b/src-tauri/src/core/test_ffmpeg.rs
@@ -96,6 +96,48 @@ pub(crate) fn require_or_skip_ffmpeg() -> Option<PathBuf> {
     }
 }
 
+/// An FFprobe binary that has been proven to launch, or `None` after recording a skip.
+///
+/// FFmpeg and FFprobe are separate binaries and are resolved separately: a test
+/// may hand the code under test an explicit FFmpeg while the FFprobe it reaches
+/// for comes from the app's own resolver. The transcription mixdown needs both —
+/// it measures audio presence with FFprobe — and without one it falls back to
+/// the stored asset metadata, reports the sequence as silent, and fails where it
+/// meant to skip.
+///
+/// Resolved exactly the way the code under test resolves it, so this cannot skip
+/// a test that would have run.
+///
+/// With `REQUIRE_FFMPEG_TESTS` set this panics instead of returning `None`, so
+/// the test cannot pass without having run.
+#[track_caller]
+pub(crate) fn require_or_skip_ffprobe() -> Option<PathBuf> {
+    let binary = crate::core::ffmpeg::resolved_ffprobe_path();
+
+    let mut cmd = std::process::Command::new(&binary);
+    crate::core::process::configure_std_command(&mut cmd);
+    let probe = cmd.args(["-hide_banner", "-version"]).output();
+
+    match probe {
+        Ok(output) if output.status.success() => Some(binary),
+        Ok(output) => {
+            skip_without_ffmpeg(&format!(
+                "`{} -version` exited with {}",
+                binary.display(),
+                output.status
+            ));
+            None
+        }
+        Err(error) => {
+            skip_without_ffmpeg(&format!(
+                "`{}` could not be launched: {error}",
+                binary.display()
+            ));
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/core/workspace/project_sync.rs
+++ b/src-tauri/src/core/workspace/project_sync.rs
@@ -95,6 +95,12 @@ pub fn apply_workspace_event_to_project(
                 }
             }
             // Auto-register any brand-new files
+            // Files the probe measured nothing about stay unregistered, and
+            // files it could not top up keep the metadata they already had;
+            // both are retried by the next pass, which sweeps the registered
+            // entries as well as the unregistered ones. The files that were
+            // registered still get their ops below. The pass logs those counts
+            // itself, so this caller does not repeat them.
             if let Err(e) = service.auto_register_discovered_files(&mut project.state, project_root)
             {
                 tracing::warn!(

--- a/src-tauri/src/core/workspace/project_sync.rs
+++ b/src-tauri/src/core/workspace/project_sync.rs
@@ -4,6 +4,14 @@
 //! them in the operation log, so a session that watched a folder change ends
 //! up with the same state a reopen would replay.
 //!
+//! One mutation is deliberately exempt: the metadata top-up
+//! [`WorkspaceService::auto_register_discovered_files`] performs on assets that
+//! already exist writes no op. It copies a probe of a file on disk into a cache
+//! of that same file, so a reopen re-derives it from the same bytes instead of
+//! replaying it. Recording those top-ups as ops as well is tracked separately;
+//! until then the invariant above holds for asset creation, removal and
+//! reconnection, not for measurements read back off the disk.
+//!
 //! Kept out of the IPC layer deliberately. The watcher loop calls this while
 //! holding the project lock, so nothing here may emit Tauri events or grant
 //! asset-protocol access — those belong to the caller, after the lock is

--- a/src-tauri/src/core/workspace/service.rs
+++ b/src-tauri/src/core/workspace/service.rs
@@ -6,7 +6,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
 
@@ -97,6 +97,25 @@ pub struct WorkspaceService {
     ignore_rules: Arc<IgnoreRules>,
     last_skipped_count: AtomicUsize,
     last_unrefreshed_count: AtomicUsize,
+    /// Workspace-relative paths whose metadata gap a *successful* probe left
+    /// open, and so no further probe of the same bytes can close.
+    ///
+    /// A container that carries no `format.duration` — a raw stream, a
+    /// zero-byte file — probes fine and still leaves `duration_sec` unset, so
+    /// [`workspace_asset_needs_metadata_refresh`] keeps saying yes forever.
+    /// Without this set the watcher would re-probe that file on every
+    /// filesystem event, with the project lock held. A path settles only after
+    /// a probe that returned `Ok` and changed nothing; a probe that measured
+    /// nothing never settles, because the next one may well succeed.
+    ///
+    /// The set lives on the service, and [`WorkspaceService::open`] runs per
+    /// IPC call, so a one-shot scan starts with an empty one and probes each
+    /// gap once. That is the intended reach: the repetition worth stopping is
+    /// the watcher loop, which holds a single service for the life of the
+    /// session. An entry is dropped again when the file itself changes (see
+    /// [`WorkspaceService::handle_event`]), because new bytes may finally
+    /// carry the measurement the old ones did not.
+    settled_metadata_gaps: Mutex<HashSet<String>>,
 }
 
 /// Builds the [`Asset`] a discovered workspace file should be registered as.
@@ -273,7 +292,20 @@ impl WorkspaceService {
             ignore_rules,
             last_skipped_count: AtomicUsize::new(0),
             last_unrefreshed_count: AtomicUsize::new(0),
+            settled_metadata_gaps: Mutex::new(HashSet::new()),
         })
+    }
+
+    /// The settled-gap set, with a poisoned lock recovered rather than
+    /// propagated.
+    ///
+    /// The set is a probe-cost cache, never a source of project state: a pass
+    /// that panicked mid-update can leave it stale at worst, which costs one
+    /// extra probe. Refusing the whole scan over that would be the larger harm.
+    fn settled_metadata_gaps(&self) -> std::sync::MutexGuard<'_, HashSet<String>> {
+        self.settled_metadata_gaps
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Perform an initial scan and populate the index
@@ -471,6 +503,9 @@ impl WorkspaceService {
                         indexed_at: now,
                         metadata_extracted: false,
                     };
+                    // The bytes changed, so a gap an earlier probe could not
+                    // close may now be measurable. Let the next pass try again.
+                    self.settled_metadata_gaps().remove(&entry.relative_path);
                     self.index.upsert(&entry)?;
                 }
             }
@@ -580,9 +615,16 @@ impl WorkspaceService {
         // missing would carry durationless assets until every file was touched
         // by hand.
         //
-        // The work is bounded twice over: files this pass already probed are
-        // skipped, and a probe only runs for an asset that still has a gap
-        // worth closing (see [`workspace_asset_needs_metadata_refresh`]).
+        // The work is bounded three times over: files this pass already probed
+        // are skipped, a probe only runs for an asset that still has a gap
+        // worth closing (see [`workspace_asset_needs_metadata_refresh`]), and a
+        // gap a successful probe already failed to close is not asked again
+        // (see [`Self::settled_metadata_gaps`]).
+        //
+        // The top-up writes to `state` without an op behind it, unlike the
+        // registrations above. That is deliberate: it copies what is on disk
+        // into a cache of what is on disk, so a reopen re-derives the same
+        // values from the same files rather than replaying them.
         let registered_entries = self.index.get_all_registered()?;
         for entry in &registered_entries {
             let Some(asset_id) = entry.asset_id.as_ref() else {
@@ -598,14 +640,26 @@ impl WorkspaceService {
                 if !workspace_asset_needs_metadata_refresh(existing_asset) {
                     continue;
                 }
-                // A top-up needs a file to measure. The project may already know
-                // this one is gone, or it may have been deleted since it was
-                // indexed with the removal not yet processed. Probing a path
-                // that is not there fails with an error this pass propagates,
-                // which would turn one deleted file into a failed scan of the
-                // whole workspace - and this pass sweeps every registered entry,
-                // not just the ones the scanner just saw on disk.
-                if existing_asset.missing || !abs_path.exists() {
+                // Checked before the filesystem is touched: a gap no probe can
+                // close is the common case here, and asking the disk about it
+                // every pass is the cost this set exists to remove.
+                if self.settled_metadata_gaps().contains(&entry.relative_path) {
+                    continue;
+                }
+                // A top-up needs a file to measure. It may have been deleted
+                // since it was indexed, with the removal not yet processed.
+                // Probing a path that is not there fails with an error this
+                // pass propagates, which would turn one deleted file into a
+                // failed scan of the whole workspace - and this pass sweeps
+                // every registered entry, not just the ones the scanner just
+                // saw on disk.
+                //
+                // Only the disk is asked. `Asset::missing` is this session's
+                // last word on the file, and it goes stale the moment the file
+                // comes back: a restored asset whose flag no watcher event has
+                // cleared yet would otherwise never get the top-up it is
+                // sitting here waiting for.
+                if !abs_path.exists() {
                     continue;
                 }
                 match refresh_existing_workspace_asset_metadata(
@@ -614,6 +668,14 @@ impl WorkspaceService {
                     &abs_path,
                     &extract,
                 ) {
+                    // A probe ran and the gap is still open, so the file simply
+                    // does not carry that measurement - a container with no
+                    // duration, say. Re-probing the same bytes would report the
+                    // same nothing, so stop asking until they change.
+                    Ok(()) if workspace_asset_needs_metadata_refresh(existing_asset) => {
+                        self.settled_metadata_gaps()
+                            .insert(entry.relative_path.clone());
+                    }
                     Ok(()) => {}
                     // The asset keeps the metadata it already has: it is real,
                     // and copying defaults over a measured codec or frame size
@@ -1233,6 +1295,181 @@ mod tests {
             .expect("a pass with nothing to do is not a failure");
 
         assert_eq!(second, AutoRegisterOutcome::default());
+    }
+
+    /// What FFprobe reports about a container that carries no duration of its
+    /// own: the streams are described, `format.duration` is simply absent.
+    fn undurated_metadata() -> crate::core::assets::MediaMetadata {
+        crate::core::assets::MediaMetadata {
+            duration_sec: 0.0,
+            video_duration_sec: None,
+            file_size: 1024,
+            video: Some(crate::core::assets::VideoInfo {
+                width: 1920,
+                height: 1080,
+                codec: "h264".to_string(),
+                ..Default::default()
+            }),
+            audio: None,
+            format: "h264".to_string(),
+            rotation_deg: 0.0,
+        }
+    }
+
+    /// A workspace holding one file, scanned and ready for a pass.
+    fn workspace_with_file(name: &str) -> (tempfile::TempDir, WorkspaceService) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("footage")).unwrap();
+        std::fs::write(dir.path().join("footage").join(name), "v").unwrap();
+
+        let service = WorkspaceService::open(dir.path().to_path_buf()).unwrap();
+        service.initial_scan().unwrap();
+        (dir, service)
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: a metadata gap no successful probe can ever close
+    ///
+    /// Given a file whose container reports no duration, so the probe succeeds
+    /// and the asset still has none
+    /// When pass after pass sweeps the registered entries
+    /// Then the file is probed once and then left alone. The gap check would
+    /// otherwise keep saying yes forever, and the watcher runs a pass per
+    /// filesystem event with the project lock held - so an unclosable gap
+    /// would spawn an FFprobe on every keystroke that touches the folder.
+    #[test]
+    fn a_gap_no_probe_can_close_is_measured_once_per_service() {
+        let (dir, service) = workspace_with_file("rawstream.mp4");
+        let probes = AtomicUsize::new(0);
+        let probe = |_: &std::path::Path| -> CoreResult<crate::core::assets::MediaMetadata> {
+            probes.fetch_add(1, Ordering::Relaxed);
+            Ok(undurated_metadata())
+        };
+
+        let mut state = ProjectState::new("Workspace Settled Gap Test");
+        let first = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), probe)
+            .expect("the file is measurable, it just has no duration to report");
+        assert_eq!(first.registered, 1);
+        assert_eq!(
+            probes.load(Ordering::Relaxed),
+            1,
+            "registering the file is one probe; the same pass must not measure it twice"
+        );
+        let asset_id = state.assets.keys().next().cloned().expect("one asset");
+        assert_eq!(
+            state.assets[&asset_id].duration_sec, None,
+            "the container reported no duration, so the asset has none"
+        );
+
+        service
+            .auto_register_discovered_files_with(&mut state, dir.path(), probe)
+            .expect("a pass over a registered file is not a failure");
+        assert_eq!(
+            probes.load(Ordering::Relaxed),
+            2,
+            "the first pass built the asset moments earlier; the retry is this one"
+        );
+
+        for _ in 0..3 {
+            service
+                .auto_register_discovered_files_with(&mut state, dir.path(), probe)
+                .expect("a pass with nothing left to measure is not a failure");
+        }
+        assert_eq!(
+            probes.load(Ordering::Relaxed),
+            2,
+            "a gap a successful probe left open is not re-measured"
+        );
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: the file whose gap was given up on is written to again
+    ///
+    /// Given a settled gap, no longer probed by any pass
+    /// When the watcher reports that the file changed
+    /// Then the next pass measures it again. New bytes may carry the duration
+    /// the old ones did not - a growing recording finalised by its camera, a
+    /// placeholder overwritten with the real take.
+    #[test]
+    fn a_modified_file_re_opens_a_settled_gap() {
+        let (dir, service) = workspace_with_file("rawstream.mp4");
+
+        let mut state = ProjectState::new("Workspace Re-Open Gap Test");
+        for _ in 0..2 {
+            service
+                .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                    Ok(undurated_metadata())
+                })
+                .expect("the file is measurable");
+        }
+        let asset_id = state.assets.keys().next().cloned().expect("one asset");
+        assert_eq!(state.assets[&asset_id].duration_sec, None);
+
+        std::fs::write(dir.path().join("footage/rawstream.mp4"), "vv").unwrap();
+        service
+            .handle_event(&WorkspaceEvent::FileModified(
+                "footage/rawstream.mp4".to_string(),
+            ))
+            .expect("an ordinary modification event");
+
+        service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| Ok(probed_metadata()))
+            .expect("the pass after the change is an ordinary one");
+
+        assert_eq!(
+            state.assets[&asset_id].duration_sec,
+            Some(12.0),
+            "the changed file is measured again, and this time it has a duration"
+        );
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: the top-up probe measured nothing, over and over
+    ///
+    /// Given a registered asset with a gap and a probe that keeps failing to
+    /// measure anything
+    /// When pass after pass reaches it
+    /// Then every pass tries again and reports it unrefreshed. Giving up is
+    /// only ever right when a probe *ran* and had nothing to add; a probe that
+    /// never measured says nothing about the file, and the FFmpeg it is
+    /// waiting on may finish installing at any moment.
+    #[test]
+    fn a_probe_that_measured_nothing_never_settles_the_gap() {
+        let (dir, service) = workspace_with_file("rawstream.mp4");
+
+        let mut state = ProjectState::new("Workspace Unsettled Gap Test");
+        service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                Ok(undurated_metadata())
+            })
+            .expect("the file is registered from what the probe did report");
+        let asset_id = state.assets.keys().next().cloned().expect("one asset");
+
+        for pass in 0..3 {
+            let outcome = service
+                .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                    Err(CoreError::FFprobeUnavailable(
+                        "Failed to run ffprobe: program not found".to_string(),
+                    ))
+                })
+                .expect("a probe that measured nothing is not a scan failure");
+            assert_eq!(
+                outcome.unrefreshed.len(),
+                1,
+                "pass {pass} must still be trying: {:?}",
+                outcome.unrefreshed
+            );
+        }
+
+        service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| Ok(probed_metadata()))
+            .expect("the pass that finally has an FFprobe is an ordinary one");
+        assert_eq!(
+            state.assets[&asset_id].duration_sec,
+            Some(12.0),
+            "the gap the failing probes deferred is closed once one works"
+        );
     }
 
     fn create_test_project(dir: &std::path::Path) {

--- a/src-tauri/src/core/workspace/service.rs
+++ b/src-tauri/src/core/workspace/service.rs
@@ -3,12 +3,14 @@
 //! Coordinates scanning, indexing, and watching for the project workspace.
 //! This is the main entry point for workspace operations.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
-use crate::core::assets::{Asset, AssetKind, MetadataExtractor};
+use crate::core::assets::{probe_measured_nothing, Asset, AssetKind, MetadataExtractor};
 use crate::core::project::ProjectState;
 use crate::core::CoreResult;
 
@@ -28,6 +30,37 @@ pub struct ScanResult {
     pub removed_files: usize,
     /// Number of files already registered as assets
     pub registered_files: usize,
+}
+
+/// What one auto-registration pass over the workspace index did.
+///
+/// A pass is not all-or-nothing: it mutates `ProjectState` file by file, and the
+/// caller turns those mutations into ops afterwards. Propagating the first file
+/// FFprobe could not be launched for would abandon that pass mid-way, leaving
+/// the assets it had already inserted in state with no op behind them — a
+/// project that diverges from its own log. So the pass carries its refusals out
+/// instead of throwing them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AutoRegisterOutcome {
+    /// Number of workspace files registered as assets during this pass.
+    pub registered: usize,
+    /// Workspace-relative paths left for a later pass because the probe
+    /// measured nothing about them. They stay unregistered in the index, so the
+    /// next scan — after FFmpeg finishes installing, say — picks them up again.
+    pub skipped: Vec<String>,
+    /// Workspace-relative paths that were linked to an asset that already
+    /// existed, but whose missing metadata could not be filled in because the
+    /// probe measured nothing.
+    ///
+    /// Separate from [`Self::skipped`] because nothing was refused: the asset
+    /// is real, carries the metadata it was imported with, and is registered in
+    /// the index. Only the top-up did not happen.
+    ///
+    /// Being registered is exactly why the retry needs its own pass: the
+    /// unregistered loop never looks at these files again, so the second pass
+    /// over already-registered entries is what fills the gaps once a probe can
+    /// run.
+    pub unrefreshed: Vec<String>,
 }
 
 /// An entry in the file tree hierarchy
@@ -62,16 +95,55 @@ pub struct WorkspaceService {
     event_tx: mpsc::Sender<WorkspaceEvent>,
     event_rx: Option<mpsc::Receiver<WorkspaceEvent>>,
     ignore_rules: Arc<IgnoreRules>,
+    last_skipped_count: AtomicUsize,
+    last_unrefreshed_count: AtomicUsize,
 }
 
-fn build_workspace_asset(entry: &IndexEntry, absolute_path: &std::path::Path) -> Asset {
+/// Builds the [`Asset`] a discovered workspace file should be registered as.
+///
+/// Fails when the probe measured nothing - FFprobe could not be started, or it
+/// ran and produced output nothing could be read from (see
+/// [`probe_measured_nothing`]) - and only then. Every default below - a
+/// zero-valued `VideoInfo`,
+/// `1920x1080` for an image, an absent duration - is a statement about a file
+/// FFprobe *looked at* and could not describe. When no probe ran, the same
+/// defaults are pure invention, and the GUI's own import path (the workspace
+/// scan that auto-registers what it finds) would silently fill a project with
+/// assets carrying a made-up frame size and no duration. The scan refuses
+/// instead, the same way `import_asset` refuses a hand-picked file. Verdicts
+/// FFprobe reached about the file itself keep the defaults: something did look,
+/// and a workspace scan should not be stopped by one unreadable file.
+/// The measurement is supplied rather than taken here. That seam is what lets a
+/// test produce one specific failure - FFprobe missing versus FFprobe rejecting
+/// the file - without installing or removing binaries. The alternative is
+/// registering a bogus FFprobe path, which is process-global and would reach
+/// every other test running beside this one.
+fn build_workspace_asset_with<F>(
+    entry: &IndexEntry,
+    absolute_path: &std::path::Path,
+    extract: F,
+) -> CoreResult<Asset>
+where
+    F: FnOnce(&std::path::Path) -> CoreResult<crate::core::assets::MediaMetadata>,
+{
     let uri = absolute_path.to_string_lossy().to_string();
     let name = entry
         .relative_path
         .rsplit('/')
         .next()
         .unwrap_or(&entry.relative_path);
-    let extracted_metadata = MetadataExtractor::extract(absolute_path).ok();
+    let extracted_metadata = match extract(absolute_path) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if probe_measured_nothing(&error) => return Err(error),
+        Err(error) => {
+            tracing::warn!(
+                path = %entry.relative_path,
+                "Registering workspace file without probed metadata: {}",
+                error
+            );
+            None
+        }
+    };
 
     let resolved_file_size = extracted_metadata
         .as_ref()
@@ -119,28 +191,49 @@ fn build_workspace_asset(entry: &IndexEntry, absolute_path: &std::path::Path) ->
         }
     }
 
-    asset.with_file_size(resolved_file_size)
+    Ok(asset.with_file_size(resolved_file_size))
 }
 
-fn refresh_existing_workspace_asset_metadata(
+/// Whether a probe could still fill something in on an already-built asset.
+///
+/// Asked before every top-up, so it decides how much probing a pass over the
+/// whole workspace costs. Only gaps a probe can actually close count: a still
+/// has no duration to measure, and treating its absence as a gap would make
+/// every image in the workspace look unmeasured forever, so every pass would
+/// re-probe every image. A codec is likewise only expected where a video stream
+/// is.
+fn workspace_asset_needs_metadata_refresh(asset: &Asset) -> bool {
+    let duration_missing = !matches!(asset.kind, AssetKind::Image) && asset.duration_sec.is_none();
+    let video_codec_missing = matches!(asset.kind, AssetKind::Video)
+        && asset
+            .video
+            .as_ref()
+            .map(|video| video.codec.trim().is_empty())
+            .unwrap_or(true);
+
+    duration_missing || asset.file_size == 0 || video_codec_missing
+}
+
+/// Fills in what an already-registered asset is missing, from a fresh probe.
+///
+/// Propagates a probe that measured nothing for the reason
+/// [`build_workspace_asset_with`] does: with no measurement, the "refreshed"
+/// asset is all defaults, and copying those over a real codec or frame size is
+/// worse than leaving the gaps alone.
+fn refresh_existing_workspace_asset_metadata<F>(
     asset: &mut Asset,
     entry: &IndexEntry,
     absolute_path: &std::path::Path,
-) {
-    let needs_refresh = asset.duration_sec.is_none()
-        || asset.file_size == 0
-        || (matches!(asset.kind, AssetKind::Video)
-            && asset
-                .video
-                .as_ref()
-                .map(|video| video.codec.trim().is_empty())
-                .unwrap_or(true));
-
-    if !needs_refresh {
-        return;
+    extract: F,
+) -> CoreResult<()>
+where
+    F: FnOnce(&std::path::Path) -> CoreResult<crate::core::assets::MediaMetadata>,
+{
+    if !workspace_asset_needs_metadata_refresh(asset) {
+        return Ok(());
     }
 
-    let refreshed = build_workspace_asset(entry, absolute_path);
+    let refreshed = build_workspace_asset_with(entry, absolute_path, extract)?;
     asset.duration_sec = asset.duration_sec.or(refreshed.duration_sec);
     if refreshed.file_size > 0 {
         asset.file_size = refreshed.file_size;
@@ -157,6 +250,8 @@ fn refresh_existing_workspace_asset_metadata(
     if asset.audio.is_none() {
         asset.audio = refreshed.audio;
     }
+
+    Ok(())
 }
 
 impl WorkspaceService {
@@ -176,6 +271,8 @@ impl WorkspaceService {
             event_tx,
             event_rx: Some(event_rx),
             ignore_rules,
+            last_skipped_count: AtomicUsize::new(0),
+            last_unrefreshed_count: AtomicUsize::new(0),
         })
     }
 
@@ -389,40 +486,71 @@ impl WorkspaceService {
 
     /// Auto-register all discovered files that don't yet have an asset_id.
     /// Creates Asset entries in ProjectState and links them in the index.
+    ///
+    /// A file the probe measured nothing about is reported in
+    /// [`AutoRegisterOutcome::skipped`] and the pass carries on with the rest;
+    /// see that type for why one such probe must not abort the pass.
     pub fn auto_register_discovered_files(
         &self,
         state: &mut ProjectState,
         project_root: &std::path::Path,
-    ) -> CoreResult<usize> {
+    ) -> CoreResult<AutoRegisterOutcome> {
+        self.auto_register_discovered_files_with(state, project_root, |path| {
+            MetadataExtractor::extract(path)
+        })
+    }
+
+    /// [`Self::auto_register_discovered_files`], with the measurement supplied.
+    ///
+    /// The seam exists for the same reason [`build_workspace_asset_with`]'s
+    /// does: a test needs one file's probe to fail without touching the
+    /// process-global FFmpeg resolution every other test shares.
+    fn auto_register_discovered_files_with<F>(
+        &self,
+        state: &mut ProjectState,
+        project_root: &std::path::Path,
+        extract: F,
+    ) -> CoreResult<AutoRegisterOutcome>
+    where
+        F: Fn(&std::path::Path) -> CoreResult<crate::core::assets::MediaMetadata>,
+    {
         let unregistered = self.index.get_unregistered()?;
-        let mut registered_count = 0;
+        let mut outcome = AutoRegisterOutcome::default();
+
+        // Files this pass has already probed. The second pass below must not
+        // measure them again: they were built moments ago, from the freshest
+        // probe there is.
+        let mut probed_in_this_pass: HashSet<String> = HashSet::new();
 
         for entry in &unregistered {
-            // Check if there's already an asset with this relative_path
-            let already_exists = state
+            // An asset for this path may already be in the project - imported
+            // by hand before the scan reached the file. Link it and leave its
+            // metadata alone. The link is made even when the asset still has
+            // gaps: refusing it would leave a real asset unlinked from the file
+            // it points at, so the explorer would show that file as
+            // unregistered and offer to import a second copy of it. Whatever is
+            // missing is filled by the pass over registered entries below, so
+            // one place tops an asset up rather than two.
+            let existing_asset_id = state
                 .assets
                 .values()
-                .any(|a| a.relative_path.as_deref() == Some(&entry.relative_path));
-            if already_exists {
-                // Link existing asset to the index entry
-                if let Some(asset) = state
-                    .assets
-                    .values()
-                    .find(|a| a.relative_path.as_deref() == Some(&entry.relative_path))
-                {
-                    let asset_id = asset.id.clone();
-                    if let Some(existing_asset) = state.assets.get_mut(&asset_id) {
-                        let abs_path = project_root.join(&entry.relative_path);
-                        refresh_existing_workspace_asset_metadata(existing_asset, entry, &abs_path);
-                    }
-                    self.index
-                        .mark_registered(&entry.relative_path, &asset_id)?;
-                }
+                .find(|asset| asset.relative_path.as_deref() == Some(&entry.relative_path))
+                .map(|asset| asset.id.clone());
+            if let Some(asset_id) = existing_asset_id {
+                self.index
+                    .mark_registered(&entry.relative_path, &asset_id)?;
                 continue;
             }
 
             let abs_path = project_root.join(&entry.relative_path);
-            let asset = build_workspace_asset(entry, &abs_path);
+            let asset = match build_workspace_asset_with(entry, &abs_path, &extract) {
+                Ok(asset) => asset,
+                Err(error) if probe_measured_nothing(&error) => {
+                    skip_unmeasurable(&mut outcome, entry);
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
 
             let asset = asset
                 .with_relative_path(&entry.relative_path)
@@ -433,41 +561,158 @@ impl WorkspaceService {
             state.assets.insert(asset_id.clone(), asset);
             self.index
                 .mark_registered(&entry.relative_path, &asset_id)?;
-            registered_count += 1;
+            probed_in_this_pass.insert(entry.relative_path.clone());
+            outcome.registered += 1;
         }
 
-        // Also handle stale entries: asset_id in index but not in state.assets.
-        // Reuse the SAME asset_id so clips referencing it remain valid.
+        // Second pass, over what the index already calls registered. Two kinds
+        // of entry need it.
+        //
+        // A stale entry names an asset id `state` no longer has; it is rebuilt
+        // under that same id so clips referencing it remain valid.
+        //
+        // A live entry names an asset `state` does have, which may still be
+        // missing the metadata an earlier pass could not measure.
+        // `mark_registered` has already run for it, so the loop above - which
+        // only sees unregistered entries - will never look at it again. Without
+        // this pass the retry [`AutoRegisterOutcome::unrefreshed`] promises
+        // would never happen, and a project opened once while FFmpeg was
+        // missing would carry durationless assets until every file was touched
+        // by hand.
+        //
+        // The work is bounded twice over: files this pass already probed are
+        // skipped, and a probe only runs for an asset that still has a gap
+        // worth closing (see [`workspace_asset_needs_metadata_refresh`]).
         let registered_entries = self.index.get_all_registered()?;
         for entry in &registered_entries {
-            if let Some(ref asset_id) = entry.asset_id {
-                if !state.assets.contains_key(asset_id) {
-                    let abs_path = project_root.join(&entry.relative_path);
-                    let mut asset = build_workspace_asset(entry, &abs_path);
-
-                    // Preserve the original asset_id from the index
-                    asset.id = asset_id.clone();
-
-                    let asset = asset
-                        .with_relative_path(&entry.relative_path)
-                        .as_workspace_managed()
-                        .with_file_size(entry.file_size);
-
-                    state.assets.insert(asset_id.clone(), asset);
-                    registered_count += 1;
-                }
+            let Some(asset_id) = entry.asset_id.as_ref() else {
+                continue;
+            };
+            if probed_in_this_pass.contains(&entry.relative_path) {
+                continue;
             }
+
+            let abs_path = project_root.join(&entry.relative_path);
+
+            if let Some(existing_asset) = state.assets.get_mut(asset_id) {
+                if !workspace_asset_needs_metadata_refresh(existing_asset) {
+                    continue;
+                }
+                // A top-up needs a file to measure. The project may already know
+                // this one is gone, or it may have been deleted since it was
+                // indexed with the removal not yet processed. Probing a path
+                // that is not there fails with an error this pass propagates,
+                // which would turn one deleted file into a failed scan of the
+                // whole workspace - and this pass sweeps every registered entry,
+                // not just the ones the scanner just saw on disk.
+                if existing_asset.missing || !abs_path.exists() {
+                    continue;
+                }
+                match refresh_existing_workspace_asset_metadata(
+                    existing_asset,
+                    entry,
+                    &abs_path,
+                    &extract,
+                ) {
+                    Ok(()) => {}
+                    // The asset keeps the metadata it already has: it is real,
+                    // and copying defaults over a measured codec or frame size
+                    // is worse than leaving the gaps for the pass after this
+                    // one.
+                    Err(error) if probe_measured_nothing(&error) => {
+                        record_unrefreshed(&mut outcome, entry);
+                    }
+                    Err(error) => return Err(error),
+                }
+                continue;
+            }
+
+            let mut asset = match build_workspace_asset_with(entry, &abs_path, &extract) {
+                Ok(asset) => asset,
+                Err(error) if probe_measured_nothing(&error) => {
+                    skip_unmeasurable(&mut outcome, entry);
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+
+            // Preserve the original asset_id from the index
+            asset.id = asset_id.clone();
+
+            let asset = asset
+                .with_relative_path(&entry.relative_path)
+                .as_workspace_managed()
+                .with_file_size(entry.file_size);
+
+            state.assets.insert(asset_id.clone(), asset);
+            outcome.registered += 1;
         }
 
-        if registered_count > 0 {
+        if outcome.registered > 0 {
             tracing::info!(
-                count = registered_count,
+                count = outcome.registered,
                 "Auto-registered workspace files as assets"
             );
         }
+        log_unmeasured_aggregate(
+            &self.last_skipped_count,
+            outcome.skipped.len(),
+            "Left workspace files unregistered: the probe measured nothing about them",
+        );
+        log_unmeasured_aggregate(
+            &self.last_unrefreshed_count,
+            outcome.unrefreshed.len(),
+            "Linked workspace files without their missing metadata: the probe measured nothing about them",
+        );
 
-        Ok(registered_count)
+        Ok(outcome)
     }
+}
+
+/// Logs one pass-level count, loudly only when it is news.
+///
+/// The watcher runs a pass per filesystem event, so a workspace opened before
+/// FFmpeg finished installing would repeat the same warning for every file that
+/// lands, drowning out the one line that matters. A count that has not moved
+/// since the previous pass says nothing new and drops to `debug!`; the first
+/// pass to reach a count still warns, and so does the next pass that reaches a
+/// different one. A count of zero is not logged at all, but is still recorded,
+/// so a workspace that recovers and then regresses warns again.
+fn log_unmeasured_aggregate(previous: &AtomicUsize, count: usize, message: &'static str) {
+    let unchanged = previous.swap(count, Ordering::Relaxed) == count;
+    if count == 0 {
+        return;
+    }
+
+    if unchanged {
+        tracing::debug!(count, "{}", message);
+    } else {
+        tracing::warn!(count, "{}", message);
+    }
+}
+
+/// Records one file the pass could not measure, and says so in the log.
+///
+/// Per-file at `debug!`: a scan of a workspace opened before FFmpeg finished
+/// installing reaches every file at once, and one `warn!` each buries the
+/// aggregate the caller actually acts on. The pass logs that count once.
+fn skip_unmeasurable(outcome: &mut AutoRegisterOutcome, entry: &IndexEntry) {
+    tracing::debug!(
+        path = %entry.relative_path,
+        "Skipping workspace file: the probe measured nothing about it"
+    );
+    outcome.skipped.push(entry.relative_path.clone());
+}
+
+/// Records one already-registered file whose metadata gaps stayed unfilled.
+///
+/// At `debug!` for the reason [`skip_unmeasurable`] is.
+fn record_unrefreshed(outcome: &mut AutoRegisterOutcome, entry: &IndexEntry) {
+    tracing::debug!(
+        path = %entry.relative_path,
+        "Linked workspace file without refreshing its metadata: the probe measured nothing about it"
+    );
+    outcome.unrefreshed.push(entry.relative_path.clone());
 }
 
 /// Build a hierarchical file tree from flat index entries
@@ -573,6 +818,422 @@ fn get_direct_child_dir(prefix: &str, full_path: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::core::assets::{AssetKind, AudioInfo};
+    use crate::core::CoreError;
+
+    /// An index entry for a file the scanner claims to have found.
+    fn index_entry(relative_path: &str, kind: AssetKind) -> IndexEntry {
+        IndexEntry {
+            relative_path: relative_path.to_string(),
+            kind,
+            file_size: 1024,
+            modified_at: 0,
+            asset_id: None,
+            indexed_at: 0,
+            metadata_extracted: false,
+        }
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: FFprobe cannot be started while the workspace is scanned
+    ///
+    /// Given a workspace file and an FFprobe that cannot be launched
+    /// When the scan builds the asset it would register
+    /// Then it refuses instead of registering one, because the frame size,
+    /// duration and codec it would otherwise attach were never measured - this
+    /// is the GUI's own import path, and it must not fill a project with
+    /// invented 1920x1080 stills and durationless clips.
+    #[test]
+    fn a_workspace_file_is_not_registered_when_ffprobe_cannot_be_launched() {
+        for kind in [AssetKind::Video, AssetKind::Image, AssetKind::Audio] {
+            let entry = index_entry("footage/subject.mp4", kind.clone());
+            let built = build_workspace_asset_with(
+                &entry,
+                std::path::Path::new("/workspace/footage/subject.mp4"),
+                |_| {
+                    Err(CoreError::FFprobeUnavailable(
+                        "Failed to run ffprobe: program not found".to_string(),
+                    ))
+                },
+            );
+
+            assert!(
+                matches!(built, Err(CoreError::FFprobeUnavailable(_))),
+                "a {kind:?} asset must not be invented when no probe ran"
+            );
+        }
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: FFprobe ran and could not describe the file
+    ///
+    /// Given a workspace file FFprobe looked at and refused
+    /// When the scan builds the asset it would register
+    /// Then the asset is still built from the index entry and the defaults,
+    /// because something did look: one unreadable file must not stop a scan.
+    #[test]
+    fn a_file_ffprobe_refused_is_still_registered_from_the_index_entry() {
+        let entry = index_entry("footage/broken.mp4", AssetKind::Video);
+        let built = build_workspace_asset_with(
+            &entry,
+            std::path::Path::new("/workspace/footage/broken.mp4"),
+            |_| {
+                Err(CoreError::FFprobeError(
+                    "FFprobe failed: Invalid data found when processing input".to_string(),
+                ))
+            },
+        );
+
+        let asset = built.expect("a verdict about the file is not a reason to refuse the scan");
+        assert_eq!(asset.name, "broken.mp4");
+        assert_eq!(asset.file_size, entry.file_size);
+        assert_eq!(asset.duration_sec, None);
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: FFprobe runs and returns output nothing can be read from
+    ///
+    /// Given a workspace file whose probe exits without a measurement
+    /// When the scan builds the asset it would register
+    /// Then it refuses, exactly as it does when no probe could be launched:
+    /// output that cannot be read is not a verdict about the file, so the
+    /// frame size and duration the defaults would supply are still invented.
+    #[test]
+    fn a_workspace_file_is_not_registered_when_the_probe_measured_nothing() {
+        let entry = index_entry("footage/subject.mp4", AssetKind::Video);
+        let built = build_workspace_asset_with(
+            &entry,
+            std::path::Path::new("/workspace/footage/subject.mp4"),
+            |_| {
+                Err(CoreError::FFprobeError(format!(
+                    "{}: failed to parse ffprobe output: EOF while parsing a value",
+                    crate::core::assets::PROBE_MEASURED_NOTHING_PREFIX
+                )))
+            },
+        );
+
+        assert!(
+            built.is_err(),
+            "an asset must not be invented from a probe that measured nothing"
+        );
+    }
+
+    /// What a successful probe of a short clip reports.
+    fn probed_metadata() -> crate::core::assets::MediaMetadata {
+        crate::core::assets::MediaMetadata {
+            duration_sec: 12.0,
+            video_duration_sec: Some(12.0),
+            file_size: 1024,
+            video: Some(crate::core::assets::VideoInfo::default()),
+            audio: None,
+            format: "mov,mp4,m4a,3gp,3g2,mj2".to_string(),
+            rotation_deg: 0.0,
+        }
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: FFprobe cannot be launched for one file of several
+    ///
+    /// Given two workspace files, one of which no FFprobe can be started for
+    /// When the scan auto-registers what it found
+    /// Then the measurable file is registered and the other is reported as
+    /// skipped - abandoning the pass at the first refusal would leave the
+    /// assets already inserted in the project state with no op behind them.
+    #[test]
+    fn one_unlaunchable_probe_does_not_abandon_the_rest_of_the_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("footage")).unwrap();
+        std::fs::write(dir.path().join("footage/measurable.mp4"), "v").unwrap();
+        std::fs::write(dir.path().join("footage/unreachable.mp4"), "v").unwrap();
+
+        let service = WorkspaceService::open(dir.path().to_path_buf()).unwrap();
+        service.initial_scan().unwrap();
+
+        let mut state = ProjectState::new("Workspace Skip Test");
+        let outcome = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |path| {
+                if path.ends_with("unreachable.mp4") {
+                    return Err(CoreError::FFprobeUnavailable(
+                        "Failed to run ffprobe: program not found".to_string(),
+                    ));
+                }
+                Ok(probed_metadata())
+            })
+            .expect("a probe that could not be launched is not a scan failure");
+
+        assert_eq!(outcome.registered, 1);
+        assert_eq!(outcome.skipped.len(), 1);
+        assert!(
+            outcome.skipped[0].ends_with("unreachable.mp4"),
+            "the unmeasurable file is the one reported: {:?}",
+            outcome.skipped
+        );
+        assert_eq!(state.assets.len(), 1);
+        assert!(
+            state
+                .assets
+                .values()
+                .any(|asset| asset.name == "measurable.mp4"),
+            "the file FFprobe did measure is still registered"
+        );
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: the file already has an asset, and the top-up probe fails
+    ///
+    /// Given a project whose asset for a workspace file is missing a duration
+    /// And a probe that measures nothing when asked to fill that gap
+    /// When the scan links the file to that existing asset
+    /// Then the link is still made and the asset keeps the metadata it was
+    /// imported with, because the asset is real: refusing the link would leave
+    /// the explorer showing an already-imported file as unregistered. The file
+    /// is reported as unrefreshed, not skipped - nothing was refused.
+    #[test]
+    fn an_existing_asset_is_still_linked_when_the_top_up_probe_measures_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("footage")).unwrap();
+        std::fs::write(dir.path().join("footage/known.mp4"), "v").unwrap();
+
+        let service = WorkspaceService::open(dir.path().to_path_buf()).unwrap();
+        service.initial_scan().unwrap();
+
+        let mut state = ProjectState::new("Workspace Relink Test");
+        let video = crate::core::assets::VideoInfo {
+            codec: "h264".to_string(),
+            ..Default::default()
+        };
+        let existing = Asset::new_video(
+            "known.mp4",
+            &dir.path().join("footage/known.mp4").to_string_lossy(),
+            video,
+        )
+        .with_relative_path("footage/known.mp4")
+        .as_workspace_managed()
+        .with_file_size(4096);
+        let existing_id = existing.id.clone();
+        state.assets.insert(existing_id.clone(), existing);
+
+        let outcome = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                Err(CoreError::FFprobeUnavailable(
+                    "Failed to run ffprobe: program not found".to_string(),
+                ))
+            })
+            .expect("a probe that measured nothing is not a scan failure");
+
+        assert!(
+            outcome.skipped.is_empty(),
+            "an asset that already exists was not refused: {:?}",
+            outcome.skipped
+        );
+        assert_eq!(outcome.unrefreshed.len(), 1);
+        assert!(outcome.unrefreshed[0].ends_with("known.mp4"));
+
+        let asset = state.assets.get(&existing_id).expect("the asset survives");
+        assert_eq!(
+            asset.file_size, 4096,
+            "imported metadata is not overwritten"
+        );
+        assert_eq!(asset.duration_sec, None, "the gap is left for a later pass");
+        assert_eq!(
+            asset.video.as_ref().map(|video| video.codec.as_str()),
+            Some("h264"),
+            "a real codec is not replaced by a default"
+        );
+
+        let linked = service
+            .index
+            .get_all()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.relative_path.ends_with("known.mp4"))
+            .expect("the file stays in the index");
+        assert_eq!(
+            linked.asset_id.as_deref(),
+            Some(existing_id.as_str()),
+            "the file is linked to the asset that already covers it"
+        );
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: the top-up a failed probe deferred is retried by a later pass
+    ///
+    /// Given a workspace file whose asset was linked without its duration,
+    /// because the probe of an earlier pass measured nothing
+    /// When a later pass runs and a probe works this time
+    /// Then the gap is filled. The file is registered in the index, so the
+    /// unregistered loop can never reach it again: only a pass over registered
+    /// entries makes the retry that `unrefreshed` promises real.
+    #[test]
+    fn a_deferred_top_up_is_retried_by_a_later_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("footage")).unwrap();
+        std::fs::write(dir.path().join("footage/known.mp4"), "v").unwrap();
+
+        let service = WorkspaceService::open(dir.path().to_path_buf()).unwrap();
+        service.initial_scan().unwrap();
+
+        let mut state = ProjectState::new("Workspace Top-Up Retry Test");
+        let video = crate::core::assets::VideoInfo {
+            codec: "h264".to_string(),
+            ..Default::default()
+        };
+        let existing = Asset::new_video(
+            "known.mp4",
+            &dir.path().join("footage/known.mp4").to_string_lossy(),
+            video,
+        )
+        .with_relative_path("footage/known.mp4")
+        .as_workspace_managed()
+        .with_file_size(4096);
+        let existing_id = existing.id.clone();
+        state.assets.insert(existing_id.clone(), existing);
+
+        let first = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                Err(CoreError::FFprobeUnavailable(
+                    "Failed to run ffprobe: program not found".to_string(),
+                ))
+            })
+            .expect("a probe that measured nothing is not a scan failure");
+
+        assert_eq!(first.unrefreshed.len(), 1);
+        assert_eq!(
+            state.assets.get(&existing_id).unwrap().duration_sec,
+            None,
+            "nothing was measured, so nothing was filled in"
+        );
+
+        let second = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| Ok(probed_metadata()))
+            .expect("the retry is an ordinary pass");
+
+        assert_eq!(
+            second.registered, 0,
+            "the file was already registered by the first pass"
+        );
+        assert!(
+            second.unrefreshed.is_empty(),
+            "the gap the first pass left is closed: {:?}",
+            second.unrefreshed
+        );
+        assert_eq!(
+            state.assets.get(&existing_id).unwrap().duration_sec,
+            Some(12.0),
+            "a working probe fills the duration the first pass could not measure"
+        );
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: a registered file is gone when the top-up pass reaches it
+    ///
+    /// Given a registered asset with a gap, whose file was deleted before the
+    /// removal reached the index
+    /// When a pass sweeps the registered entries looking for gaps to fill
+    /// Then it leaves that entry alone. The pass covers every registered file,
+    /// not only the ones the scanner just saw, so probing one that is no longer
+    /// there would fail the scan of the whole workspace.
+    #[test]
+    fn a_deleted_file_does_not_fail_the_top_up_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("footage")).unwrap();
+        std::fs::write(dir.path().join("footage/gone.mp4"), "v").unwrap();
+
+        let service = WorkspaceService::open(dir.path().to_path_buf()).unwrap();
+        service.initial_scan().unwrap();
+
+        let mut state = ProjectState::new("Workspace Deleted File Test");
+        let registered = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                Err(CoreError::FFprobeUnavailable(
+                    "Failed to run ffprobe: program not found".to_string(),
+                ))
+            })
+            .expect("an unmeasurable file is not a scan failure");
+        assert_eq!(registered.skipped.len(), 1);
+
+        // Register it for real, so the next pass has a linked asset with a gap.
+        let outcome = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                Ok(crate::core::assets::MediaMetadata {
+                    duration_sec: 0.0,
+                    video_duration_sec: None,
+                    file_size: 0,
+                    video: None,
+                    audio: None,
+                    format: "mov,mp4,m4a,3gp,3g2,mj2".to_string(),
+                    rotation_deg: 0.0,
+                })
+            })
+            .expect("the file is registered from what the probe did report");
+        assert_eq!(outcome.registered, 1);
+
+        std::fs::remove_file(dir.path().join("footage/gone.mp4")).unwrap();
+
+        let after_delete = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                panic!("a file that is no longer on disk must not be probed")
+            })
+            .expect("a deleted file does not fail the pass");
+
+        assert_eq!(after_delete, AutoRegisterOutcome::default());
+    }
+
+    /// Feature: workspace auto-registration
+    /// Scenario: a pass over a workspace with nothing left to fill in
+    ///
+    /// Given a workspace whose assets are all fully measured, including a still
+    /// When another pass runs with a probe that would panic if it were called
+    /// Then no probe runs. A still has no duration to measure, so treating its
+    /// absence as a gap would re-probe every image in the workspace on every
+    /// pass, for a measurement that can never arrive.
+    #[test]
+    fn a_pass_does_not_re_probe_files_that_have_nothing_left_to_fill() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("footage")).unwrap();
+        std::fs::write(dir.path().join("footage/still.png"), "i").unwrap();
+
+        let service = WorkspaceService::open(dir.path().to_path_buf()).unwrap();
+        service.initial_scan().unwrap();
+
+        // What FFprobe reports about a still: dimensions, bytes, no duration.
+        let still_metadata = crate::core::assets::MediaMetadata {
+            duration_sec: 0.0,
+            video_duration_sec: None,
+            file_size: 1024,
+            video: Some(crate::core::assets::VideoInfo {
+                width: 1920,
+                height: 1080,
+                codec: "png".to_string(),
+                ..Default::default()
+            }),
+            audio: None,
+            format: "png_pipe".to_string(),
+            rotation_deg: 0.0,
+        };
+
+        let mut state = ProjectState::new("Workspace Re-Probe Test");
+        let first = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                Ok(still_metadata.clone())
+            })
+            .expect("the still is measurable");
+        assert_eq!(first.registered, 1);
+        assert!(
+            state
+                .assets
+                .values()
+                .all(|asset| asset.duration_sec.is_none()),
+            "a still has no duration to report"
+        );
+
+        let second = service
+            .auto_register_discovered_files_with(&mut state, dir.path(), |_| {
+                panic!("a fully measured workspace must not be probed again")
+            })
+            .expect("a pass with nothing to do is not a failure");
+
+        assert_eq!(second, AutoRegisterOutcome::default());
+    }
 
     fn create_test_project(dir: &std::path::Path) {
         std::fs::create_dir_all(dir.join("footage")).unwrap();

--- a/src-tauri/src/ipc/commands/asset.rs
+++ b/src-tauri/src/ipc/commands/asset.rs
@@ -254,6 +254,32 @@ pub async fn import_asset(
                     );
                     Some(media_info)
                 }
+                // A probe that never started measured nothing, so the
+                // "defaults" below would be an invented duration and an
+                // invented frame size on an asset the user thinks was
+                // imported. Refuse instead, in the wording the frontend maps
+                // to "FFmpeg is not installed".
+                Err(e) if e.is_launch_failure() => {
+                    return Err(CoreError::FFprobeUnavailable(format!(
+                        "Failed to run ffprobe for {}: {}",
+                        name, e
+                    ))
+                    .to_ipc_error());
+                }
+                // A probe killed by the watchdog, or one whose output could not
+                // be read, measured nothing either - the defaults would be just
+                // as invented. The cause is named rather than hidden behind
+                // "FFmpeg is not installed", because FFmpeg is installed and
+                // ran; it is this file it got nowhere on.
+                Err(e) if e.measured_nothing() => {
+                    return Err(CoreError::FFprobeError(format!(
+                        "{} about {}: {}",
+                        crate::core::assets::PROBE_MEASURED_NOTHING_PREFIX,
+                        name,
+                        e
+                    ))
+                    .to_ipc_error());
+                }
                 Err(e) => {
                     tracing::warn!(
                         "Failed to extract metadata for {}: {}. Using defaults.",
@@ -264,11 +290,14 @@ pub async fn import_asset(
                 }
             }
         } else {
-            tracing::warn!(
-                "FFmpeg not available for metadata extraction of {}. Using defaults.",
+            // No runner means FFmpeg was never resolved, so nothing has looked
+            // at this file at all - the same "no measurement was taken" the
+            // launch-failure arm refuses, and it gets the same answer.
+            return Err(CoreError::FFprobeUnavailable(format!(
+                "FFmpeg is not available to probe {}",
                 name
-            );
-            None
+            ))
+            .to_ipc_error());
         }
     };
 
@@ -543,6 +572,29 @@ pub async fn relink_asset(
         if let Some(runner) = ffmpeg_guard.runner() {
             match runner.probe(&path).await {
                 Ok(media_info) => Some(media_info),
+                // As in `import_asset`: unmeasured defaults would silently
+                // overwrite the asset's real duration and frame size.
+                Err(e) if e.is_launch_failure() => {
+                    return Err(CoreError::FFprobeUnavailable(format!(
+                        "Failed to run ffprobe for {}: {}",
+                        name, e
+                    ))
+                    .to_ipc_error());
+                }
+                // Also as in `import_asset`: a probe the watchdog killed, or one
+                // whose output could not be read, measured nothing either. A
+                // relink writes what it measured over the asset, so falling
+                // through here would clear a real duration, video and audio to
+                // `None` on the strength of no measurement at all.
+                Err(e) if e.measured_nothing() => {
+                    return Err(CoreError::FFprobeError(format!(
+                        "{} about {}: {}",
+                        crate::core::assets::PROBE_MEASURED_NOTHING_PREFIX,
+                        name,
+                        e
+                    ))
+                    .to_ipc_error());
+                }
                 Err(e) => {
                     tracing::warn!(
                         "Failed to extract replacement metadata for {}: {}. Using defaults.",
@@ -553,11 +605,13 @@ pub async fn relink_asset(
                 }
             }
         } else {
-            tracing::warn!(
-                "FFmpeg not available for replacement metadata extraction of {}. Using defaults.",
+            // No runner means nothing has looked at the replacement file at
+            // all, so there is nothing to relink to but invented defaults.
+            return Err(CoreError::FFprobeUnavailable(format!(
+                "FFmpeg is not available to probe {}",
                 name
-            );
-            None
+            ))
+            .to_ipc_error());
         }
     };
 

--- a/src-tauri/src/ipc/commands/project.rs
+++ b/src-tauri/src/ipc/commands/project.rs
@@ -980,13 +980,38 @@ pub async fn get_sequence_render_graph(
     sequence_id: String,
     state: State<'_, AppState>,
 ) -> Result<crate::core::render::RenderGraph, String> {
+    // Measured audio presence, the same way `render graph` and the export do:
+    // an A/V file the GUI imported without a probe carries no audio metadata, and
+    // reading the guess here would show the user a silent graph for a render that
+    // has sound. Measurements are memoized per file, so a repeated poll is free.
+    //
+    // The probe is taken with the project lock released — it spawns FFprobe, and
+    // holding the lock across a child process parks every other IPC command.
+    let probe_targets = {
+        let guard = state.project.lock().await;
+        let project = guard
+            .as_ref()
+            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+        crate::core::render::sequence_probe_targets(&project.state, &sequence_id)
+    };
+    let audio_probe = crate::core::render::probe_assets_audio_info_off_runtime(probe_targets).await;
+
     let guard = state.project.lock().await;
     let project = guard
         .as_ref()
         .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
 
-    crate::core::render::build_render_graph(&project.state, &sequence_id)
-        .map_err(|error| error.to_ipc_error())
+    // Measurements the project still stands behind: an asset relinked while the
+    // probe ran is dropped rather than answered from the file it no longer
+    // points at.
+    let audio_info = audio_probe.measurements_for(&project.state);
+
+    crate::core::render::build_render_graph_with_audio_info(
+        &project.state,
+        &sequence_id,
+        &audio_info,
+    )
+    .map_err(|error| error.to_ipc_error())
 }
 
 /// Returns the backend effect capability contract used by export validation.

--- a/src-tauri/src/ipc/commands/render.rs
+++ b/src-tauri/src/ipc/commands/render.rs
@@ -12,13 +12,45 @@ use crate::core::{
         validate_scoped_output_path,
     },
     render::{
-        cancel_render_job, is_agent_render_output, prune_agent_renders, register_render_job,
-        unregister_render_job, AudioExportFormat, ExportError, ImageFormat, VideoExportRequest,
-        MAX_AGENT_RENDERS,
+        cancel_render_job, clear_transient_probes, is_agent_render_output, prune_agent_renders,
+        register_render_job, unregister_render_job, AudioExportFormat, ExportError, ImageFormat,
+        VideoExportRequest, MAX_AGENT_RENDERS,
     },
     CoreError,
 };
 use crate::AppState;
+
+/// Measures a sequence's audio presence without holding the project lock.
+///
+/// The probe is one FFprobe spawn per unmeasured video asset. Running it while
+/// `state.project` is held parks every other IPC command behind a child
+/// process — and the render graph is rebuilt on paths that are polled, not just
+/// clicked: [`get_render_cache_status`] runs on every cache progress event.
+///
+/// So the asset list is read under the lock, the guard is dropped, and the probe
+/// runs on a blocking thread. The caller re-locks to build the graph; between
+/// the two the project may have changed, which is no worse than the graph any
+/// other await point in these commands already races with — an asset the probe
+/// measured but the sequence no longer uses is simply not looked up.
+///
+/// The one change an asset id cannot survive is a relink, so the result is a
+/// [`crate::core::render::SequenceAudioProbe`] rather than a bare map: the
+/// caller turns it into measurements with `measurements_for` *after* re-locking,
+/// which drops anything now pointing at a different file.
+async fn probe_sequence_audio_info_off_lock(
+    app_state: &crate::AppState,
+    sequence_id: &str,
+) -> Result<crate::core::render::SequenceAudioProbe, String> {
+    let targets = {
+        let guard = app_state.project.lock().await;
+        let project = guard
+            .as_ref()
+            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+        crate::core::render::sequence_probe_targets(&project.state, sequence_id)
+    };
+
+    Ok(crate::core::render::probe_assets_audio_info_off_runtime(targets).await)
+}
 
 /// Runs export validation without blocking the async runtime.
 ///
@@ -545,6 +577,16 @@ pub async fn validate_export(
         }
     }
 
+    // This is the check the export dialog answers "will this clip be silent?"
+    // with, and the user opened that dialog on purpose. Answering it out of the
+    // window that suppresses re-probing after a failure that reached no verdict
+    // would warn about silence in a file that has been reachable for a while.
+    clear_transient_probes();
+
+    // FFprobe must not run under the project lock: see
+    // `probe_sequence_audio_info_off_lock`.
+    let audio_probe = probe_sequence_audio_info_off_lock(&state, &sequence_id).await?;
+
     let (sequence, assets, effects, render_graph, project_path) = {
         let guard = state.project.lock().await;
 
@@ -559,8 +601,16 @@ pub async fn validate_export(
             .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
             .clone();
 
-        let render_graph = crate::core::render::build_render_graph(&project.state, &sequence_id)
-            .map_err(|e| e.to_ipc_error())?;
+        // Measurements the project still stands behind: an asset relinked
+        // while the probe ran is dropped rather than answered from the
+        // file it no longer points at.
+        let audio_info = audio_probe.measurements_for(&project.state);
+        let render_graph = crate::core::render::build_render_graph_with_audio_info(
+            &project.state,
+            &sequence_id,
+            &audio_info,
+        )
+        .map_err(|e| e.to_ipc_error())?;
 
         let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
             .state
@@ -648,6 +698,16 @@ pub async fn start_render(
     use crate::core::render::{ExportEngine, ExportProgress};
     use tauri::Emitter;
 
+    // A render the user asked for is not a status poll, so the window that
+    // suppresses re-probing after a failure that reached no verdict is dropped
+    // before measuring: a file that was locked or on a dropped share when the
+    // last poll ran is exactly what this export needs asked about again.
+    clear_transient_probes();
+
+    // FFprobe must not run under the project lock: see
+    // `probe_sequence_audio_info_off_lock`.
+    let audio_probe = probe_sequence_audio_info_off_lock(&state, &sequence_id).await?;
+
     // Get sequence/assets/effects + project path from project state
     let (sequence, assets, effects, render_graph, project_path) = {
         let guard = state.project.lock().await;
@@ -663,8 +723,16 @@ pub async fn start_render(
             .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
             .clone();
 
-        let render_graph = crate::core::render::build_render_graph(&project.state, &sequence_id)
-            .map_err(|e| e.to_ipc_error())?;
+        // Measurements the project still stands behind: an asset relinked
+        // while the probe ran is dropped rather than answered from the
+        // file it no longer points at.
+        let audio_info = audio_probe.measurements_for(&project.state);
+        let render_graph = crate::core::render::build_render_graph_with_audio_info(
+            &project.state,
+            &sequence_id,
+            &audio_info,
+        )
+        .map_err(|e| e.to_ipc_error())?;
 
         let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
             .state
@@ -971,6 +1039,14 @@ pub async fn render_range(
         return Err("In point must be non-negative".to_string());
     }
 
+    // As in [`start_render`]: a user-initiated render drops the post-failure
+    // suppression window so every asset is asked about again.
+    clear_transient_probes();
+
+    // FFprobe must not run under the project lock: see
+    // `probe_sequence_audio_info_off_lock`.
+    let audio_probe = probe_sequence_audio_info_off_lock(&state, &sequence_id).await?;
+
     // Get sequence/assets/effects + project path
     let (sequence, assets, effects, render_graph, project_path) = {
         let guard = state.project.lock().await;
@@ -985,8 +1061,16 @@ pub async fn render_range(
             .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
             .clone();
 
-        let render_graph = crate::core::render::build_render_graph(&project.state, &sequence_id)
-            .map_err(|e| e.to_ipc_error())?;
+        // Measurements the project still stands behind: an asset relinked
+        // while the probe ran is dropped rather than answered from the
+        // file it no longer points at.
+        let audio_info = audio_probe.measurements_for(&project.state);
+        let render_graph = crate::core::render::build_render_graph_with_audio_info(
+            &project.state,
+            &sequence_id,
+            &audio_info,
+        )
+        .map_err(|e| e.to_ipc_error())?;
 
         let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
             .state
@@ -1215,6 +1299,14 @@ pub async fn batch_render(
         return Err("Batch render requires at least one item".to_string());
     }
 
+    // As in [`start_render`]: a user-initiated render drops the post-failure
+    // suppression window so every asset is asked about again.
+    clear_transient_probes();
+
+    // FFprobe must not run under the project lock: see
+    // `probe_sequence_audio_info_off_lock`.
+    let audio_probe = probe_sequence_audio_info_off_lock(&state, &sequence_id).await?;
+
     // Get project state (shared across all batch items)
     let (sequence, assets, effects, render_graph, project_path) = {
         let guard = state.project.lock().await;
@@ -1229,8 +1321,16 @@ pub async fn batch_render(
             .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
             .clone();
 
-        let render_graph = crate::core::render::build_render_graph(&project.state, &sequence_id)
-            .map_err(|e| e.to_ipc_error())?;
+        // Measurements the project still stands behind: an asset relinked
+        // while the probe ran is dropped rather than answered from the
+        // file it no longer points at.
+        let audio_info = audio_probe.measurements_for(&project.state);
+        let render_graph = crate::core::render::build_render_graph_with_audio_info(
+            &project.state,
+            &sequence_id,
+            &audio_info,
+        )
+        .map_err(|e| e.to_ipc_error())?;
 
         let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
             .state
@@ -1663,6 +1763,14 @@ pub async fn export_audio_only(
         _ => return Err(format!("Unsupported audio format: {}", format)),
     };
 
+    // As in [`start_render`]: a user-initiated render drops the post-failure
+    // suppression window so every asset is asked about again.
+    clear_transient_probes();
+
+    // FFprobe must not run under the project lock: see
+    // `probe_sequence_audio_info_off_lock`.
+    let audio_probe = probe_sequence_audio_info_off_lock(&state, &sequence_id).await?;
+
     // Get sequence/assets/effects + project path
     let (sequence, assets, effects, render_graph, project_path) = {
         let guard = state.project.lock().await;
@@ -1677,8 +1785,16 @@ pub async fn export_audio_only(
             .ok_or_else(|| format!("Sequence not found: {}", sequence_id))?
             .clone();
 
-        let render_graph = crate::core::render::build_render_graph(&project.state, &sequence_id)
-            .map_err(|e| e.to_ipc_error())?;
+        // Measurements the project still stands behind: an asset relinked
+        // while the probe ran is dropped rather than answered from the
+        // file it no longer points at.
+        let audio_info = audio_probe.measurements_for(&project.state);
+        let render_graph = crate::core::render::build_render_graph_with_audio_info(
+            &project.state,
+            &sequence_id,
+            &audio_info,
+        )
+        .map_err(|e| e.to_ipc_error())?;
 
         let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
             .state
@@ -2624,28 +2740,45 @@ pub async fn get_cache_status(
 ) -> Result<crate::core::render::RenderCacheStatus, String> {
     use crate::core::render::cache::{cache_status_snapshot, preview_profile_hash};
 
+    // This command is polled on every cache progress event, so the FFprobe the
+    // graph needs is taken before the lock rather than under it.
+    let seq_id = {
+        let guard = state.project.lock().await;
+        let project = guard
+            .as_ref()
+            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+        project
+            .state
+            .active_sequence_id
+            .clone()
+            .ok_or_else(|| "No active sequence".to_string())?
+    };
+    let audio_probe = probe_sequence_audio_info_off_lock(&state, &seq_id).await?;
+
     let guard = state.project.lock().await;
     let project = guard
         .as_ref()
         .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
 
-    let seq_id = project
-        .state
-        .active_sequence_id
-        .as_ref()
-        .ok_or_else(|| "No active sequence".to_string())?;
-
     let sequence = project
         .state
         .sequences
-        .get(seq_id)
+        .get(&seq_id)
         .ok_or_else(|| format!("Sequence not found: {seq_id}"))?;
 
     // The status snapshot re-fingerprints a private copy of the manifest so the
     // indicator reports staleness honestly (it never persists). That needs the
     // same render graph / assets / effects the fill path builds.
-    let render_graph = crate::core::render::build_render_graph(&project.state, seq_id)
-        .map_err(|error| format!("Failed to build render graph: {error}"))?;
+    // Measurements the project still stands behind: an asset relinked
+    // while the probe ran is dropped rather than answered from the
+    // file it no longer points at.
+    let audio_info = audio_probe.measurements_for(&project.state);
+    let render_graph = crate::core::render::build_render_graph_with_audio_info(
+        &project.state,
+        &seq_id,
+        &audio_info,
+    )
+    .map_err(|error| format!("Failed to build render graph: {error}"))?;
 
     let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
         .state
@@ -3051,17 +3184,25 @@ struct CacheRenderInputs {
 async fn gather_cache_render_inputs(
     state: &State<'_, AppState>,
 ) -> Result<CacheRenderInputs, String> {
+    let seq_id = {
+        let guard = state.project.lock().await;
+        let project = guard
+            .as_ref()
+            .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
+        project
+            .state
+            .active_sequence_id
+            .clone()
+            .ok_or_else(|| "No active sequence".to_string())?
+    };
+    // FFprobe must not run under the project lock: see
+    // `probe_sequence_audio_info_off_lock`.
+    let audio_probe = probe_sequence_audio_info_off_lock(state, &seq_id).await?;
+
     let guard = state.project.lock().await;
     let project = guard
         .as_ref()
         .ok_or_else(|| CoreError::NoProjectOpen.to_ipc_error())?;
-
-    let seq_id = project
-        .state
-        .active_sequence_id
-        .as_ref()
-        .ok_or_else(|| "No active sequence".to_string())?
-        .clone();
 
     let sequence = project
         .state
@@ -3070,8 +3211,16 @@ async fn gather_cache_render_inputs(
         .ok_or_else(|| format!("Sequence not found: {seq_id}"))?
         .clone();
 
-    let render_graph = crate::core::render::build_render_graph(&project.state, &seq_id)
-        .map_err(|error| format!("Failed to build render graph: {error}"))?;
+    // Measurements the project still stands behind: an asset relinked
+    // while the probe ran is dropped rather than answered from the
+    // file it no longer points at.
+    let audio_info = audio_probe.measurements_for(&project.state);
+    let render_graph = crate::core::render::build_render_graph_with_audio_info(
+        &project.state,
+        &seq_id,
+        &audio_info,
+    )
+    .map_err(|error| format!("Failed to build render graph: {error}"))?;
 
     let assets: std::collections::HashMap<String, crate::core::assets::Asset> = project
         .state
@@ -3616,6 +3765,17 @@ fn ensure_cache_fill(
             // Retracts the identity on every path out of this iteration.
             let _armed = ArmedSegmentGuard(task_cancel.clone());
 
+            // FFprobe must not run under the project lock: see
+            // `probe_sequence_audio_info_off_lock`. A project closed underneath
+            // this fill answers with no measurements, and the re-lock below
+            // reports the closure the way it always did.
+            let segment_audio_probe = {
+                let app_state = app_handle.state::<crate::AppState>();
+                probe_sequence_audio_info_off_lock(&app_state, &job_seq_id)
+                    .await
+                    .unwrap_or_default()
+            };
+
             // Re-acquire fresh project state for each segment to avoid rendering
             // with stale data if the user edits the timeline during cache rendering.
             let (fresh_sequence, fresh_assets, fresh_effects, fresh_render_graph) = {
@@ -3647,9 +3807,13 @@ fn ensure_cache_fill(
                                 break;
                             }
                         };
-                        let graph = match crate::core::render::build_render_graph(
+                        // Measurements the project still stands behind: an asset relinked
+                        // while the probe ran is dropped rather than answered from the
+                        // file it no longer points at.
+                        let graph = match crate::core::render::build_render_graph_with_audio_info(
                             &project.state,
                             &job_seq_id,
+                            &segment_audio_probe.measurements_for(&project.state),
                         ) {
                             Ok(graph) => graph,
                             Err(error) => {

--- a/src-tauri/src/ipc/commands/transcription.rs
+++ b/src-tauri/src/ipc/commands/transcription.rs
@@ -602,7 +602,7 @@ pub async fn transcribe_sequence(
     state: State<'_, AppState>,
 ) -> Result<TranscriptionResultDto, String> {
     use crate::core::captions::{
-        audio::{load_audio_samples, mix_sequence_audio_for_transcription},
+        audio::{load_audio_samples, mix_sequence_audio_for_transcription, AudioWindow},
         whisper::{subtitle_ready_segments, TranscriptionOptions, WhisperEngine},
     };
 
@@ -683,6 +683,9 @@ pub async fn transcribe_sequence(
             &project_state,
             &resolved_sequence_id,
             &audio_path,
+            // The GUI transcribes the whole sequence; only the CLI and MCP
+            // surfaces expose a range today.
+            AudioWindow::FULL,
             Some(ffmpeg_path.as_str()),
         )
         .map_err(|e| format!("Sequence audio mixdown failed: {}", e))?;

--- a/src-tauri/src/ipc/commands/workspace.rs
+++ b/src-tauri/src/ipc/commands/workspace.rs
@@ -59,6 +59,10 @@ pub struct WorkspaceScanResultDto {
     pub registered_files: usize,
     /// Number of files auto-registered during this scan
     pub auto_registered_files: usize,
+    /// Number of files left unregistered because the probe measured nothing
+    /// about them - FFprobe could not be launched, or it returned nothing
+    /// readable. They stay in the index, so a later scan picks them up.
+    pub skipped_files: usize,
 }
 
 /// A file imported into the workspace from an external OS file drop.
@@ -234,6 +238,8 @@ pub async fn scan_workspace(state: State<'_, AppState>) -> Result<WorkspaceScanR
         let auto_registered = service
             .auto_register_discovered_files(&mut project.state, &project_root)
             .map_err(|e| e.to_ipc_error())?;
+        let skipped_files = auto_registered.skipped.len();
+        let auto_registered = auto_registered.registered;
 
         let new_asset_ids: Vec<String> = project
             .state
@@ -262,6 +268,7 @@ pub async fn scan_workspace(state: State<'_, AppState>) -> Result<WorkspaceScanR
             removed = result.removed_files,
             registered = result.registered_files,
             auto_registered = auto_registered,
+            skipped = skipped_files,
             "Workspace scan completed"
         );
 
@@ -271,6 +278,7 @@ pub async fn scan_workspace(state: State<'_, AppState>) -> Result<WorkspaceScanR
             removed_files: result.removed_files,
             registered_files: result.registered_files,
             auto_registered_files: auto_registered,
+            skipped_files,
         };
     } // project lock released here
 
@@ -586,6 +594,10 @@ pub async fn import_external_files_to_workspace(
         let existing_asset_ids: HashSet<String> = project.state.assets.keys().cloned().collect();
         let service = WorkspaceService::open(project.path.clone()).map_err(|e| e.to_ipc_error())?;
 
+        // A file that could not be indexed is a failure, not an import.
+        // Leaving it in `imported_files` as well would have the caller count it
+        // twice and still report it as imported.
+        let mut unimported_relative_paths: HashSet<String> = HashSet::new();
         for imported_file in &result.imported_files {
             if let Err(error) = service.handle_event(&WorkspaceEvent::FileAdded(
                 imported_file.relative_path.clone(),
@@ -597,12 +609,58 @@ pub async fn import_external_files_to_workspace(
                         imported_file.relative_path, error
                     ),
                 });
+                unimported_relative_paths.insert(imported_file.relative_path.clone());
             }
         }
 
-        service
+        // Everything that reached the index is on disk and in the tree, so the
+        // explorer is told about all of it - including the files the probe then
+        // refuses to measure, which are real files the user can see.
+        let indexed_relative_paths: Vec<String> = result
+            .imported_files
+            .iter()
+            .filter(|file| !unimported_relative_paths.contains(&file.relative_path))
+            .map(|file| file.relative_path.clone())
+            .collect();
+
+        let auto_registered = service
             .auto_register_discovered_files(&mut project.state, &project.path)
             .map_err(|e| e.to_ipc_error())?;
+        // A dropped file the probe measured nothing about is copied into the
+        // workspace but not registered, so it has no asset id and nothing in
+        // the app can use it yet. Counting it as imported would report the drop
+        // green for a file that will not reach the project until something
+        // scans again, so it is reported as a failure carrying the one thing
+        // that is true: it is on disk, and a later scan picks it up. The rest
+        // of the drop still lands.
+        for skipped_path in &auto_registered.skipped {
+            // A file that already failed to index is already reported. It can
+            // reach this list too - an earlier pass may have indexed it - and
+            // one file must not cost the user two failure lines.
+            if unimported_relative_paths.contains(skipped_path) {
+                continue;
+            }
+
+            if let Some(imported_file) = result
+                .imported_files
+                .iter()
+                .find(|file| &file.relative_path == skipped_path)
+            {
+                result.failed_files.push(ExternalWorkspaceImportFailureDto {
+                    source_path: imported_file.source_path.clone(),
+                    message: format!(
+                        "'{}' was copied but could not be measured: FFprobe could not be \
+                         launched, or returned nothing readable; it registers on the next scan",
+                        skipped_path
+                    ),
+                });
+                unimported_relative_paths.insert(skipped_path.clone());
+            }
+        }
+
+        result
+            .imported_files
+            .retain(|file| !unimported_relative_paths.contains(&file.relative_path));
 
         let new_asset_ids: Vec<String> = project
             .state
@@ -632,11 +690,7 @@ pub async fn import_external_files_to_workspace(
             }
         }
 
-        imported_relative_paths = result
-            .imported_files
-            .iter()
-            .map(|file| file.relative_path.clone())
-            .collect();
+        imported_relative_paths = indexed_relative_paths;
     }
 
     drop(guard);

--- a/src-tauri/src/ipc/events.rs
+++ b/src-tauri/src/ipc/events.rs
@@ -332,20 +332,6 @@ pub struct WorkspaceFileEvent {
     pub kind: Option<AssetKind>,
 }
 
-/// Workspace scan complete event payload.
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkspaceScanCompleteEvent {
-    /// Total number of media files found
-    pub total_files: usize,
-    /// Number of new files discovered
-    pub new_files: usize,
-    /// Number of files removed since last scan
-    pub removed_files: usize,
-    /// Number of files already registered as assets
-    pub registered_files: usize,
-}
-
 // =============================================================================
 // Event Emitter
 // =============================================================================
@@ -514,6 +500,15 @@ impl EventEmitter {
                     )
                     .map_err(|e| format!("Failed to emit marker deleted event: {}", e))?;
                 }
+                StateChange::CaptionsSnappedToFrameGrid { count, dropped } => {
+                    app.emit(
+                        "caption:snapped-to-frame-grid",
+                        &serde_json::json!({ "count": count, "dropped": dropped }),
+                    )
+                    .map_err(|e| {
+                        format!("Failed to emit caption snapped-to-frame-grid event: {}", e)
+                    })?;
+                }
             }
         }
         Ok(())
@@ -640,24 +635,6 @@ impl EventEmitter {
         app.emit(event_names::WORKSPACE_FILE_MODIFIED, &event)
             .map_err(|e| format!("Failed to emit workspace file modified event: {}", e))
     }
-
-    /// Emits a workspace scan complete event
-    pub fn emit_workspace_scan_complete(
-        app: &AppHandle,
-        total_files: usize,
-        new_files: usize,
-        removed_files: usize,
-        registered_files: usize,
-    ) -> Result<(), String> {
-        let event = WorkspaceScanCompleteEvent {
-            total_files,
-            new_files,
-            removed_files,
-            registered_files,
-        };
-        app.emit(event_names::WORKSPACE_SCAN_COMPLETE, &event)
-            .map_err(|e| format!("Failed to emit workspace scan complete event: {}", e))
-    }
 }
 
 // =============================================================================
@@ -747,23 +724,5 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("old_file.mp4"));
         assert!(json.contains("null"));
-    }
-
-    #[test]
-    fn test_workspace_scan_complete_event() {
-        let event = WorkspaceScanCompleteEvent {
-            total_files: 42,
-            new_files: 10,
-            removed_files: 2,
-            registered_files: 30,
-        };
-
-        let json = serde_json::to_string(&event).unwrap();
-        assert!(json.contains("totalFiles"));
-        assert!(json.contains("42"));
-        assert!(json.contains("newFiles"));
-        assert!(json.contains("10"));
-        assert!(json.contains("removedFiles"));
-        assert!(json.contains("registeredFiles"));
     }
 }

--- a/src-tauri/src/ipc/payloads.rs
+++ b/src-tauri/src/ipc/payloads.rs
@@ -922,6 +922,30 @@ pub struct ImportGeneratedCaptionsPayload {
     /// Whether to clear the track's existing captions before importing.
     #[serde(default)]
     pub replace_existing: bool,
+    /// Whether cue boundaries are moved onto the sequence's frame grid.
+    ///
+    /// Defaults to `true`: a transcriber's millisecond times otherwise land
+    /// between frames and make every composite and render warn about each cue.
+    ///
+    /// Rounding alone moves each boundary by at most half a frame. A second
+    /// pass then restores the ordering rounding can break — these cues were
+    /// de-overlapped by the readability rules, and two of them a fraction of a
+    /// frame apart can round onto the same frame — by pushing the later cue
+    /// forward, which can move it by more than half a frame. That push is
+    /// bounded at two frames; a cue that would need more is dropped rather than
+    /// dragged further and further from the speech.
+    ///
+    /// Snapping rewrites times the caller supplied, so it is reported rather
+    /// than silent: the command answers with a `captionsSnappedToFrameGrid`
+    /// state change carrying how many cues moved and how many were dropped,
+    /// which is the GUI's cue to say so. No change is emitted when nothing
+    /// moved and nothing was dropped, or when this is `false`.
+    #[serde(default = "default_snap_to_frames")]
+    pub snap_to_frames: bool,
+}
+
+fn default_snap_to_frames() -> bool {
+    true
 }
 
 /// Payload for `DeleteCaption` (remove one caption line).
@@ -2430,7 +2454,8 @@ impl CommandPayload {
                     ImportGeneratedCaptionsCommand::new(&p.sequence_id, &p.track_id, segments)
                         .with_style(p.style)
                         .with_position(p.position)
-                        .replace_existing(p.replace_existing),
+                        .replace_existing(p.replace_existing)
+                        .snap_to_frames(p.snap_to_frames),
                 )
             }
             CommandPayload::DeleteCaption(p) => Box::new(DeleteCaptionCommand::new(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,15 @@
  * Shows WelcomeScreen when no project is loaded, Editor when project is active.
  */
 
-import { lazy, Suspense, useCallback, useState, useEffect, useMemo } from 'react';
+import { lazy, Suspense, useCallback, useRef, useState, useEffect, useMemo } from 'react';
 import { ErrorBoundary } from './components/shared';
 import { FFmpegWarning, ToastContainer, type ToastVariant } from './components/ui';
-import { useProjectStore, setupProxyEventListeners, cleanupProxyEventListeners } from './stores';
+import {
+  useProjectStore,
+  useWorkspaceStore,
+  setupProxyEventListeners,
+  cleanupProxyEventListeners,
+} from './stores';
 import {
   useFFmpegStatus,
   useAutoSave,
@@ -119,6 +124,24 @@ function App(): JSX.Element {
       setShowFFmpegWarning(true);
     }
   }, [isFFmpegLoading, isFFmpegAvailable, ffmpegWarningDismissed]);
+
+  // A workspace opened before FFmpeg finished installing left every file it
+  // could not probe unregistered. Nothing else re-asks for those: the watcher
+  // only fires on filesystem changes, and the files have not changed. So the
+  // moment FFmpeg becomes available is the one event that can make them
+  // registerable, and the store re-scans then - and only if a scan actually
+  // left files behind.
+  const wasFFmpegAvailableRef = useRef(false);
+  useEffect(() => {
+    if (isFFmpegLoading) {
+      return;
+    }
+    const becameAvailable = isFFmpegAvailable && !wasFFmpegAvailableRef.current;
+    wasFFmpegAvailableRef.current = isFFmpegAvailable;
+    if (becameAvailable) {
+      void useWorkspaceStore.getState().rescanUnmeasuredFiles();
+    }
+  }, [isFFmpegLoading, isFFmpegAvailable]);
 
   // Load recent projects and version on mount
   useEffect(() => {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -6437,7 +6437,28 @@ stylePack?: string | null;
 /**
  * Whether to clear the track's existing captions before importing.
  */
-replaceExisting?: boolean }
+replaceExisting?: boolean; 
+/**
+ * Whether cue boundaries are moved onto the sequence's frame grid.
+ * 
+ * Defaults to `true`: a transcriber's millisecond times otherwise land
+ * between frames and make every composite and render warn about each cue.
+ * 
+ * Rounding alone moves each boundary by at most half a frame. A second
+ * pass then restores the ordering rounding can break — these cues were
+ * de-overlapped by the readability rules, and two of them a fraction of a
+ * frame apart can round onto the same frame — by pushing the later cue
+ * forward, which can move it by more than half a frame. That push is
+ * bounded at two frames; a cue that would need more is dropped rather than
+ * dragged further and further from the speech.
+ * 
+ * Snapping rewrites times the caller supplied, so it is reported rather
+ * than silent: the command answers with a `captionsSnappedToFrameGrid`
+ * state change carrying how many cues moved and how many were dropped,
+ * which is the GUI's cue to say so. No change is emitted when nothing
+ * moved and nothing was dropped, or when this is `false`.
+ */
+snapToFrames?: boolean }
 /**
  * Payload for `InsertClip` (primitive placement at an exact timeline position).
  * 
@@ -9031,6 +9052,17 @@ export type StateChange =
  */
 { type: "sequenceModified"; sequence_id: string } | 
 /**
+ * Imported caption cues were moved onto the sequence's frame grid.
+ * 
+ * Reported so a GUI can say "41 cues were nudged onto the frame grid, 2
+ * dropped" rather than leaving a silent rewrite of the times the user
+ * handed over. `count` is how many cues moved and `dropped` how many were
+ * given up on because keeping them in order would have pushed them off
+ * their own time; the change is only emitted when at least one cue was
+ * moved or dropped.
+ */
+{ type: "captionsSnappedToFrameGrid"; count: number; dropped: number } | 
+/**
  * A new marker was created
  */
 { type: "markerCreated"; marker_id: string } | 
@@ -10968,7 +11000,13 @@ registeredFiles: number;
 /**
  * Number of files auto-registered during this scan
  */
-autoRegisteredFiles: number }
+autoRegisteredFiles: number; 
+/**
+ * Number of files left unregistered because the probe measured nothing
+ * about them - FFprobe could not be launched, or it returned nothing
+ * readable. They stay in the index, so a later scan picks them up.
+ */
+skippedFiles: number }
 
 /** tauri-specta globals **/
 

--- a/src/components/explorer/ProjectExplorer.test.tsx
+++ b/src/components/explorer/ProjectExplorer.test.tsx
@@ -6,7 +6,13 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import type { Asset, FileTreeEntry } from '@/types';
+
+const workspaceGateway = vi.hoisted(() => ({
+  importExternalFilesToWorkspaceFromBackend: vi.fn(),
+  fetchWorkspaceTreeFromBackend: vi.fn(),
+}));
 
 const mockState = vi.hoisted(() => ({
   scanWorkspace: vi.fn(),
@@ -28,6 +34,7 @@ const mockState = vi.hoisted(() => ({
   downloadTranscriptionModel: vi.fn(),
   fileTree: [] as FileTreeEntry[],
   assets: new Map<string, Asset>(),
+  scanWarning: null as string | null,
 }));
 
 vi.mock('@/stores', () => ({
@@ -37,6 +44,7 @@ vi.mock('@/stores', () => ({
       isScanning: false,
       scanWorkspace: mockState.scanWorkspace,
       importExternalFiles: mockState.importExternalFiles,
+      scanWarning: mockState.scanWarning,
     };
     return typeof selector === 'function' ? selector(state) : state;
   },
@@ -99,6 +107,24 @@ vi.mock('@/bindings', () => ({
 
 vi.mock('@tauri-apps/api/core', () => ({
   isTauri: () => false,
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => undefined),
+}));
+
+// The real workspace store is driven directly by one test below, so its only
+// boundary - the Tauri gateway - is what gets mocked, not the store itself.
+vi.mock('@/services/workspaceGateway', () => ({
+  importExternalFilesToWorkspaceFromBackend:
+    workspaceGateway.importExternalFilesToWorkspaceFromBackend,
+  fetchWorkspaceTreeFromBackend: workspaceGateway.fetchWorkspaceTreeFromBackend,
+  scanWorkspaceFromBackend: vi.fn(),
+  createFolderInBackend: vi.fn(),
+  renameFileInBackend: vi.fn(),
+  moveFileInBackend: vi.fn(),
+  deleteFileInBackend: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
@@ -111,6 +137,8 @@ vi.mock('@/services/logger', () => ({
     debug: vi.fn(),
     error: vi.fn(),
     warn: vi.fn(),
+    time: vi.fn(),
+    timeEnd: vi.fn(),
   }),
 }));
 
@@ -119,10 +147,12 @@ vi.mock('./FileTree', () => ({
     entries,
     onFileClick,
     onFileDoubleClick,
+    onContextMenu,
   }: {
     entries: FileTreeEntry[];
     onFileClick?: (entry: FileTreeEntry) => void;
     onFileDoubleClick?: (entry: FileTreeEntry) => void;
+    onContextMenu?: (event: ReactMouseEvent, entry: FileTreeEntry) => void;
   }) => (
     <div data-testid="file-tree">
       {entries.map((entry) => (
@@ -133,6 +163,7 @@ vi.mock('./FileTree', () => ({
           data-workspace-entry-directory={entry.isDirectory ? 'true' : 'false'}
           onClick={() => onFileClick?.(entry)}
           onDoubleClick={() => onFileDoubleClick?.(entry)}
+          onContextMenu={(event) => onContextMenu?.(event, entry)}
         >
           {entry.name}
         </button>
@@ -142,7 +173,17 @@ vi.mock('./FileTree', () => ({
 }));
 
 vi.mock('./FileTreeContextMenu', () => ({
-  FileTreeContextMenu: () => null,
+  FileTreeContextMenu: ({
+    entry,
+    onRelinkAsset,
+  }: {
+    entry: FileTreeEntry;
+    onRelinkAsset?: (entry: FileTreeEntry) => void;
+  }) => (
+    <button type="button" data-testid="context-relink" onClick={() => onRelinkAsset?.(entry)}>
+      Relink
+    </button>
+  ),
 }));
 
 vi.mock('@/components/ui', () => ({
@@ -154,6 +195,7 @@ vi.mock('@/components/features/transcription', () => ({
 }));
 
 import { ProjectExplorer } from './ProjectExplorer';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 function createFileEntry(overrides: Partial<FileTreeEntry>): FileTreeEntry {
   return {
@@ -206,6 +248,7 @@ describe('ProjectExplorer', () => {
     vi.clearAllMocks();
     mockState.fileTree = [];
     mockState.assets = new Map();
+    mockState.scanWarning = null;
     mockState.createFolder.mockResolvedValue(undefined);
     mockState.renameFile.mockResolvedValue(undefined);
     mockState.deleteFile.mockResolvedValue(undefined);
@@ -219,6 +262,8 @@ describe('ProjectExplorer', () => {
       importedFiles: [],
       failedFiles: [],
     });
+    useWorkspaceStore.getState().reset();
+    workspaceGateway.fetchWorkspaceTreeFromBackend.mockResolvedValue([]);
     mockState.getTranscriptionStatus.mockResolvedValue({
       featureAvailable: true,
       ready: true,
@@ -434,6 +479,52 @@ describe('ProjectExplorer', () => {
     expect(screen.getByTestId('import-status')).toHaveTextContent('Imported 2/3 files; 1 failed');
   });
 
+  it('should report a drop as failed when the backend could not measure the files', async () => {
+    // The backend copies a file it cannot probe into the workspace but does not
+    // register it as an asset, so it comes back as a failure rather than an
+    // import. Counting it as imported would tell the user a file landed that
+    // nothing in the app can actually use yet.
+    //
+    // The real store action runs here, with only the Tauri gateway mocked: a
+    // drop where nothing landed is exactly the case a store that threw would
+    // turn into a generic error, hiding the per-file reason below.
+    const backendMessage =
+      "'unreachable.mp4' was copied but could not be measured: FFprobe could not be launched, or returned nothing readable; it registers on the next scan";
+    workspaceGateway.importExternalFilesToWorkspaceFromBackend.mockResolvedValue({
+      importedFiles: [],
+      failedFiles: [
+        {
+          sourcePath: '/Users/test/Desktop/unreachable.mp4',
+          message: backendMessage,
+        },
+      ],
+    });
+    mockState.importExternalFiles.mockImplementation((sourcePaths: string[], targetDir?: string) =>
+      useWorkspaceStore.getState().importExternalFiles(sourcePaths, targetDir),
+    );
+    mockState.openDialog.mockResolvedValue(['/Users/test/Desktop/unreachable.mp4']);
+
+    render(<ProjectExplorer />);
+
+    fireEvent.click(screen.getByTestId('import-files-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('import-status')).toHaveTextContent('Imported 0/1 files; 1 failed');
+    });
+    expect(screen.getByTestId('import-status')).toHaveTextContent(backendMessage);
+  });
+
+  it('should surface the warning when a scan left files unmeasured', async () => {
+    mockState.scanWarning =
+      '2 files could not be measured: FFprobe could not be launched, or returned nothing readable, so they are not available as media yet. Check FFmpeg is installed, then scan again.';
+
+    render(<ProjectExplorer />);
+
+    expect(screen.getByTestId('workspace-scan-warning')).toHaveTextContent(
+      'FFprobe could not be launched, or returned nothing readable',
+    );
+  });
+
   it('should import externally dropped files into a hovered folder', async () => {
     mockState.fileTree = [
       createFileEntry({
@@ -498,6 +589,36 @@ describe('ProjectExplorer', () => {
 
     expect(screen.getByRole('button', { name: 'music.wav' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'interview.mp4' })).not.toBeInTheDocument();
+  });
+
+  it('should report the failure in the status line when relinking an asset fails', async () => {
+    mockState.fileTree = [
+      createFileEntry({
+        relativePath: 'footage/interview.mp4',
+        name: 'interview.mp4',
+        kind: 'video',
+        assetId: 'video-1',
+      }),
+    ];
+    mockState.assets = new Map([['video-1', createAsset('video-1', 'video')]]);
+    mockState.openDialog.mockResolvedValue('/Users/test/Desktop/replacement.mp4');
+    mockState.relinkAsset.mockRejectedValue(
+      new Error('FFprobe could not be run: Failed to run ffprobe for replacement.mp4 (os error 2)'),
+    );
+
+    render(<ProjectExplorer />);
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'interview.mp4' }));
+    fireEvent.click(screen.getByTestId('context-relink'));
+
+    await waitFor(() => {
+      expect(mockState.relinkAsset).toHaveBeenCalledWith(
+        'video-1',
+        '/Users/test/Desktop/replacement.mp4',
+      );
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/FFmpeg is not installed/i);
   });
 
   it('should request proxy generation automatically for high-resolution video assets', async () => {

--- a/src/components/explorer/ProjectExplorer.tsx
+++ b/src/components/explorer/ProjectExplorer.tsx
@@ -339,6 +339,7 @@ export function ProjectExplorer({ onAddToTimeline }: ProjectExplorerProps = {}) 
   const isScanning = useWorkspaceStore((state) => state.isScanning);
   const scanWorkspace = useWorkspaceStore((state) => state.scanWorkspace);
   const importExternalFiles = useWorkspaceStore((state) => state.importExternalFiles);
+  const scanWarning = useWorkspaceStore((state) => state.scanWarning);
 
   // Project store
   const {
@@ -530,6 +531,10 @@ export function ProjectExplorer({ onAddToTimeline }: ProjectExplorerProps = {}) 
         const importedCount = result.importedFiles.length;
         const failedCount = result.failedFiles.length;
         const totalCount = importedCount + failedCount || sourcePaths.length;
+        // The count alone does not say what to do next; the backend's reason
+        // does ("copied but could not be measured", say). One is enough to act
+        // on, and a drop usually fails for one reason.
+        const firstFailure = result.failedFiles[0]?.message;
 
         setImportStatus({
           kind: failedCount > 0 ? 'warning' : 'success',
@@ -537,7 +542,9 @@ export function ProjectExplorer({ onAddToTimeline }: ProjectExplorerProps = {}) 
             importedCount === 0 && failedCount === 0
               ? 'No new files imported'
               : failedCount > 0
-                ? `Imported ${importedCount.toLocaleString()}/${totalCount.toLocaleString()} files; ${failedCount.toLocaleString()} failed`
+                ? `Imported ${importedCount.toLocaleString()}/${totalCount.toLocaleString()} files; ${failedCount.toLocaleString()} failed${
+                    firstFailure ? `. ${firstFailure}` : ''
+                  }`
                 : `Imported ${importedCount.toLocaleString()} file${importedCount === 1 ? '' : 's'}`,
         });
 
@@ -878,6 +885,14 @@ export function ProjectExplorer({ onAddToTimeline }: ProjectExplorerProps = {}) 
             relativePath: entry.relativePath,
           });
         } catch (error) {
+          // Relink is how a user rescues a missing asset, and the file it
+          // points at is the one thing they can act on. A failure that only
+          // reaches the log leaves the entry looking unchanged, so it is
+          // surfaced in the same status line the import paths use.
+          setImportStatus({
+            kind: 'error',
+            message: getUserFriendlyError(error, { includeTechnicalDetails: false }),
+          });
           logger.error('Failed to relink asset', {
             assetId,
             relativePath: entry.relativePath,
@@ -1284,6 +1299,16 @@ export function ProjectExplorer({ onAddToTimeline }: ProjectExplorerProps = {}) 
           role={importStatus.kind === 'error' ? 'alert' : 'status'}
         >
           {importStatus.message}
+        </div>
+      )}
+
+      {scanWarning && (
+        <div
+          data-testid="workspace-scan-warning"
+          className="min-w-0 break-words border-b border-editor-border px-3 py-2 text-xs text-amber-300 [overflow-wrap:anywhere]"
+          role="status"
+        >
+          {scanWarning}
         </div>
       )}
 

--- a/src/schemas/workspaceSchemas.test.ts
+++ b/src/schemas/workspaceSchemas.test.ts
@@ -69,6 +69,7 @@ describe('workspaceSchemas', () => {
         removedFiles: 1,
         registeredFiles: 5,
         autoRegisteredFiles: 2,
+        skippedFiles: 1,
       });
 
       expect(parsed).toEqual({
@@ -77,6 +78,7 @@ describe('workspaceSchemas', () => {
         removedFiles: 1,
         registeredFiles: 5,
         autoRegisteredFiles: 2,
+        skippedFiles: 1,
       });
     });
 
@@ -88,6 +90,7 @@ describe('workspaceSchemas', () => {
           removedFiles: 1,
           registeredFiles: 5,
           autoRegisteredFiles: 0,
+          skippedFiles: 0,
         }),
       ).toThrow('Invalid workspace scan result payload');
     });

--- a/src/schemas/workspaceSchemas.ts
+++ b/src/schemas/workspaceSchemas.ts
@@ -93,6 +93,7 @@ export const WorkspaceScanResultSchema = z
     removedFiles: WorkspaceScanCountSchema,
     registeredFiles: WorkspaceScanCountSchema,
     autoRegisteredFiles: WorkspaceScanCountSchema,
+    skippedFiles: WorkspaceScanCountSchema,
   })
   .strict() satisfies z.ZodType<WorkspaceScanResult>;
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -42,6 +42,12 @@ import {
   parseExternalChangeEvent,
   type ExternalChangeNotice,
 } from '@/utils/externalChange';
+import {
+  CAPTION_SNAPPED_TO_FRAME_GRID_EVENT,
+  formatCaptionGridNotice,
+  parseCaptionGridNotice,
+} from '@/utils/captionGridNotice';
+import { useToastStore } from '@/hooks/useToast';
 import { useWorkspaceStore, setupWorkspaceEventListeners } from '@/stores/workspaceStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useCommandPaletteStore } from '@/stores/commandPaletteStore';
@@ -1361,6 +1367,8 @@ function isTauriRuntime(): boolean {
  * - asset:proxy-generating: Proxy generation started
  * - asset:proxy-ready: Proxy generation completed successfully
  * - asset:proxy-failed: Proxy generation failed
+ * - project:external-change: Another process appended to the project's op log
+ * - caption:snapped-to-frame-grid: An import moved cue times onto the frame grid
  */
 export async function setupProxyEventListeners(): Promise<void> {
   // Prevent re-entrant setup
@@ -1462,6 +1470,29 @@ export async function setupProxyEventListeners(): Promise<void> {
       newUnlisteners.push(unlistenExternalChange);
     } catch (error) {
       logger.error('Failed to setup project external-change listener', { error });
+    }
+
+    // Caption cue times the backend rewrote onto the sequence frame grid.
+    // Snapping is on by default, so without this the user's supplied times
+    // change under them - and a dropped cue disappears - with nothing said.
+    try {
+      const unlistenCaptionGrid = await listen<unknown>(
+        CAPTION_SNAPPED_TO_FRAME_GRID_EVENT,
+        (event) => {
+          const notice = parseCaptionGridNotice(event.payload);
+          if (!notice) {
+            return;
+          }
+          logger.info('Imported captions were moved onto the frame grid', { ...notice });
+          useToastStore.getState().addToast({
+            message: formatCaptionGridNotice(notice),
+            variant: notice.dropped > 0 ? 'warning' : 'info',
+          });
+        },
+      );
+      newUnlisteners.push(unlistenCaptionGrid);
+    } catch (error) {
+      logger.error('Failed to setup caption frame-grid listener', { error });
     }
 
     // Only assign after all setup attempts complete

--- a/src/stores/videoGenStore.test.ts
+++ b/src/stores/videoGenStore.test.ts
@@ -78,7 +78,7 @@ describe('videoGenStore placement sync', () => {
 
     mockedInvoke.mockImplementation(async (command) => {
       if (command === 'download_generated_video') return { outputPath: '/project/generated.mp4' };
-      if (command === 'import_asset') return { id: 'asset-generated' };
+      if (command === 'import_asset') return { assetId: 'asset-generated' };
       if (command === 'generate_asset_thumbnail') return null;
       throw new Error(`Unhandled invoke: ${command}`);
     });
@@ -163,7 +163,7 @@ describe('videoGenStore placement sync', () => {
 
     mockedInvoke.mockImplementation(async (command) => {
       if (command === 'download_generated_video') return { outputPath: '/project/generated.mp4' };
-      if (command === 'import_asset') return { id: 'asset-generated' };
+      if (command === 'import_asset') return { assetId: 'asset-generated' };
       if (command === 'generate_asset_thumbnail') return null;
       throw new Error(`Unhandled invoke: ${command}`);
     });

--- a/src/stores/videoGenStore.ts
+++ b/src/stores/videoGenStore.ts
@@ -522,14 +522,14 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
         });
 
         // Import as asset
-        const importResult = await invoke<{ id: string }>('import_asset', {
+        const importResult = await invoke<{ assetId: string }>('import_asset', {
           uri: downloadResult.outputPath,
         });
 
         // Generate thumbnail
         try {
           await invoke('generate_asset_thumbnail', {
-            assetId: importResult.id,
+            assetId: importResult.assetId,
           });
         } catch (thumbErr) {
           logger.warn('Thumbnail generation failed', { error: String(thumbErr) });
@@ -544,7 +544,7 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
             const placementResult = await insertAgentMediaClip({
               sequenceId: placement.sequenceId,
               trackId: placement.trackId,
-              assetId: importResult.id,
+              assetId: importResult.assetId,
               timelineStart: placement.timelineStart,
             });
             placedClipId = placementResult.clipId;
@@ -567,7 +567,7 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
             placementError = error instanceof Error ? error.message : String(error);
             logger.error('Generated asset placement failed', {
               jobId,
-              assetId: importResult.id,
+              assetId: importResult.assetId,
               error: placementError,
             });
           }
@@ -577,7 +577,7 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
           const j = state.jobs.get(jobId);
           if (j) {
             j.status = 'completed';
-            j.assetId = importResult.id;
+            j.assetId = importResult.assetId;
             j.placedClipId = placedClipId;
             j.placementError = placementError;
             j.completedAt = new Date().toISOString();
@@ -587,7 +587,7 @@ export const useVideoGenStore = create<VideoGenState & VideoGenActions>()(
 
         logger.info('Video generation completed and imported', {
           jobId,
-          assetId: importResult.id,
+          assetId: importResult.assetId,
           placedClipId,
         });
       } catch (error) {

--- a/src/stores/workspaceStore.test.ts
+++ b/src/stores/workspaceStore.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Workspace Store Tests
+ *
+ * Feature: reporting the files a scan could not measure
+ *
+ * The backend leaves a workspace file unregistered when no probe could be
+ * launched for it: it stays on disk and in the tree, but is not an asset, so
+ * nothing in the app can put it on a timeline. The store is the only place that
+ * sees that count, so it is the place that has to keep it visible and act on the
+ * one event that can change it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WorkspaceScanResult } from '@/types';
+
+const gateway = vi.hoisted(() => ({
+  scanWorkspaceFromBackend: vi.fn(),
+  fetchWorkspaceTreeFromBackend: vi.fn(),
+  importExternalFilesToWorkspaceFromBackend: vi.fn(),
+}));
+
+vi.mock('@/services/workspaceGateway', () => ({
+  scanWorkspaceFromBackend: gateway.scanWorkspaceFromBackend,
+  fetchWorkspaceTreeFromBackend: gateway.fetchWorkspaceTreeFromBackend,
+  createFolderInBackend: vi.fn(),
+  renameFileInBackend: vi.fn(),
+  moveFileInBackend: vi.fn(),
+  deleteFileInBackend: vi.fn(),
+  importExternalFilesToWorkspaceFromBackend: gateway.importExternalFilesToWorkspaceFromBackend,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => undefined),
+}));
+
+import { useWorkspaceStore } from './workspaceStore';
+
+function scanResult(overrides: Partial<WorkspaceScanResult> = {}): WorkspaceScanResult {
+  return {
+    totalFiles: 3,
+    newFiles: 3,
+    removedFiles: 0,
+    registeredFiles: 0,
+    autoRegisteredFiles: 3,
+    skippedFiles: 0,
+    ...overrides,
+  };
+}
+
+describe('workspaceStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceStore.getState().reset();
+    gateway.fetchWorkspaceTreeFromBackend.mockResolvedValue([]);
+  });
+
+  it('should warn about the files it could not measure when a scan skips some', async () => {
+    gateway.scanWorkspaceFromBackend.mockResolvedValue(
+      scanResult({ autoRegisteredFiles: 1, skippedFiles: 2 }),
+    );
+
+    await useWorkspaceStore.getState().scanWorkspace();
+
+    const warning = useWorkspaceStore.getState().scanWarning;
+    expect(warning).toContain('2 files');
+    expect(warning).toContain('FFprobe could not be launched');
+  });
+
+  it('should leave no warning when the scan measured everything', async () => {
+    gateway.scanWorkspaceFromBackend.mockResolvedValue(scanResult({ skippedFiles: 0 }));
+
+    await useWorkspaceStore.getState().scanWorkspace();
+
+    expect(useWorkspaceStore.getState().scanWarning).toBeNull();
+  });
+
+  it('should clear a previous warning once a later scan measures everything', async () => {
+    gateway.scanWorkspaceFromBackend.mockResolvedValueOnce(scanResult({ skippedFiles: 2 }));
+    await useWorkspaceStore.getState().scanWorkspace();
+    expect(useWorkspaceStore.getState().scanWarning).not.toBeNull();
+
+    gateway.scanWorkspaceFromBackend.mockResolvedValueOnce(scanResult({ skippedFiles: 0 }));
+    await useWorkspaceStore.getState().scanWorkspace();
+
+    expect(useWorkspaceStore.getState().scanWarning).toBeNull();
+  });
+
+  it('should re-scan when FFmpeg becomes available and the last scan left files unmeasured', async () => {
+    gateway.scanWorkspaceFromBackend.mockResolvedValueOnce(scanResult({ skippedFiles: 2 }));
+    await useWorkspaceStore.getState().scanWorkspace();
+
+    gateway.scanWorkspaceFromBackend.mockResolvedValueOnce(
+      scanResult({ autoRegisteredFiles: 3, skippedFiles: 0 }),
+    );
+    await useWorkspaceStore.getState().rescanUnmeasuredFiles();
+
+    expect(gateway.scanWorkspaceFromBackend).toHaveBeenCalledTimes(2);
+    expect(useWorkspaceStore.getState().scanWarning).toBeNull();
+  });
+
+  it('should not re-scan when nothing was left unmeasured', async () => {
+    gateway.scanWorkspaceFromBackend.mockResolvedValue(scanResult({ skippedFiles: 0 }));
+    await useWorkspaceStore.getState().scanWorkspace();
+
+    await useWorkspaceStore.getState().rescanUnmeasuredFiles();
+
+    // A whole-workspace scan is not worth spending on an event that says
+    // nothing about the workspace's contents.
+    expect(gateway.scanWorkspaceFromBackend).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not re-scan before any scan has run', async () => {
+    await useWorkspaceStore.getState().rescanUnmeasuredFiles();
+
+    expect(gateway.scanWorkspaceFromBackend).not.toHaveBeenCalled();
+  });
+
+  it('should return the result rather than throw when a drop imported nothing', async () => {
+    // Every entry in `failedFiles` already carries the backend's reason for
+    // that file. Throwing would replace all of them with one generic error, and
+    // the explorer would have nothing specific left to show.
+    gateway.importExternalFilesToWorkspaceFromBackend.mockResolvedValue({
+      importedFiles: [],
+      failedFiles: [
+        { sourcePath: '/drop/unreachable.mp4', message: "'unreachable.mp4' was copied but ..." },
+      ],
+    });
+
+    const result = await useWorkspaceStore
+      .getState()
+      .importExternalFiles(['/drop/unreachable.mp4']);
+
+    expect(result.failedFiles).toHaveLength(1);
+  });
+
+  it('should re-scan when FFmpeg becomes available and a drop left files unregistered', async () => {
+    // A drop's leftovers never reach `scanResult.skippedFiles` - that counts
+    // what a scan left out - so a guard reading only the scan would strand the
+    // dropped file until the user scanned by hand.
+    gateway.importExternalFilesToWorkspaceFromBackend.mockResolvedValue({
+      importedFiles: [],
+      failedFiles: [
+        { sourcePath: '/drop/unreachable.mp4', message: "'unreachable.mp4' was copied but ..." },
+      ],
+    });
+    await useWorkspaceStore.getState().importExternalFiles(['/drop/unreachable.mp4']);
+
+    gateway.scanWorkspaceFromBackend.mockResolvedValue(
+      scanResult({ autoRegisteredFiles: 1, skippedFiles: 0 }),
+    );
+    await useWorkspaceStore.getState().rescanUnmeasuredFiles();
+
+    expect(gateway.scanWorkspaceFromBackend).toHaveBeenCalledTimes(1);
+
+    // The scan was the retry those files were waiting for, so the next event
+    // must not scan the whole workspace all over again.
+    await useWorkspaceStore.getState().rescanUnmeasuredFiles();
+    expect(gateway.scanWorkspaceFromBackend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -55,11 +55,41 @@ interface WorkspaceState {
   scanResult: WorkspaceScanResult | null;
   /** Error message from the last operation */
   error: string | null;
+  /**
+   * Why the last scan left some files out, or null when it left none out.
+   *
+   * Separate from {@link error}: the scan itself succeeded, and everything it
+   * could measure did land. This is the part of the result the user has to know
+   * about, because those files are on disk and in the tree but are not assets
+   * yet, so nothing in the app can put them on a timeline.
+   */
+  scanWarning: string | null;
+  /**
+   * How many files the external drops so far left out of the project.
+   *
+   * A drop reports those files as failures, not as imports: they are on disk
+   * but were never registered, usually because no probe could measure them.
+   * {@link WorkspaceScanResult.skippedFiles} does not see them - it counts only
+   * what a *scan* left out - so this is the other half of the "something is
+   * waiting for a probe" question {@link WorkspaceActions.rescanUnmeasuredFiles}
+   * asks.
+   */
+  unregisteredDropCount: number;
 }
 
 interface WorkspaceActions {
   /** Scan the project workspace for media files */
   scanWorkspace: () => Promise<void>;
+  /**
+   * Re-scan, but only when something is still waiting to be measured.
+   *
+   * Called when FFmpeg becomes available: the files a scan skipped, and the
+   * files a drop could not register, were left out because no probe could
+   * measure them - exactly the condition that just changed. When nothing is
+   * waiting there is nothing to pick up, and a scan of a whole workspace is not
+   * worth spending on an event that says nothing about its contents.
+   */
+  rescanUnmeasuredFiles: () => Promise<void>;
   /** Refresh the file tree from the backend */
   refreshTree: () => Promise<void>;
   /** Create a new folder in the workspace */
@@ -91,10 +121,30 @@ const initialState: WorkspaceState = {
   isWatching: false,
   scanResult: null,
   error: null,
+  scanWarning: null,
+  unregisteredDropCount: 0,
 };
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The warning a scan result carries, or null when it carries none.
+ *
+ * @param skippedFiles - How many files the scan could not measure.
+ */
+function unmeasuredFilesWarning(skippedFiles: number): string | null {
+  if (skippedFiles <= 0) {
+    return null;
+  }
+  // The backend leaves a file out whenever the probe measured nothing, which
+  // covers a probe that never started *and* one that ran and returned nothing
+  // readable. Naming only the first would tell someone with FFmpeg installed
+  // that it is not, and send them to fix what is not broken.
+  return `${skippedFiles.toLocaleString()} file${skippedFiles === 1 ? '' : 's'} could not be measured: FFprobe could not be launched, or returned nothing readable, so ${
+    skippedFiles === 1 ? 'it is' : 'they are'
+  } not available as media yet. Check FFmpeg is installed, then scan again.`;
 }
 
 /**
@@ -167,6 +217,9 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
       set((state) => {
         state.isScanning = true;
         state.error = null;
+        // The warning describes the *last* scan. Clearing it here means a scan
+        // in flight never shows a stale count next to a fresh result.
+        state.scanWarning = null;
       });
 
       try {
@@ -175,10 +228,21 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           totalFiles: result.totalFiles,
           newFiles: result.newFiles,
           autoRegisteredFiles: result.autoRegisteredFiles,
+          skippedFiles: result.skippedFiles,
         });
 
+        const warning = unmeasuredFilesWarning(result.skippedFiles);
+        if (warning !== null) {
+          logger.warn('Workspace scan left files unmeasured', {
+            skippedFiles: result.skippedFiles,
+          });
+        }
+
+        // The warning is part of the result, so it lands with it: two writes
+        // would let a render in between show a result with no warning on it.
         set((state) => {
           state.scanResult = result;
+          state.scanWarning = warning;
           state.isScanning = false;
         });
 
@@ -200,6 +264,25 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
         set((state) => {
           state.isScanning = false;
           state.error = message;
+        });
+      }
+    },
+
+    rescanUnmeasuredFiles: async () => {
+      const { scanResult, unregisteredDropCount } = get();
+      if ((scanResult?.skippedFiles ?? 0) === 0 && unregisteredDropCount === 0) {
+        return;
+      }
+      logger.info('Re-scanning workspace: FFmpeg became available');
+      await get().scanWorkspace();
+
+      // The scan is the retry those dropped files were waiting for. Whatever it
+      // still could not measure is in the fresh `skippedFiles`, which is what
+      // the next event reads; leaving the drop count standing would re-scan the
+      // whole workspace on every later event forever.
+      if (get().error === null) {
+        set((state) => {
+          state.unregisteredDropCount = 0;
         });
       }
     },
@@ -310,17 +393,20 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           logger.warn(message, { failedFiles: result.failedFiles });
           set((state) => {
             state.error = message;
+            // Every entry here is a file that reached disk but not the project.
+            // A later scan is what picks it up, so remember that one is owed.
+            state.unregisteredDropCount += result.failedFiles.length;
           });
-
-          if (result.importedFiles.length === 0) {
-            throw new Error(message);
-          }
         } else {
           set((state) => {
             state.error = null;
           });
         }
 
+        // A drop where nothing landed still returns its result rather than
+        // throwing. Every failure in it is already reported per file, and
+        // throwing would replace those messages - the only place that says
+        // *why* each file was left out - with one generic error.
         return result;
       } catch (error) {
         const message = toErrorMessage(error);
@@ -410,12 +496,14 @@ export async function setupWorkspaceEventListeners(): Promise<void> {
           removedFiles: event.removedFiles,
           registeredFiles: event.registeredFiles,
           autoRegisteredFiles: event.autoRegisteredFiles,
+          skippedFiles: event.skippedFiles,
         });
 
         useWorkspaceStore.setState({
           scanResult: event,
           isScanning: false,
           error: null,
+          scanWarning: unmeasuredFilesWarning(event.skippedFiles),
         });
 
         scheduleWorkspaceTreeRefresh('workspace:scan-complete');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -322,6 +322,11 @@ export interface WorkspaceScanResult {
   registeredFiles: number;
   /** Number of files auto-registered during this scan */
   autoRegisteredFiles: number;
+  /**
+   * Number of files left unregistered because FFprobe could not be launched to
+   * measure them. They stay in the index, so a later scan picks them up.
+   */
+  skippedFiles: number;
 }
 
 /** Result of registering a workspace file as a project asset */
@@ -354,6 +359,11 @@ export interface WorkspaceScanCompleteEvent {
   registeredFiles: number;
   /** Number of files auto-registered during this scan */
   autoRegisteredFiles: number;
+  /**
+   * Number of files left unregistered because FFprobe could not be launched to
+   * measure them.
+   */
+  skippedFiles: number;
 }
 
 // =============================================================================

--- a/src/utils/captionGridNotice.test.ts
+++ b/src/utils/captionGridNotice.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { parseCaptionGridNotice, formatCaptionGridNotice } from './captionGridNotice';
+
+describe('captionGridNotice', () => {
+  describe('parseCaptionGridNotice', () => {
+    it('should read a count and a drop count when the backend reports both', () => {
+      expect(parseCaptionGridNotice({ count: 41, dropped: 2 })).toEqual({ count: 41, dropped: 2 });
+    });
+
+    it('should default dropped to zero when the payload omits it', () => {
+      expect(parseCaptionGridNotice({ count: 41 })).toEqual({ count: 41, dropped: 0 });
+    });
+
+    it('should return null when nothing happened, so nothing is announced', () => {
+      expect(parseCaptionGridNotice({ count: 0, dropped: 0 })).toBeNull();
+    });
+
+    it('should return null for a payload that is not a pair of counts', () => {
+      expect(parseCaptionGridNotice(null)).toBeNull();
+      expect(parseCaptionGridNotice('41')).toBeNull();
+      expect(parseCaptionGridNotice({})).toBeNull();
+      expect(parseCaptionGridNotice({ count: -1 })).toBeNull();
+      expect(parseCaptionGridNotice({ count: Number.NaN })).toBeNull();
+      expect(parseCaptionGridNotice({ count: 1, dropped: 'two' })).toBeNull();
+    });
+  });
+
+  describe('formatCaptionGridNotice', () => {
+    it('should say only what happened when no cue was dropped', () => {
+      expect(formatCaptionGridNotice({ count: 41, dropped: 0 })).toBe(
+        '41 captions moved onto the sequence frame grid.',
+      );
+    });
+
+    it('should name the dropped cues when the grid gave up on some', () => {
+      expect(formatCaptionGridNotice({ count: 41, dropped: 2 })).toContain('2 captions dropped');
+    });
+
+    it('should report drops alone when nothing else moved', () => {
+      expect(formatCaptionGridNotice({ count: 0, dropped: 1 })).toBe(
+        '1 caption dropped: the frame grid could not keep them in order.',
+      );
+    });
+
+    it('should speak of one caption in the singular', () => {
+      expect(formatCaptionGridNotice({ count: 1, dropped: 0 })).toBe(
+        '1 caption moved onto the sequence frame grid.',
+      );
+    });
+  });
+});

--- a/src/utils/captionGridNotice.ts
+++ b/src/utils/captionGridNotice.ts
@@ -1,0 +1,80 @@
+/**
+ * Caption frame-grid notices.
+ *
+ * Importing generated captions snaps every cue onto the sequence's frame grid
+ * by default, and drops the few cues the grid cannot keep in order without
+ * dragging them off their own time. Both rewrite what the caller supplied, so
+ * the backend reports them instead of doing them silently; these helpers turn
+ * that report into the line a user reads.
+ */
+
+/**
+ * Tauri event the backend emits after an import moved cues onto the frame grid.
+ *
+ * Keep in sync with the emit in `src-tauri/src/ipc/events.rs`.
+ */
+export const CAPTION_SNAPPED_TO_FRAME_GRID_EVENT = 'caption:snapped-to-frame-grid';
+
+/** What an import's frame-grid pass did to the cues it was handed. */
+export interface CaptionGridNotice {
+  /** How many cues were moved onto a different pair of frames. */
+  count: number;
+  /** How many cues were dropped rather than pushed off their own time. */
+  dropped: number;
+}
+
+function readCount(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return Math.trunc(value);
+}
+
+/**
+ * Reads a `caption:snapped-to-frame-grid` payload.
+ *
+ * Returns `null` for anything that is not a pair of non-negative counts, and
+ * for a notice that reports nothing happened — there is nothing to tell the
+ * user then. `dropped` is optional so a backend that predates it still reports.
+ */
+export function parseCaptionGridNotice(payload: unknown): CaptionGridNotice | null {
+  if (typeof payload !== 'object' || payload === null) {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const count = readCount(record.count);
+  if (count === null) {
+    return null;
+  }
+
+  const dropped = record.dropped === undefined ? 0 : readCount(record.dropped);
+  if (dropped === null) {
+    return null;
+  }
+
+  if (count === 0 && dropped === 0) {
+    return null;
+  }
+
+  return { count, dropped };
+}
+
+function cues(count: number): string {
+  return count === 1 ? '1 caption' : `${count} captions`;
+}
+
+/** The sentence a user sees for a frame-grid notice. */
+export function formatCaptionGridNotice(notice: CaptionGridNotice): string {
+  const moved = `${cues(notice.count)} moved onto the sequence frame grid`;
+  if (notice.dropped === 0) {
+    return `${moved}.`;
+  }
+
+  const dropped = `${cues(notice.dropped)} dropped: the frame grid could not keep them in order`;
+  if (notice.count === 0) {
+    return `${dropped}.`;
+  }
+
+  return `${moved}; ${dropped}.`;
+}

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -454,6 +454,29 @@ describe('Edge Cases', () => {
       );
     });
 
+    it('should ask for a retry when the marker arrives without an error-kind prefix', () => {
+      // Not every surface wraps the probe error in `FFprobe error: ` before it
+      // reaches the UI, so the marker also has to be recognised at the very
+      // start of the message.
+      const result = getUserFriendlyError(
+        'FFprobe reported nothing about interview.mp4: FFmpeg operation timed out'
+      );
+      expect(result).toBe(
+        'FFprobe could not measure this file (it may be on a slow or disconnected drive). Try again once the file is reachable.'
+      );
+    });
+
+    it('should still blame the file when a verdict merely quotes the marker', () => {
+      // The marker means "no measurement happened", and the Rust side only
+      // means it when it writes it first. Here FFprobe did look and did have
+      // something to say, so telling the user to retry would send them back to
+      // a file that will fail the same way every time.
+      const result = getUserFriendlyError(
+        'FFprobe error: Invalid data found when processing input; the log says FFprobe reported nothing usable'
+      );
+      expect(result).toBe('Could not read media information. The file may be corrupted.');
+    });
+
     it('should point at the missing FFmpeg when FFprobe could not be run', () => {
       const result = getUserFriendlyError(
         'FFprobe could not be run: Failed to run ffprobe: The system cannot find the file specified. (os error 2)'

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -426,6 +426,52 @@ describe('Edge Cases', () => {
       const result = getUserFriendlyError('FFprobe error: Invalid data found');
       expect(result).toBe('Could not read media information. The file may be corrupted.');
     });
+
+    it('should ask for a retry when FFprobe reached no verdict about the file', () => {
+      // The backend refuses an import or a relink rather than attaching an
+      // invented duration when the probe was killed or unreadable. The file
+      // itself is usually fine, so the user is not sent looking for corruption.
+      const result = getUserFriendlyError(
+        'FFprobe error: FFprobe reported nothing about interview.mp4: FFmpeg operation timed out'
+      );
+      expect(result).toBe(
+        'FFprobe could not measure this file (it may be on a slow or disconnected drive). Try again once the file is reachable.'
+      );
+    });
+
+    it('should ask for a retry when the probe output could not be read', () => {
+      // The exact string the Rust side produces from
+      // `PROBE_MEASURED_NOTHING_PREFIX` when ffprobe exits cleanly and returns
+      // output nothing can be built from. The prefix is shared with
+      // `probe_measured_nothing`, so this pattern has to keep matching it
+      // verbatim: the backend refuses the import, and this is the only place
+      // that tells the user what to do about it.
+      const result = getUserFriendlyError(
+        'FFprobe error: FFprobe reported nothing: failed to parse ffprobe output: EOF while parsing a value at line 1 column 0'
+      );
+      expect(result).toBe(
+        'FFprobe could not measure this file (it may be on a slow or disconnected drive). Try again once the file is reachable.'
+      );
+    });
+
+    it('should point at the missing FFmpeg when FFprobe could not be run', () => {
+      const result = getUserFriendlyError(
+        'FFprobe could not be run: Failed to run ffprobe: The system cannot find the file specified. (os error 2)'
+      );
+      expect(result).toBe('FFmpeg is not installed. Export and preview features require FFmpeg.');
+    });
+
+    it('should point at the missing FFmpeg when launching FFprobe was refused', () => {
+      // Windows and Unix report a blocked or non-executable binary as an access
+      // failure, not as a missing file; both are still "there is no usable
+      // FFprobe here", not "your media is locked".
+      for (const detail of ['Access is denied. (os error 5)', 'Permission denied (os error 13)']) {
+        const result = getUserFriendlyError(
+          `FFprobe could not be run: Failed to run ffprobe: ${detail}`
+        );
+        expect(result).toBe('FFmpeg is not installed. Export and preview features require FFmpeg.');
+      }
+    });
   });
 
   describe('Empty and unusual inputs', () => {

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -72,6 +72,18 @@ const ERROR_PATTERNS: Array<{
     pattern: /File not found/i,
     message: () => 'The file could not be found. Please check if it exists.',
   },
+  // Ahead of the generic FFprobe entry: a probe that was killed by the watchdog
+  // or whose output could not be read reached no verdict about the file at all,
+  // so "the file may be corrupted" would be a guess. The file is usually fine
+  // and simply too slow to reach, which makes retrying the right next step.
+  // The retry is deliberately not named as an import: the same probe backs
+  // relinking, scanning and rendering, and telling someone whose export warned
+  // about this to import again sends them nowhere.
+  {
+    pattern: /FFprobe reported nothing/i,
+    message: () =>
+      'FFprobe could not measure this file (it may be on a slow or disconnected drive). Try again once the file is reachable.',
+  },
   {
     pattern: /FFprobe error/i,
     message: () => 'Could not read media information. The file may be corrupted.',
@@ -156,6 +168,15 @@ const ERROR_PATTERNS: Array<{
   },
 
   // Permission Errors
+  // Ahead of every raw OS-error pattern: a failure to launch FFprobe surfaces
+  // as "FFprobe could not be run: ... (os error 2)" when the binary is gone and
+  // as "(os error 5)" / "(os error 13)" when something refuses to execute it.
+  // Matched later, those would send the user looking for their media or their
+  // folder permissions instead of FFmpeg.
+  {
+    pattern: /FFprobe could not be run/i,
+    message: () => 'FFmpeg is not installed. Export and preview features require FFmpeg.',
+  },
   {
     pattern: /Permission denied/i,
     message: () => 'Access denied. Check file permissions.',

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -79,8 +79,16 @@ const ERROR_PATTERNS: Array<{
   // The retry is deliberately not named as an import: the same probe backs
   // relinking, scanning and rendering, and telling someone whose export warned
   // about this to import again sends them nowhere.
+  //
+  // Anchored, and case-sensitive, because this is one exact string the Rust
+  // side writes (`PROBE_MEASURED_NOTHING_PREFIX`) at the *start* of the probe
+  // error, not a phrase to hunt for: `^` catches the bare message and `: `
+  // catches it after the `FFprobe error: ` an inner `CoreError` is displayed
+  // behind. A loose match would also claim a verdict FFprobe did reach that
+  // happened to quote these words, and send the user off retrying a file that
+  // is genuinely broken.
   {
-    pattern: /FFprobe reported nothing/i,
+    pattern: /(^|: )FFprobe reported nothing/,
     message: () =>
       'FFprobe could not measure this file (it may be on a slow or disconnected drive). Try again once the file is reachable.',
   },


### PR DESCRIPTION
### **User description**
## Summary

Found on a real talk: an A/V mp4 inserted on the video track (the default agent path) rendered with audio at -16.6 LUFS, yet `transcription generate-sequence` refused it with "Sequence has no audible audio clips" and `render graph` showed `audioLayers: []`.

- **One audibility predicate** (`render::audio_presence::clip_carries_audio`) shared by export, `render graph` and the transcription mixdown; the render graph now emits an audio layer for any clip that reaches the render with sound (a hidden-but-audible video track included), and audibility is measured with ffprobe instead of read from metadata the CLI import never recorded.
- **`--start/--end`** on `transcription generate` (asset seconds) and `generate-sequence` (timeline seconds), MCP `start`/`end`: only the window is decoded (`-ss` before `-i`), timestamps stay absolute — captioning a 90 s excerpt no longer transcribes a 14-minute asset.
- **Frame-grid snapping** of imported cues (`generate-sequence`, `caption import`, `ImportGeneratedCaptions`): nearest frame, ≥1 frame long, neighbours kept ordered and non-overlapping (later start moved rather than collapsing the earlier cue), `--no-snap` opt-out, `snappedCues` reported. A draft render of a 41-cue import now prints zero alignment warnings.

## Verification
- clippy (CI command) clean; `cargo test -p openreelio transcription` 7, `captions` 184, `render` 846; CLI `transcription` 8+2, `caption` 7+15, `render` 11+39
- The `generate-sequence` acceptance test ran end to end with the installed Whisper model; `render start --proxy` asserts zero `not aligned to sequence frame boundaries` warnings


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Unifies audio presence logic across export, render graph, and transcription to include video-track audio.

- Adds `--start` and `--end` windowing to transcription commands to decode only requested excerpts.

- Implements frame-grid snapping for imported captions to eliminate alignment warnings during rendering.

- Enhances `render graph` to use `ffprobe` for accurate audio detection on unprobed assets.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI/MCP Input"] -- "start/end window" --> B["Audio Extraction"]
  B -- "ffprobe detection" --> C["Transcription Mixdown"]
  C -- "Whisper Inference" --> D["Caption Import"]
  D -- "Snap to Frames" --> E["Sequence Timeline"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>audio_presence.rs</strong><dd><code>Centralize audio presence detection logic using ffprobe</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-cc1f921c4e12b9335ba576389039c54a296e4915eaf2f2420cf55d5780c0523a">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>audio.rs</strong><dd><code>Add time-windowed audio extraction and sequence mixdown</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-c98a36028001dacf84d67a63f54b501767c167d5f3ef29929cc3f171af8d11c8">+350/-24</a></td>

</tr>

<tr>
  <td><strong>caption.rs</strong><dd><code>Implement frame-grid snapping logic for caption cues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-53a364efaff2c8190669569c762f7bf8e798a18e8877ae2f434d970594d25d5e">+278/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.rs</strong><dd><code>Expose start/end and no-snap options to transcription CLI</code></dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-2a5e846a6e19dee27807a217fb99429b1d20fa875e5cd67e391846a7642b7f4d">+80/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>caption.rs</strong><dd><code>Integrate frame snapping into caption import command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-57ce46b7a549091037f84030307fe41615baba99edaf2ead0fa5ad01e8d1eda8">+75/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>payloads.rs</strong><dd><code>Add snapToFrames field to caption import IPC payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-1efed79e6d1ef23a178231ecb231d1034cfafe2660c00fc389179577224de950">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bindings.ts</strong><dd><code>Update TypeScript types for caption import payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-d652c79b7c7fa86780222eb798f141975680c7e3f32435b9f762f2e87a9c49dc">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>graph.rs</strong><dd><code>Update render graph to report audio from video tracks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-163180d6ca9e483678d174a42eaf8446f6c405a5d8df9372ecf143f1dafb00f3">+246/-26</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>export.rs</strong><dd><code>Refactor audio companion and playable audio checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-e6847089c7d250f2356653a6003733d6ea681538eb287ad5c106c210875b92b2">+31/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>integration.rs</strong><dd><code>Add integration tests for audio detection and snapping</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-dae1e81419bf7fa4cb966507d40fab16356121fb13ebaf2031a408b076d89829">+239/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>help_json.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-617f22992e6d15b8efeb91d32acd274a4951e6146f2e601ff770dfce23b808a1">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-ea0ffedac9e558fbf8683774498282d31084018ceeec6cd6b20ae11498d453ed">+63/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-280e1b2f4fcfd0aff373db2f4103f98a471444033d18d9ad282608a80355019f">+15/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REFERENCE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-3108771c2d44e2b7db9e9097acfa4590082bf896c1561d2cc81899e9fbbfb0f3">+30/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT_GUIDE.md</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-609f4b6b6395bee5b56f2cb041c6803bc2afd043dbb10d33c31349b6e8c96a26">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ffmpeg_plan.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-7f93452cf29faaec41eb667dd7d07cf667603dace2d8f99aba49ae2e38c3e2df">+17/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-56d7d1f30a90506239b488113f2d54a16431d0a0d4d438529b28df276039dfe0">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.rs</strong></td>
  <td><a href="https://github.com/openreelio/openreelio/pull/876/files#diff-8f3bc0f34153988c4c381f436da7aaa711daad3d84418067f3505cfb3055b5cc">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Caption imports now snap cue boundaries to the sequence frame grid by default; `--no-snap` preserves original timings.
  - Imports report moved and dropped cues, with notices shown in the app.
  - Transcription supports optional `--start` and `--end` time ranges.
  - Audio from audiovisual clips on video tracks is included in rendering and transcription.
  - Render results report planned video and audio layer counts.

- **Bug Fixes**
  - Improved audio detection across rendering, previews, exports, and transcription.
  - FFmpeg and relink failures now provide clearer guidance.
  - Overlapping captions and duplicate validation warnings are handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->